### PR TITLE
feat(cli): info derives config descriptions from [config] comments (#85 item 1)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/config_comments.rs
+++ b/crates/oxo-flow-cli/src/commands/config_comments.rs
@@ -1,0 +1,403 @@
+//! Extract per-key descriptions from `#` comments in a workflow's `[config]`
+//! section.
+//!
+//! The engine's TOML parser discards comments, so `info` re-reads the raw
+//! file text and associates comment lines with the `[config]` keys they
+//! describe. The association rules are deliberately simple and were validated
+//! against the oxo-community staging workflows:
+//!
+//! - a contiguous block of `#` lines immediately above a key line (no blank
+//!   line in between) is that key's description;
+//! - a trailing `#` comment on the key line itself is the fallback;
+//! - comments inside multi-line values or outside `[config]` never associate;
+//! - comments above `[config.<name>]` subtable headers describe the table key.
+
+use std::collections::BTreeMap;
+
+/// Extract `[config]` key descriptions from raw workflow text.
+///
+/// Description lines are joined with single spaces; empty `#` lines and pure
+/// decorator lines (`# ----`) are dropped.
+pub fn extract_config_descriptions(text: &str) -> BTreeMap<String, String> {
+    let mut descriptions: BTreeMap<String, String> = BTreeMap::new();
+    let mut section: Option<String> = None;
+    let mut pending: Vec<String> = Vec::new();
+    let mut value_depth = 0usize;
+
+    for line in text.lines() {
+        let line = line.trim();
+
+        // Inside a multi-line value: only track bracket balance. This runs
+        // before header parsing so value lines like `["x"]` are never taken
+        // for section headers. Comment lines here describe array elements,
+        // not the parameter.
+        if section.as_deref() == Some("config") && value_depth > 0 {
+            value_depth = bracket_balance(line, value_depth);
+            continue;
+        }
+
+        // `[name]`, `[name.sub]`, `[[name]]` — any header leaves `[config]`.
+        if let Some(header) = section_header(line) {
+            let is_config = header == "config";
+            let is_subtable = header.starts_with("config.");
+            section = Some(header.clone());
+            // `[config.<name>]`: pending comments describe the table key.
+            if is_subtable {
+                attach(&mut descriptions, &mut pending, &header["config.".len()..]);
+            }
+            if !is_config && !is_subtable {
+                pending.clear();
+            }
+            value_depth = 0;
+            continue;
+        }
+        if section.as_deref() != Some("config") {
+            continue;
+        }
+
+        if let Some(comment) = comment_text(line) {
+            // Empty `#` lines and pure decorator lines carry no meaning.
+            if !comment.is_empty() && !is_decorator(&comment) {
+                pending.push(comment);
+            }
+            continue;
+        }
+
+        if line.is_empty() {
+            // A blank line severs the comment block from any following key.
+            pending.clear();
+            continue;
+        }
+
+        let Some((key, value)) = key_line(line) else {
+            continue;
+        };
+        value_depth = open_bracket_depth(value);
+        if pending.is_empty() {
+            if let Some(trailing) = trailing_comment(value) {
+                descriptions.insert(key, trailing);
+            }
+        } else {
+            attach(&mut descriptions, &mut pending, &key);
+        }
+    }
+    descriptions
+}
+
+/// `[name]`, `[name.sub]`, `[[name]]` → header name (any trailing comment
+/// stripped); other lines → `None`.
+fn section_header(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+    let inner = trimmed.trim_start_matches('[');
+    let inner = inner.strip_prefix('[').unwrap_or(inner);
+    let end = inner.find(']')?;
+    let name = inner[..end].trim();
+    let rest = inner[end + 1..].trim_start();
+    let closes = if rest.starts_with(']') { 1 } else { 0 };
+    if closes == 0 && !rest.is_empty() && !rest.starts_with('#') {
+        return None;
+    }
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// `# comment` → `comment` (leading `#` and one space stripped, trimmed);
+/// non-comment lines → `None`.
+fn comment_text(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+    let body = trimmed.trim_start_matches('#').trim();
+    Some(body.to_string())
+}
+
+/// Pure decorator lines (`# ----`, `# ====`) carry no meaning.
+fn is_decorator(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c == '-' || c == '=')
+}
+
+/// `key = value` → `(key, value-after-=)` for bare TOML keys; `None` for
+/// other lines. Value lines inside `[...]` arrays are handled by the caller.
+fn key_line(line: &str) -> Option<(String, &str)> {
+    let eq = line.find('=')?;
+    let key = line[..eq].trim();
+    if key.is_empty()
+        || !key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return None;
+    }
+    Some((key.to_string(), line[eq + 1..].trim()))
+}
+
+/// Bracket depth opened by a value line (`known_indels = [` → 1, balanced
+/// arrays/strings → 0). Quote-aware so `"["` inside strings does not count.
+fn open_bracket_depth(value: &str) -> usize {
+    bracket_balance(value, 0)
+}
+
+/// New bracket depth after scanning `text`, starting from `depth` (which the
+/// caller guarantees is > 0 when scanning continuation lines).
+fn bracket_balance(text: &str, mut depth: usize) -> usize {
+    let mut in_string: Option<char> = None;
+    let mut escaped = false;
+    for c in text.chars() {
+        match in_string {
+            Some(quote) => {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == quote {
+                    in_string = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' => in_string = Some(c),
+                '[' => depth += 1,
+                ']' => depth = depth.saturating_sub(1),
+                _ => {}
+            },
+        }
+    }
+    depth
+}
+
+/// Trailing `# comment` outside quotes, with non-whitespace content;
+/// `None` when the line has no trailing comment (e.g. `key = "#FF0000"`).
+fn trailing_comment(value: &str) -> Option<String> {
+    let mut in_string: Option<char> = None;
+    let mut escaped = false;
+    for (idx, c) in value.char_indices() {
+        match in_string {
+            Some(quote) => {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == quote {
+                    in_string = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' => in_string = Some(c),
+                '#' => {
+                    let comment = value[idx + 1..].trim();
+                    return (!comment.is_empty()).then(|| comment.to_string());
+                }
+                _ => {}
+            },
+        }
+    }
+    None
+}
+
+/// Join pending comment lines into a description for `key`.
+fn attach(descriptions: &mut BTreeMap<String, String>, pending: &mut Vec<String>, key: &str) {
+    if let Some(description) = join(pending) {
+        descriptions.insert(key.to_string(), description);
+    }
+    pending.clear();
+}
+
+/// `--- Banner line ---` (starts and ends with 3+ dashes).
+fn is_banner(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.len() >= 6 && trimmed.starts_with("---") && trimmed.ends_with("---")
+}
+
+/// `--- MultiQC ---` → `MultiQC`.
+fn strip_banner_dashes(line: &str) -> String {
+    line.trim()
+        .trim_start_matches('-')
+        .trim()
+        .trim_end_matches('-')
+        .trim()
+        .to_string()
+}
+
+/// Join comment lines with single spaces; `None` when nothing meaningful.
+/// Banner lines (`--- section ---`) act as section markers: when the block
+/// also has regular text they are dropped; a lone banner keeps its interior.
+fn join(lines: &[String]) -> Option<String> {
+    let kept: Vec<String> = if lines.iter().any(|line| !is_banner(line)) {
+        lines
+            .iter()
+            .filter(|line| !is_banner(line))
+            .cloned()
+            .collect()
+    } else {
+        lines.iter().map(|line| strip_banner_dashes(line)).collect()
+    };
+    let description = kept.join(" ");
+    if description.is_empty() {
+        None
+    } else {
+        Some(description)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_comment_line_above_key_becomes_description() {
+        let text = "[config]\n# Output directory.\nout_dir = \"results\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([("out_dir".to_string(), "Output directory.".to_string())])
+        );
+    }
+
+    #[test]
+    fn multi_line_block_joins_with_spaces_and_skips_empty_lines() {
+        let text = "[config]\n# Optional: pre-trained classifier\n#\n# for the 16S region.\nclassifier = \"\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([(
+                "classifier".to_string(),
+                "Optional: pre-trained classifier for the 16S region.".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn trailing_comment_is_fallback_when_no_block_above() {
+        let text = "[config]\nsave_output_as_bam = false # CRAM output mode\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([(
+                "save_output_as_bam".to_string(),
+                "CRAM output mode".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn preceding_block_wins_over_trailing_comment() {
+        let text = "[config]\n# Block comment.\nkey = 1 # trailing comment\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([("key".to_string(), "Block comment.".to_string())])
+        );
+    }
+
+    #[test]
+    fn hash_inside_quoted_value_is_not_a_trailing_comment() {
+        let text = "[config]\ncolor = \"#FF0000\"\n";
+        assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn blank_line_severs_comment_block_from_key() {
+        // The comment reads as a section note, not a key description.
+        let text = "[config]\n# Section-level note.\n\nrmats_cstat = 0.0001\n";
+        assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn comments_inside_multiline_arrays_do_not_associate() {
+        let text = "[config]\n# Known indels.\nknown_indels = [\n  # chr1\n  \"/a.vcf.gz\",\n  \"/b.vcf.gz\",\n]\n# Next key.\nnext_key = 1\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([
+                ("known_indels".to_string(), "Known indels.".to_string()),
+                ("next_key".to_string(), "Next key.".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn bracket_inside_quoted_array_element_does_not_break_balance() {
+        let text =
+            "[config]\n# Paired brackets.\nkeys = [\n  \"a[b]\",\n]\n# After array.\nafter = 1\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([
+                ("keys".to_string(), "Paired brackets.".to_string()),
+                ("after".to_string(), "After array.".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn comments_outside_config_section_are_ignored() {
+        let text = "# Workflow-level note.\n[workflow]\nname = \"wf\"\n\n[config]\nkey = 1\n\n[[rules]]\n# Rule shell note — not a config description.\nname = \"align\"\n";
+        assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn dangling_block_before_next_section_header_is_discarded() {
+        // Mirrors gallery 06: a comment block above [[sample_groups]].
+        let text = "[config]\nreference = \"/ref/genome.fa\"\n\n# Sample cohort for {sample} expansion.\n[[sample_groups]]\nname = \"cohort\"\n";
+        assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn subtable_header_takes_pending_comments_for_table_key() {
+        let text = "[config]\n# Alignment settings.\n[config.align]\nthreads = 4\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([("align".to_string(), "Alignment settings.".to_string())])
+        );
+    }
+
+    #[test]
+    fn decorator_lines_are_filtered_from_descriptions() {
+        let text = "[config]\n# ----\n# Meaningful text.\n# ----\nkey = 1\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([("key".to_string(), "Meaningful text.".to_string())])
+        );
+    }
+
+    #[test]
+    fn comments_above_config_header_do_not_attach_to_first_key() {
+        // Only comments INSIDE `[config]` associate.
+        let text = "# User configuration.\n[config]\nkey = 1\n";
+        assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn lone_banner_line_keeps_interior_text_without_dashes() {
+        // `--- MultiQC ---` is a section marker; the interior names the
+        // group the key belongs to.
+        let text = "[config]\n# --- MultiQC ---\nmultiqc_title = \"\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([("multiqc_title".to_string(), "MultiQC".to_string())])
+        );
+    }
+
+    #[test]
+    fn banner_line_is_dropped_when_block_has_regular_text() {
+        // Section marker + description: keep the description only.
+        let text = "[config]\n# --- Input reads (upstream samplesheet) ---\n# Directory holding raw files.\nraw_dir = \"raw\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([(
+                "raw_dir".to_string(),
+                "Directory holding raw files.".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn array_element_line_that_looks_like_a_header_is_not_one() {
+        // `["x"]` as the last array element (no trailing comma) must not be
+        // parsed as a section header while inside the multi-line value.
+        let text = "[config]\n# Nested arrays.\nkeys = [\n  [\"x\"]\n]\n# After.\nafter = 1\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([
+                ("keys".to_string(), "Nested arrays.".to_string()),
+                ("after".to_string(), "After.".to_string()),
+            ])
+        );
+    }
+}

--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -5,6 +5,7 @@
 //! config keys, sample groups, pairs, references) directly from the workflow
 //! file, so hand-maintained catalog entries can be diffed against it.
 
+use crate::commands::config_comments::extract_config_descriptions;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use oxo_flow_core::config::WorkflowConfig;
@@ -20,10 +21,15 @@ use std::path::{Path, PathBuf};
 /// JSON is the default output (stdout, machine-readable); `--format text`
 /// prints a human-readable summary instead.
 pub fn info_command(workflow: PathBuf, format: Option<String>) -> Result<()> {
+    // Re-read the raw text: the TOML parser discards comments, and `info`
+    // surfaces the `[config]` section comments as parameter descriptions.
+    let text = std::fs::read_to_string(&workflow)
+        .with_context(|| format!("failed to read workflow {}", workflow.display()))?;
+    let descriptions = extract_config_descriptions(&text);
     let cfg = WorkflowConfig::from_file(&workflow)
         .with_context(|| format!("failed to parse workflow {}", workflow.display()))?;
 
-    let meta = derive_meta(&workflow, &cfg);
+    let meta = derive_meta(&workflow, &cfg, &descriptions);
 
     match format.as_deref() {
         Some("text") => print_text(&meta),
@@ -38,7 +44,13 @@ pub fn info_command(workflow: PathBuf, format: Option<String>) -> Result<()> {
 }
 
 /// Derive the machine-checkable catalog metadata from a parsed workflow.
-fn derive_meta(workflow: &Path, cfg: &WorkflowConfig) -> Value {
+/// `descriptions` carries the per-key `[config]` comments (see
+/// `config_comments::extract_config_descriptions`).
+fn derive_meta(
+    workflow: &Path,
+    cfg: &WorkflowConfig,
+    descriptions: &BTreeMap<String, String>,
+) -> Value {
     // Tools: conda/mamba env YAML stems + container image names, deduped
     // and sorted. Versions are NOT part of the catalog tool list — they live
     // in the TOML pins (oxo-community playbook §12).
@@ -134,7 +146,7 @@ fn derive_meta(workflow: &Path, cfg: &WorkflowConfig) -> Value {
         },
         "environments": environments,
         "config_keys": config_keys,
-        "config": config_params(cfg),
+        "config": config_params(cfg, descriptions),
         "sample_groups": sample_groups,
         "pairs": pairs,
         "references": references,
@@ -144,9 +156,10 @@ fn derive_meta(workflow: &Path, cfg: &WorkflowConfig) -> Value {
 }
 
 /// `[config]` parameter records for the catalog parameter table: the default
-/// value, its derived type, and the rules that reference `{config.<key>}` in
-/// their shell/script or input/output patterns.
-fn config_params(cfg: &WorkflowConfig) -> Vec<Value> {
+/// value, its derived type, the rules that reference `{config.<key>}` in
+/// their shell/script or input/output patterns, and — when the workflow
+/// carries one — the `#` comment describing the key.
+fn config_params(cfg: &WorkflowConfig, descriptions: &BTreeMap<String, String>) -> Vec<Value> {
     let mut records: Vec<Value> = cfg
         .config
         .iter()
@@ -173,12 +186,18 @@ fn config_params(cfg: &WorkflowConfig) -> Vec<Value> {
                 .map(|rule| rule.name.as_str())
                 .collect();
             used_by.sort_unstable();
-            json!({
+            let mut record = json!({
                 "key": key,
                 "default": default,
                 "value_type": value_type,
                 "used_by": used_by,
-            })
+            });
+            // Only present when the workflow comments the key — the field is
+            // optional so uncommented keys keep a minimal record.
+            if let Some(description) = descriptions.get(key) {
+                record["description"] = Value::String(description.clone());
+            }
+            record
         })
         .collect();
     records.sort_by(|a, b| a["key"].as_str().cmp(&b["key"].as_str()));
@@ -475,6 +494,18 @@ mod tests {
         WorkflowConfig::from_file(Path::new(path)).unwrap()
     }
 
+    /// Load a gallery fixture and derive its metadata end-to-end, extracting
+    /// comment descriptions from the raw file text like `info_command` does.
+    fn meta(display: &str, fixture: &str) -> Value {
+        let cfg = config(fixture);
+        let text = std::fs::read_to_string(fixture).unwrap();
+        derive_meta(
+            Path::new(display),
+            &cfg,
+            &extract_config_descriptions(&text),
+        )
+    }
+
     #[test]
     fn conda_stem_keeps_only_file_stem() {
         assert_eq!(conda_stem("envs/fastqc.yaml"), "fastqc");
@@ -497,8 +528,10 @@ mod tests {
 
     #[test]
     fn derive_meta_from_gallery_05() {
-        let cfg = config("../../examples/gallery/05_conda_environments.oxoflow");
-        let meta = derive_meta(Path::new("05_conda_environments.oxoflow"), &cfg);
+        let meta = meta(
+            "05_conda_environments.oxoflow",
+            "../../examples/gallery/05_conda_environments.oxoflow",
+        );
 
         assert_eq!(meta["name"], "environment-showcase");
         assert_eq!(meta["version"], "1.0.0");
@@ -523,8 +556,10 @@ mod tests {
 
     #[test]
     fn derive_meta_from_gallery_13() {
-        let cfg = config("../../examples/gallery/13_simple_variant_calling.oxoflow");
-        let meta = derive_meta(Path::new("13_simple_variant_calling.oxoflow"), &cfg);
+        let meta = meta(
+            "13_simple_variant_calling.oxoflow",
+            "../../examples/gallery/13_simple_variant_calling.oxoflow",
+        );
 
         assert_eq!(meta["name"], "simple-variant-calling");
         // singularity images count as container tools ("docker://" stripped).
@@ -542,8 +577,10 @@ mod tests {
 
     #[test]
     fn derive_meta_config_details() {
-        let cfg = config("../../examples/gallery/13_simple_variant_calling.oxoflow");
-        let meta = derive_meta(Path::new("13_simple_variant_calling.oxoflow"), &cfg);
+        let meta = meta(
+            "13_simple_variant_calling.oxoflow",
+            "../../examples/gallery/13_simple_variant_calling.oxoflow",
+        );
 
         assert_eq!(
             meta["config"],
@@ -602,7 +639,7 @@ mod tests {
         )
         .unwrap();
         let cfg = WorkflowConfig::from_file(&path).unwrap();
-        let meta = derive_meta(&path, &cfg);
+        let meta = derive_meta(&path, &cfg, &std::collections::BTreeMap::new());
         let keys = meta["config_keys"].as_array().unwrap();
         assert_eq!(keys.len(), 2, "{keys:?}");
         let names: Vec<&str> = keys.iter().filter_map(|k| k.as_str()).collect();
@@ -640,23 +677,55 @@ mod tests {
         )
         .unwrap();
         let cfg = WorkflowConfig::from_file(&path).unwrap();
-        let meta = derive_meta(&path, &cfg);
+        let meta = derive_meta(&path, &cfg, &std::collections::BTreeMap::new());
         assert_eq!(meta["resources"]["max_threads"], 4);
         assert_eq!(meta["resources"]["max_memory"], "8G");
     }
 
     #[test]
     fn derive_meta_config_empty_when_no_keys() {
-        let cfg = config("../../examples/gallery/05_conda_environments.oxoflow");
-        let meta = derive_meta(Path::new("05_conda_environments.oxoflow"), &cfg);
+        let meta = meta(
+            "05_conda_environments.oxoflow",
+            "../../examples/gallery/05_conda_environments.oxoflow",
+        );
 
         assert_eq!(meta["config"], json!([]));
     }
 
     #[test]
+    fn derive_meta_config_description_from_comments() {
+        let meta = meta(
+            "16_16s_qiime2_amplicon.oxoflow",
+            "../../examples/gallery/16_16s_qiime2_amplicon.oxoflow",
+        );
+
+        // `classifier` carries a 4-line comment block (joined with spaces);
+        // uncommented keys omit the field entirely.
+        let records = meta["config"].as_array().unwrap();
+        let classifier = records
+            .iter()
+            .find(|record| record["key"] == "classifier")
+            .unwrap();
+        assert_eq!(
+            classifier["description"],
+            "Optional: pre-trained classifier for the target 16S region \
+             (e.g. silva-138-99-515-806-nb-classifier.qza). Set via \
+             `oxo-flow run wf.oxoflow classifier=/path/to/classifier.qza`; \
+             without it, skip the classify step or train a classifier first."
+        );
+        let trim_left_f = records
+            .iter()
+            .find(|record| record["key"] == "trim_left_f")
+            .unwrap();
+        assert!(trim_left_f.get("description").is_none());
+    }
+
+    #[test]
     fn derive_meta_config_used_by_when_expressions() {
-        let cfg = config("../../examples/gallery/11_conditional_workflow.oxoflow");
-        let meta = derive_meta(Path::new("11_conditional_workflow.oxoflow"), &cfg);
+        let meta = meta(
+            "11_conditional_workflow.oxoflow",
+            "../../examples/gallery/11_conditional_workflow.oxoflow",
+        );
 
         // `when` conditions use the brace-less `config.<key>` form and must
         // count as usage alongside `{config.<key>}` in shells and I/O paths.

--- a/crates/oxo-flow-cli/src/commands/mod.rs
+++ b/crates/oxo-flow-cli/src/commands/mod.rs
@@ -206,6 +206,7 @@ pub mod bundle;
 pub mod clean;
 pub mod cluster;
 pub mod completions;
+pub mod config_comments;
 pub mod info;
 pub mod infra;
 pub mod output;

--- a/docs/guide/src/commands/info.md
+++ b/docs/guide/src/commands/info.md
@@ -46,6 +46,13 @@ oxo-flow info [OPTIONS] <WORKFLOW>
       "default": "/data/reference/GRCh38.fa",
       "value_type": "string",
       "used_by": ["apply_bqsr", "base_recalibrator", "bwa_align", "haplotype_caller"]
+    },
+    {
+      "key": "out_dir",
+      "default": "results",
+      "value_type": "string",
+      "used_by": [],
+      "description": "Output directory (upstream: --outdir)."
     }
   ],
   "sample_groups": [],
@@ -57,15 +64,27 @@ oxo-flow info [OPTIONS] <WORKFLOW>
 ```
 
 - **`config`** — every `[config]` parameter with its default value, its
-  derived type (`string` / `int` / `float` / `bool` / `array` / `table`), and
-  the rules that reference it: `{config.<key>}` in shells, scripts, inputs, or
-  outputs, plus brace-less `config.<key>` in `when` conditions. Declared
-  parameters (`key = { default, type, … }`) render their typed default from
-  the declaration metadata. Keys sorted, rule lists sorted.
+  derived type (`string` / `int` / `float` / `bool` / `array` / `table`), the
+  rules that reference it (`{config.<key>}` in shells, scripts, inputs, or
+  outputs, plus brace-less `config.<key>` in `when` conditions), and — when
+  the workflow comments the key — its `description` taken verbatim from the
+  `[config]` section comments. Declared parameters
+  (`key = { default, type, … }`) render their typed default from the
+  declaration metadata. Keys sorted, rule lists sorted.
   Engine-injected keys are excluded — the run-time churn keys
   (`samples_list`, `pairs_list`, `samples_*`), the reference keyed-config
   values (`config.<reference name>` = its output), and the
   `reference_dir`-derived paths — `config_keys` carries the bare key list.
+- **`config[].description`** — optional; present only when the key is
+  commented. A contiguous block of `#` lines immediately above the key line
+  (no blank line in between) is the description, joined into one line; a
+  trailing `#` comment on the key line itself is the fallback. Empty `#`
+  lines and pure decorator lines (`# ----`) are dropped. Banner lines
+  (`# --- section ---`) act as section markers: dropped when the block also
+  has regular text, otherwise kept with their dashes stripped. Comments
+  inside multi-line values (e.g. `#` lines within an array) never associate,
+  and comments above `[config.<name>]` subtable headers describe the table
+  key itself.
 - **`tools`** — conda/mamba environment YAML stems and container image names
   (registry path and tag stripped), deduped and sorted.
 - **`resources`** — max threads/memory across rules on the defaults-applied


### PR DESCRIPTION
## What

Item 1 of #85: `oxo-flow info` now surfaces each `[config]` key's own `#` comment as an optional `description` field in the JSON config records — the data behind the catalog site's Parameters table Description column (paired site PR: oxo-flow-community/oxo-flow-community.github.io#1).

The TOML parser discards comments, so `info` re-reads the raw file text and associates comment lines with the `[config]` keys they describe, with rules validated against all 24 oxo-community staging workflows (670 config keys):

- a contiguous `#` block immediately above the key line (no blank line in between) is the description, joined into one line — the dominant convention in the community ports (163/164 commented keys);
- a trailing `#` comment on the key line is the fallback (covers e.g. `save_output_as_bam = false # CRAM output mode`);
- a blank line severs the association (the one real gap case is a section note, not a key description);
- banner lines (`# --- section ---`) act as section markers: dropped when the block has regular text, otherwise kept with dashes stripped (`--- MultiQC ---` → `MultiQC`);
- empty `#` lines and pure decorator lines are dropped; comments inside multi-line values (quote-aware bracket tracking) never associate; comments above `[config.<name>]` subtable headers describe the table key;
- only comments *inside* `[config]` count — comments above the header or in other sections are ignored.

The field is optional: uncommented keys keep their minimal record, so existing `info --json` consumers see a purely additive change.

## Changes

- `crates/oxo-flow-cli/src/commands/config_comments.rs` (new) — pure line-scan extractor `extract_config_descriptions(&str) -> BTreeMap<String, String>`
- `crates/oxo-flow-cli/src/commands/info.rs` — wires descriptions into `derive_meta`/`config_params`
- `crates/oxo-flow-cli/src/commands/mod.rs` — module registration
- `docs/guide/src/commands/info.md` — documents the field and its association semantics

## Test plan

- [x] 16 new unit tests (TDD, red→green) covering every association rule above + a gallery-16 end-to-end test asserting the `classifier` record carries its 4-line comment block
- [x] `cargo test -p oxo-flow-cli`: 99 passed; full workspace `make ci` green
- [x] Live verification against all 24 staged community workflows: 204/670 parameters carry descriptions; spot-checked block, trailing, banner and subtable forms; existing fixtures (gallery 05/11/13) unchanged — output is backward compatible
- [x] `cargo clippy --all-targets` clean

## Notes

- Item 2 (Tube Map) needs no engine change — `graph -f dot` already exports the rule-level DAG; it ships in the paired site PR.
- Known scope: quoted TOML keys and dotted keys in `[config]` are not associated (zero occurrences across the 24 staged workflows); interior keys of `[config.<name>]` subtables are skipped (the catalog lists top-level keys only).
