### PR TITLE
fix: propagate rule failures transitively, count skips once

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -287,6 +287,10 @@ pub async fn run_command(
     let failed_rules_set: Arc<Mutex<std::collections::HashSet<String>>> =
         Arc::new(Mutex::new(std::collections::HashSet::new()));
     let failures: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    // Rules that never ran because an upstream dependency failed, paired with the
+    // dependency that blocked them. Reported separately from genuine failures so
+    // the root cause stays distinguishable from the fallout.
+    let blocked: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
 
     let checkpoint_path = workdir
         .as_ref()
@@ -455,20 +459,9 @@ pub async fn run_command(
         }
     }
 
-    // Pre-loop: evaluate rule conditions, mark false-condition rules as skipped
-    for rule in config.rules.iter() {
-        if !order.contains(&rule.name) {
-            continue;
-        }
-        if let Some(ref condition) = rule.when {
-            let config_values: HashMap<String, toml::Value> = config.config.clone();
-            if !oxo_flow_core::executor::process::evaluate_condition(condition, &config_values) {
-                skipped_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                progress.inc(1);
-                continue;
-            }
-        }
-    }
+    // Rule `when` conditions are evaluated by the executor itself, which reports
+    // them back as JobStatus::Skipped. Pre-evaluating them here as well would
+    // count every condition-skipped rule twice.
 
     // Execute rules in parallel groups (topological levels).
     // Rules within a group have no dependencies on each other and can run concurrently.
@@ -491,18 +484,32 @@ pub async fn run_command(
         let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
         for rule_name in group {
-            // Skip if already in failed set (from previous groups)
-            let skip_from_failure = {
+            // Skip if any direct dependency failed or was itself blocked.
+            // `dag.dependencies()` returns direct predecessors only, so a blocked
+            // rule must join the failed set for the block to reach its own
+            // dependents. Groups are processed in topological order, so a rule's
+            // dependencies are always resolved before the rule is considered.
+            let blocked_by = {
                 let frs = failed_rules_set.lock().await;
-                if let Ok(deps) = dag.dependencies(rule_name) {
-                    deps.iter().any(|d| frs.contains(d.as_str()))
-                } else {
-                    false
-                }
+                dag.dependencies(rule_name)
+                    .ok()
+                    .and_then(|deps| deps.into_iter().find(|d| frs.contains(d.as_str())))
             };
 
-            if skip_from_failure {
+            if let Some(dep) = blocked_by {
                 skipped_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                {
+                    let mut frs = failed_rules_set.lock().await;
+                    frs.insert(rule_name.clone());
+                }
+                blocked.lock().await.push((rule_name.clone(), dep));
+                if !is_tty {
+                    eprintln!(
+                        "  {} {} (blocked by failed dependency)",
+                        "⊘".yellow(),
+                        rule_name
+                    );
+                }
                 progress.inc(1);
                 continue;
             }
@@ -702,6 +709,7 @@ pub async fn run_command(
     let skipped_count = skipped_count.load(std::sync::atomic::Ordering::Relaxed);
     let checkpoint = checkpoint.lock().await;
     let failures = failures.lock().await;
+    let blocked = blocked.lock().await;
 
     progress.finish_and_clear();
     eprintln!(
@@ -718,6 +726,15 @@ pub async fn run_command(
         eprintln!("\n{}", "Failed rules:".bold().red());
         for (name, reason) in failures.iter() {
             eprintln!("  {} {} — {}", "✗".red(), name.bold(), reason);
+        }
+    }
+
+    // Blocked rules did not run and produced no outputs. Listing them keeps the
+    // fallout of a failure visible without disguising it as a genuine failure.
+    if !blocked.is_empty() {
+        eprintln!("\n{}", "Blocked rules (did not run):".bold().yellow());
+        for (name, dep) in blocked.iter() {
+            eprintln!("  {} {} — depends on '{}'", "⊘".yellow(), name.bold(), dep);
         }
     }
 
@@ -790,6 +807,7 @@ pub async fn run_command(
                 "succeeded": success_count,
                 "skipped": skipped_count,
                 "failed": fail_count,
+                "blocked": blocked.len(),
             }),
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2447,3 +2447,122 @@ fn cli_schema_outputs_valid_json() {
         "schema should define rules property"
     );
 }
+
+// ─── transitive failure propagation / skip accounting ───────────────────
+
+/// A three-rule chain `a -> b -> c` where `a` fails. `c` must not execute:
+/// `dag.dependencies()` reports direct predecessors only, so a blocked rule
+/// has to join the failed set for the block to reach its own dependents.
+#[test]
+fn cli_run_keep_going_blocks_transitive_dependents() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("chain.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"chain\"\nversion = \"1.0.0\"\n\n\
+         [[rules]]\nname = \"a_fails\"\noutput = [\"a.txt\"]\nshell = \"exit 1\"\n\n\
+         [[rules]]\nname = \"b_child\"\ninput = [\"a.txt\"]\noutput = [\"b.txt\"]\n\
+         depends_on = [\"a_fails\"]\nshell = \"cat {input[0]} > {output[0]}\"\n\n\
+         [[rules]]\nname = \"c_grandchild\"\ninput = [\"b.txt\"]\noutput = [\"c.txt\"]\n\
+         depends_on = [\"b_child\"]\nshell = \"cat {input[0]} 2>/dev/null > {output[0]}; exit 0\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-k"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // The grandchild tolerates a missing input, so if it runs it "succeeds"
+    // and writes an empty file — the silent-corruption case this guards.
+    assert!(
+        !dir.path().join("c.txt").exists(),
+        "grandchild of a failed rule must not execute"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("0 succeeded"),
+        "no rule should succeed: {stderr}"
+    );
+    assert!(
+        stderr.contains("Blocked rules"),
+        "blocked rules should be reported: {stderr}"
+    );
+    assert!(
+        stderr.contains("c_grandchild"),
+        "grandchild should be listed as blocked: {stderr}"
+    );
+}
+
+/// A blocked rule produces no outputs, so it must never be checkpointed as
+/// completed — otherwise a later run skips it forever and the pipeline reports
+/// success while an output is silently empty.
+#[test]
+fn cli_run_blocked_rule_is_not_checkpointed() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("chain.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"chain\"\nversion = \"1.0.0\"\n\n\
+         [[rules]]\nname = \"a_fails\"\noutput = [\"a.txt\"]\nshell = \"exit 1\"\n\n\
+         [[rules]]\nname = \"b_child\"\ninput = [\"a.txt\"]\noutput = [\"b.txt\"]\n\
+         depends_on = [\"a_fails\"]\nshell = \"cat {input[0]} 2>/dev/null > {output[0]}; exit 0\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-k"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let checkpoint = dir.path().join(".oxo-flow/checkpoint.json");
+    if checkpoint.exists() {
+        let raw = fs::read_to_string(&checkpoint).unwrap();
+        assert!(
+            !raw.contains("b_child") || !raw.contains("\"completed_rules\":[\"b_child\"]"),
+            "blocked rule must not be recorded as completed: {raw}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        if let Some(done) = parsed["completed_rules"].as_array() {
+            assert!(
+                !done.iter().any(|r| r.as_str() == Some("b_child")),
+                "blocked rule must not be checkpointed as completed: {raw}"
+            );
+        }
+    }
+}
+
+/// A rule skipped by a false `when` condition must be counted once, not once
+/// by a pre-pass and again by the executor that actually evaluates it.
+#[test]
+fn cli_run_condition_skip_counted_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("cond.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"cond\"\nversion = \"1.0.0\"\n\n\
+         [config]\nmode = \"dna\"\n\n\
+         [[rules]]\nname = \"only_rna\"\noutput = [\"rna.txt\"]\n\
+         when = 'config.mode == \"rna\"'\nshell = \"echo x > {output[0]}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("0 succeeded, 1 skipped, 0 failed"),
+        "one rule skipped once, not twice: {stderr}"
+    );
+    assert!(
+        !dir.path().join("rna.txt").exists(),
+        "rule with a false condition must not run"
+    );
+}


### PR DESCRIPTION
Two defects in the parallel run accounting that came in with `-j`.

## Transitive failure propagation

`dag.dependencies()` returns direct predecessors only (`dag.rs:289`). A rule skipped because a dependency failed was counted and passed over, but never added to `failed_rules_set`, so the block reached exactly one level down.

In a chain `a -> b -> c` where `a` fails, `b` was correctly skipped but `c` executed with its input missing:

```
$ oxo-flow run chain.oxoflow -k
  ✗ rule 'a_fails' failed
  Running: c_grandchild
  ✗ c_grandchild — cat: b.txt: No such file or directory
Done: 0 succeeded, 1 skipped, 2 failed
```

When the downstream command tolerates a missing input, it is worse than a confusing error. It exits 0, writes an empty output, passes `validate_outputs()`, and is checkpointed as completed:

```
Done: 1 succeeded, 1 skipped, 1 failed
✓ 1 output files verified (0B total)
```

A later run then skips it as up to date, so fixing the upstream failure never regenerates it. Re-running the same workflow after fixing `a_fails` reports a fully green pipeline with a silently empty output:

```
Done: 2 succeeded, 1 skipped, 0 failed
✓ 3 output files verified (20B total)

a.txt    10 bytes: REAL_DATA
b.txt    10 bytes: REAL_DATA
c.txt    0 bytes:            ← never regenerated
```

This reopens the checkpoint-integrity hole closed in `fab8e62` through a different door. Only reachable under `--keep-going`, which is the common mode for long runs.

Blocked rules now join the failed set so the block reaches the whole downstream cone. They are reported separately from genuine failures, so the root cause stays distinguishable from its fallout:

```
Done: 0 succeeded, 2 skipped, 1 failed

Failed rules:
  ✗ a_fails — exit code 1 — A blows up

Blocked rules (did not run):
  ⊘ b_child — depends on 'a_fails'
  ⊘ c_grandchild — depends on 'b_child'
```

`--json` gains a `blocked` count.

## Double-counted condition skips

A pre-pass evaluated every rule's `when` condition and incremented the skip counter, then left the rule in the execution order for the executor to evaluate and report as `Skipped` again. One skipped rule was reported as two, in both the summary line and `--json`:

```
$ oxo-flow run cond.oxoflow --json    # workflow has exactly one rule
Done: 0 succeeded, 2 skipped, 0 failed
```

The pre-pass had no other effect and is removed; the executor remains the single evaluator.

## Tests

Three regression tests covering transitive blocking, the checkpoint-poisoning path, and single-counted condition skips.

`cargo fmt`, `cargo clippy --workspace -- -D warnings`, and the full suite (1191 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
