### PR TITLE
fix(core): resolve nested {config.x} references deterministically

### DIFF
--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1393,15 +1393,19 @@ impl<S> WorkflowState<S> {
 
 /// Expand `{config.name}` placeholders in a path using provided config values.
 fn expand_config_vars_in_path(path: &str, config: &HashMap<String, toml::Value>) -> String {
-    let mut result = path.to_string();
-    for (key, value) in config {
-        let string_val = match value {
-            toml::Value::String(s) => s.clone(),
-            other => other.to_string(),
-        };
-        result = result.replace(&format!("{{config.{key}}}"), &string_val);
-    }
-    result
+    // Stringify every value once, then expand to a fixed point so nested
+    // `{config.x}` references resolve regardless of map iteration order.
+    let stringified: HashMap<String, String> = config
+        .iter()
+        .map(|(key, value)| {
+            let string_val = match value {
+                toml::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            (format!("config.{key}"), string_val)
+        })
+        .collect();
+    crate::executor::expand_to_fixed_point(path, &stringified, |value| value.to_owned())
 }
 
 impl WorkflowConfig {

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -884,11 +884,7 @@ pub fn should_skip_rule(
 /// Only performs simple key-value substitution (no `{input[N]}` / `{output[N]}` logic).
 /// Used for checking output file existence after expansion of config variables.
 pub fn expand_config_in_path(path: &str, wildcard_values: &HashMap<String, String>) -> String {
-    let mut result = path.to_string();
-    for (key, value) in wildcard_values {
-        result = result.replace(&format!("{{{key}}}"), value);
-    }
-    result
+    super::expand_to_fixed_point(path, wildcard_values, |value| value.to_owned())
 }
 
 /// Validate that declared output files exist after execution.

--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -3,6 +3,8 @@
 //! Executes workflow rules as local processes, handling concurrency,
 //! status tracking, and environment activation.
 
+use std::collections::HashMap;
+
 use sysinfo::System;
 
 pub mod checkpoint;
@@ -30,6 +32,59 @@ pub fn available_memory_gb() -> u64 {
     let mut sys = System::new();
     sys.refresh_memory();
     sys.available_memory() / (1024 * 1024 * 1024) // Convert bytes to GB
+}
+
+/// Maximum substitution passes for placeholder expansion before giving up on
+/// a (presumably cyclic) reference.
+const MAX_EXPANSION_ITERATIONS: usize = 32;
+
+/// Expand `{key}` placeholders in `template` to a fixed point.
+///
+/// Substitution repeats until the string stops changing, so values that
+/// themselves contain placeholders (nested `{config.x}` references) resolve
+/// deterministically regardless of `HashMap` iteration order. The `render`
+/// callback normalizes each value (e.g. shell-friendly array joining); pass an
+/// identity such as `|value| value.to_owned()` when no normalization is needed.
+///
+/// A cyclic reference (`a = "{b}"` with `b = "{a}"`) never reaches a fixed
+/// point; iteration is capped at [`MAX_EXPANSION_ITERATIONS`] and the
+/// best-effort result is returned.
+#[must_use]
+pub(crate) fn expand_to_fixed_point(
+    template: &str,
+    values: &HashMap<String, String>,
+    render: impl Fn(&str) -> String,
+) -> String {
+    // Pre-render every value and pre-compute its placeholder once, so the
+    // convergence loop below performs no per-iteration allocation beyond the
+    // substitutions themselves.
+    let pairs: Vec<(String, String)> = values
+        .iter()
+        .map(|(key, value)| (format!("{{{key}}}"), render(value)))
+        .collect();
+
+    let mut result = template.to_string();
+    for _ in 0..MAX_EXPANSION_ITERATIONS {
+        let mut changed = false;
+        for (placeholder, rendered) in &pairs {
+            if result.contains(placeholder.as_str()) {
+                let replaced = result.replace(placeholder.as_str(), rendered);
+                changed |= replaced != result;
+                result = replaced;
+            }
+        }
+        if !changed {
+            return result;
+        }
+    }
+    // Did not converge: the template contains a cyclic reference (or a
+    // dependency chain deeper than MAX_EXPANSION_ITERATIONS). Leave the
+    // unresolved placeholder in place but surface it for diagnosis.
+    tracing::warn!(
+        iterations = MAX_EXPANSION_ITERATIONS,
+        "placeholder expansion did not converge (cyclic or overly deep reference); leaving unresolved placeholders"
+    );
+    result
 }
 
 // Re-export common items for backward compatibility and convenience

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1831,9 +1831,7 @@ fn render_shell_command_inner(
         };
         expanded = expanded.replace(&format!("{{params.{key}}}"), &string_val);
     }
-    for (key, value) in wildcard_values {
-        expanded = expanded.replace(&format!("{{{key}}}"), &render_wildcard_value(value));
-    }
+    expanded = super::expand_to_fixed_point(&expanded, wildcard_values, render_wildcard_value);
     expanded
 }
 
@@ -1841,11 +1839,7 @@ fn render_shell_command_inner(
 /// wildcard values, using shell-friendly rendering for array config values
 /// (same semantics as the trailing wildcard pass of `render_shell_command`).
 fn expand_wildcards_in_pattern(pattern: &str, wildcard_values: &HashMap<String, String>) -> String {
-    let mut expanded = pattern.to_string();
-    for (key, value) in wildcard_values {
-        expanded = expanded.replace(&format!("{{{key}}}"), &render_wildcard_value(value));
-    }
-    expanded
+    super::expand_to_fixed_point(pattern, wildcard_values, render_wildcard_value)
 }
 
 /// Render a path as absolute under `root` when `root` is given and the path

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -344,6 +344,82 @@ fn render_shell_config_values() {
     assert_eq!(result, "bwa mem /data/ref.fa > hello.txt");
 }
 
+#[test]
+fn render_shell_command_nested_config() {
+    // Nested `{config.x}` references must resolve to a fixed point,
+    // independent of HashMap iteration order.
+    let rule = Rule {
+        name: "test".to_string(),
+        output: vec!["out.bam".to_string()].into(),
+        ..Default::default()
+    };
+    let mut values = HashMap::new();
+    values.insert(
+        "config.reference_dir".to_string(),
+        "/data/refs/GRCh38".to_string(),
+    );
+    values.insert(
+        "config.reference_fasta".to_string(),
+        "{config.reference_dir}/genome.fa".to_string(),
+    );
+    let result = render_shell_command(
+        "bwa mem {config.reference_fasta} > {output[0]}",
+        &rule,
+        &values,
+    );
+    assert_eq!(result, "bwa mem /data/refs/GRCh38/genome.fa > out.bam");
+}
+
+#[test]
+fn render_shell_command_three_level_nested_config() {
+    // Three levels of nesting exercise multi-pass convergence.
+    let rule = Rule {
+        name: "test".to_string(),
+        output: vec!["out.txt".to_string()].into(),
+        ..Default::default()
+    };
+    let mut values = HashMap::new();
+    values.insert("config.a".to_string(), "{config.b}".to_string());
+    values.insert("config.b".to_string(), "{config.c}".to_string());
+    values.insert("config.c".to_string(), "/final".to_string());
+    let result = render_shell_command("cp {config.a} {output[0]}", &rule, &values);
+    assert_eq!(result, "cp /final out.txt");
+}
+
+#[test]
+fn expand_config_in_path_nested() {
+    let mut values = HashMap::new();
+    values.insert("config.dir".to_string(), "/data/out".to_string());
+    values.insert(
+        "config.subdir".to_string(),
+        "{config.dir}/sample".to_string(),
+    );
+    let result = expand_config_in_path("{config.subdir}/file.txt", &values);
+    assert_eq!(result, "/data/out/sample/file.txt");
+}
+
+#[test]
+fn expand_to_fixed_point_cyclic_reference_terminates() {
+    // A cyclic reference never converges; the helper must still terminate
+    // (capped iterations) rather than loop forever. The exact best-effort
+    // result depends on map iteration order, so assert only membership.
+    let mut values = HashMap::new();
+    values.insert("config.a".to_string(), "{config.b}".to_string());
+    values.insert("config.b".to_string(), "{config.a}".to_string());
+    let result = super::expand_to_fixed_point("{config.a}", &values, |value| value.to_owned());
+    assert!(result == "{config.a}" || result == "{config.b}");
+}
+
+#[test]
+fn expand_to_fixed_point_self_reference_terminates() {
+    // `a = "{a}"` substitutes to itself; the loop must detect "no change"
+    // and return instead of spinning.
+    let mut values = HashMap::new();
+    values.insert("config.a".to_string(), "{config.a}".to_string());
+    let result = super::expand_to_fixed_point("{config.a}", &values, |value| value.to_owned());
+    assert_eq!(result, "{config.a}");
+}
+
 #[tokio::test]
 async fn execute_output_index_expansion() {
     let tmp = std::env::temp_dir().join("oxo_test_output_index");


### PR DESCRIPTION
## Summary

Fixes #87 — nested `{config.x}` references (values that themselves reference other config keys, e.g. `reference_fasta = "{config.reference_dir}/genome.fa"`) rendered non-deterministically because substitution made a single pass over a `HashMap`, whose iteration order is random.

## Root cause

Three call sites replaced `{config.x}` / wildcard placeholders with a single `for (key, value) in map { replace }` loop:

- `executor::process::render_shell_command_inner` (shell command rendering)
- `executor::process::expand_wildcards_in_pattern` (wildcard expansion)
- `executor::checkpoint::expand_config_in_path` (checkpoint path existence check)
- `config::expand_config_vars_in_path` (config path expansion)

For flat configs this always works. For nested references it depends on iteration order: if the *referenced* key is substituted first, the placeholder is gone before its own expansion and the inner reference is never resolved.

## Fix

Add `executor::expand_to_fixed_point` — a fixed-point substitution loop that iterates until the string stops changing, so nested references resolve deterministically regardless of `HashMap` order. The loop is capped at `MAX_EXPANSION_ITERATIONS = 32`, so cyclic/self-references terminate instead of hanging and emit a `tracing::warn!` with the unresolved placeholder left in place for diagnosis.

All four call sites now route through it (config path expansion stringifies values once into `config.{key}`-prefixed pairs first).

## Tests

Five new regression tests in `executor/tests.rs`:

- `render_shell_command_nested_config`
- `render_shell_command_three_level_nested_config`
- `expand_config_in_path_nested`
- `expand_to_fixed_point_cyclic_reference_terminates`
- `expand_to_fixed_point_self_reference_terminates`

## Verification

- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (workspace-wide, no warnings)
- `cargo test --workspace` ✅ (one pre-existing flaky webhook integration test passed on rerun)
- `cargo audit` ✅ (no vulnerabilities; yanked-crate check skipped locally due to rsproxy sparse-index limitation, works on CI's official index)
