### PR TITLE
perf: avoid sysinfo System::new_all() when only one metric is needed

### DIFF
--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1267,7 +1267,10 @@ impl WorkflowConfig {
         let system_threads = num_cpus::get() as u32;
         let system_memory_mb = {
             use sysinfo::System;
-            let mut sys = System::new_all();
+            // Only memory is needed here; `System::new_all()` would walk all of
+            // /proc (every process, disk, and network interface) just to read
+            // total RAM, adding ~50ms to every parse/validate/dry-run/run call.
+            let mut sys = System::new();
             sys.refresh_memory();
             sys.total_memory() / 1024 / 1024
         };

--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -17,13 +17,15 @@ mod tests;
 /// Get available CPU threads for auto-scaling.
 #[must_use]
 pub fn available_threads() -> u32 {
-    System::new_all().cpus().len() as u32
+    num_cpus::get() as u32
 }
 
 /// Get available memory in GB for auto-scaling.
 #[must_use]
 pub fn available_memory_gb() -> u64 {
-    let mut sys = System::new_all();
+    // Only memory is needed; `System::new_all()` would also walk every process,
+    // disk, and network interface in /proc for no reason.
+    let mut sys = System::new();
     sys.refresh_memory();
     sys.available_memory() / (1024 * 1024 * 1024) // Convert bytes to GB
 }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -300,7 +300,8 @@ fn detect_total_memory_mb() -> u64 {
     // Primary: sysinfo crate (cross-platform)
     if let Ok(mb) = std::panic::catch_unwind(|| {
         use sysinfo::System;
-        let mut sys = System::new_all();
+        // Only memory is needed; avoid `System::new_all()` scanning all of /proc.
+        let mut sys = System::new();
         sys.refresh_memory();
         sys.total_memory() / 1024 / 1024
     }) && mb > 0


### PR DESCRIPTION
## What

`WorkflowConfig::validate()` called `sysinfo::System::new_all()` — which walks all of `/proc` (every process, disk, and network interface) — just to read total system memory. That added a fixed **~50 ms** to every `parse` / `validate` / `dry-run` / `run`.

Fix: probe only memory with `System::new()` + `refresh_memory()`. Behavior is identical — `total_memory()` still returns bytes in sysinfo 0.38, so the `/1024/1024` math and the emitted warnings are unchanged. The same pattern is fixed in `executor::available_memory_gb`, `available_threads` (now `num_cpus::get()`), and `process::detect_total_memory_mb`.

## How I found it

Running the existing criterion suite, `parse/10_simple` and `parse/1000_simple` both clocked ~50 ms — flat, regardless of rule count — while `dag/chain_10000` built 10,000 rules in 3 ms. A fixed cost that didn't scale with the workload pointed straight at the per-call `new_all()`.

## Result

| Bench | Before | After |
|---|---:|---:|
| `parse/10_simple` | 50.0 ms | 38.6 µs |
| `parse/1000_simple` | 55.1 ms | 1.52 ms |
| `lifecycle/10_simple` | 107 ms | 67.4 µs |

Parsing now scales with rule count instead of being pinned at ~50 ms.

`cargo fmt --check` + `cargo clippy --workspace -D warnings` clean; `cargo test --workspace --lib` → 890 passed.
