### PR TITLE
fix: bundle confirmation gate probes stdin; lint test code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Lint (clippy)
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Build
         run: cargo build --workspace

--- a/crates/oxo-flow-ai/src/config.rs
+++ b/crates/oxo-flow-ai/src/config.rs
@@ -362,9 +362,11 @@ name = "test"
 
     #[test]
     fn resolve_chain_workflow_overrides_global() {
-        let mut global = AiConfig::default();
-        global.enabled = true;
-        global.max_retries = 3;
+        let global = AiConfig {
+            enabled: true,
+            max_retries: 3,
+            ..AiConfig::default()
+        };
 
         let workflow = AiConfig {
             enabled: true,
@@ -379,8 +381,10 @@ name = "test"
 
     #[test]
     fn resolve_chain_rule_disables() {
-        let mut global = AiConfig::default();
-        global.enabled = true;
+        let global = AiConfig {
+            enabled: true,
+            ..AiConfig::default()
+        };
 
         let rule = AiConfig {
             enabled: false,

--- a/crates/oxo-flow-cli/src/commands/bundle.rs
+++ b/crates/oxo-flow-cli/src/commands/bundle.rs
@@ -212,3 +212,40 @@ pub fn find_manifest_in_dir(dir: &Path) -> Result<PathBuf> {
         )
     }
 }
+
+/// Whether the bundle confirmation prompt can be shown and answered.
+///
+/// Writing the prompt needs a terminal on stderr, and reading the answer needs
+/// an interactive stdin — a redirected stdin reaches `read_line`, hits EOF, and
+/// looks like a cancellation the user never made. `--json` marks the invocation
+/// as machine-driven, so it is never interactive regardless of the terminal.
+pub fn can_prompt_for_confirmation(json: bool, stderr_is_tty: bool, stdin_is_tty: bool) -> bool {
+    !json && stderr_is_tty && stdin_is_tty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::can_prompt_for_confirmation;
+
+    #[test]
+    fn prompts_only_on_a_fully_interactive_terminal() {
+        assert!(can_prompt_for_confirmation(false, true, true));
+    }
+
+    #[test]
+    fn redirected_stdin_is_not_promptable() {
+        // `oxo-flow run --bundle b.tar.zst < /dev/null` from a terminal: stderr
+        // is still a tty, but there is nobody to answer.
+        assert!(!can_prompt_for_confirmation(false, true, false));
+    }
+
+    #[test]
+    fn piped_stderr_is_not_promptable() {
+        assert!(!can_prompt_for_confirmation(false, false, true));
+    }
+
+    #[test]
+    fn json_is_never_promptable() {
+        assert!(!can_prompt_for_confirmation(true, true, true));
+    }
+}

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -721,10 +721,15 @@ async fn main() -> Result<()> {
                     }
                     eprintln!("  Source:   {}", bundle_path.display());
 
-                    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
-                    if !is_tty {
+                    let can_prompt = crate::commands::bundle::can_prompt_for_confirmation(
+                        cli.json,
+                        std::io::IsTerminal::is_terminal(&std::io::stderr()),
+                        std::io::IsTerminal::is_terminal(&std::io::stdin()),
+                    );
+                    if !can_prompt {
                         anyhow::bail!(
-                            "Running a bundle requires confirmation. Use --yes to skip the prompt in CI/scripts.\n\
+                            "Running a bundle requires confirmation, and this session cannot prompt for it. \
+                             Use --yes to confirm in CI, scripts, or with --json.\n\
                              Bundle: {}",
                             bundle_path.display()
                         );

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -3437,10 +3437,36 @@ mod tests {
 
     #[test]
     fn resolve_includes_depth_limit() {
-        // Verify the depth constant is reasonable
+        let dir = tempfile::tempdir().unwrap();
+
+        // A file that includes itself recurses forever unless the depth guard
+        // stops it — each level re-reads the same content from disk.
+        let circular = r#"
+            [workflow]
+            name = "circular"
+
+            [[include]]
+            path = "circular.oxoflow"
+
+            [[rules]]
+            name = "step"
+            shell = "echo hi"
+        "#;
+        std::fs::write(dir.path().join("circular.oxoflow"), circular).unwrap();
+
+        let mut config: WorkflowConfig = toml::from_str(circular).unwrap();
+        let err = config
+            .resolve_includes(dir.path())
+            .expect_err("self-including workflow should hit the depth limit");
+
+        let message = err.to_string();
         assert!(
-            MAX_INCLUDE_DEPTH >= 8,
-            "include depth limit should be at least 8"
+            message.contains(&MAX_INCLUDE_DEPTH.to_string()),
+            "error should name the depth limit, got: {message}"
+        );
+        assert!(
+            message.contains("circular includes"),
+            "error should point at circular includes, got: {message}"
         );
     }
 

--- a/crates/oxo-flow-web/src/domains/ai/agents/orchestrator.rs
+++ b/crates/oxo-flow-web/src/domains/ai/agents/orchestrator.rs
@@ -328,7 +328,22 @@ mod tests {
             .unwrap();
         assert_eq!(result.intent, "RNA-seq analysis");
         assert!(result.toml_content.contains("[workflow]"));
-        assert!(result.validation.valid || !result.validation.valid);
+        // The generated pipeline may or may not validate cleanly, but the report
+        // has to be internally consistent: `valid` is false exactly when some
+        // check failed at error severity.
+        assert!(
+            !result.validation.checks.is_empty(),
+            "validation should have run at least one check"
+        );
+        let has_blocking_failure = result
+            .validation
+            .checks
+            .iter()
+            .any(|c| !c.passed && c.severity == "error");
+        assert_eq!(
+            result.validation.valid, !has_blocking_failure,
+            "`valid` should agree with the individual checks"
+        );
         // At minimum should have a pipeline_id
         assert!(!result.pipeline_id.is_empty());
     }

--- a/crates/oxo-flow-web/src/infra/quota.rs
+++ b/crates/oxo-flow-web/src/infra/quota.rs
@@ -176,8 +176,10 @@ mod tests {
 
     #[test]
     fn test_quota_concurrent_limit() {
-        let mut config = QuotaConfig::default();
-        config.max_concurrent_runs = 1;
+        let config = QuotaConfig {
+            max_concurrent_runs: 1,
+            ..QuotaConfig::default()
+        };
         let tracker = QuotaTracker::new(config);
         tracker.record_start("user1", 1, 1024);
         let result = tracker.check("user1", 1, 1024);

--- a/crates/oxo-flow-web/tests/ai_security.rs
+++ b/crates/oxo-flow-web/tests/ai_security.rs
@@ -1,10 +1,10 @@
-/// Verify AI service has zero write access and security boundaries are enforced.
-///
-/// Tests:
-/// 1. Static: AI module source code must not import DB write, FS write, or process spawn
-/// 2. Runtime: Path traversal prevention in sandbox
-/// 3. Runtime: SQL injection prevention (parameterized queries)
-/// 4. Runtime: Auth bypass prevention
+//! Verify AI service has zero write access and security boundaries are enforced.
+//!
+//! Tests:
+//! 1. Static: AI module source code must not import DB write, FS write, or process spawn
+//! 2. Runtime: Path traversal prevention in sandbox
+//! 3. Runtime: SQL injection prevention (parameterized queries)
+//! 4. Runtime: Auth bypass prevention
 
 /// Strip Rust comments from source so comment text does not trigger false positives.
 fn strip_comments(source: &str) -> String {
@@ -86,12 +86,7 @@ fn test_ai_copilot_no_write_imports() {
 #[test]
 fn test_path_traversal_prevention() {
     // Test the sandbox sanitize function
-    let func = |s: &str| -> String {
-        s.replace("..", "_")
-            .replace('/', "_")
-            .replace('\\', "_")
-            .replace('\0', "_")
-    };
+    let func = |s: &str| -> String { s.replace("..", "_").replace(['/', '\\', '\0'], "_") };
 
     // Normal paths should pass through
     assert_eq!(func("run-123"), "run-123");

--- a/crates/oxo-flow-web/tests/simulation_20users.rs
+++ b/crates/oxo-flow-web/tests/simulation_20users.rs
@@ -1280,7 +1280,7 @@ async fn scenario_u13_api_developer_rest_lifecycle() {
         let (s, b) = post_auth(uri, json!({"toml_content": MINIMAL_TOML}), &token).await;
         assert_eq!(s, 200, "endpoint {uri} should return 200");
         assert!(
-            b.get(key).map_or(false, |v| !v.is_null()),
+            b.get(key).is_some_and(|v| !v.is_null()),
             "endpoint {uri} should have key {key}"
         );
     }


### PR DESCRIPTION
Two follow-ups on the `run --bundle` confirmation gate from #51, plus a CI gap that was hiding them.

## The gate probed the wrong stream

`main.rs` checked `IsTerminal` on **stderr**, then read the answer from **stdin**. When stderr is a terminal but stdin is not, the prompt prints, `read_line` returns 0 bytes at EOF, and the run aborts as though the user declined:

```
$ oxo-flow run --bundle wf-bundle.tar.zst < /dev/null
  ⚠ Proceed with execution? [y/N] Error: execution cancelled by user
```

Nobody cancelled anything. This shows up with `< /dev/null`, inside `xargs`, and under most job runners that give a pty but close stdin. Prompting now requires a terminal on both streams:

```
Error: Running a bundle requires confirmation, and this session cannot prompt for it.
Use --yes to confirm in CI, scripts, or with --json.
```

## `--json` now implies non-interactive

The gate never consulted the global `--json` flag, so a `--json` invocation from a terminal still blocked on an interactive prompt. `--json` means a machine is driving, so it now takes the same path as any other non-interactive caller and requires `--yes`. `--json --yes` still emits clean JSON on stdout — the gate's output was always on stderr, so nothing changes there.

The decision moved into `bundle::can_prompt_for_confirmation(json, stderr_is_tty, stdin_is_tty)` so the three conditions are unit-testable without standing up a pty. I verified all four end-to-end paths under `script`: `y` runs, `n` cancels, redirected stdin refuses, `--json --yes` runs clean.

If you'd rather `--json` still prompt when a human is clearly present, that's an easy revert of one condition — I went with refusing because it's the safer default for the automation case.

## CI was not linting test code

`ci.yml` ran `cargo clippy --workspace -- -D warnings` without `--all-targets`, so every `#[cfg(test)]` block and every file in `tests/` went unlinted. Adding the flag surfaced seven errors on `main` today.

Two were tests that asserted nothing, and both looked worth fixing properly rather than silencing:

- `orchestrator.rs` had `assert!(result.validation.valid || !result.validation.valid)` — a tautology that passes for any input. It now asserts the report is internally consistent: at least one check ran, and `valid` is false exactly when some check failed at error severity.
- `config.rs::resolve_includes_depth_limit` asserted `MAX_INCLUDE_DEPTH >= 8` and never called `resolve_includes`. It now writes a self-including workflow to a tempdir and asserts the depth guard actually fires with the expected message.

The other five were mechanical: two `field_reassign_with_default`, `map_or(false, ..)` → `is_some_and`, consecutive `str::replace` calls, and a file-level `///` in `ai_security.rs` that should have been `//!`.

Worth noting the clippy change is the kind that can go stale again as new lints land in future toolchains. If you'd rather keep CI's lint scope narrow and not have test code able to block a merge, I'm happy to split it into a separate non-blocking job instead.

## Tests

Four unit tests on `can_prompt_for_confirmation` covering the interactive, redirected-stdin, piped-stderr, and `--json` cases.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full suite (1,312 tests across 18 suites) all pass.

Separately, I've been going through the cluster/SLURM path in some depth and have found enough to be worth its own discussion — I'll open an issue for that rather than fold any of it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
