### PR TITLE
fix: drop redundant borrow in ai_provider Authorization header

### DIFF
--- a/crates/oxo-flow-web/src/ai_provider.rs
+++ b/crates/oxo-flow-web/src/ai_provider.rs
@@ -103,7 +103,7 @@ mod internal {
                 .client
                 .post(&self.api_url)
                 .header("x-api-key", &self.api_key)
-                .header("Authorization", format!("Bearer {}", &self.api_key))
+                .header("Authorization", format!("Bearer {}", self.api_key))
                 .header("anthropic-version", "2023-06-01")
                 .header("content-type", "application/json")
                 .json(&body)


### PR DESCRIPTION
The workspace clippy gate (`cargo clippy --workspace -- -D warnings`) fails on current stable (clippy >= 1.97) with `useless_borrows_in_formatting`:

```
error: redundant reference in `format!` argument
  --> crates/oxo-flow-web/src/ai_provider.rs:106
   |
   | .header("Authorization", format!("Bearer {}", &self.api_key))
   |                                                ^^^^^^^^^^^^^ help: remove the redundant `&`: `self.api_key`
```

This is pre-existing on `main` (landed in #45); newer clippy tightened the lint, so the gate now blocks every PR built on this toolchain. Fix passes the field by value. No behavior change.