### PR TITLE
fix: publish scans [rules.environment] for env files

### DIFF
--- a/crates/oxo-flow-cli/src/commands/publish.rs
+++ b/crates/oxo-flow-cli/src/commands/publish.rs
@@ -47,35 +47,28 @@ pub fn publish_command(workflow: PathBuf, output: Option<PathBuf>) -> Result<()>
 
     let mut referenced_files: Vec<(String, PathBuf)> = Vec::new();
 
-    // Scan [[rules]] for environment spec file references
+    // Scan [[rules]] for environment spec file references.
+    //
+    // The schema is `[rules.environment]` (EnvironmentSpec). Only the fields
+    // that point at a local file are bundleable: `conda`/`pixi`/`venv` and the
+    // optional `venv_requirements`. `docker`/`singularity` are image refs and
+    // `modules` are HPC module names — nothing to copy.
     if let Some(rules) = toml_value.get("rules").and_then(|v| v.as_array()) {
         for rule in rules {
-            // Check for env.file (table format: [rules.env])
-            if let Some(env) = rule.get("env")
-                && let Some(env_file) = env.get("file").and_then(|v| v.as_str())
-            {
-                let abs_path = workflow_dir.join(env_file);
-                if abs_path.exists() {
-                    let filename = abs_path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    if !referenced_files.iter().any(|(name, _)| name == &filename) {
-                        referenced_files.push((filename, abs_path));
-                    }
-                }
-            }
-
-            // Check for conda_env field
-            if let Some(conda_env) = rule.get("conda_env").and_then(|v| v.as_str()) {
-                let abs_path = workflow_dir.join(conda_env);
-                if abs_path.exists() {
-                    let filename = abs_path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    if !referenced_files.iter().any(|(name, _)| name == &filename) {
-                        referenced_files.push((filename, abs_path));
+            let Some(env) = rule.get("environment") else {
+                continue;
+            };
+            for field in ["conda", "pixi", "venv", "venv_requirements"] {
+                if let Some(env_file) = env.get(field).and_then(|v| v.as_str()) {
+                    let abs_path = workflow_dir.join(env_file);
+                    if abs_path.exists() {
+                        let filename = abs_path
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default();
+                        if !referenced_files.iter().any(|(name, _)| name == &filename) {
+                            referenced_files.push((filename, abs_path));
+                        }
                     }
                 }
             }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1688,6 +1688,40 @@ fn cli_publish_creates_bundle() {
 }
 
 #[test]
+fn cli_publish_bundles_environment_conda_file() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join("envs")).unwrap();
+    fs::write(
+        dir.path().join("envs/fastp.yaml"),
+        "name: fastp\ndependencies: [fastp]\n",
+    )
+    .unwrap();
+    let wf = dir.path().join("pub_env.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"pub-env\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"s\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output[0]}\"\n\n[rules.environment]\nconda = \"envs/fastp.yaml\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["publish", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let bundle = dir.path().join("pub_env-bundle");
+    assert!(
+        bundle.join("fastp.yaml").exists(),
+        "conda env file from [rules.environment] should be bundled"
+    );
+    let manifest = fs::read_to_string(bundle.join("manifest.json")).unwrap();
+    assert!(
+        manifest.contains("fastp.yaml"),
+        "manifest should list the bundled env file"
+    );
+}
+
+#[test]
 fn cli_publish_nonexistent_workflow() {
     oxo_flow_cmd()
         .args(["publish", "/nonexistent/path/workflow.oxoflow"])


### PR DESCRIPTION
publish scanned each rule for `[rules.env].file` and a `conda_env` field, neither of which exists in the schema. The real schema is `[rules.environment]` (EnvironmentSpec) with `conda`/`pixi`/`venv`/`venv_requirements` file paths.

Result: publish collected zero env files and bundled none — silently, while reporting success. A rule with `[rules.environment]`/`conda = "envs/fastp.yaml"` matched nothing.

This scans the environment table's file-bearing fields instead. `docker`/`singularity` (image refs) and `modules` (HPC module names) are not files and are left out. Adds an integration test covering a conda env declared under `[rules.environment]`.

`make ci` passes (fmt/clippy/build/test); the audit leg needs `cargo-audit` installed locally.

### Known follow-up (out of scope here)
Referenced env files are still flattened to their basename on copy: `envs/fastp.yaml` lands in the bundle as `fastp.yaml`, but the bundled workflow keeps referencing `envs/fastp.yaml`, so the path does not resolve. This PR fixes only the schema-scanning bug (envs bundled at all vs. silently dropped); preserving the relative layout is a separate fix to follow.