### PR TITLE
feat(cli): unify sample selection under --samples with @path override

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -420,57 +420,6 @@ fn apply_cli_overrides(
     Ok(())
 }
 
-/// Merge `--sample` CLI flags into sample groups and `samples_list` — the
-/// same merge `run` performs (shared with dry-run, issue #77 parity).
-fn merge_extra_samples(config: &mut WorkflowConfig, extra_samples: &[String]) {
-    if extra_samples.is_empty() {
-        return;
-    }
-    if let Some(group) = config
-        .sample_groups
-        .iter_mut()
-        .find(|g| g.name == "auto-discovered")
-    {
-        for s in extra_samples {
-            if !group.samples.contains(s) {
-                group.samples.push(s.clone());
-            }
-        }
-    } else {
-        config
-            .sample_groups
-            .push(oxo_flow_core::config::SampleGroup {
-                name: "cli-specified".to_string(),
-                samples: extra_samples.to_vec(),
-                metadata: std::collections::HashMap::new(),
-            });
-    }
-    let existing = config
-        .config
-        .get("samples_list")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let mut merged: Vec<String> = existing
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .collect();
-    for s in extra_samples {
-        if !merged.contains(s) {
-            merged.push(s.clone());
-        }
-    }
-    config.config.insert(
-        "samples_list".to_string(),
-        toml::Value::String(merged.join(",")),
-    );
-    eprintln!(
-        "  {} Added {} sample(s) via --sample flag",
-        "Samples:".cyan(),
-        extra_samples.len()
-    );
-}
-
 #[allow(clippy::too_many_arguments)]
 pub async fn run_command(
     workflow: Option<PathBuf>,
@@ -490,7 +439,6 @@ pub async fn run_command(
     provenance: bool,
     json: bool,
     cli_args: Vec<String>,
-    extra_samples: Vec<String>,
     ai_recover: bool,
     _ai_max_retries: Option<u32>,
     samples_filter: Vec<String>,
@@ -558,10 +506,7 @@ pub async fn run_command(
 
     apply_cli_overrides(&mut config, &cli_arg_values)?;
 
-    // ── Merge --sample CLI flags into sample groups and samples_list ───
-    merge_extra_samples(&mut config, &extra_samples);
-
-    // ── Filter to a sample subset (--samples first:N / names / ready) ────
+    // ── Filter to a sample subset (--samples @path / first:N / names / ready) ────
     // Runs after CLI overrides so `ready` resolution sees the final config
     // values in `{config.x}` paths (issue #63).
     if !samples_filter.is_empty()
@@ -2057,7 +2002,6 @@ pub async fn dry_run_command(
     profile: Option<String>,
     skip_ref_build: bool,
     cli_args: Vec<String>,
-    extra_samples: Vec<String>,
     rerun: bool,
     resume_failed: bool,
 ) -> Result<()> {
@@ -2071,8 +2015,8 @@ pub async fn dry_run_command(
     let mut config = WorkflowConfig::from_file(&workflow)
         .with_context(|| format!("failed to parse {}", workflow.display()))?;
 
-    // ── CLI config overrides + --sample (shared with run, issue #77) ─────
-    // Applied in run's exact order: overrides first, then --sample, then
+    // ── CLI config overrides (shared with run, issue #77) ─────
+    // Applied in run's exact order: overrides first, then
     // the --samples subset filter — so the preview config is structurally
     // identical to what `run` would execute. The workflow's own [config]
     // keys gate the `--KEY VALUE` space form (same rule as run, issue #71).
@@ -2080,7 +2024,6 @@ pub async fn dry_run_command(
         config.config.keys().cloned().collect();
     let cli_arg_values = parse_cli_overrides(cli_args, &declared_config_keys)?;
     apply_cli_overrides(&mut config, &cli_arg_values)?;
-    merge_extra_samples(&mut config, &extra_samples);
 
     // ── Filter to a sample subset (--samples first:N / names / ready) ──
     // `ready` resolves against a scratch expanded clone; the report covers
@@ -3263,7 +3206,6 @@ pub async fn resume_command(
         false,             // provenance (checkpoint already has checksums)
         false,             // json (resume defaults to human-readable)
         Vec::new(),        // cli_args (resume reuses checkpoint state)
-        Vec::new(),        // extra_samples (resume uses existing groups)
         ai_recover,
         ai_max_retries,
         Vec::new(), // samples_filter (resume restores checkpoint state as-is)

--- a/crates/oxo-flow-cli/src/commands/samples.rs
+++ b/crates/oxo-flow-cli/src/commands/samples.rs
@@ -1,9 +1,11 @@
-//! `--samples` filtering helpers: pilot subsets, explicit names, and the
-//! `ready` spec for incremental data arrival (issue #63).
+//! `--samples` sample-selection helpers: sheet override (`@path`), sheet
+//! append (`+@path`), name declaration on template workflows, pilot
+//! subsets (`first:N`), explicit-name filters, and the `ready` spec for
+//! incremental data arrival (issue #63).
 
 use anyhow::{Context, Result};
 use colored::Colorize;
-use oxo_flow_core::config::WorkflowConfig;
+use oxo_flow_core::config::{SampleGroup, WorkflowConfig};
 use oxo_flow_core::readiness::ReadinessReport;
 
 /// Replace a `ready` spec (issue #63) with the names of samples whose entry
@@ -66,7 +68,102 @@ pub(crate) fn apply_samples_filter(
     bail_on_empty: bool,
     base_dir: &std::path::Path,
 ) -> Result<Option<ReadinessReport>> {
-    let (resolved, report) = resolve_ready_spec(config, specs, base_dir)?;
+    // Split specs, applying sheet operations IN ORDER (a later `@path`
+    // resets earlier `+@path` appends):
+    //   `@path`  — REPLACE: the sheet's groups override the workflow's set
+    //              (samples the workflow never declared become the new set);
+    //   `+@path` — APPEND: same-name groups merge (union, dedup), new
+    //              groups are added — the sheet can only add samples;
+    //   names / `first:N` / `ready` — FILTER the (possibly replaced or
+    //              appended) set to a subset; unknown names fail (issue
+    //              #79's phantom-sample guard). Filters apply AFTER every
+    //              sheet op, regardless of their position in the spec.
+    let mut did_sample_op = false;
+    let mut filter_specs: Vec<String> = Vec::new();
+    for spec in specs {
+        for part in spec.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let (action, path) = if let Some(path) = part.strip_prefix("+@") {
+                ("append", path)
+            } else if let Some(path) = part.strip_prefix('@') {
+                ("override", path)
+            } else {
+                filter_specs.push(part.to_string());
+                continue;
+            };
+            let groups = SampleGroup::load_from_file(std::path::Path::new(path))
+                .with_context(|| format!("failed to load samplesheet '{path}'"))?;
+            // A samplesheet with no data rows must fail loudly: silently
+            // falling back to the discovered samples would run the WRONG
+            // set (the whole point of the @ signals is explicitness).
+            if groups.is_empty() {
+                anyhow::bail!(
+                    "--samples {} '{path}' contains no sample rows \
+                     (expected a 'name'/'samples' sheet)",
+                    if action == "append" { "+@" } else { "@" }
+                );
+            }
+            if action == "append" {
+                config.append_sample_groups(groups)?;
+            } else {
+                let kept = config.override_sample_groups(groups)?;
+                // An override that selects nothing is a static authoring
+                // error — never a silent zero-instance run.
+                if kept.is_empty() {
+                    anyhow::bail!(
+                        "--samples @path override produced no samples (all rows are empty)"
+                    );
+                }
+            }
+            did_sample_op = true;
+        }
+    }
+
+    // No subset filter: the sheet operation alone defines the run set.
+    if did_sample_op && filter_specs.is_empty() {
+        let total: usize = config.sample_groups.iter().map(|g| g.samples.len()).sum();
+        eprintln!(
+            "  {} Running {} sample(s) via --samples (sheet selection)",
+            "Samples:".cyan(),
+            total
+        );
+        return Ok(None);
+    }
+
+    // Bare names on a workflow that declares NO samples are a sample
+    // DECLARATION (replace), not a filter — the template-workflow
+    // invocation pattern (`--samples SRR1,SRR2` on a workflow shipped
+    // without fixtures). On a workflow WITH declared samples the same
+    // names keep their filter semantics, so the phantom-sample guard
+    // still fails typos there.
+    let mut bare_names: Vec<String> = Vec::new();
+    let mut pure_filter_specs: Vec<String> = Vec::new();
+    for part in &filter_specs {
+        if part.starts_with("first:") || part == "ready" {
+            pure_filter_specs.push(part.clone());
+        } else {
+            bare_names.push(part.clone());
+        }
+    }
+    if config.sample_groups.is_empty() && !bare_names.is_empty() {
+        config.override_samples(&bare_names)?;
+        if pure_filter_specs.is_empty() {
+            eprintln!(
+                "  {} Running {} sample(s) via --samples (name declaration)",
+                "Samples:".cyan(),
+                bare_names.len()
+            );
+            return Ok(None);
+        }
+        // Template workflow + names + first:N/ready: names declare the
+        // set, the remaining specs filter it.
+        filter_specs = pure_filter_specs;
+    }
+
+    let (resolved, report) = resolve_ready_spec(config, &filter_specs, base_dir)?;
     let pairs_before = config.pairs.len();
     let (kept, unknown) = config.filter_samples(&resolved)?;
     let pairs_dropped = pairs_before - config.pairs.len();
@@ -156,5 +253,153 @@ pub(crate) fn print_readiness_section(report: &ReadinessReport) {
             "⚠".yellow(),
             report.missing_global.join(", ")
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxo_flow_core::config::WorkflowConfig;
+
+    fn config_with_inline_samples() -> WorkflowConfig {
+        WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[rules]]
+            name = "align"
+            input = ["raw/{sample}.fq"]
+            output = ["aln/{sample}.bam"]
+            shell = "touch {output}"
+            "#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn samplesheet_override_replaces_inline_samples() {
+        let path = std::env::temp_dir().join("oxo_flow_override_test_samples.tsv");
+        std::fs::write(&path, "name\tsamples\ncohort\tSRR1,SRR2\n").unwrap();
+
+        let mut config = config_with_inline_samples();
+        let spec = format!("@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_ok(), "override should succeed: {result:?}");
+        assert_eq!(config.sample_groups.len(), 1);
+        assert_eq!(config.sample_groups[0].name, "cohort");
+        assert_eq!(
+            config.sample_groups[0].samples,
+            vec!["SRR1".to_string(), "SRR2".to_string()]
+        );
+    }
+
+    #[test]
+    fn append_sheet_merges_same_name_group() {
+        let path = std::env::temp_dir().join("oxo_flow_append_test_samples.tsv");
+        std::fs::write(&path, "name\tsamples\ncohort\tS2,S3\n").unwrap();
+
+        let mut config = config_with_inline_samples();
+        let spec = format!("+@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_ok(), "append should succeed: {result:?}");
+        // S1 from the workflow, S2 deduped, S3 appended.
+        assert_eq!(
+            config.sample_groups[0].samples,
+            vec!["S1".to_string(), "S2".to_string(), "S3".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_samplesheet_fails_loudly() {
+        // Header-only sheet: must fail — silently falling back to the
+        // workflow's own samples would run the WRONG set.
+        let path = std::env::temp_dir().join("oxo_flow_empty_samples.tsv");
+        std::fs::write(&path, "name\tsamples\n").unwrap();
+
+        let mut config = config_with_inline_samples();
+        let spec = format!("@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err(), "empty sheet must fail");
+        assert!(format!("{result:?}").contains("no sample rows"));
+    }
+
+    #[test]
+    fn override_with_only_empty_rows_fails_loudly() {
+        // A row with an empty samples cell selects nothing — a static
+        // authoring error, never a silent zero-instance run.
+        let path = std::env::temp_dir().join("oxo_flow_empty_rows_samples.tsv");
+        std::fs::write(&path, "name\tsamples\ncohort\t\n").unwrap();
+
+        let mut config = config_with_inline_samples();
+        let spec = format!("@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err(), "empty rows must fail");
+        assert!(format!("{result:?}").contains("produced no samples"));
+    }
+
+    #[test]
+    fn bare_names_declare_samples_on_template_workflows() {
+        // A workflow without any declared samples: bare names are a sample
+        // DECLARATION (replace) — the template-workflow invocation pattern.
+        let mut config = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "template"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "analyze"
+            output = ["out/{sample}.txt"]
+            shell = "echo {sample} > {output}"
+            "#,
+        )
+        .unwrap();
+        let result = apply_samples_filter(
+            &mut config,
+            &["SRR1,SRR2".to_string()],
+            true,
+            std::path::Path::new("."),
+        );
+        assert!(result.is_ok(), "name declaration: {result:?}");
+        assert_eq!(config.sample_groups.len(), 1);
+        assert_eq!(config.sample_groups[0].name, "samples");
+        assert_eq!(
+            config.sample_groups[0].samples,
+            vec!["SRR1".to_string(), "SRR2".to_string()]
+        );
+    }
+
+    #[test]
+    fn explicit_names_still_filter_and_reject_unknown() {
+        // Known name → subset filter holds.
+        let mut config = config_with_inline_samples();
+        let result = apply_samples_filter(
+            &mut config,
+            &["S1".to_string()],
+            true,
+            std::path::Path::new("."),
+        );
+        assert!(result.is_ok(), "known name filter: {result:?}");
+        assert_eq!(config.sample_groups[0].samples, vec!["S1".to_string()]);
+
+        // Unknown name → the phantom-sample guard fails the selection.
+        let mut config = config_with_inline_samples();
+        let result = apply_samples_filter(
+            &mut config,
+            &["S99".to_string()],
+            true,
+            std::path::Path::new("."),
+        );
+        assert!(result.is_err(), "unknown name must fail: {result:?}");
     }
 }

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -144,12 +144,6 @@ pub enum Commands {
             help = "Direct config overrides: KEY=VALUE or --KEY=VALUE; --KEY VALUE (space form) is accepted for declared [config] keys — unknown --flags are rejected"
         )]
         config_overrides: Vec<String>,
-        #[arg(
-            long = "sample",
-            value_name = "SAMPLE",
-            help = "Add a sample to the run (repeatable, merges with all sources)"
-        )]
-        extra_samples: Vec<String>,
         /// Enable AI error recovery on rule failure.
         #[arg(long)]
         ai_recover: bool,
@@ -157,12 +151,11 @@ pub enum Commands {
         #[arg(long = "ai-max-retries", value_name = "N")]
         ai_max_retries: Option<u32>,
         /// Filter to a subset of samples: `first:N` or explicit names
-        /// (repeatable, comma-separated). Mutually exclusive with --sample.
+        /// (repeatable, comma-separated)
         #[arg(
             long = "samples",
             value_name = "LIST",
-            conflicts_with = "extra_samples",
-            help = "Run only these samples: first:N (pilot), explicit names, or ready (complete inputs; repeatable, comma-separated)"
+            help = "Sample selection: '@path' replaces the workflow's samples from a samplesheet, '+@path' appends (same-name groups merge); names, first:N (pilot), or ready (complete inputs) filter to a subset. Repeatable, comma-separated."
         )]
         samples_filter: Vec<String>,
         /// Re-execute every rule selected for this run even if outputs are
@@ -242,7 +235,7 @@ pub enum Commands {
         #[arg(
             long = "samples",
             value_name = "LIST",
-            help = "Preview only these samples: first:N (pilot), explicit names, or ready (complete inputs; repeatable, comma-separated)"
+            help = "Sample selection: '@path' replaces the workflow's samples from a samplesheet, '+@path' appends (same-name groups merge); names, first:N (pilot), or ready (complete inputs) filter to a subset. Repeatable, comma-separated."
         )]
         samples_filter: Vec<String>,
         #[arg(
@@ -279,13 +272,6 @@ pub enum Commands {
         )]
         config_overrides: Vec<String>,
         /// Add a sample to the preview (repeatable, merges with all
-        /// sources) — same semantics as `run --sample`.
-        #[arg(
-            long = "sample",
-            value_name = "SAMPLE",
-            help = "Add a sample to the run (repeatable, merges with all sources)"
-        )]
-        extra_samples: Vec<String>,
         /// Force re-execution of this run's rules (ignore up-to-date
         /// checks) — previews exactly what `run --rerun` would execute.
         #[arg(long)]
@@ -1023,7 +1009,6 @@ async fn main() -> Result<()> {
             yes,
             args,
             config_overrides,
-            extra_samples,
             ai_recover,
             ai_max_retries,
             samples_filter,
@@ -1146,7 +1131,6 @@ async fn main() -> Result<()> {
                 provenance,
                 cli.json,
                 merged_args,
-                extra_samples,
                 ai_recover,
                 ai_max_retries,
                 samples_filter,
@@ -1188,7 +1172,6 @@ async fn main() -> Result<()> {
             skip_ref_build,
             args,
             config_overrides,
-            extra_samples,
             rerun,
             resume_failed,
         } => {
@@ -1208,7 +1191,6 @@ async fn main() -> Result<()> {
                 profile,
                 skip_ref_build,
                 merged_args,
-                extra_samples,
                 rerun,
                 resume_failed,
             )
@@ -1463,7 +1445,6 @@ async fn main() -> Result<()> {
                 profile.clone(),
                 false,
                 vec![],
-                vec![],
                 false,
                 false,
             )
@@ -1494,7 +1475,6 @@ async fn main() -> Result<()> {
                     false,           // provenance
                     cli.json,
                     vec![], // cli_args
-                    vec![], // extra_samples
                     false,  // ai_recover
                     None,   // ai_max_retries
                     samples_filter.clone(),

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1750,6 +1750,147 @@ impl WorkflowConfig {
         Ok((kept, unknown))
     }
 
+    /// Replace the workflow's sample groups outright and keep the injected
+    /// config lists (`samples_list` / `samples_<group>` / `pairs_list`) and
+    /// `[[pairs]]` in sync with the new set.
+    ///
+    /// This is the "override" path: the given groups REPLACE the inline /
+    /// auto-discovered / file-loaded groups instead of filtering them. It is
+    /// how the CLI lets a workflow ship with fixture samples (e.g. `S1`/`S2`)
+    /// and a caller swap in real identifiers without editing the file.
+    ///
+    /// Returns the final deduplicated, order-preserving sample list.
+    pub fn override_sample_groups(&mut self, groups: Vec<SampleGroup>) -> Result<Vec<String>> {
+        let mut final_samples: Vec<String> = Vec::new();
+        for group in &groups {
+            for sample in &group.samples {
+                if !final_samples.iter().any(|s| s == sample) {
+                    final_samples.push(sample.clone());
+                }
+            }
+        }
+
+        // Group names that existed before the override: their injected
+        // `samples_<group>` keys must not survive when the group is gone
+        // (expand_inputs would keep resolving the stale list).
+        let old_group_names: std::collections::HashSet<String> =
+            self.sample_groups.iter().map(|g| g.name.clone()).collect();
+
+        self.sample_groups = groups;
+
+        // Prune stale injected samples_<group> keys for dropped groups.
+        let new_group_names: std::collections::HashSet<String> =
+            self.sample_groups.iter().map(|g| g.name.clone()).collect();
+        for stale in old_group_names.difference(&new_group_names) {
+            self.config.remove(&format!("samples_{stale}"));
+        }
+
+        // Drop pairs whose experiment/control are no longer selected.
+        self.pairs.retain(|p| {
+            final_samples.iter().any(|s| s == &p.experiment)
+                && p.control
+                    .as_ref()
+                    .is_none_or(|c| final_samples.iter().any(|s| s == c))
+        });
+
+        // Keep the injected config lists in sync with the surviving set.
+        self.config.insert(
+            "samples_list".to_string(),
+            toml::Value::String(final_samples.join(",")),
+        );
+        for group in &self.sample_groups {
+            self.config.insert(
+                format!("samples_{}", group.name),
+                toml::Value::String(group.samples.join(",")),
+            );
+        }
+        let mut pair_ids: Vec<String> = self.pairs.iter().map(|p| p.pair_id.clone()).collect();
+        pair_ids.sort();
+        pair_ids.dedup();
+        self.config.insert(
+            "pairs_list".to_string(),
+            toml::Value::String(pair_ids.join(",")),
+        );
+
+        Ok(final_samples)
+    }
+
+    /// Append sample groups on top of the workflow's current set — the
+    /// "add" counterpart of [`Self::override_sample_groups`] (`+@path` on
+    /// the CLI). A sheet group whose name matches an existing group extends
+    /// it (union, dedup, order-preserving); new group names are added
+    /// as-is. `[[pairs]]` are left untouched: appending can only ADD
+    /// samples, never remove a pair's side.
+    ///
+    /// Returns the final deduplicated, order-preserving sample list.
+    pub fn append_sample_groups(&mut self, groups: Vec<SampleGroup>) -> Result<Vec<String>> {
+        for incoming in groups {
+            if let Some(existing) = self
+                .sample_groups
+                .iter_mut()
+                .find(|g| g.name == incoming.name)
+            {
+                for sample in incoming.samples {
+                    if !existing.samples.contains(&sample) {
+                        existing.samples.push(sample);
+                    }
+                }
+            } else {
+                self.sample_groups.push(incoming);
+            }
+        }
+
+        let mut final_samples: Vec<String> = Vec::new();
+        for group in &self.sample_groups {
+            for sample in &group.samples {
+                if !final_samples.iter().any(|s| s == sample) {
+                    final_samples.push(sample.clone());
+                }
+            }
+        }
+        self.config.insert(
+            "samples_list".to_string(),
+            toml::Value::String(final_samples.join(",")),
+        );
+        for group in &self.sample_groups {
+            self.config.insert(
+                format!("samples_{}", group.name),
+                toml::Value::String(group.samples.join(",")),
+            );
+        }
+        Ok(final_samples)
+    }
+
+    /// Override the workflow's samples with a flat list — collapses every
+    /// group into a single group (reusing the first group's name, or
+    /// `"samples"` when the workflow declares no groups) so `{group}` /
+    /// `{sample}` expansion keeps working. See [`Self::override_sample_groups`].
+    ///
+    /// Returns the final deduplicated, order-preserving sample list.
+    pub fn override_samples(&mut self, names: &[String]) -> Result<Vec<String>> {
+        let mut final_samples: Vec<String> = Vec::new();
+        for name in names {
+            let name = name.trim();
+            if !name.is_empty() && !final_samples.iter().any(|s| s == name) {
+                final_samples.push(name.to_string());
+            }
+        }
+
+        // Reuse the first group's name so `{group}` references keep resolving;
+        // fall back to `"samples"` when the workflow declares no groups.
+        let group_name = self
+            .sample_groups
+            .first()
+            .map(|g| g.name.clone())
+            .unwrap_or_else(|| "samples".to_string());
+
+        self.override_sample_groups(vec![SampleGroup {
+            name: group_name,
+            samples: final_samples,
+            metadata: HashMap::new(),
+        }])
+    }
+
     /// Validate the workflow configuration for internal consistency.
     #[must_use = "validation returns a Result that must be checked"]
     pub fn validate(&self) -> Result<()> {
@@ -4934,6 +5075,228 @@ mod tests {
         "#;
         let mut config = WorkflowConfig::parse(toml).unwrap();
         assert!(config.filter_samples(&["first:abc".to_string()]).is_err());
+    }
+
+    #[test]
+    fn override_samples_replaces_inline_samples() {
+        // `--samples` explicit names replace inline [[sample_groups]] fixture
+        // names instead of filtering them — the fix for "inline samples can't
+        // be replaced from the CLI".
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[rules]]
+            name = "align"
+            input = ["raw/{sample}.fq"]
+            output = ["aln/{sample}.bam"]
+            shell = "touch {output}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let kept = config
+            .override_samples(&["SRR6357072".to_string(), "SRR6357076".to_string()])
+            .unwrap();
+
+        // The explicit list becomes the final set (order preserved).
+        assert_eq!(kept, vec!["SRR6357072", "SRR6357076"]);
+        // One group remains, reusing the original group name.
+        assert_eq!(config.sample_groups.len(), 1);
+        assert_eq!(config.sample_groups[0].name, "cohort");
+        assert_eq!(
+            config.sample_groups[0].samples,
+            vec!["SRR6357072".to_string(), "SRR6357076".to_string()]
+        );
+        // Injected config lists track the new set.
+        assert_eq!(
+            config.config.get("samples_list").and_then(|v| v.as_str()),
+            Some("SRR6357072,SRR6357076")
+        );
+        assert_eq!(
+            config.config.get("samples_cohort").and_then(|v| v.as_str()),
+            Some("SRR6357072,SRR6357076")
+        );
+
+        // {sample} expansion now binds to the override, not S1/S2.
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let rule_names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+        assert!(rule_names.iter().any(|n| n.contains("SRR6357072")));
+        assert!(rule_names.iter().any(|n| n.contains("SRR6357076")));
+        assert!(
+            !rule_names
+                .iter()
+                .any(|n| n.contains("S1") || n.contains("S2"))
+        );
+    }
+
+    #[test]
+    fn override_samples_dedups_and_prunes_pairs() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "S1"
+            control = "S2"
+
+            [[pairs]]
+            pair_id = "P2"
+            experiment = "S3"
+            control = "S4"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let kept = config
+            .override_samples(&[
+                "S3".to_string(),
+                "S3".to_string(), // duplicate dropped
+                "S4".to_string(),
+            ])
+            .unwrap();
+        assert_eq!(kept, vec!["S3", "S4"]);
+        // P1 (S1/S2) is gone; P2 (S3/S4) survives.
+        assert_eq!(config.pairs.len(), 1);
+        assert_eq!(config.pairs[0].pair_id, "P2");
+        assert_eq!(
+            config.config.get("pairs_list").and_then(|v| v.as_str()),
+            Some("P2")
+        );
+    }
+
+    #[test]
+    fn override_samples_prunes_stale_group_keys() {
+        // Override drops the 'case' group — its injected samples_case key
+        // must be pruned too, or expand_inputs keeps resolving the stale
+        // list (a silent phantom-group reference). Loaded via from_file:
+        // the samples_<group> injection happens on file load, not parse.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prune.oxoflow");
+        std::fs::write(
+            &path,
+            r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[sample_groups]]
+            name = "case"
+            samples = ["S3"]
+            "#,
+        )
+        .unwrap();
+        let mut config = WorkflowConfig::from_file(&path).unwrap();
+        assert!(config.config.contains_key("samples_case"));
+        config
+            .override_sample_groups(vec![SampleGroup {
+                name: "cohort".to_string(),
+                samples: vec!["A".to_string(), "B".to_string()],
+                metadata: HashMap::new(),
+            }])
+            .unwrap();
+        assert!(
+            !config.config.contains_key("samples_case"),
+            "stale samples_<group> key must be pruned"
+        );
+        assert_eq!(
+            config
+                .config
+                .get("samples_cohort")
+                .and_then(toml::Value::as_str),
+            Some("A,B")
+        );
+    }
+
+    #[test]
+    fn append_sample_groups_merges_and_adds_without_touching_pairs() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "S1"
+            control = "S2"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let kept = config
+            .append_sample_groups(vec![
+                SampleGroup {
+                    name: "cohort".to_string(),
+                    samples: vec!["S2".to_string(), "S3".to_string()], // S2 dup, S3 new
+                    metadata: HashMap::new(),
+                },
+                SampleGroup {
+                    name: "case".to_string(),
+                    samples: vec!["C1".to_string()],
+                    metadata: HashMap::new(),
+                },
+            ])
+            .unwrap();
+        // Union with dedup, original order preserved; new group appended.
+        assert_eq!(kept, vec!["S1", "S2", "S3", "C1"]);
+        assert_eq!(config.sample_groups.len(), 2);
+        assert_eq!(
+            config.sample_groups[0].samples,
+            vec!["S1".to_string(), "S2".to_string(), "S3".to_string()]
+        );
+        assert_eq!(config.sample_groups[1].name, "case");
+        // Pairs untouched: append can only add samples, never drop sides.
+        assert_eq!(config.pairs.len(), 1);
+        assert_eq!(
+            config
+                .config
+                .get("samples_list")
+                .and_then(toml::Value::as_str),
+            Some("S1,S2,S3,C1")
+        );
+        assert_eq!(
+            config
+                .config
+                .get("samples_case")
+                .and_then(toml::Value::as_str),
+            Some("C1")
+        );
+    }
+
+    #[test]
+    fn override_samples_uses_default_group_name_without_groups() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "align"
+            input = ["raw/{sample}.fq"]
+            output = ["aln/{sample}.bam"]
+            shell = "touch {output}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let kept = config
+            .override_samples(&["A".to_string(), "B".to_string()])
+            .unwrap();
+        assert_eq!(kept, vec!["A", "B"]);
+        assert_eq!(config.sample_groups.len(), 1);
+        assert_eq!(config.sample_groups[0].name, "samples");
     }
 
     #[test]

--- a/docs/guide/src/commands/dry-run.md
+++ b/docs/guide/src/commands/dry-run.md
@@ -11,7 +11,7 @@ oxo-flow dry-run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 ```
 
 `dry-run` accepts the same configuration inputs as `run` — `--arg`,
-`--sample`, trailing `KEY=VALUE` overrides, `--profile`, `--rerun`, and
+trailing `KEY=VALUE` overrides, `--profile`, `--rerun`, and
 `--resume-failed` — and predicts the execution set with the exact same
 machinery (issue #77 parity contract). The preview also mirrors the
 executor's freshness gate: a rule with no checkpoint entry whose outputs
@@ -33,12 +33,11 @@ are up to date is predicted as skipped, exactly as `run` would skip it.
 | Option | Short | Description |
 |---|---|---|
 | `--target` | `-t` | Run only specific target rules and their dependencies (repeatable, prefix matching) |
-| `--samples <LIST>` | — | Preview only a subset of samples: `first:N` (pilot), explicit names, or `ready` (samples whose entry inputs are complete; repeatable, comma-separated) |
+| `--samples <LIST>` | — | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--workdir <DIR>` | `-d` | Resolve relative paths against this directory (default: the workflow file's directory) |
 | `--profile <NAME>` | — | Execution profile loaded from `profiles/<NAME>.toml` — the SAME merge semantics as `run` |
 | `--arg <KEY=VALUE>` | — | Set a workflow config value (overrides `[config]` defaults). Repeatable |
 | `KEY=VALUE`… | — | Direct config overrides as trailing positionals (`KEY=VALUE`, `--KEY=VALUE`, `--KEY VALUE`) — the same forms `run` accepts; command flags must come before them |
-| `--sample <SAMPLE>` | — | Add a sample to the preview (repeatable, merges with all sources) — same semantics as `run --sample` |
 | `--rerun` | — | Preview `run --rerun`: every rule in the execution set is forced (`when`-false rules still skip) |
 | `--resume-failed` | — | Preview `run --resume-failed`: failed rules re-run, completed rules stay skipped |
 | `--skip-ref-build` | — | Skip automatic reference/index building (assume pre-built) — the preview otherwise lists required builds |

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -40,12 +40,11 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--profile` | — | — | Execution profile name, loaded from `profiles/<NAME>.toml` or `profiles/<NAME>.oxoflow` (see [Execution profiles](#execution-profiles)) |
 | `--provenance` | — | — | Track output file checksums for later verification |
 | `--arg` | — | — | Legacy form: set a workflow config value (`KEY=VALUE`). Repeatable. See `[config]` in workflow-format |
-| `--sample` | — | — | Add a sample to the run. Repeatable. Merges with sample_pattern/CSV sources |
 | `--bundle` | — | — | Execute from a published bundle (`.tar.zst` or `.tar.gz`). Extracts, verifies checksums, shows resource requirements, and prompts for confirmation |
 | `--yes` | — | — | Skip the confirmation prompt when running a bundle (required in non-interactive sessions: CI, scripts, redirected input, or `--json`) |
 | `--ai-recover` | — | — | Enable AI error recovery on rule failure |
 | `--ai-max-retries` | — | — | Maximum AI retries (overrides `[ai]` config) |
-| `--samples` | — | `LIST` | Run only a subset of samples: `first:N` (pilot), explicit names, or `ready` (samples whose entry inputs are complete). Repeatable, comma-separated. Filters `[[sample_groups]]`, `sample_pattern` discovery, and `[[pairs]]`. Mutually exclusive with `--sample` |
+| `--samples` | — | `LIST` | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--rerun` | — | — | Force re-execution of this run's rules (ignore up-to-date checks). Checkpoint records for rules outside this run are kept |
 | `--no-report-snapshot` | — | — | Skip the automatic report snapshot written after the run (see [Report snapshots](#report-snapshots)); `resume` has the same flag |
 | `--verbose` | `-v` | — | Enable debug-level logging |

--- a/docs/guide/src/how-to/cohort-sample-groups.md
+++ b/docs/guide/src/how-to/cohort-sample-groups.md
@@ -188,3 +188,58 @@ fastq files over days), check readiness with
 [`dry-run`](../commands/dry-run.md#sample-readiness) and run what is
 complete with
 [`--samples ready`](../commands/run.md#incremental-data-arrival-samples-ready).
+
+## Selecting Samples on the Command Line
+
+`--samples` is the single selection entry point. One parameter, four
+orthogonal semantics — **replace**, **append**, and **filter** (by name,
+pilot size, or readiness):
+
+| Spec | Semantics |
+| --- | --- |
+| `--samples @sheet.tsv` | **Replace** — the sheet's groups become the run set, overwriting the workflow's inline / auto-discovered / file-loaded groups |
+| `--samples +@sheet.tsv` | **Append** — same-name groups merge (union, deduplicated); new group names are added. `[[pairs]]` are untouched: appending can only add samples |
+| `--samples S1,S2` | **Filter** on workflows with declared samples (unknown names fail — no phantom samples); **declare** on workflows that ship with no samples at all (the template-workflow invocation pattern) |
+| `--samples first:3` / `--samples ready` | **Filter** — narrow the (possibly replaced, appended, or declared) set to a subset / to samples whose entry inputs are complete (see [Incremental data arrival](#incremental-data-arrival-samples-ready)) |
+
+Sheet specs apply in order and can combine with filters:
+`--samples @real.tsv,first:2` replaces with `real.tsv` then runs the first
+two. A later `@path` resets earlier `+@path` appends (the last replace
+wins).
+
+### Replacing fixture samples with real identifiers
+
+The core invocation-side use case: a workflow ships with fixture names
+(e.g. `S1`/`S2`) and the caller runs real identifiers without editing the
+file:
+
+```bash
+# samplesheet.tsv: one group per row (TSV / CSV / JSON)
+#   name     samples
+#   cohort   SRR6357072,SRR6357076
+
+oxo-flow run cohort.oxoflow --samples @samplesheet.tsv
+```
+
+The sheet's groups **replace** the inline `[[sample_groups]]` (and any
+`sample_pattern` / `sample_groups_file` sources). Samples the workflow never
+declared are **added** as new samples, so `{group}`/`{sample}` expansion
+binds to the override. `[[pairs]]` whose experiment/control are no longer
+selected are dropped, and stale injected `samples_<group>` config keys for
+dropped groups are pruned. A sheet with no data rows (or rows with empty
+samples) fails the run loudly — it never silently falls back to the
+workflow's own samples.
+
+### Appending to a cohort
+
+```bash
+# Adds S3 to the declared cohort (S2 is deduplicated):
+#   name     samples
+#   cohort   S2,S3
+oxo-flow run cohort.oxoflow --samples +@more.tsv
+```
+
+Same-name groups merge with the declared samples (union, deduplicated,
+original order preserved); a new group name adds a whole new group.
+`[[pairs]]` stay as declared — appending never removes a pair's side.
+

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -114,6 +114,126 @@ fn cli_samples_pilot_then_scale_up() {
     assert!(dir.path().join("out/S3.txt").exists());
 }
 
+/// `--samples @sheet` REPLACES inline fixture samples with the sheet's —
+/// the invocation-side sample swap (workflow ships S1/S2, caller runs
+/// real identifiers without editing the file).
+#[test]
+fn cli_samples_sheet_override_replaces_inline_fixtures() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("cohort.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"cohort\"\nversion = \"1.0.0\"\n\n[[sample_groups]]\nname = \"cohort\"\nsamples = [\"S1\", \"S2\"]\n\n[[rules]]\nname = \"analyze\"\noutput = [\"out/{sample}.txt\"]\nshell = \"echo {sample} > {output}\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("samples.tsv"),
+        "name\tsamples\ncohort\tSRR6357072,SRR6357076\n",
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--samples", "@samples.tsv"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "override run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(dir.path().join("out/SRR6357072.txt").exists());
+    assert!(dir.path().join("out/SRR6357076.txt").exists());
+    assert!(
+        !dir.path().join("out/S1.txt").exists(),
+        "fixture samples must be replaced, not run"
+    );
+}
+
+/// `+@sheet` APPENDS: same-name groups merge, new groups are added.
+#[test]
+fn cli_samples_sheet_append_merges_with_declared() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("cohort.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"cohort\"\nversion = \"1.0.0\"\n\n[[sample_groups]]\nname = \"cohort\"\nsamples = [\"S1\", \"S2\"]\n\n[[rules]]\nname = \"analyze\"\noutput = [\"out/{sample}.txt\"]\nshell = \"echo {sample} > {output}\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("more.tsv"),
+        "name\tsamples\ncohort\tS2,S3\n",
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--samples", "+@more.tsv"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "append run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    // Declared S1/S2 kept (S2 deduped) + appended S3.
+    assert!(dir.path().join("out/S1.txt").exists());
+    assert!(dir.path().join("out/S2.txt").exists());
+    assert!(dir.path().join("out/S3.txt").exists());
+}
+
+/// dry-run previews the overridden set exactly like run (parity contract).
+#[test]
+fn cli_dry_run_sheet_override_parity_with_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("cohort.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"cohort\"\nversion = \"1.0.0\"\n\n[[sample_groups]]\nname = \"cohort\"\nsamples = [\"S1\", \"S2\"]\n\n[[rules]]\nname = \"analyze\"\noutput = [\"out/{sample}.txt\"]\nshell = \"echo {sample} > {output}\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("samples.tsv"),
+        "name\tsamples\ncohort\tA1,A2\n",
+    )
+    .unwrap();
+
+    let dry = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap(), "--samples", "@samples.tsv"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(dry.status.success());
+    let stderr = String::from_utf8_lossy(&dry.stderr);
+    assert!(stderr.contains("A1"), "dry-run must preview A1: {stderr}");
+    assert!(stderr.contains("A2"), "dry-run must preview A2: {stderr}");
+    assert!(
+        !stderr.contains("analyze_cohort_S1"),
+        "fixture samples must not appear: {stderr}"
+    );
+}
+
+/// The deleted --sample flag now errors as unknown (simplicity over
+/// deprecation: --samples @/+/filter covers every selection scenario).
+#[test]
+fn cli_sample_flag_removed_reports_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("w.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"w\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"r\"\noutput = [\"o.txt\"]\nshell = \"echo hi > o.txt\"\n",
+    )
+    .unwrap();
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--sample", "S1"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "'--sample' is a command flag, not a config override",
+        ));
+}
+
 /// --rerun forces re-execution even when outputs are up to date, while a
 /// plain second run skips everything via the checkpoint.
 #[test]

--- a/tests/preview_parity.rs
+++ b/tests/preview_parity.rs
@@ -743,7 +743,7 @@ fn parity_arg_override_and_positional_forms_match_run() {
     assert_eq!(a, b, "--arg and KEY=VALUE must agree");
 }
 
-/// 13. `--sample`: preview and run merge CLI samples identically.
+/// 13. `--samples @sheet`: preview and run expand the sheet samples identically.
 ///
 /// The wildcard instance is named `analyze_cli-specified_S2` (group +
 /// underscore naming) while the fixture shell logs `analyze-{sample}` →
@@ -751,7 +751,7 @@ fn parity_arg_override_and_positional_forms_match_run() {
 /// comparing — the parity contract is about WHICH instances run, not the
 /// underscore/hyphen spelling.
 #[test]
-fn parity_sample_flag_expands_the_same_instances() {
+fn parity_samples_sheet_override_expands_the_same_instances() {
     let normalize = |names: &HashSet<String>| -> HashSet<String> {
         names
             .iter()
@@ -781,12 +781,16 @@ output = ["out/{sample}.txt"]
 shell = "echo analyze-{sample} >> exec_log.txt; touch out/{sample}.txt"
 "#;
     let wf = write_workflow(dir.path(), "wf.oxoflow", wf_toml);
-    baseline_run(dir.path(), &wf, &["--sample", "S1"]);
+    // Invocation-side sample selection: a workflow with NO declared samples
+    // gains them from a samplesheet (the `--samples @path` override).
+    fs::write(dir.path().join("s1.tsv"), "name\tsamples\ncohort\tS1\n").unwrap();
+    fs::write(dir.path().join("s2.tsv"), "name\tsamples\ncohort\tS2\n").unwrap();
+    baseline_run(dir.path(), &wf, &["--samples", "@s1.tsv"]);
 
-    let (pred, _) = preview_plan(dir.path(), &["wf.oxoflow", "--sample", "S2"]);
+    let (pred, _) = preview_plan(dir.path(), &["wf.oxoflow", "--samples", "@s2.tsv"]);
     let _ = fs::remove_file(dir.path().join(EXEC_LOG));
     let out = oxo_flow()
-        .args(["run", "-j", "2", "wf.oxoflow", "--sample", "S2"])
+        .args(["run", "-j", "2", "wf.oxoflow", "--samples", "@s2.tsv"])
         .current_dir(dir.path())
         .output()
         .unwrap();
@@ -799,11 +803,11 @@ shell = "echo analyze-{sample} >> exec_log.txt; touch out/{sample}.txt"
     assert_eq!(
         normalize(&pred),
         normalize(&actual),
-        "sample-flag parity violation (pred {pred:?} vs run {actual:?})"
+        "samples-sheet parity violation (pred {pred:?} vs run {actual:?})"
     );
     assert!(
         normalize(&pred).contains("S2"),
-        "expected the new sample's instance: {pred:?}"
+        "expected the sheet sample's instance: {pred:?}"
     );
 }
 

--- a/tests/web_integration.rs
+++ b/tests/web_integration.rs
@@ -964,7 +964,9 @@ async fn web_wildcard_run_status_matches_checkpoint_instances() {
     );
 }
 
-/// P1-07 regression (issue #79): the Samples field was wired to `--sample`
+/// P1-07 regression (issue #79): the Samples field must filter the cohort
+/// (it was once wired to the old `--sample` append flag, which ran the full
+/// cohort — that flag no longer exists; the field maps to `--samples`)
 /// (append) so filling in a name silently ran the FULL cohort plus a phantom
 /// sample. Now it maps to `--samples` filter semantics: a known sample runs
 /// alone; an unknown name warns and fails instead of phantom-executing.


### PR DESCRIPTION
## 背景

引擎目前对样本的选择入口是**割裂且偏向"追加"**的：

- `--sample <name>` 把样本**追加**到 `sample_groups_file`/`sample_pattern` 发现的结果之后（无法替换）；
- `--samples <list>` 只能**过滤**已发现的样本（unknown 名字会报错）；
- 当一个工作流用 `[[sample_groups]]` 内联了 fixture 名字（如 `S1`/`S2`）时，**没有任何办法从 CLI 用真实样本替换它们**——要么改 `.oxoflow` 文件，要么另写一个 samplesheet 再改配置。

这是一个**一致性设计缺口**：`--sample`（追加）与 `--samples`（过滤）语义混淆，且都缺少"覆盖"这一最自然的操作。

## 方案

统一到单一入口 `--samples`，用 `@` 前缀区分两种语义（`@` 是业界通用的"从文件读参数"信号，对齐 curl `--data @file` / GCC `@file`，也对齐 nf-core 的 `--input samplesheet.csv`）：

| 用法 | 语义 |
| --- | --- |
| `--samples @samplesheet.tsv` | **覆盖**：用 samplesheet 的 groups 整体替换工作流声明的样本（明确 opt-in） |
| `--samples S1,S2 / first:N / ready` | **过滤**：把已发现的样本收窄到子集（unknown 名字 fail，保持不变） |

`--sample` 标记为 DEPRECATED，运行时报 warning。

## 为什么不直接让"显式名字 = 覆盖"

最初方案是让 `--samples S99` 直接覆盖（把 S99 当新样本静默加入），但这会**破坏 #79 修复的"幽灵样本执行"guard**——`--samples S99`（typo）必须 fail 而不是静默跑一个不存在的样本。

用 `@path` 作为覆盖的明确信号，把"覆盖"和"过滤"在同一个参数下分离，是唯一能同时满足「统一入口 + 保留 unknown 安全 + 提供覆盖能力」三者兼顾的方案。

## 改动

**core**（`config.rs`）
- 新增 `WorkflowConfig::override_sample_groups` / `override_samples`：整体替换 `sample_groups`，同步 `samples_list` / `samples_<group>` / `pairs_list`，剪掉 experiment/control 不在新集合的 `[[pairs]]`。

**cli**（`samples.rs` / `main.rs` / `run.rs`）
- `apply_samples_filter`：把 specs 拆成 `@path`（覆盖）与名字/`first:N`/`ready`（过滤）；覆盖先替换集合，可选过滤器再收窄。
- `--samples` help 更新为两种语义；`--sample` 标 DEPRECATED 并加运行时 warning。

**测试**
- core 3 个：覆盖替换、去重 + pairs 剪枝、无 group 时的默认组名。
- cli 2 个：`@path` 覆盖替换 inline 样本；显式名字仍过滤且 unknown fail。

**文档**
- `run.md` / `dry-run.md` 参数说明；`cohort-sample-groups.md` 新增 "Overriding the Cohort" 章节。

## 验证

- `cargo build -p oxo-flow-cli` 通过，`cargo test` 全量通过（含 web_integration 28 个、core 223 个）。
- 手动 `dry-run` 三种行为均正确：
  1. `--samples @samplesheet.tsv` → 覆盖为真实样本，规则展开为 `gather_cohort_SRR6357072/...`；
  2. `--samples S99` → "not found in workflow samples" + fail（安全保留）；
  3. `--samples S1` → 只跑 S1（过滤）。
