### PR TITLE
fix: reserve signatures in manifest, harden bundle extraction path

### DIFF
--- a/crates/oxo-flow-cli/Cargo.toml
+++ b/crates/oxo-flow-cli/Cargo.toml
@@ -37,6 +37,7 @@ tar = "0.4"
 zstd = { version = "0.13", default-features = false }
 walkdir = "2"
 reqwest = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/oxo-flow-cli/src/commands/bundle.rs
+++ b/crates/oxo-flow-cli/src/commands/bundle.rs
@@ -17,9 +17,22 @@ pub fn extract_and_verify_bundle(bundle_path: &Path) -> Result<(PathBuf, PathBuf
     let bundle_abs = std::path::absolute(bundle_path)
         .with_context(|| format!("failed to resolve bundle path: {}", bundle_path.display()))?;
 
-    // Extract to a temp directory
-    let extract_dir = std::env::temp_dir().join(format!("oxo-bundle-{}", std::process::id()));
-    std::fs::create_dir_all(&extract_dir)?;
+    // Extract to a freshly created temp directory.
+    //
+    // The previous `temp_dir()/oxo-bundle-<pid>` path was predictable and created
+    // with `create_dir_all`, which succeeds against a directory that already
+    // exists — on a shared machine another user can pre-create it, and PIDs are
+    // reused. `tempdir()` creates a uniquely named directory with 0700
+    // permissions, failing if it cannot create it exclusively.
+    //
+    // The directory is deliberately kept rather than dropped: it becomes the
+    // working directory for the run and holds the workflow's output files, so it
+    // has to outlive this function.
+    let extract_dir = tempfile::Builder::new()
+        .prefix("oxo-bundle-")
+        .tempdir()
+        .context("failed to create temporary directory for bundle extraction")?
+        .keep();
 
     // Open and decompress
     let file = std::fs::File::open(&bundle_abs)

--- a/crates/oxo-flow-cli/src/commands/publish.rs
+++ b/crates/oxo-flow-cli/src/commands/publish.rs
@@ -120,6 +120,11 @@ pub fn publish_command(
         "entrypoint": workflow_path.file_name().and_then(|s| s.to_str()),
         "files": &manifest_files,
         "containers": &container_refs,
+        // Reserved for bundle signing. Always empty today — present so that adding
+        // signatures later is an additive change rather than a manifest format bump.
+        // Consumers read the manifest field-by-field, so an empty array is ignored
+        // by older versions of oxo-flow.
+        "signatures": serde_json::Value::Array(Vec::new()),
     });
 
     let manifest_json = serde_json::to_string_pretty(&manifest)?;

--- a/docs/guide/src/commands/publish.md
+++ b/docs/guide/src/commands/publish.md
@@ -83,9 +83,39 @@ The `manifest.json` inside each bundle:
       "type": "docker",
       "image": "biocontainers/bwa:0.7.17"
     }
-  ]
+  ],
+  "signatures": []
 }
 ```
+
+`signatures` is reserved for future bundle signing and is always empty today.
+It is present so that adding signatures later is an additive change rather than
+a manifest format bump.
+
+## Reproducibility Caveats
+
+A bundle captures the workflow, its environment specifications, and checksums for
+every file. That makes a bundle *verifiable* — you can prove you received exactly
+what was published. It does not make execution *identical* everywhere, and it is
+worth being explicit about the limits:
+
+- **Environment specs are resolved on the consumer's machine.** `publish` bundles
+  `environment.yaml` / `pixi.toml` spec files, not solved environments. A solve
+  run months later, or against different channels, can pick different package
+  versions. Use `--with-lockfiles` to pin the resolution.
+- **Lockfiles still are not binaries.** Even an exact package set can behave
+  differently across glibc versions, CPU features, or filesystem layouts. Tools
+  built against a newer glibc will not run on an older host.
+- **Container images are referenced, not vendored.** The manifest records image
+  type and tag. The image is pulled at run time, so a mutable tag can resolve to
+  different content later. Prefer digest-pinned references where it matters.
+- **Containers do not normalise resources.** An image that runs fine on the
+  publisher's machine can be OOM-killed on a smaller host, and thread counts vary
+  with the available CPUs.
+
+None of these are specific to oxo-flow — they apply to Snakemake and Nextflow
+bundles equally. The goal is honest reproducibility, not a guarantee we cannot
+make.
 
 ## See Also
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2809,3 +2809,98 @@ fn cli_run_when_condition_matches_config_and_runs() {
         "output file should exist when rule executed"
     );
 }
+
+/// The manifest reserves an empty `signatures` array so that adding bundle
+/// signing later is an additive change rather than a manifest format bump.
+#[test]
+fn cli_publish_manifest_reserves_signatures_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("sig.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"sig\"\nversion = \"1.0.0\"\n\n\
+         [[rules]]\nname = \"s\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output[0]}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["publish", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "publish failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let archive = dir.path().join("sig-bundle.tar.zst");
+    let file = std::fs::File::open(&archive).unwrap();
+    let decoder = zstd::stream::read::Decoder::new(file).unwrap();
+    let mut tar = tar::Archive::new(decoder);
+
+    let mut manifest_json = String::new();
+    for entry in tar.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        if entry.path().unwrap().to_string_lossy() == "manifest.json" {
+            use std::io::Read as _;
+            entry.read_to_string(&mut manifest_json).unwrap();
+        }
+    }
+    assert!(!manifest_json.is_empty(), "manifest.json should be present");
+
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_json).unwrap();
+    let signatures = manifest
+        .get("signatures")
+        .unwrap_or_else(|| panic!("manifest should reserve a signatures field: {manifest_json}"));
+    assert!(
+        signatures.is_array(),
+        "signatures should be an array, got: {signatures}"
+    );
+    assert!(
+        signatures.as_array().unwrap().is_empty(),
+        "signatures should be empty until signing is implemented"
+    );
+}
+
+/// Bundles must not extract to a predictable path. The old
+/// `temp_dir()/oxo-bundle-<pid>` location could be pre-created by another user
+/// on a shared machine, and PIDs are reused.
+#[test]
+fn cli_run_bundle_extracts_to_unpredictable_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("tmp.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"tmp\"\nversion = \"1.0.0\"\n\n\
+         [[rules]]\nname = \"s\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output[0]}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["publish", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let archive = dir.path().join("tmp-bundle.tar.zst");
+    assert!(archive.exists(), "bundle should exist");
+
+    let output = oxo_flow_cmd()
+        .args(["run", "--bundle", archive.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "bundle run failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The pid-derived path must no longer be the extraction target.
+    let legacy = std::env::temp_dir().join(format!("oxo-bundle-{}", std::process::id()));
+    assert!(
+        !legacy.exists(),
+        "extraction must not use the predictable pid-based path: {}",
+        legacy.display()
+    );
+}


### PR DESCRIPTION
Picks up the three items from #51 that had no open design question — the ones that just look unimplemented. The two direction questions (archive format abstraction, confirmation gate) are left in the issue thread rather than assumed here.

## Reserved `signatures` field in the manifest

Added as an always-empty array:

```json
"containers": [ ... ],
"signatures": []
```

`bundle.rs` reads the manifest field-by-field through `serde_json::Value`, so an older oxo-flow ignores the new key and a newer one tolerates its absence. Reserving it now keeps real signing an additive change later instead of an `oxoflow-bundle-v1` format bump.

## Bundle extraction path

Extraction targeted a predictable path and created it permissively:

```rust
let extract_dir = std::env::temp_dir().join(format!("oxo-bundle-{}", std::process::id()));
std::fs::create_dir_all(&extract_dir)?;
```

`create_dir_all` succeeds against a directory that already exists, so on a shared machine another user can pre-create `/tmp/oxo-bundle-<pid>` ahead of a run, and PIDs are reused across runs regardless. Now:

```rust
let extract_dir = tempfile::Builder::new()
    .prefix("oxo-bundle-")
    .tempdir()?
    .keep();
```

Unique name, `0700`, and creation fails rather than silently adopting an existing directory.

Two notes for review:

- The directory is still deliberately persisted rather than dropped. It becomes the working directory for the run and holds the workflow's output files, so removing it on scope exit would delete the user's results. Cleanup would need to happen after the run completes, which felt like a separate change.
- This promotes `tempfile` from a dev-dependency to a runtime dependency of `oxo-flow-cli`. It was already in the workspace and in the lockfile, so no new transitive dependencies — happy to hand-roll a unique path instead if you'd rather not add it to the runtime set.

`tar`'s `unpack` already blocks path traversal, so that side was fine.

## Reproducibility caveats in the docs

Adds a section to `publish.md` covering what a bundle does and does not guarantee: environment specs resolve on the consumer's machine (with `--with-lockfiles` as the pin), lockfiles still are not binaries so glibc and CPU differences apply, container images are referenced rather than vendored so mutable tags can drift, and containers do not normalise memory or CPU. Framed as honest limits that apply equally to Snakemake and Nextflow bundles, not as an oxo-flow shortcoming.

## Tests

Two regression tests: the manifest reserves an empty `signatures` array, and bundle extraction no longer lands on the pid-derived path.

`cargo fmt`, `cargo clippy --workspace -- -D warnings`, and the full suite (1294 tests) all pass.

Not included here: rule-level `resources` in the manifest. It touches the consumer side and has an open question about whether a shortfall should warn or hard-error, so I'd rather do it as a follow-up once you've weighed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
