### PR TITLE
fix(core): verify conda envs after setup; repair broken ones

### DIFF
--- a/crates/oxo-flow-cli/src/commands/cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/cluster.rs
@@ -267,6 +267,7 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
                     rule,
                     &wildcard_values,
                     &config.workflow.interpreter_map,
+                    oxo_flow_core::scheduler::detect_system_limits(),
                 ) {
                     Some(cmd) => cmd,
                     None => {

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -11,6 +11,21 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+/// Flatten workflow config values into the `{config.key}` placeholder map
+/// used for path expansion (DAG edge matching, run-time rendering, …).
+fn config_placeholder_values(config: &HashMap<String, toml::Value>) -> HashMap<String, String> {
+    config
+        .iter()
+        .map(|(key, value)| {
+            let string_val = match value {
+                toml::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            (format!("config.{key}"), string_val)
+        })
+        .collect()
+}
+
 /// Print the config-change impact summary (issue #62).
 ///
 /// Distinguishes the full invalidation set (checkpoint mutation; includes
@@ -534,7 +549,11 @@ pub async fn run_command(
         .expand_wildcards()
         .context("failed to expand wildcard rules")?;
 
-    let mut dag = WorkflowDag::from_rules(&config.rules).context("failed to build workflow DAG")?;
+    let mut dag = WorkflowDag::from_rules_with_config(
+        &config.rules,
+        &config_placeholder_values(&config.config),
+    )
+    .context("failed to build workflow DAG")?;
 
     let mut order = if target.is_empty() {
         dag.execution_order()?
@@ -630,16 +649,9 @@ pub async fn run_command(
         rerun,
     );
 
-    let mut wildcard_values: HashMap<String, String> = HashMap::new();
     // All config values (including CLI --arg overrides) become {config.key} in templates.
-    for (key, value) in &config.config {
-        let string_val = match value {
-            toml::Value::String(s) => s.clone(),
-            other => other.to_string(),
-        };
-        wildcard_values.insert(format!("config.{key}"), string_val);
-    }
-    let wildcard_values: Arc<HashMap<String, String>> = Arc::new(wildcard_values);
+    let wildcard_values: Arc<HashMap<String, String>> =
+        Arc::new(config_placeholder_values(&config.config));
     let workdir_actual = Arc::new(workdir.as_ref().unwrap_or(&workdir_default).clone());
 
     // ── Input manifest comparison (issue #72) ──────────────────────────────
@@ -1227,8 +1239,11 @@ pub async fn run_command(
             let replayed =
                 oxo_flow_core::reentry::replay_valid_reentries(&mut config, &ck.reentries, &valid)?;
             tracing::info!(count = replayed.len(), "replayed checkpoint re-entries");
-            dag = WorkflowDag::from_rules(&config.rules)
-                .context("failed to rebuild workflow DAG after re-entry replay")?;
+            dag = WorkflowDag::from_rules_with_config(
+                &config.rules,
+                &config_placeholder_values(&config.config),
+            )
+            .context("failed to rebuild workflow DAG after re-entry replay")?;
             order = if target.is_empty() {
                 dag.execution_order()?
             } else {
@@ -2189,7 +2204,11 @@ pub async fn dry_run_command(
         .expand_wildcards()
         .context("failed to expand wildcard rules")?;
 
-    let mut dag = WorkflowDag::from_rules(&config.rules).context("failed to build workflow DAG")?;
+    let mut dag = WorkflowDag::from_rules_with_config(
+        &config.rules,
+        &config_placeholder_values(&config.config),
+    )
+    .context("failed to build workflow DAG")?;
 
     // Compute the execution set (respects --target), then display it in
     // parallel-group order — the same grouping `run` uses for scheduling.
@@ -2294,8 +2313,11 @@ pub async fn dry_run_command(
                 count = replayed.len(),
                 "dry-run replayed checkpoint re-entries"
             );
-            dag = WorkflowDag::from_rules(&config.rules)
-                .context("failed to rebuild workflow DAG after re-entry replay")?;
+            dag = WorkflowDag::from_rules_with_config(
+                &config.rules,
+                &config_placeholder_values(&config.config),
+            )
+            .context("failed to rebuild workflow DAG after re-entry replay")?;
             let new_order: Vec<String> = if target.is_empty() {
                 let order_set: std::collections::HashSet<String> =
                     dag.execution_order()?.into_iter().collect();
@@ -2906,7 +2928,11 @@ logical errors. Output format per rule:
         }
     }
 
-    let dag = WorkflowDag::from_rules(&config.rules).context("failed to build workflow DAG")?;
+    let dag = WorkflowDag::from_rules_with_config(
+        &config.rules,
+        &config_placeholder_values(&config.config),
+    )
+    .context("failed to build workflow DAG")?;
 
     let rules_to_show: Vec<&oxo_flow_core::rule::Rule> = if let Some(ref name) = rule_name {
         match config.rules.iter().find(|r| r.name == *name) {
@@ -3040,8 +3066,11 @@ async fn process_reentry(
         order_set.insert(name.clone());
         order.push(name.clone());
     }
-    *dag = WorkflowDag::from_rules(&config.rules)
-        .context("failed to rebuild workflow DAG after re-entry")?;
+    *dag = WorkflowDag::from_rules_with_config(
+        &config.rules,
+        &config_placeholder_values(&config.config),
+    )
+    .context("failed to rebuild workflow DAG after re-entry")?;
     tracing::info!(
         rule = %rule.name,
         round = round,

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1058,11 +1058,10 @@ pub async fn run_command(
                 // genomeGenerate died with 'could not open genomeFastaFile:
                 // {source}' — the placeholder was never substituted).
                 if let Some(source) = ref_def.source.as_deref() {
-                    let expanded =
-                        oxo_flow_core::executor::checkpoint::expand_config_in_path(
-                            source,
-                            &wildcard_values,
-                        );
+                    let expanded = oxo_flow_core::executor::checkpoint::expand_config_in_path(
+                        source,
+                        &wildcard_values,
+                    );
                     build_cmd = build_cmd.replace("{source}", &expanded);
                 }
                 // References that need workflow tools (bowtie2-build, STAR
@@ -2503,8 +2502,12 @@ pub async fn dry_run_command(
         }
 
         if let Some(ref cmd) = rule.shell {
-            let expanded =
-                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values, oxo_flow_core::scheduler::detect_system_limits());
+            let expanded = oxo_flow_core::executor::process::render_shell_command(
+                cmd,
+                rule,
+                &wildcard_values,
+                oxo_flow_core::scheduler::detect_system_limits(),
+            );
             eprintln!("     command: {}", expanded);
         }
 
@@ -2983,8 +2986,12 @@ logical errors. Output format per rule:
         }
 
         if let Some(ref cmd) = rule.shell {
-            let expanded =
-                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values, oxo_flow_core::scheduler::detect_system_limits());
+            let expanded = oxo_flow_core::executor::process::render_shell_command(
+                cmd,
+                rule,
+                &wildcard_values,
+                oxo_flow_core::scheduler::detect_system_limits(),
+            );
             eprintln!("  {} {}", "Shell (expanded):".dimmed(), expanded);
         }
 

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1051,6 +1051,7 @@ pub async fn run_command(
                     &ref_def.build,
                     &synthetic_rule,
                     &wildcard_values,
+                    oxo_flow_core::scheduler::detect_system_limits(),
                 );
                 // `{source}` is the builder-template spelling of the same
                 // thing; render it too (live evidence: tcasia's STAR
@@ -2503,7 +2504,7 @@ pub async fn dry_run_command(
 
         if let Some(ref cmd) = rule.shell {
             let expanded =
-                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values);
+                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values, oxo_flow_core::scheduler::detect_system_limits());
             eprintln!("     command: {}", expanded);
         }
 
@@ -2752,6 +2753,7 @@ pub async fn dry_run_command(
                         cmd,
                         rule,
                         &wildcard_values,
+                        oxo_flow_core::scheduler::detect_system_limits(),
                     )
                 });
                 // Declared patterns stay raw in inputs/outputs (the stable
@@ -2891,6 +2893,7 @@ pub async fn debug_command(workflow: PathBuf, rule_name: Option<String>, ai: boo
                     shell_cmd,
                     r,
                     &debug_wildcards,
+                    oxo_flow_core::scheduler::detect_system_limits(),
                 );
                 format!(
                     "## {}\nthreads={}, memory={}, env={:?}\n```bash\n{}\n```",
@@ -2981,7 +2984,7 @@ logical errors. Output format per rule:
 
         if let Some(ref cmd) = rule.shell {
             let expanded =
-                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values);
+                oxo_flow_core::executor::process::render_shell_command(cmd, rule, &wildcard_values, oxo_flow_core::scheduler::detect_system_limits());
             eprintln!("  {} {}", "Shell (expanded):".dimmed(), expanded);
         }
 

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1023,15 +1023,35 @@ pub async fn run_command(
             };
 
             if let Some(reason) = rebuild_reason {
+                let synthetic_rule = oxo_flow_core::rule::Rule {
+                    name: format!("ref:{}", ref_def.name),
+                    // `{input}` is the renderer's alias for the reference
+                    // source (documented in config_impact::reference_fingerprint).
+                    input: ref_def
+                        .source
+                        .as_deref()
+                        .map(|s| vec![s.to_string()].into())
+                        .unwrap_or_default(),
+                    output: vec![output_path.clone()].into(),
+                    ..Default::default()
+                };
                 let mut build_cmd = oxo_flow_core::executor::process::render_shell_command(
                     &ref_def.build,
-                    &oxo_flow_core::rule::Rule {
-                        name: format!("ref:{}", ref_def.name),
-                        output: vec![output_path.clone()].into(),
-                        ..Default::default()
-                    },
+                    &synthetic_rule,
                     &wildcard_values,
                 );
+                // `{source}` is the builder-template spelling of the same
+                // thing; render it too (live evidence: tcasia's STAR
+                // genomeGenerate died with 'could not open genomeFastaFile:
+                // {source}' — the placeholder was never substituted).
+                if let Some(source) = ref_def.source.as_deref() {
+                    let expanded =
+                        oxo_flow_core::executor::checkpoint::expand_config_in_path(
+                            source,
+                            &wildcard_values,
+                        );
+                    build_cmd = build_cmd.replace("{source}", &expanded);
+                }
                 // References that need workflow tools (bowtie2-build, STAR
                 // genomeGenerate, …) declare an `environment` — same spec as
                 // `[rules.environment]`. The env is created on first use and

--- a/crates/oxo-flow-core/src/backend/mod.rs
+++ b/crates/oxo-flow-core/src/backend/mod.rs
@@ -153,7 +153,12 @@ fn build_rule(
         message: format!("rule '{name}' not found in workflow"),
     })?;
     let Some(cmd) =
-        build_execution_command(rule, wildcard_values, &config.workflow.interpreter_map)
+        build_execution_command(
+            rule,
+            wildcard_values,
+            &config.workflow.interpreter_map,
+            crate::scheduler::detect_system_limits(),
+        )
     else {
         return Ok(None); // no shell/script — not schedulable
     };

--- a/crates/oxo-flow-core/src/backend/mod.rs
+++ b/crates/oxo-flow-core/src/backend/mod.rs
@@ -152,14 +152,12 @@ fn build_rule(
     let rule = config.get_rule(name).ok_or_else(|| OxoFlowError::Config {
         message: format!("rule '{name}' not found in workflow"),
     })?;
-    let Some(cmd) =
-        build_execution_command(
-            rule,
-            wildcard_values,
-            &config.workflow.interpreter_map,
-            crate::scheduler::detect_system_limits(),
-        )
-    else {
+    let Some(cmd) = build_execution_command(
+        rule,
+        wildcard_values,
+        &config.workflow.interpreter_map,
+        crate::scheduler::detect_system_limits(),
+    ) else {
         return Ok(None); // no shell/script — not schedulable
     };
     let wrapped = env_resolver

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -54,6 +54,27 @@ impl WorkflowDag {
     /// Returns an error if a cycle is detected or if duplicate rule names exist.
     #[must_use = "building a DAG returns a Result that must be used"]
     pub fn from_rules(rules: &[Rule]) -> Result<Self> {
+        Self::from_rules_with_config(rules, &HashMap::new())
+    }
+
+    /// Build a DAG from a list of rules, expanding `{config.x}` placeholders
+    /// in input/output paths against the provided config values before edge
+    /// matching.
+    ///
+    /// Rules frequently express the same logical path through different
+    /// config keys (`{config.umap_n_neighbors}` vs `{config.leiden_n_neighbors}`),
+    /// or the same key at different nesting — without expansion those inputs
+    /// never match any producer and the edge is silently lost (live evidence:
+    /// the unsupervised workflow scheduled every leiden rule before its
+    /// umap_graph producer).
+    #[must_use = "building a DAG returns a Result that must be used"]
+    pub fn from_rules_with_config(
+        rules: &[Rule],
+        config_values: &HashMap<String, String>,
+    ) -> Result<Self> {
+        let expand = |path: &str| {
+            crate::executor::expand_to_fixed_point(path, config_values, |value| value.to_owned())
+        };
         let mut graph = DiGraph::new();
         let mut name_to_node = HashMap::new();
         let mut output_to_node: HashMap<String, Vec<NodeIndex>> = HashMap::new();
@@ -73,9 +94,14 @@ impl WorkflowDag {
             name_to_node.insert(rule.name.clone(), node);
 
             // Register outputs — every producer, not just the last (a
-            // shared output string must link ALL of its producers).
+            // shared output string must link ALL of its producers),
+            // config-expanded so inputs referencing the same path through
+            // a different config key still match.
             for output in &rule.output {
-                output_to_node.entry(output.clone()).or_default().push(node);
+                output_to_node
+                    .entry(expand(output))
+                    .or_default()
+                    .push(node);
             }
         }
 
@@ -121,7 +147,9 @@ impl WorkflowDag {
             // iterator yields the directory path; prefix-match it against
             // every producer output, optionally restricted by the filter glob.
             let declared_dir: Option<(String, Option<String>)> = match &rule.input {
-                FilePatterns::Dir { path, pattern } => Some((path.clone(), pattern.clone())),
+                FilePatterns::Dir { path, pattern } => {
+                    Some((expand(path), pattern.clone()))
+                }
                 _ => None,
             };
 
@@ -131,11 +159,15 @@ impl WorkflowDag {
             let infer = |input: &str,
                          graph: &mut DiGraph<DagNode, ()>,
                          declared_dir: Option<&(String, Option<String>)>| {
+                // Config placeholders are expanded before matching so the
+                // same logical path expressed through different config keys
+                // still connects (see from_rules_with_config).
+                let input = expand(input);
                 // 1. Exact template-level match (legacy behavior, kept first).
                 //    Every producer declaring the same output string links —
                 //    shared-directory outputs must order ALL writers before
                 //    any consumer of the directory.
-                if let Some(producers) = output_to_node.get(input) {
+                if let Some(producers) = output_to_node.get(&input) {
                     for &producer_node in producers {
                         add_edge_dedup(graph, producer_node, consumer_node);
                     }
@@ -155,12 +187,12 @@ impl WorkflowDag {
                             add_edge_dedup(graph, *producer_node, consumer_node);
                         }
                     }
-                } else if has_glob_chars(input) {
+                } else if has_glob_chars(&input) {
                     // 3. Glob input (`mapped/*.bam`): compile the glob and
                     //    match it against producer outputs. A glob that
                     //    cannot be compiled (unbalanced bracket, …) keeps the
                     //    legacy behavior — no edges, no error.
-                    if let Some(glob_re) = glob_pattern_to_regex(input) {
+                    if let Some(glob_re) = glob_pattern_to_regex(&input) {
                         for (output, producer_node) in &producer_outputs {
                             if glob_re.is_match(output) {
                                 add_edge_dedup(graph, *producer_node, consumer_node);
@@ -175,7 +207,7 @@ impl WorkflowDag {
                     //    heuristic for extension-less inputs.
                     for (output, matcher) in &template_matchers {
                         if let Some(re) = matcher
-                            && re.is_match(input)
+                            && re.is_match(&input)
                             && let Some(producers) = output_to_node.get(output)
                         {
                             for &producer_node in producers {
@@ -183,7 +215,7 @@ impl WorkflowDag {
                             }
                         }
                     }
-                    if looks_like_directory(input) {
+                    if looks_like_directory(&input) {
                         let base = input.trim_end_matches('/');
                         let prefix = format!("{base}/");
                         for (output, producer_node) in &producer_outputs {
@@ -1781,6 +1813,46 @@ mod tests {
         let c = make_rule("cons", vec!["data/[.txt"], vec!["out.txt"]);
         let dag = WorkflowDag::from_rules(&[p, c]).unwrap();
         assert!(dag.dependencies("cons").unwrap().is_empty());
+    }
+
+    #[test]
+    fn config_placeholder_paths_connect_when_values_align() {
+        // The same logical path expressed through different config keys
+        // (unsupervised: umap_n_neighbors vs leiden_n_neighbors) must form
+        // an edge once both expand to the same string.
+        let prod = make_rule(
+            "umap",
+            vec![],
+            vec!["results/{config.umap_metric}_{config.umap_n_neighbors}_graph.pickle"],
+        );
+        let cons = make_rule(
+            "leiden",
+            vec!["results/{config.leiden_metric}_{config.leiden_n_neighbors}_graph.pickle"],
+            vec!["out.csv"],
+        );
+        let values = HashMap::from([
+            ("config.umap_metric".to_string(), "euclidean".to_string()),
+            ("config.umap_n_neighbors".to_string(), "15".to_string()),
+            ("config.leiden_metric".to_string(), "euclidean".to_string()),
+            ("config.leiden_n_neighbors".to_string(), "15".to_string()),
+        ]);
+        let dag =
+            WorkflowDag::from_rules_with_config(&[prod.clone(), cons.clone()], &values).unwrap();
+        assert_eq!(dag.dependencies("leiden").unwrap(), vec!["umap"]);
+
+        // Different values → no edge.
+        let divergent = HashMap::from([
+            ("config.umap_metric".to_string(), "euclidean".to_string()),
+            ("config.umap_n_neighbors".to_string(), "15".to_string()),
+            ("config.leiden_metric".to_string(), "cosine".to_string()),
+            ("config.leiden_n_neighbors".to_string(), "15".to_string()),
+        ]);
+        let dag = WorkflowDag::from_rules_with_config(
+            &[prod.clone(), cons.clone()],
+            &divergent,
+        )
+        .unwrap();
+        assert!(dag.dependencies("leiden").unwrap().is_empty());
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -98,10 +98,7 @@ impl WorkflowDag {
             // config-expanded so inputs referencing the same path through
             // a different config key still match.
             for output in &rule.output {
-                output_to_node
-                    .entry(expand(output))
-                    .or_default()
-                    .push(node);
+                output_to_node.entry(expand(output)).or_default().push(node);
             }
         }
 
@@ -147,9 +144,7 @@ impl WorkflowDag {
             // iterator yields the directory path; prefix-match it against
             // every producer output, optionally restricted by the filter glob.
             let declared_dir: Option<(String, Option<String>)> = match &rule.input {
-                FilePatterns::Dir { path, pattern } => {
-                    Some((expand(path), pattern.clone()))
-                }
+                FilePatterns::Dir { path, pattern } => Some((expand(path), pattern.clone())),
                 _ => None,
             };
 
@@ -1852,11 +1847,8 @@ mod tests {
             ("config.leiden_metric".to_string(), "cosine".to_string()),
             ("config.leiden_n_neighbors".to_string(), "15".to_string()),
         ]);
-        let dag = WorkflowDag::from_rules_with_config(
-            &[prod.clone(), cons.clone()],
-            &divergent,
-        )
-        .unwrap();
+        let dag =
+            WorkflowDag::from_rules_with_config(&[prod.clone(), cons.clone()], &divergent).unwrap();
         assert!(dag.dependencies("leiden").unwrap().is_empty());
     }
 
@@ -1871,10 +1863,7 @@ mod tests {
             vec!["{config.out_dir}/GenomeBinning/QC"],
             vec!["{config.out_dir}/GenomeBinning/QC/quast_bin_summary.tsv"],
         );
-        let values = HashMap::from([(
-            "config.out_dir".to_string(),
-            "results".to_string(),
-        )]);
+        let values = HashMap::from([("config.out_dir".to_string(), "results".to_string())]);
         let dag = WorkflowDag::from_rules_with_config(&[rule], &values).unwrap();
         assert!(dag.dependencies("concat_quast").unwrap().is_empty());
     }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -616,9 +616,14 @@ impl WorkflowDag {
 ///
 /// Input matching can reach the same producer through several paths (exact
 /// match, glob, directory prefix, template pattern, `depends_on`) — parallel
-/// edges would corrupt edge counts and metrics.
+/// edges would corrupt edge counts and metrics. A rule never depends on
+/// itself: write-back-into-input-directory patterns (e.g. a quast/multiqc
+/// summary that reads a directory and writes its report into it) make the
+/// directory-prefix inference match the rule's own output — self-edges are
+/// dropped rather than reported as cycles (live evidence: mag's
+/// `concat_quast` reads `QC/` and writes `QC/quast_bin_summary.tsv`).
 fn add_edge_dedup(graph: &mut DiGraph<DagNode, ()>, from: NodeIndex, to: NodeIndex) {
-    if graph.find_edge(from, to).is_none() {
+    if from != to && graph.find_edge(from, to).is_none() {
         graph.add_edge(from, to, ());
     }
 }
@@ -1853,6 +1858,25 @@ mod tests {
         )
         .unwrap();
         assert!(dag.dependencies("leiden").unwrap().is_empty());
+    }
+
+    #[test]
+    fn write_back_into_input_dir_does_not_create_a_self_edge() {
+        // A summary rule reads a directory and writes its report INTO it
+        // (mag's concat_quast: input `QC/`, output `QC/quast_bin_summary.tsv`).
+        // The directory-prefix inference must not make the rule depend on
+        // itself — that would surface as a bogus cycle.
+        let rule = make_rule(
+            "concat_quast",
+            vec!["{config.out_dir}/GenomeBinning/QC"],
+            vec!["{config.out_dir}/GenomeBinning/QC/quast_bin_summary.tsv"],
+        );
+        let values = HashMap::from([(
+            "config.out_dir".to_string(),
+            "results".to_string(),
+        )]);
+        let dag = WorkflowDag::from_rules_with_config(&[rule], &values).unwrap();
+        assert!(dag.dependencies("concat_quast").unwrap().is_empty());
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -1533,7 +1533,9 @@ mod tests {
     fn mamba_verify_command_uses_binary() {
         let backend = MambaBackend::new();
         let cmd = backend.verify_command("envs/qc.yaml").unwrap().unwrap();
-        assert!(cmd.contains("mamba run -n qc"));
+        // The detection chain picks mamba → micromamba → conda; assert on
+        // the backend's actual binary, not a hardcoded name.
+        assert!(cmd.contains(&format!("{} run -n qc", backend.binary)));
         assert!(cmd.contains("CONDA_PREFIX/bin"));
     }
 

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -4,7 +4,7 @@
 //! managers (conda, pixi, docker, singularity, venv) and a resolver that
 //! selects the appropriate backend for each rule.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -850,6 +850,8 @@ pub struct EnvironmentResolver {
     modules: ModulesBackend,
     system: SystemBackend,
     cache: Arc<Mutex<EnvironmentCache>>,
+    /// Per-cache-key setup mutexes (see [`Self::setup_lock`]).
+    setup_locks: std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl Default for EnvironmentResolver {
@@ -871,6 +873,7 @@ impl EnvironmentResolver {
             modules: ModulesBackend,
             system: SystemBackend,
             cache: Arc::new(Mutex::new(EnvironmentCache::new())),
+            setup_locks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -886,6 +889,7 @@ impl EnvironmentResolver {
             modules: ModulesBackend,
             system: SystemBackend,
             cache: Arc::new(Mutex::new(EnvironmentCache::with_cache_dir(cache_dir))),
+            setup_locks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -1010,6 +1014,16 @@ impl EnvironmentResolver {
             return self.modules.setup_command(&env_spec.modules.join(","));
         }
         self.system.setup_command("")
+    }
+
+    /// Per-environment setup mutex: concurrent rule instances that share an
+    /// env must not run `conda env create` simultaneously — the loser's
+    /// create transaction removes the winner's just-installed packages
+    /// (live evidence: rnaseq S1/S2 race left `-fq` right after `+fq` in
+    /// the env history and an empty env marked ready).
+    pub fn setup_lock(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.setup_locks.lock().unwrap();
+        locks.entry(key.to_string()).or_default().clone()
     }
 
     /// Post-setup usability check for the environment (conda/mamba verify
@@ -1763,6 +1777,18 @@ mod tests {
     }
 
     // --- cache file persistence test -----------------------------------------
+
+    #[test]
+    fn setup_lock_is_shared_per_key() {
+        let resolver = EnvironmentResolver::new();
+        let a = resolver.setup_lock("conda:envs/fq.yaml");
+        let b = resolver.setup_lock("conda:envs/fq.yaml");
+        let other = resolver.setup_lock("conda:envs/star.yaml");
+        // Same key → same mutex (concurrent rule instances serialize their
+        // env setup); different keys → independent mutexes.
+        assert!(Arc::ptr_eq(&a, &b));
+        assert!(!Arc::ptr_eq(&a, &other));
+    }
 
     #[test]
     fn environment_cache_dir_initialization() {

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -200,6 +200,18 @@ impl CondaBackend {
     }
 }
 
+/// Container-internal shell shim: re-exec the user script under `bash -c`
+/// when the image provides bash, otherwise run it with the container `sh`
+/// (the previous behaviour).
+///
+/// The container default `sh` is often dash/busybox, while nf-core-derived
+/// images ship bash and their scripts rely on bash features (`set -o
+/// pipefail`, `[[ ]]`); eager 2.5.3 (`set: Illegal option -o pipefail`) and
+/// the nanoseq qcat `[[ ]]` failures were both this mismatch. The script is
+/// passed as `$1` so it is never re-escaped into the shim text.
+const CONTAINER_BASH_SHIM: &str = "if command -v bash >/dev/null 2>&1; \
+then exec bash -c \"$1\"; else exec sh -c \"$1\"; fi";
+
 /// Escape a string for safe embedding inside a `sh -c '...'` invocation.
 ///
 /// Replaces every `'` with `'\''` (close quote, escaped literal quote, reopen quote)
@@ -421,7 +433,7 @@ impl EnvironmentBackend for DockerBackend {
         }
 
         Ok(format!(
-            "docker run --rm --user $(id -u):$(id -g){mem_arg} -v {workdir}:{workdir} -w {workdir} {spec} sh -c '{escaped_cmd}'"
+            "docker run --rm --user $(id -u):$(id -g){mem_arg} -v {workdir}:{workdir} -w {workdir} {spec} sh -c '{CONTAINER_BASH_SHIM}' sh '{escaped_cmd}'"
         ))
     }
 
@@ -499,7 +511,7 @@ impl EnvironmentBackend for SingularityBackend {
         let escaped_cmd = escape_for_sh_single_quote(command);
 
         Ok(format!(
-            "{} exec --bind {workdir}:{workdir} {spec} sh -c '{escaped_cmd}'",
+            "{} exec --bind {workdir}:{workdir} {spec} sh -c '{CONTAINER_BASH_SHIM}' sh '{escaped_cmd}'",
             self.binary
         ))
     }
@@ -1186,6 +1198,46 @@ mod tests {
             .wrap_command("echo hi", "ubuntu:24.04", None, &abs)
             .unwrap();
         assert!(docker.contains(&format!("-v {}:{}", abs.display(), abs.display())));
+    }
+
+    // ── Container bash re-exec shim ─────────────────────────────────
+
+    #[test]
+    fn container_wrappers_reexec_under_bash_when_available() {
+        // nf-core-derived containers ship bash; their scripts need it
+        // (`set -o pipefail` is rejected by dash/busybox `sh`).
+        let workdir = std::path::Path::new("/tmp/oxo-shim-test");
+        let docker = DockerBackend
+            .wrap_command("echo hi", "ubuntu:24.04", None, workdir)
+            .unwrap();
+        assert!(
+            docker.contains("sh -c 'if command -v bash >/dev/null 2>&1; then exec bash -c \"$1\"; else exec sh -c \"$1\"; fi' sh 'echo hi'"),
+            "{docker}"
+        );
+        let sing = SingularityBackend::new()
+            .wrap_command("echo hi", "ubuntu:24.04", None, workdir)
+            .unwrap();
+        assert!(
+            sing.contains("sh -c 'if command -v bash >/dev/null 2>&1; then exec bash -c \"$1\"; else exec sh -c \"$1\"; fi' sh 'echo hi'"),
+            "{sing}"
+        );
+    }
+
+    #[test]
+    fn container_shim_keeps_user_script_out_of_shim_text() {
+        // The user script travels as the `$1` argument (single-quote-escaped
+        // for the host shell) — it is never interpolated into the shim, so
+        // scripts containing quotes or shim-like tokens survive intact.
+        let script = "echo 'a b'; grep \" sh -c '\" x";
+        let docker = DockerBackend
+            .wrap_command(script, "ubuntu:24.04", None, std::path::Path::new("/tmp/x"))
+            .unwrap();
+        let shim_marker = format!("sh -c '{CONTAINER_BASH_SHIM}' sh '");
+        assert!(docker.contains(&shim_marker), "{docker}");
+        // everything after the shim marker is the escaped script…
+        let rest = docker.split(&shim_marker).nth(1).unwrap();
+        assert!(rest.contains("grep"), "{docker}");
+        assert!(rest.contains("sh -c"), "{docker}"); // script content preserved verbatim
     }
 
     // ── SystemBackend ──────────────────────────────────────────────

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -42,6 +42,16 @@ pub trait EnvironmentBackend: Send + Sync {
     /// or `None` if no cleanup is needed.
     fn teardown_command(&self, spec: &str) -> Result<Option<String>>;
 
+    /// Return a shell command that verifies the environment is actually
+    /// usable after setup, or `None` when setup success is sufficient proof.
+    ///
+    /// Needed because conda/mamba's create/update can exit 0 while leaving
+    /// a broken env behind (interrupted transactions on loaded machines;
+    /// prefixes that exist but are not complete environments — live evidence:
+    /// tx-ubuntu, where `conda env update --prune` left an env with no
+    /// `bin/` and the engine marked it ready on exit code alone).
+    fn verify_command(&self, spec: &str) -> Result<Option<String>>;
+
     /// Return a cache key that uniquely identifies this environment
     /// configuration so it can be reused across rules.
     fn cache_key(&self, spec: &str) -> String;
@@ -118,6 +128,16 @@ impl EnvironmentBackend for CondaBackend {
     fn teardown_command(&self, spec: &str) -> Result<Option<String>> {
         let env_name = conda_env_name_from_spec(spec);
         Ok(Some(format!("conda env remove -n {env_name} -y")))
+    }
+
+    fn verify_command(&self, spec: &str) -> Result<Option<String>> {
+        // `conda run` succeeds even when the env's own bin/ is missing
+        // (tools then resolve from the system PATH), so the check must
+        // target the env prefix itself — CONDA_PREFIX is set by `conda run`.
+        let env_name = conda_env_name_from_spec(spec);
+        Ok(Some(format!(
+            "conda run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\"'"
+        )))
     }
 
     fn cache_key(&self, spec: &str) -> String {
@@ -351,6 +371,14 @@ impl EnvironmentBackend for MambaBackend {
         Ok(Some(format!("{} env remove -n {env_name} -y", self.binary)))
     }
 
+    fn verify_command(&self, spec: &str) -> Result<Option<String>> {
+        let env_name = conda_env_name_from_spec(spec);
+        Ok(Some(format!(
+            "{} run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+            self.binary
+        )))
+    }
+
     fn cache_key(&self, spec: &str) -> String {
         format!("mamba:{}:{spec}", self.binary)
     }
@@ -402,6 +430,10 @@ impl EnvironmentBackend for DockerBackend {
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
         Ok(None)
     }
 
@@ -480,6 +512,10 @@ impl EnvironmentBackend for SingularityBackend {
         Ok(None)
     }
 
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     fn cache_key(&self, spec: &str) -> String {
         format!("singularity:{spec}")
     }
@@ -526,6 +562,10 @@ impl EnvironmentBackend for VenvBackend {
             });
         }
         Ok(Some(format!("rm -rf {spec}")))
+    }
+
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
     }
 
     fn cache_key(&self, spec: &str) -> String {
@@ -589,6 +629,10 @@ impl EnvironmentBackend for PixiBackend {
         Ok(None)
     }
 
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     fn cache_key(&self, spec: &str) -> String {
         format!("pixi:{spec}")
     }
@@ -623,6 +667,10 @@ impl EnvironmentBackend for SystemBackend {
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
         Ok(None)
     }
 
@@ -682,6 +730,10 @@ fi
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn verify_command(&self, _spec: &str) -> Result<Option<String>> {
         Ok(None)
     }
 
@@ -958,6 +1010,34 @@ impl EnvironmentResolver {
             return self.modules.setup_command(&env_spec.modules.join(","));
         }
         self.system.setup_command("")
+    }
+
+    /// Post-setup usability check for the environment (conda/mamba verify
+    /// the env's `bin/` exists; other backends return `None`).
+    pub fn verify_command(&self, env_spec: &EnvironmentSpec) -> Result<Option<String>> {
+        if let Some(ref mamba) = env_spec.mamba {
+            return self.mamba.verify_command(mamba);
+        }
+        if let Some(ref conda) = env_spec.conda {
+            return self.conda.verify_command(conda);
+        }
+        Ok(None)
+    }
+
+    /// Get the teardown command for an environment specification
+    /// (removes the env so a broken one can be recreated cleanly).
+    pub fn teardown_command(&self, env_spec: &EnvironmentSpec) -> Result<Option<String>> {
+        if let Some(ref mamba) = env_spec.mamba {
+            return self
+                .mamba
+                .teardown_command_with_opts(mamba, env_spec.mamba_prefix.as_deref());
+        }
+        if let Some(ref conda) = env_spec.conda {
+            return self
+                .conda
+                .teardown_command_with_opts(conda, env_spec.conda_prefix.as_deref());
+        }
+        Ok(None)
     }
 
     /// Check which environment backends are available on the system.
@@ -1435,6 +1515,32 @@ mod tests {
         let backend = MambaBackend::new();
         let result = backend.teardown_command("envs/qc.yaml").unwrap();
         assert!(result.unwrap().contains("env remove"));
+    }
+
+    #[test]
+    fn conda_verify_command_checks_env_bin_directory() {
+        let backend = CondaBackend;
+        let cmd = backend.verify_command("envs/qc.yaml").unwrap().unwrap();
+        assert!(cmd.contains("conda run -n qc"));
+        // The check must target the env's own prefix (CONDA_PREFIX), not a
+        // tool lookup — a broken env with no bin/ still lets `true` resolve
+        // from the system PATH.
+        assert!(cmd.contains("test -d"));
+        assert!(cmd.contains("CONDA_PREFIX/bin"));
+    }
+
+    #[test]
+    fn mamba_verify_command_uses_binary() {
+        let backend = MambaBackend::new();
+        let cmd = backend.verify_command("envs/qc.yaml").unwrap().unwrap();
+        assert!(cmd.contains("mamba run -n qc"));
+        assert!(cmd.contains("CONDA_PREFIX/bin"));
+    }
+
+    #[test]
+    fn docker_verify_command_is_none() {
+        let backend = DockerBackend;
+        assert!(backend.verify_command("image:tag").unwrap().is_none());
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/env_create_lock.rs
+++ b/crates/oxo-flow-core/src/executor/env_create_lock.rs
@@ -78,23 +78,24 @@ mod tests {
 
     #[test]
     fn lock_is_exclusive_across_handles() {
-        let dir = home_dir().expect("HOME must be set in tests");
-        let lock_path = dir.join(".oxo-flow/env-create.lock");
-        let first = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)
-            .unwrap();
+        // A temp dir, not the real ~/.oxo-flow: the test must not depend on
+        // (or touch) the developer's home state, and a fresh CI runner has
+        // no ~/.oxo-flow yet (live evidence: CI failure, NotFound on open).
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("env-create.lock");
+        let open = || {
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .unwrap()
+        };
+        let first = open();
         first.lock_exclusive().unwrap();
 
         // A second handle cannot take the lock while the first holds it.
-        let second = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)
-            .unwrap();
+        let second = open();
         assert!(second.try_lock_exclusive().is_err());
 
         drop(first);

--- a/crates/oxo-flow-core/src/executor/env_create_lock.rs
+++ b/crates/oxo-flow-core/src/executor/env_create_lock.rs
@@ -1,0 +1,104 @@
+//! Cross-process serialization of environment creation.
+//!
+//! Two `oxo-flow run` processes on the same machine used to create conda
+//! envs concurrently: conda's package-cache/post-link contention plus the
+//! stacked memory peaks OOM-killed small boxes (live evidence: the
+//! tx-ubuntu campaign overload episodes, load 56-79). This advisory flock
+//! serializes the whole create+verify sequence across processes; the OS
+//! releases it automatically when the holder exits, so there are no stale
+//! locks to clean up.
+
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+/// An exclusive machine-wide lock for environment creation, held across the
+/// whole setup+verify sequence. Blocking by design: a concurrent run's env
+/// create waits for this one to finish instead of racing it.
+#[derive(Debug)]
+pub struct EnvCreateLock {
+    file: File,
+    path: PathBuf,
+}
+
+/// Best-effort home directory (no external dependency for one path).
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
+}
+
+impl EnvCreateLock {
+    /// Acquire the blocking exclusive lock, creating `~/.oxo-flow` if needed.
+    ///
+    /// Best-effort: on filesystem errors returns `None` and env setup
+    /// proceeds unlocked rather than failing the run.
+    #[must_use]
+    pub fn acquire() -> Option<Self> {
+        let dir = home_dir()?.join(".oxo-flow");
+        std::fs::create_dir_all(&dir).ok()?;
+        let path = dir.join("env-create.lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .ok()?;
+        match file.lock_exclusive() {
+            Ok(()) => Some(Self { file, path }),
+            Err(_) => None,
+        }
+    }
+
+    /// Path of the lock file (for diagnostics).
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for EnvCreateLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_is_exclusive_across_handles() {
+        let dir = home_dir().expect("HOME must be set in tests");
+        let lock_path = dir.join(".oxo-flow/env-create.lock");
+        let first = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        first.lock_exclusive().unwrap();
+
+        // A second handle cannot take the lock while the first holds it.
+        let second = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        assert!(second.try_lock_exclusive().is_err());
+
+        drop(first);
+        // After release the lock is acquirable again.
+        assert!(second.try_lock_exclusive().is_ok());
+    }
+}

--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 use sysinfo::System;
 
 pub mod checkpoint;
-pub mod process;
 pub mod env_create_lock;
+pub mod process;
 pub mod rss;
 pub mod security;
 pub mod staging;

--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -9,6 +9,7 @@ use sysinfo::System;
 
 pub mod checkpoint;
 pub mod process;
+pub mod env_create_lock;
 pub mod rss;
 pub mod security;
 pub mod staging;

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -533,6 +533,21 @@ impl LocalExecutor {
             return Ok(());
         }
         let setup_cmd = self.env_resolver.setup_command(env_spec)?;
+        // Some packages' post-link scripts download data during
+        // `conda env create` (bioconductor-genomeinfodbdata fetches its
+        // annotation tarballs) — before the new env's own ca-certificates
+        // bundle is linked, so their curls die with SSL 77 (live evidence:
+        // clindet + enrichment region_enrichment_analysis envs). Export
+        // the base conda CA bundle for the setup command when available.
+        let kind = env_spec.kind();
+        let setup_cmd = if kind == "conda" || kind == "mamba" {
+            format!(
+                "CB=\"$(dirname \"$(dirname \"$(command -v conda)\")\")/ssl/cacert.pem\"; \
+                 [ -f \"$CB\" ] && export SSL_CERT_FILE=\"$CB\"; {setup_cmd}"
+            )
+        } else {
+            setup_cmd
+        };
         let output = Command::new("sh")
             .arg("-c")
             .arg(&setup_cmd)

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -378,16 +378,15 @@ pub(crate) fn detect_swap_mb() -> u64 {
     }
     if let Ok(content) = std::fs::read_to_string("/proc/meminfo") {
         for line in content.lines() {
-            if line.starts_with("SwapTotal:") {
-                if let Some(kb_str) = line
+            if line.starts_with("SwapTotal:")
+                && let Some(kb_str) = line
                     .split_whitespace()
                     .nth(1)
                     .and_then(|s| s.parse::<u64>().ok())
-                {
-                    let mb = kb_str / 1024;
-                    if mb > 0 {
-                        return mb;
-                    }
+            {
+                let mb = kb_str / 1024;
+                if mb > 0 {
+                    return mb;
                 }
             }
         }
@@ -564,11 +563,11 @@ impl LocalExecutor {
         // `conda env update --prune` re-resolves every dependency — live:
         // tcasia's majiq==2.5 pip resolution failed on a flaky mirror even
         // though the env was fully installed.
-        if let Ok(Some(verify)) = self.env_resolver.verify_command(env_spec) {
-            if self.env_verify(&verify).await {
-                self.env_resolver.cache_mark_ready(&key).await;
-                return Ok(());
-            }
+        if let Ok(Some(verify)) = self.env_resolver.verify_command(env_spec)
+            && self.env_verify(&verify).await
+        {
+            self.env_resolver.cache_mark_ready(&key).await;
+            return Ok(());
         }
         // Serialize setup per environment: concurrent rule instances sharing
         // an env (e.g. S1 + S2 instances of the same rule) used to run two
@@ -604,14 +603,15 @@ impl LocalExecutor {
         // contention + stacked memory peaks — live evidence: tx-ubuntu
         // overload episodes). The blocking flock waits for the other run's
         // create+verify sequence; held until this function returns.
-        let cross_process_guard = tokio::task::spawn_blocking(
-            super::env_create_lock::EnvCreateLock::acquire,
-        )
-        .await
-        .ok()
-        .flatten();
+        let cross_process_guard =
+            tokio::task::spawn_blocking(super::env_create_lock::EnvCreateLock::acquire)
+                .await
+                .ok()
+                .flatten();
         if cross_process_guard.is_none() {
-            tracing::warn!("env-create cross-process lock unavailable — env setup proceeds unlocked");
+            tracing::warn!(
+                "env-create cross-process lock unavailable — env setup proceeds unlocked"
+            );
         }
         let output = Command::new("sh")
             .arg("-c")
@@ -1031,14 +1031,20 @@ impl LocalExecutor {
                 wildcard_values,
                 &self.config.interpreter_map,
                 &self.config.workdir,
-                crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
+                crate::scheduler::ResourceLimits {
+                    threads: self.system_threads,
+                    memory_mb: self.system_memory_mb,
+                },
             )
         } else {
             build_execution_command(
                 &rule,
                 wildcard_values,
                 &self.config.interpreter_map,
-                crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
+                crate::scheduler::ResourceLimits {
+                    threads: self.system_threads,
+                    memory_mb: self.system_memory_mb,
+                },
             )
         };
         let base_cmd = match base_cmd {
@@ -1177,10 +1183,21 @@ impl LocalExecutor {
                     &rule,
                     wildcard_values,
                     &self.config.workdir,
-                    crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
+                    crate::scheduler::ResourceLimits {
+                        threads: self.system_threads,
+                        memory_mb: self.system_memory_mb,
+                    },
                 )
             } else {
-                render_shell_command(pre_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb })
+                render_shell_command(
+                    pre_cmd,
+                    &rule,
+                    wildcard_values,
+                    crate::scheduler::ResourceLimits {
+                        threads: self.system_threads,
+                        memory_mb: self.system_memory_mb,
+                    },
+                )
             };
             if let Err(e) = validate_shell_safety(&rendered) {
                 // Nothing ran yet — drop the empty scratch dir rather than
@@ -1379,7 +1396,15 @@ impl LocalExecutor {
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
-                        &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
+                        &render_shell_command(
+                            hook_cmd,
+                            &rule,
+                            wildcard_values,
+                            crate::scheduler::ResourceLimits {
+                                threads: self.system_threads,
+                                memory_mb: self.system_memory_mb,
+                            },
+                        ),
                         &rule,
                         &self.config.workdir,
                     )
@@ -1407,7 +1432,15 @@ impl LocalExecutor {
                         );
                         if let Some(ref hook_cmd) = rule.on_failure {
                             run_hook(
-                                &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
+                                &render_shell_command(
+                                    hook_cmd,
+                                    &rule,
+                                    wildcard_values,
+                                    crate::scheduler::ResourceLimits {
+                                        threads: self.system_threads,
+                                        memory_mb: self.system_memory_mb,
+                                    },
+                                ),
                                 &rule,
                                 &self.config.workdir,
                             )
@@ -1417,7 +1450,15 @@ impl LocalExecutor {
                     } else {
                         if let Some(ref hook_cmd) = rule.on_success {
                             run_hook(
-                                &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
+                                &render_shell_command(
+                                    hook_cmd,
+                                    &rule,
+                                    wildcard_values,
+                                    crate::scheduler::ResourceLimits {
+                                        threads: self.system_threads,
+                                        memory_mb: self.system_memory_mb,
+                                    },
+                                ),
                                 &rule,
                                 &self.config.workdir,
                             )
@@ -1460,7 +1501,15 @@ impl LocalExecutor {
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
-                        &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
+                        &render_shell_command(
+                            hook_cmd,
+                            &rule,
+                            wildcard_values,
+                            crate::scheduler::ResourceLimits {
+                                threads: self.system_threads,
+                                memory_mb: self.system_memory_mb,
+                            },
+                        ),
                         &rule,
                         &self.config.workdir,
                     )
@@ -1475,7 +1524,15 @@ impl LocalExecutor {
             cleanup_temp_outputs(&rule, &self.config.workdir).await;
             if let Some(ref hook_cmd) = rule.on_failure {
                 run_hook(
-                    &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
+                    &render_shell_command(
+                        hook_cmd,
+                        &rule,
+                        wildcard_values,
+                        crate::scheduler::ResourceLimits {
+                            threads: self.system_threads,
+                            memory_mb: self.system_memory_mb,
+                        },
+                    ),
                     &rule,
                     &self.config.workdir,
                 )
@@ -1605,7 +1662,13 @@ pub(crate) fn build_execution_command_in_scratch(
     workdir: &Path,
     limits: crate::scheduler::ResourceLimits,
 ) -> Option<String> {
-    build_execution_command_inner(rule, wildcard_values, interpreter_map, Some(workdir), limits)
+    build_execution_command_inner(
+        rule,
+        wildcard_values,
+        interpreter_map,
+        Some(workdir),
+        limits,
+    )
 }
 
 fn build_execution_command_inner(

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -519,6 +519,19 @@ impl LocalExecutor {
         if self.env_resolver.cache_is_ready(&key).await {
             return Ok(());
         }
+        // Serialize setup per environment: concurrent rule instances sharing
+        // an env (e.g. S1 + S2 instances of the same rule) used to run two
+        // `conda env create` in parallel — the loser's transaction removes
+        // the winner's just-installed packages (live evidence: rnaseq's
+        // env history shows `+fq` followed by `-fq` 12s later, leaving an
+        // empty env that the cache then marked ready).
+        let setup_lock = self.env_resolver.setup_lock(&key);
+        let _setup_guard = setup_lock.lock().await;
+        // Double-check: another task may have completed the setup while we
+        // waited for the lock.
+        if self.env_resolver.cache_is_ready(&key).await {
+            return Ok(());
+        }
         let setup_cmd = self.env_resolver.setup_command(env_spec)?;
         let output = Command::new("sh")
             .arg("-c")

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -548,6 +548,20 @@ impl LocalExecutor {
         } else {
             setup_cmd
         };
+        // Cross-process serialization: another oxo-flow run on this machine
+        // may be creating a different env right now (conda cache/post-link
+        // contention + stacked memory peaks — live evidence: tx-ubuntu
+        // overload episodes). The blocking flock waits for the other run's
+        // create+verify sequence; held until this function returns.
+        let cross_process_guard = tokio::task::spawn_blocking(
+            super::env_create_lock::EnvCreateLock::acquire,
+        )
+        .await
+        .ok()
+        .flatten();
+        if cross_process_guard.is_none() {
+            tracing::warn!("env-create cross-process lock unavailable — env setup proceeds unlocked");
+        }
         let output = Command::new("sh")
             .arg("-c")
             .arg(&setup_cmd)

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -798,15 +798,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| OxoFlowError::Execution {
-                        rule: rule.name.clone(),
-                        message: format!(
-                            "failed to create output directory {}: {e}",
-                            parent.display()
-                        ),
-                    })?;
+                create_rule_dir(&parent, rule, "output")?;
             }
             move_path(&src, &dest)
                 .await
@@ -1031,15 +1023,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| OxoFlowError::Execution {
-                        rule: rule.name.clone(),
-                        message: format!(
-                            "failed to create output directory {}: {e}",
-                            parent.display()
-                        ),
-                    })?;
+                create_rule_dir(&parent, &rule, "output")?;
             }
         }
 
@@ -1053,15 +1037,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| OxoFlowError::Execution {
-                        rule: rule.name.clone(),
-                        message: format!(
-                            "failed to create log directory {}: {e}",
-                            parent.display()
-                        ),
-                    })?;
+                create_rule_dir(&parent, &rule, "log")?;
             }
         }
 
@@ -1081,15 +1057,7 @@ impl LocalExecutor {
         // Create the scratch working directory now that execution is
         // certain; its name was already decided for env wrapping above.
         if let Some(scratch) = &scratch_dir {
-            tokio::fs::create_dir_all(scratch)
-                .await
-                .map_err(|e| OxoFlowError::Execution {
-                    rule: rule.name.clone(),
-                    message: format!(
-                        "failed to create scratch directory {}: {e}",
-                        scratch.display()
-                    ),
-                })?;
+            create_rule_dir(scratch, &rule, "scratch")?;
         }
         // The rule's shell cwd: scratch for scratch rules, main workdir
         // otherwise (docker/singularity run with `-w`/inherited cwd in the
@@ -1646,6 +1614,19 @@ fn warn_shell_fallback_once() {
     }
 }
 
+/// Create a rule's output/log/scratch parent directory synchronously.
+///
+/// Directory creation is a handful of fast syscalls; routing it through
+/// tokio's blocking pool meant failures surfaced as the opaque
+/// "background task failed" (observed repeatedly in live runs), hiding
+/// the real error (ENOSPC, EACCES, …) from operators.
+fn create_rule_dir(path: &Path, rule: &Rule, what: &str) -> Result<()> {
+    std::fs::create_dir_all(path).map_err(|e| OxoFlowError::Execution {
+        rule: rule.name.clone(),
+        message: format!("failed to create {what} directory {}: {e}", path.display()),
+    })
+}
+
 /// Directory-name-safe rule names: alphanumerics plus `. _ -` survive,
 /// everything else becomes `_` (rule names admit `:` per `Rule::validate`,
 /// which is not a safe directory character everywhere).
@@ -1668,10 +1649,11 @@ fn sanitize_dir_component(name: &str) -> String {
 /// The container backends wrap commands as plain shell strings that
 /// bind-mount only the executor workdir (environment.rs). Scratch rules
 /// need an additional scratch bind and — for docker — the `-w` working
-/// directory switched to the scratch dir. Only the prefix before ` sh -c '`
-/// is touched, so a user command that coincidentally contains the same
-/// tokens is never rewritten. Non-container wrappers pass through
-/// unchanged.
+/// directory switched to the scratch dir. Only the prefix before the
+/// first ` sh -c '` is touched (with the bash re-exec shim that is the
+/// shim's own `sh -c`, which still precedes all mounts), so a user command
+/// that coincidentally contains the same tokens is never rewritten.
+/// Non-container wrappers pass through unchanged.
 pub(super) fn fixup_container_wrapper(
     wrapped: &str,
     kind: &str,

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -326,7 +326,7 @@ pub struct LocalExecutor {
 /// Detect total system memory in MB using the most reliable method available
 /// on the current platform. On Linux, falls back to parsing `/proc/meminfo`
 /// if the sysinfo crate returns unexpected results.
-fn detect_total_memory_mb() -> u64 {
+pub(crate) fn detect_total_memory_mb() -> u64 {
     // Primary: sysinfo crate (cross-platform)
     if let Ok(mb) = std::panic::catch_unwind(|| {
         use sysinfo::System;
@@ -813,7 +813,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                create_rule_dir(&parent, rule, "output")?;
+                create_rule_dir(parent, rule, "output")?;
             }
             move_path(&src, &dest)
                 .await
@@ -951,9 +951,15 @@ impl LocalExecutor {
                 wildcard_values,
                 &self.config.interpreter_map,
                 &self.config.workdir,
+                crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
             )
         } else {
-            build_execution_command(&rule, wildcard_values, &self.config.interpreter_map)
+            build_execution_command(
+                &rule,
+                wildcard_values,
+                &self.config.interpreter_map,
+                crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
+            )
         };
         let base_cmd = match base_cmd {
             Some(cmd) => cmd,
@@ -1038,7 +1044,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                create_rule_dir(&parent, &rule, "output")?;
+                create_rule_dir(parent, &rule, "output")?;
             }
         }
 
@@ -1052,7 +1058,7 @@ impl LocalExecutor {
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                create_rule_dir(&parent, &rule, "log")?;
+                create_rule_dir(parent, &rule, "log")?;
             }
         }
 
@@ -1091,9 +1097,10 @@ impl LocalExecutor {
                     &rule,
                     wildcard_values,
                     &self.config.workdir,
+                    crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb },
                 )
             } else {
-                render_shell_command(pre_cmd, &rule, wildcard_values)
+                render_shell_command(pre_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb })
             };
             if let Err(e) = validate_shell_safety(&rendered) {
                 // Nothing ran yet — drop the empty scratch dir rather than
@@ -1292,7 +1299,7 @@ impl LocalExecutor {
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
-                        &render_shell_command(hook_cmd, &rule, wildcard_values),
+                        &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
                         &rule,
                         &self.config.workdir,
                     )
@@ -1320,7 +1327,7 @@ impl LocalExecutor {
                         );
                         if let Some(ref hook_cmd) = rule.on_failure {
                             run_hook(
-                                &render_shell_command(hook_cmd, &rule, wildcard_values),
+                                &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
                                 &rule,
                                 &self.config.workdir,
                             )
@@ -1330,7 +1337,7 @@ impl LocalExecutor {
                     } else {
                         if let Some(ref hook_cmd) = rule.on_success {
                             run_hook(
-                                &render_shell_command(hook_cmd, &rule, wildcard_values),
+                                &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
                                 &rule,
                                 &self.config.workdir,
                             )
@@ -1373,7 +1380,7 @@ impl LocalExecutor {
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
-                        &render_shell_command(hook_cmd, &rule, wildcard_values),
+                        &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
                         &rule,
                         &self.config.workdir,
                     )
@@ -1388,7 +1395,7 @@ impl LocalExecutor {
             cleanup_temp_outputs(&rule, &self.config.workdir).await;
             if let Some(ref hook_cmd) = rule.on_failure {
                 run_hook(
-                    &render_shell_command(hook_cmd, &rule, wildcard_values),
+                    &render_shell_command(hook_cmd, &rule, wildcard_values, crate::scheduler::ResourceLimits { threads: self.system_threads, memory_mb: self.system_memory_mb }),
                     &rule,
                     &self.config.workdir,
                 )
@@ -1503,8 +1510,9 @@ pub fn build_execution_command(
     rule: &Rule,
     wildcard_values: &HashMap<String, String>,
     interpreter_map: &HashMap<String, String>,
+    limits: crate::scheduler::ResourceLimits,
 ) -> Option<String> {
-    build_execution_command_inner(rule, wildcard_values, interpreter_map, None)
+    build_execution_command_inner(rule, wildcard_values, interpreter_map, None, limits)
 }
 
 /// Scratch-mode variant: input and script paths render absolute (they live
@@ -1515,8 +1523,9 @@ pub(crate) fn build_execution_command_in_scratch(
     wildcard_values: &HashMap<String, String>,
     interpreter_map: &HashMap<String, String>,
     workdir: &Path,
+    limits: crate::scheduler::ResourceLimits,
 ) -> Option<String> {
-    build_execution_command_inner(rule, wildcard_values, interpreter_map, Some(workdir))
+    build_execution_command_inner(rule, wildcard_values, interpreter_map, Some(workdir), limits)
 }
 
 fn build_execution_command_inner(
@@ -1524,15 +1533,16 @@ fn build_execution_command_inner(
     wildcard_values: &HashMap<String, String>,
     interpreter_map: &HashMap<String, String>,
     abs_root: Option<&Path>,
+    limits: crate::scheduler::ResourceLimits,
 ) -> Option<String> {
     let shell_cmd = rule
         .shell
         .as_ref()
-        .map(|cmd| render_shell_command_inner(cmd, rule, wildcard_values, abs_root));
+        .map(|cmd| render_shell_command_inner(cmd, rule, wildcard_values, abs_root, limits));
 
     let script_cmd = rule.script.as_ref().map(|script_path| {
         let expanded_script =
-            render_shell_command_inner(script_path, rule, wildcard_values, abs_root);
+            render_shell_command_inner(script_path, rule, wildcard_values, abs_root, limits);
         let base_script = expanded_script
             .split_whitespace()
             .next()
@@ -1558,7 +1568,7 @@ fn build_execution_command_inner(
     // Auto-create output directories to eliminate mkdir -p boilerplate in shells
     let mut dirs_to_create: Vec<String> = Vec::new();
     for output in &rule.output {
-        let expanded = render_shell_command_inner(output, rule, wildcard_values, abs_root);
+        let expanded = render_shell_command_inner(output, rule, wildcard_values, abs_root, limits);
         // Only create dirs for paths with directory separators, skip wildcards
         if expanded.contains('/')
             && !expanded.contains('{')
@@ -1827,8 +1837,9 @@ pub fn render_shell_command(
     cmd: &str,
     rule: &Rule,
     wildcard_values: &HashMap<String, String>,
+    limits: crate::scheduler::ResourceLimits,
 ) -> String {
-    render_shell_command_inner(cmd, rule, wildcard_values, None)
+    render_shell_command_inner(cmd, rule, wildcard_values, None, limits)
 }
 
 /// Scratch-mode rendering: `{input}` and `{log}` render as absolute paths
@@ -1840,8 +1851,9 @@ pub(crate) fn render_shell_command_in_scratch(
     rule: &Rule,
     wildcard_values: &HashMap<String, String>,
     workdir: &Path,
+    limits: crate::scheduler::ResourceLimits,
 ) -> String {
-    render_shell_command_inner(cmd, rule, wildcard_values, Some(workdir))
+    render_shell_command_inner(cmd, rule, wildcard_values, Some(workdir), limits)
 }
 
 fn render_shell_command_inner(
@@ -1849,6 +1861,7 @@ fn render_shell_command_inner(
     rule: &Rule,
     wildcard_values: &HashMap<String, String>,
     abs_root: Option<&Path>,
+    limits: crate::scheduler::ResourceLimits,
 ) -> String {
     let mut expanded = cmd.to_string();
     // `{log}` resolves to the rule's log path with the same wildcard and
@@ -1860,7 +1873,7 @@ fn render_shell_command_inner(
         let expanded_log = if cmd == log_path || log_path.contains("{log}") {
             log_path.clone()
         } else {
-            render_shell_command_inner(log_path, rule, wildcard_values, abs_root)
+            render_shell_command_inner(log_path, rule, wildcard_values, abs_root, limits)
         };
         let rendered_log = absolute_path(abs_root, &expanded_log);
         expanded = expanded.replace("{log}", &rendered_log);
@@ -1907,6 +1920,12 @@ fn render_shell_command_inner(
     if let Some(mem) = rule.effective_memory() {
         expanded = expanded.replace("{memory}", mem);
     }
+    // Tool-facing effective resources: the declared request clamped to the
+    // machine, so tools can size their own flags (e.g. -Xmx{effective_memory_mb}m)
+    // instead of hardcoding HPC-scale values that OOM small boxes.
+    let (eff_threads, eff_mem_mb) = crate::scheduler::effective_tool_resources(rule, limits);
+    expanded = expanded.replace("{effective_threads}", &eff_threads.to_string());
+    expanded = expanded.replace("{effective_memory_mb}", &eff_mem_mb.to_string());
     for (key, value) in &rule.params {
         let string_val = match value {
             toml::Value::String(s) => s.clone(),

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -519,6 +519,18 @@ impl LocalExecutor {
         if self.env_resolver.cache_is_ready(&key).await {
             return Ok(());
         }
+        // Cold cache but the env may already exist (checkpoint wipe, a
+        // previous run, an external `conda create`): verify it in place
+        // instead of re-running the setup. The setup's fallback
+        // `conda env update --prune` re-resolves every dependency — live:
+        // tcasia's majiq==2.5 pip resolution failed on a flaky mirror even
+        // though the env was fully installed.
+        if let Ok(Some(verify)) = self.env_resolver.verify_command(env_spec) {
+            if self.env_verify(&verify).await {
+                self.env_resolver.cache_mark_ready(&key).await;
+                return Ok(());
+            }
+        }
         // Serialize setup per environment: concurrent rule instances sharing
         // an env (e.g. S1 + S2 instances of the same rule) used to run two
         // `conda env create` in parallel — the loser's transaction removes

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -2375,20 +2375,29 @@ pub fn hostname() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rule::{EnvironmentSpec, Resources};
 
     fn executor_with(max_threads: u32, max_memory_mb: u64) -> LocalExecutor {
-        let mut cfg = ExecutorConfig::default();
-        cfg.max_threads = Some(max_threads);
-        cfg.max_memory_mb = Some(max_memory_mb);
-        LocalExecutor::new(cfg)
+        LocalExecutor::new(ExecutorConfig {
+            max_threads: Some(max_threads),
+            max_memory_mb: Some(max_memory_mb),
+            ..Default::default()
+        })
     }
 
     fn docker_rule(memory: &str) -> Rule {
-        let mut rule = Rule::default();
-        rule.name = "bigmem".to_string();
-        rule.resources.memory = Some(memory.to_string());
-        rule.environment.docker = Some("img:latest".to_string());
-        rule
+        Rule {
+            name: "bigmem".to_string(),
+            resources: Resources {
+                memory: Some(memory.to_string()),
+                ..Default::default()
+            },
+            environment: EnvironmentSpec {
+                docker: Some("img:latest".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -361,6 +361,40 @@ pub(crate) fn detect_total_memory_mb() -> u64 {
     0
 }
 
+/// Detect total swap in MB (0 when absent). Swap is backable memory the
+/// kernel will use under pressure — the effective resource ceiling is
+/// RAM + swap, so tools sized by `{effective_memory_mb}` and the
+/// container `--memory` clamp use the whole backable budget on
+/// small-memory boxes (live: tx-ubuntu's 3.7G RAM + 6G swap).
+pub(crate) fn detect_swap_mb() -> u64 {
+    if let Ok(mb) = std::panic::catch_unwind(|| {
+        use sysinfo::System;
+        let mut sys = System::new();
+        sys.refresh_memory();
+        sys.total_swap() / 1024 / 1024
+    }) && mb > 0
+    {
+        return mb;
+    }
+    if let Ok(content) = std::fs::read_to_string("/proc/meminfo") {
+        for line in content.lines() {
+            if line.starts_with("SwapTotal:") {
+                if let Some(kb_str) = line
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|s| s.parse::<u64>().ok())
+                {
+                    let mb = kb_str / 1024;
+                    if mb > 0 {
+                        return mb;
+                    }
+                }
+            }
+        }
+    }
+    0
+}
+
 impl LocalExecutor {
     pub fn new(config: ExecutorConfig) -> Self {
         let semaphore = Arc::new(Semaphore::new(config.max_jobs));
@@ -399,9 +433,14 @@ impl LocalExecutor {
             num_cpus::get() as u32
         });
 
-        // Cross-platform memory detection with Linux /proc/meminfo fallback
+        // Cross-platform memory detection with Linux /proc/meminfo fallback.
+        // The ceiling is RAM + swap: swap is backable memory the kernel
+        // will use under pressure, and ignoring it leaves real capacity
+        // unused on small boxes (live: 3.7G RAM + 6G swap runs better
+        // sized to ~9.7G). Override with --max-memory when the swap
+        // should not count (e.g. latency-sensitive lanes).
         let max_memory_mb = config.max_memory_mb.unwrap_or_else(|| {
-            let detected = detect_total_memory_mb();
+            let detected = detect_total_memory_mb() + detect_swap_mb();
             if detected > 0 {
                 detected
             } else {

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -529,8 +529,58 @@ impl LocalExecutor {
 
         match output {
             Ok(o) if o.status.success() => {
-                self.env_resolver.cache_mark_ready(&key).await;
-                Ok(())
+                // Setup reported success — but conda/mamba can exit 0 while
+                // leaving a broken env behind (interrupted transactions on
+                // loaded machines; live evidence: tx-ubuntu, where
+                // `conda env update --prune` left an env with no bin/ and
+                // exit code 0). Verify usability; on failure, tear the env
+                // down and retry setup once before reporting an error.
+                match self.env_resolver.verify_command(env_spec)? {
+                    None => {
+                        self.env_resolver.cache_mark_ready(&key).await;
+                        Ok(())
+                    }
+                    Some(verify) => {
+                        let mut verified = Self::env_verify(self, &verify).await;
+                        if !verified
+                            && let Ok(Some(teardown)) = self.env_resolver.teardown_command(env_spec)
+                        {
+                            tracing::warn!(
+                                rule = %rule.name,
+                                "environment setup exited 0 but verification failed — tearing down and retrying once"
+                            );
+                            let _ = Command::new("sh")
+                                .arg("-c")
+                                .arg(&teardown)
+                                .current_dir(&self.config.workdir)
+                                .output()
+                                .await;
+                            if let Ok(retry) = Command::new("sh")
+                                .arg("-c")
+                                .arg(&setup_cmd)
+                                .current_dir(&self.config.workdir)
+                                .output()
+                                .await
+                                && retry.status.success()
+                            {
+                                verified = Self::env_verify(self, &verify).await;
+                            }
+                        }
+                        if verified {
+                            self.env_resolver.cache_mark_ready(&key).await;
+                            Ok(())
+                        } else {
+                            Err(OxoFlowError::Environment {
+                                kind: env_spec.kind().to_string(),
+                                message:
+                                    "environment setup exited 0 but verification failed — the \
+                                     environment is broken (a previous interrupted creation \
+                                     may have left a partial prefix)"
+                                        .to_string(),
+                            })
+                        }
+                    }
+                }
             }
             Ok(o) => {
                 let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
@@ -557,6 +607,17 @@ impl LocalExecutor {
                 })
             }
         }
+    }
+
+    /// Run an environment verification command (success = usable env).
+    async fn env_verify(&self, verify: &str) -> bool {
+        Command::new("sh")
+            .arg("-c")
+            .arg(verify)
+            .current_dir(&self.config.workdir)
+            .output()
+            .await
+            .is_ok_and(|o| o.status.success())
     }
 
     fn resolve_command(&self, command: &str, rule: &Rule, scratch_dir: Option<&Path>) -> String {

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -663,10 +663,25 @@ impl LocalExecutor {
     }
 
     fn resolve_command(&self, command: &str, rule: &Rule, scratch_dir: Option<&Path>) -> String {
+        // Container backends use the declared memory as their cgroup limit.
+        // Cap it at the machine total so cgroup-aware tools (cellranger,
+        // picard, STAR) see an honest limit the kernel can actually back
+        // instead of an upstream HPC label copied verbatim by a port —
+        // same policy as the pool clamp in check_resources. Live: eager's
+        // MarkDuplicates container got --memory 4096M on a 3723MB machine.
+        let mut resources = rule.resources.clone();
+        if let Some(declared) = resources
+            .memory
+            .as_deref()
+            .and_then(crate::scheduler::parse_memory_mb)
+            && declared > self.system_memory_mb
+        {
+            resources.memory = Some(format!("{}M", self.system_memory_mb));
+        }
         match self.env_resolver.wrap_command(
             command,
             &rule.environment,
-            Some(&rule.resources),
+            Some(&resources),
             &self.config.workdir,
         ) {
             Ok(wrapped) => match scratch_dir {
@@ -2241,4 +2256,40 @@ pub fn hostname() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("COMPUTERNAME"))
         .unwrap_or_else(|_| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn executor_with(max_threads: u32, max_memory_mb: u64) -> LocalExecutor {
+        let mut cfg = ExecutorConfig::default();
+        cfg.max_threads = Some(max_threads);
+        cfg.max_memory_mb = Some(max_memory_mb);
+        LocalExecutor::new(cfg)
+    }
+
+    fn docker_rule(memory: &str) -> Rule {
+        let mut rule = Rule::default();
+        rule.name = "bigmem".to_string();
+        rule.resources.memory = Some(memory.to_string());
+        rule.environment.docker = Some("img:latest".to_string());
+        rule
+    }
+
+    #[test]
+    fn resolve_command_clamps_container_memory_to_system_total() {
+        let ex = executor_with(4, 2048);
+        // 72G (an upstream HPC label) on a 2G box — the container cgroup
+        // must reflect the machine, not the declaration.
+        let cmd = ex.resolve_command("echo hi", &docker_rule("72G"), None);
+        assert!(cmd.contains("--memory 2048M"), "cmd: {cmd}");
+    }
+
+    #[test]
+    fn resolve_command_keeps_declared_memory_when_within_system_total() {
+        let ex = executor_with(4, 2048);
+        let cmd = ex.resolve_command("echo hi", &docker_rule("1G"), None);
+        assert!(cmd.contains("--memory 1G"), "cmd: {cmd}");
+    }
 }

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -25,6 +25,10 @@ fn make_rule(name: &str, shell: &str) -> Rule {
     }
 }
 
+/// Fixed machine limits for render_shell_command tests.
+const TEST_LIMITS: crate::scheduler::ResourceLimits =
+    crate::scheduler::ResourceLimits { threads: 8, memory_mb: 16384 };
+
 #[test]
 fn job_status_display() {
     assert_eq!(JobStatus::Pending.to_string(), "pending");
@@ -282,7 +286,8 @@ fn render_shell_command_named_io() {
         "bwa mem {input.reads} > {output.bam}",
         &rule,
         &HashMap::new(),
-    );
+
+    TEST_LIMITS);
     assert_eq!(result, "bwa mem data.fq > sorted.bam");
 }
 
@@ -295,7 +300,8 @@ fn render_shell_output_indexed() {
         shell: None,
         ..Default::default()
     };
-    let result = render_shell_command("cat {input[0]} > {output[0]}", &rule, &HashMap::new());
+    let result = render_shell_command("cat {input[0]} > {output[0]}", &rule, &HashMap::new(),
+TEST_LIMITS);
     assert_eq!(result, "cat in.txt > out.txt");
 }
 
@@ -308,7 +314,8 @@ fn render_shell_output_all() {
         shell: None,
         ..Default::default()
     };
-    let result = render_shell_command("cat {input} > {output}", &rule, &HashMap::new());
+    let result = render_shell_command("cat {input} > {output}", &rule, &HashMap::new(),
+TEST_LIMITS);
     assert_eq!(result, "cat a.txt b.txt > out.txt");
 }
 
@@ -327,7 +334,8 @@ fn render_shell_threads() {
         "bwa mem -t {threads} ref.fa > {output[0]}",
         &rule,
         &HashMap::new(),
-    );
+
+    TEST_LIMITS);
     assert_eq!(result, "bwa mem -t 8 ref.fa > out.bam");
 }
 
@@ -340,7 +348,8 @@ fn render_shell_config_values() {
     };
     let mut values = HashMap::new();
     values.insert("config.reference".to_string(), "/data/ref.fa".to_string());
-    let result = render_shell_command("bwa mem {config.reference} > {output[0]}", &rule, &values);
+    let result = render_shell_command("bwa mem {config.reference} > {output[0]}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "bwa mem /data/ref.fa > hello.txt");
 }
 
@@ -366,7 +375,8 @@ fn render_shell_command_nested_config() {
         "bwa mem {config.reference_fasta} > {output[0]}",
         &rule,
         &values,
-    );
+
+    TEST_LIMITS);
     assert_eq!(result, "bwa mem /data/refs/GRCh38/genome.fa > out.bam");
 }
 
@@ -382,7 +392,8 @@ fn render_shell_command_three_level_nested_config() {
     values.insert("config.a".to_string(), "{config.b}".to_string());
     values.insert("config.b".to_string(), "{config.c}".to_string());
     values.insert("config.c".to_string(), "/final".to_string());
-    let result = render_shell_command("cp {config.a} {output[0]}", &rule, &values);
+    let result = render_shell_command("cp {config.a} {output[0]}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "cp /final out.txt");
 }
 
@@ -1266,7 +1277,8 @@ fn render_shell_log_placeholder() {
         log: Some("logs/run.log".to_string()),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new());
+    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(),
+TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/run.log");
 }
 
@@ -1278,7 +1290,8 @@ fn render_shell_log_indexed() {
         log: Some("logs/run.log".to_string()),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log[0]}", &rule, &HashMap::new());
+    let result = render_shell_command("echo hi 2> {log[0]}", &rule, &HashMap::new(),
+TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/run.log");
 }
 
@@ -1293,7 +1306,8 @@ fn render_shell_log_expands_sample_and_config() {
     let mut values = HashMap::new();
     values.insert("sample".to_string(), "S1".to_string());
     values.insert("config.results_dir".to_string(), "results".to_string());
-    let result = render_shell_command("echo hi 2> {log}", &rule, &values);
+    let result = render_shell_command("echo hi 2> {log}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/S1/results/run.log");
 }
 
@@ -1304,7 +1318,8 @@ fn render_shell_log_absent_keeps_placeholder() {
         output: vec!["out.txt".to_string()].into(),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new());
+    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(),
+TEST_LIMITS);
     assert_eq!(result, "echo hi 2> {log}");
 }
 
@@ -1323,7 +1338,8 @@ fn render_shell_config_array_joins_with_space() {
         "config.files".to_string(),
         "[\"a.fa\", \"b.fa\"]".to_string(),
     );
-    let result = render_shell_command("cat {config.files} > {output[0]}", &rule, &values);
+    let result = render_shell_command("cat {config.files} > {output[0]}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "cat a.fa b.fa > out.txt");
 }
 
@@ -1336,7 +1352,8 @@ fn render_shell_config_array_non_string_elements() {
     };
     let mut values = HashMap::new();
     values.insert("config.ids".to_string(), "[1, 2]".to_string());
-    let result = render_shell_command("echo {config.ids}", &rule, &values);
+    let result = render_shell_command("echo {config.ids}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "echo 1 2");
 }
 
@@ -1352,7 +1369,8 @@ fn render_shell_config_scalar_unchanged() {
     // through untouched (only array literals join).
     values.insert("config.reference".to_string(), "/data/ref.fa".to_string());
     values.insert("config.mode".to_string(), "1".to_string());
-    let result = render_shell_command("bwa mem {config.reference} {config.mode}", &rule, &values);
+    let result = render_shell_command("bwa mem {config.reference} {config.mode}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(result, "bwa mem /data/ref.fa 1");
 }
 
@@ -1705,10 +1723,12 @@ fn scratch_render_inputs_absolute_outputs_relative() {
         &rule,
         &values,
         Path::new("/data/work"),
+        TEST_LIMITS,
     );
     assert_eq!(rendered, "bwa mem /data/work/reads/S1.fq > out/S1.sam");
     // Non-scratch rendering keeps relative input paths.
-    let plain = render_shell_command("bwa mem {input[0]} > {output[0]}", &rule, &values);
+    let plain = render_shell_command("bwa mem {input[0]} > {output[0]}", &rule, &values,
+TEST_LIMITS);
     assert_eq!(plain, "bwa mem reads/S1.fq > out/S1.sam");
 }
 

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -26,8 +26,10 @@ fn make_rule(name: &str, shell: &str) -> Rule {
 }
 
 /// Fixed machine limits for render_shell_command tests.
-const TEST_LIMITS: crate::scheduler::ResourceLimits =
-    crate::scheduler::ResourceLimits { threads: 8, memory_mb: 16384 };
+const TEST_LIMITS: crate::scheduler::ResourceLimits = crate::scheduler::ResourceLimits {
+    threads: 8,
+    memory_mb: 16384,
+};
 
 #[test]
 fn job_status_display() {
@@ -286,8 +288,8 @@ fn render_shell_command_named_io() {
         "bwa mem {input.reads} > {output.bam}",
         &rule,
         &HashMap::new(),
-
-    TEST_LIMITS);
+        TEST_LIMITS,
+    );
     assert_eq!(result, "bwa mem data.fq > sorted.bam");
 }
 
@@ -300,8 +302,12 @@ fn render_shell_output_indexed() {
         shell: None,
         ..Default::default()
     };
-    let result = render_shell_command("cat {input[0]} > {output[0]}", &rule, &HashMap::new(),
-TEST_LIMITS);
+    let result = render_shell_command(
+        "cat {input[0]} > {output[0]}",
+        &rule,
+        &HashMap::new(),
+        TEST_LIMITS,
+    );
     assert_eq!(result, "cat in.txt > out.txt");
 }
 
@@ -314,8 +320,12 @@ fn render_shell_output_all() {
         shell: None,
         ..Default::default()
     };
-    let result = render_shell_command("cat {input} > {output}", &rule, &HashMap::new(),
-TEST_LIMITS);
+    let result = render_shell_command(
+        "cat {input} > {output}",
+        &rule,
+        &HashMap::new(),
+        TEST_LIMITS,
+    );
     assert_eq!(result, "cat a.txt b.txt > out.txt");
 }
 
@@ -334,8 +344,8 @@ fn render_shell_threads() {
         "bwa mem -t {threads} ref.fa > {output[0]}",
         &rule,
         &HashMap::new(),
-
-    TEST_LIMITS);
+        TEST_LIMITS,
+    );
     assert_eq!(result, "bwa mem -t 8 ref.fa > out.bam");
 }
 
@@ -348,8 +358,12 @@ fn render_shell_config_values() {
     };
     let mut values = HashMap::new();
     values.insert("config.reference".to_string(), "/data/ref.fa".to_string());
-    let result = render_shell_command("bwa mem {config.reference} > {output[0]}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command(
+        "bwa mem {config.reference} > {output[0]}",
+        &rule,
+        &values,
+        TEST_LIMITS,
+    );
     assert_eq!(result, "bwa mem /data/ref.fa > hello.txt");
 }
 
@@ -375,8 +389,8 @@ fn render_shell_command_nested_config() {
         "bwa mem {config.reference_fasta} > {output[0]}",
         &rule,
         &values,
-
-    TEST_LIMITS);
+        TEST_LIMITS,
+    );
     assert_eq!(result, "bwa mem /data/refs/GRCh38/genome.fa > out.bam");
 }
 
@@ -392,8 +406,7 @@ fn render_shell_command_three_level_nested_config() {
     values.insert("config.a".to_string(), "{config.b}".to_string());
     values.insert("config.b".to_string(), "{config.c}".to_string());
     values.insert("config.c".to_string(), "/final".to_string());
-    let result = render_shell_command("cp {config.a} {output[0]}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command("cp {config.a} {output[0]}", &rule, &values, TEST_LIMITS);
     assert_eq!(result, "cp /final out.txt");
 }
 
@@ -1277,8 +1290,7 @@ fn render_shell_log_placeholder() {
         log: Some("logs/run.log".to_string()),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(),
-TEST_LIMITS);
+    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(), TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/run.log");
 }
 
@@ -1290,8 +1302,7 @@ fn render_shell_log_indexed() {
         log: Some("logs/run.log".to_string()),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log[0]}", &rule, &HashMap::new(),
-TEST_LIMITS);
+    let result = render_shell_command("echo hi 2> {log[0]}", &rule, &HashMap::new(), TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/run.log");
 }
 
@@ -1306,8 +1317,7 @@ fn render_shell_log_expands_sample_and_config() {
     let mut values = HashMap::new();
     values.insert("sample".to_string(), "S1".to_string());
     values.insert("config.results_dir".to_string(), "results".to_string());
-    let result = render_shell_command("echo hi 2> {log}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command("echo hi 2> {log}", &rule, &values, TEST_LIMITS);
     assert_eq!(result, "echo hi 2> logs/S1/results/run.log");
 }
 
@@ -1318,8 +1328,7 @@ fn render_shell_log_absent_keeps_placeholder() {
         output: vec!["out.txt".to_string()].into(),
         ..Default::default()
     };
-    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(),
-TEST_LIMITS);
+    let result = render_shell_command("echo hi 2> {log}", &rule, &HashMap::new(), TEST_LIMITS);
     assert_eq!(result, "echo hi 2> {log}");
 }
 
@@ -1338,8 +1347,12 @@ fn render_shell_config_array_joins_with_space() {
         "config.files".to_string(),
         "[\"a.fa\", \"b.fa\"]".to_string(),
     );
-    let result = render_shell_command("cat {config.files} > {output[0]}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command(
+        "cat {config.files} > {output[0]}",
+        &rule,
+        &values,
+        TEST_LIMITS,
+    );
     assert_eq!(result, "cat a.fa b.fa > out.txt");
 }
 
@@ -1352,8 +1365,7 @@ fn render_shell_config_array_non_string_elements() {
     };
     let mut values = HashMap::new();
     values.insert("config.ids".to_string(), "[1, 2]".to_string());
-    let result = render_shell_command("echo {config.ids}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command("echo {config.ids}", &rule, &values, TEST_LIMITS);
     assert_eq!(result, "echo 1 2");
 }
 
@@ -1369,8 +1381,12 @@ fn render_shell_config_scalar_unchanged() {
     // through untouched (only array literals join).
     values.insert("config.reference".to_string(), "/data/ref.fa".to_string());
     values.insert("config.mode".to_string(), "1".to_string());
-    let result = render_shell_command("bwa mem {config.reference} {config.mode}", &rule, &values,
-TEST_LIMITS);
+    let result = render_shell_command(
+        "bwa mem {config.reference} {config.mode}",
+        &rule,
+        &values,
+        TEST_LIMITS,
+    );
     assert_eq!(result, "bwa mem /data/ref.fa 1");
 }
 
@@ -1727,8 +1743,12 @@ fn scratch_render_inputs_absolute_outputs_relative() {
     );
     assert_eq!(rendered, "bwa mem /data/work/reads/S1.fq > out/S1.sam");
     // Non-scratch rendering keeps relative input paths.
-    let plain = render_shell_command("bwa mem {input[0]} > {output[0]}", &rule, &values,
-TEST_LIMITS);
+    let plain = render_shell_command(
+        "bwa mem {input[0]} > {output[0]}",
+        &rule,
+        &values,
+        TEST_LIMITS,
+    );
     assert_eq!(plain, "bwa mem reads/S1.fq > out/S1.sam");
 }
 

--- a/crates/oxo-flow-core/src/references.rs
+++ b/crates/oxo-flow-core/src/references.rs
@@ -558,6 +558,7 @@ mod tests {
                 ..Default::default()
             },
             &wildcard_values,
+            crate::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
         );
         let mut command = std::process::Command::new("sh");
         command.arg("-c").arg(&cmd).current_dir(workdir);

--- a/crates/oxo-flow-core/src/references.rs
+++ b/crates/oxo-flow-core/src/references.rs
@@ -558,7 +558,10 @@ mod tests {
                 ..Default::default()
             },
             &wildcard_values,
-            crate::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
+            crate::scheduler::ResourceLimits {
+                threads: 4,
+                memory_mb: 8192,
+            },
         );
         let mut command = std::process::Command::new("sh");
         command.arg("-c").arg(&cmd).current_dir(workdir);

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -1107,7 +1107,10 @@ mod tests {
 
     #[test]
     fn effective_tool_resources_clamps_to_machine() {
-        let limits = ResourceLimits { threads: 4, memory_mb: 3723 };
+        let limits = ResourceLimits {
+            threads: 4,
+            memory_mb: 3723,
+        };
         let rule = Rule {
             name: "star".to_string(),
             threads: Some(12),
@@ -1119,7 +1122,10 @@ mod tests {
 
     #[test]
     fn effective_tool_resources_under_capacity_passes_through() {
-        let limits = ResourceLimits { threads: 16, memory_mb: 65536 };
+        let limits = ResourceLimits {
+            threads: 16,
+            memory_mb: 65536,
+        };
         let rule = Rule {
             name: "fastqc".to_string(),
             threads: Some(2),
@@ -1131,7 +1137,10 @@ mod tests {
 
     #[test]
     fn effective_tool_resources_unset_defaults_are_usable() {
-        let limits = ResourceLimits { threads: 8, memory_mb: 32768 };
+        let limits = ResourceLimits {
+            threads: 8,
+            memory_mb: 32768,
+        };
         let rule = Rule {
             name: "no_resources".to_string(),
             ..Default::default()

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -514,7 +514,8 @@ pub fn detect_system_limits() -> ResourceLimits {
         let threads = std::thread::available_parallelism()
             .map(|n| n.get() as u32)
             .unwrap_or(1);
-        let memory_mb = crate::executor::process::detect_total_memory_mb();
+        let memory_mb = crate::executor::process::detect_total_memory_mb()
+            + crate::executor::process::detect_swap_mb();
         ResourceLimits { threads, memory_mb }
     })
 }

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -488,6 +488,49 @@ fn reservation_memory_mb(rule: &Rule, capacity: u64) -> u64 {
         .min(capacity)
 }
 
+/// Machine-level resource limits (threads + total memory), cgroup-aware where
+/// the platform supports it. These are the values shell expansion clamps
+/// tool-facing placeholders (`{effective_threads}` / `{effective_memory_mb}`)
+/// against, and they double as the pool capacity when building the pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceLimits {
+    /// Machine CPU threads.
+    pub threads: u32,
+    /// Machine total memory in MB.
+    pub memory_mb: u64,
+}
+
+/// Tool-facing effective resources for a rule: the declared request clamped
+/// to the machine. Unlike the pool reservation (which treats unset values as
+/// 0 so the rule never blocks scheduling), tool-facing placeholders need a
+/// usable number: unset threads default to 1 and unset memory defaults to the
+/// whole machine — the tool may use everything the box has.
+/// Detect machine-level limits once per process (threads via
+/// `available_parallelism` — cgroup-aware on Linux — and total memory via
+/// sysinfo with a `/proc/meminfo` fallback).
+pub fn detect_system_limits() -> ResourceLimits {
+    static SYSTEM_LIMITS: std::sync::OnceLock<ResourceLimits> = std::sync::OnceLock::new();
+    *SYSTEM_LIMITS.get_or_init(|| {
+        let threads = std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1);
+        let memory_mb = crate::executor::process::detect_total_memory_mb();
+        ResourceLimits { threads, memory_mb }
+    })
+}
+
+pub fn effective_tool_resources(rule: &Rule, limits: ResourceLimits) -> (u32, u64) {
+    let threads = match rule.effective_threads() {
+        0 => 1, // unset sentinel (threads <= 1 documented convention)
+        n => n.min(limits.threads.max(1)),
+    };
+    let memory_mb = match rule.effective_memory().and_then(parse_memory_mb) {
+        Some(m) if m > 0 => m.min(limits.memory_mb),
+        _ => limits.memory_mb,
+    };
+    (threads, memory_mb)
+}
+
 /// Resource pool tracking available system resources and custom resource groups.
 #[derive(Debug, Clone)]
 pub struct ResourcePool {
@@ -1059,6 +1102,41 @@ mod tests {
         let mem = effective_memory_mb(&rule, 2048);
         // Explicit memory takes precedence: 32G = 32768MB
         assert_eq!(mem, 32768);
+    }
+
+    #[test]
+    fn effective_tool_resources_clamps_to_machine() {
+        let limits = ResourceLimits { threads: 4, memory_mb: 3723 };
+        let rule = Rule {
+            name: "star".to_string(),
+            threads: Some(12),
+            memory: Some("72G".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(effective_tool_resources(&rule, limits), (4, 3723));
+    }
+
+    #[test]
+    fn effective_tool_resources_under_capacity_passes_through() {
+        let limits = ResourceLimits { threads: 16, memory_mb: 65536 };
+        let rule = Rule {
+            name: "fastqc".to_string(),
+            threads: Some(2),
+            memory: Some("4G".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(effective_tool_resources(&rule, limits), (2, 4096));
+    }
+
+    #[test]
+    fn effective_tool_resources_unset_defaults_are_usable() {
+        let limits = ResourceLimits { threads: 8, memory_mb: 32768 };
+        let rule = Rule {
+            name: "no_resources".to_string(),
+            ..Default::default()
+        };
+        // Unset threads -> 1 (safe default), unset memory -> whole machine.
+        assert_eq!(effective_tool_resources(&rule, limits), (1, 32768));
     }
 }
 

--- a/docs/guide/src/how-to/china-mirrors.md
+++ b/docs/guide/src/how-to/china-mirrors.md
@@ -31,18 +31,40 @@ channels:
   - defaults
 show_channel_urls: true
 default_channels:
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/r
+  - https://mirrors.sustech.edu.cn/anaconda/pkgs/main
+  - https://mirrors.sustech.edu.cn/anaconda/pkgs/r
 custom_channels:
-  conda-forge: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
-  bioconda: https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud
+  conda-forge: https://mirrors.sustech.edu.cn/anaconda/cloud
+  bioconda: https://mirrors.sustech.edu.cn/anaconda/cloud
 ```
 
-Alternative mirrors:
+Alternative mirrors (in rough order of stability as observed during the
+2026-08 catalog live-run campaign on a mainland server):
 
-- **USTC**: `https://mirrors.ustc.edu.cn/anaconda`
-- **Aliyun**: `https://mirrors.aliyun.com/anaconda`
+- **SUSTech**: `https://mirrors.sustech.edu.cn/anaconda` — stable direct
+  downloads, no cross-mirror redirects.
+- **USTC**: `https://mirrors.ustc.edu.cn/anaconda` — fast when up, but had
+  repeated flapping windows (HTTP 000 / "Network is unreachable") during the
+  campaign.
+- **Tsinghua Tuna**: `https://mirrors.tuna.tsinghua.edu.cn/anaconda` — the
+  repodata serves, but package blobs can be redirected to NJU
+  (`mirrors.nju.edu.cn`), where SSL handshakes were repeatedly killed
+  mid-transfer. Prefer SUSTech/USTC for package downloads.
+- **Aliyun**: `https://mirrors.aliyun.com/anaconda` (geo-blocked in some
+  regions)
 - **Tencent**: `https://mirrors.cloud.tencent.com/anaconda`
+
+> **Before changing anything**, run `conda config --show-sources`. Miniforge
+> installs ship a bundled `~/miniforge3/.condarc` that takes precedence over
+> `~/.condarc` — writing your mirror config only to `~/.condarc` silently
+> does nothing when that bundled file exists. Update whichever file
+> `--show-sources` lists first, or delete the bundled one.
+
+> **Keep workflow repos mirror-neutral.** Mirror configuration belongs on
+> the machine (`.condarc` / docker daemon), never in workflow files — a
+> workflow that embeds a mirror URL works only inside China and breaks for
+> every other user. Workflow env files should declare channel *names*
+> (`conda-forge`, `bioconda`) and let each user's conda config resolve them.
 
 ---
 
@@ -91,8 +113,23 @@ index-url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 > discontinued in 2024. Community mirrors change frequently — check a
 > current, community-maintained mirror list before relying on any URL.
 
-The most stable approach is a per-container HTTP proxy in
-`~/.docker/config.json`:
+Two workable options as of 2026-08:
+
+**Registry mirror** — configure `/etc/docker/daemon.json` (system-wide
+`docker pull`, including the pulls oxo-flow's docker backend performs):
+
+```json
+{
+  "registry-mirrors": ["https://docker.1ms.run"]
+}
+```
+
+Then `sudo systemctl restart docker`. The `docker.1ms.run` mirror served
+all `quay.io/biocontainers` + `quay.io/nf-core` pulls during the catalog
+live-run campaign; the Tencent mirror (`mirror.ccs.tencentyun.com`) timed
+out on large blobs and was dropped.
+
+**HTTP proxy** — a per-container proxy in `~/.docker/config.json`:
 
 ```json
 {
@@ -213,10 +250,15 @@ These files can include channel configuration inline:
 # envs/fastp.yaml
 name: fastp-env
 channels:
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/bioconda
-  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge
+  - bioconda
+  - conda-forge
 dependencies:
   - fastp=0.23.4
 ```
 
-This ensures reproducibility regardless of the user's global mirror settings.
+> **Do not embed mirror URLs here.** Channel *names* resolve against each
+> user's own `.condarc` — the same workflow file then works identically in
+> China (mirror-configured machines) and elsewhere (default anaconda.org).
+> Inlining a mirror URL (`https://mirrors.…/anaconda/cloud/bioconda`) makes
+> the workflow usable only where that mirror is reachable, which defeats
+> portability — the catalog workflows deliberately ship channel names only.

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -44,18 +44,20 @@ pub struct DagNode {
 
 ## Building the DAG
 
-### `WorkflowDag::from_rules()`
+### `WorkflowDag::from_rules()` / `from_rules_with_config()`
 
 Given a list of rules, the DAG is built by:
 
 1. **Adding nodes** — one per rule, keyed by `rule.name`
-2. **Inferring edges** — for each rule B, if any of B's inputs appear in another rule A's outputs, add an edge A → B
+2. **Inferring edges** — for each rule B, if any of B's inputs appear in another rule A's outputs, add an edge A → B. Before matching, `{config.x}` placeholders in input/output paths are expanded against the workflow config (`from_rules_with_config`; the CLI passes the config at every build site), so the same logical path expressed through different config keys (`{config.umap_n_neighbors}` vs `{config.leiden_n_neighbors}`) still connects. `from_rules` keeps the legacy no-config matching.
 3. **Cycle detection** — verify the graph is acyclic
 4. **Validation** — reject duplicate rule names; inputs with no producer are treated as source files
 
 ```rust
 let dag = WorkflowDag::from_rules(&config.rules)?;
 ```
+
+Inference is strictly best-effort string matching: unresolved wildcards/globs that cannot be matched keep the legacy behavior (no edge, never an error) — use explicit `depends_on` when the data flow cannot be expressed by path matching.
 
 If the DAG contains a cycle, an `OxoFlowError::CycleDetected` error is returned with the cycle path (e.g., `A → B → A`).
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1153,6 +1153,11 @@ box runs with `--memory 4G`, not a limit the kernel can never back).
 cgroup-aware tools (picard, STAR, Cell Ranger) therefore see an honest
 limit on every machine size.
 
+**The ceiling counts swap** — the machine total above is RAM + swap
+(swap is backable memory the kernel uses under pressure; ignoring it
+left real capacity unused on small boxes). Pass `--max-memory` to pin
+the ceiling to RAM only when latency matters more than headroom.
+
 **Existing environments are verified before setup** — when the
 environment cache is cold (e.g. after `--rerun` wipes the checkpoint)
 but the conda environment already exists, oxo-flow verifies it in place

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -532,6 +532,13 @@ environment = { conda = "envs/tools.yaml" }
 
 # # Conda with custom prefix
 # environment = { conda = "envs/qc.yaml", conda_prefix = ".oxo-flow/envs" }
+```
+
+**Container shell:** `docker`/`singularity` rules run under `bash` inside
+the container when the image provides it (falling back to `sh` otherwise).
+nf-core-derived images ship bash, and their scripts rely on bash features
+(`set -o pipefail`, `[[ ]]`) that the container default `sh` (often dash)
+rejects — the re-exec shim keeps these scripts working unmodified.
 
 # # Mamba / micromamba (auto-detects binary, same YAML format as conda)
 # environment = { mamba = "envs/qc.yaml", mamba_prefix = ".oxo-flow/envs" }

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1134,8 +1134,17 @@ Built-in placeholders use the same syntax but have reserved meanings:
 | `{output.name}` | The output file named `name` from `named_output` |
 | `{threads}` | Thread count assigned to this rule |
 | `{memory}` | Memory allocation assigned to this rule |
+| `{effective_threads}` | Declared threads clamped to the machine's CPUs — the tool-facing concurrency. Use it for flags like `--threads`/`-t` when the declared value is an HPC-scale label (e.g. a rule declaring `threads = 12` renders `4` on a 4-core box). Unset threads render as `1` |
+| `{effective_memory_mb}` | Declared memory clamped to the machine's total memory, as an integer number of MB — the tool-facing heap budget. Use it for JVM flags (`-Xmx{effective_memory_mb}m`, `-Xms…`) so tools size themselves to the box instead of OOM-ing on hardcoded HPC values (`-Xmx29491M` class). Unset memory renders as the machine's full total |
 | `{log}` | Path of the rule's `log` field (every instance wildcard — `{sample}`, `{pair_id}`, `{assembler}` … — and `{config.x}` are expanded per instance; the parent directory is created automatically) |
 | `{config.*}` | Value from the `[config]` section (plain value, declared default, or CLI override) |
+
+**Why the effective pair exists** — `{threads}`/`{memory}` render the
+*declared* values, which keep the pool semantics (an over-capacity rule
+reserves the whole pool and runs alone). The `{effective_*}` pair renders
+what the tool can *actually* get on this machine. Rules that embed
+resource-sized flags should use the effective pair; rules that only pass
+the pool declaration through can keep the plain pair.
 
 **Array-valued `{config.*}`** — a `[config]` key holding an array renders
 as a space-joined list in the shell (`["a", "b"]` → `a b`), matching the

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1146,6 +1146,19 @@ what the tool can *actually* get on this machine. Rules that embed
 resource-sized flags should use the effective pair; rules that only pass
 the pool declaration through can keep the plain pair.
 
+**Container memory follows the same policy** — docker/singularity rules
+get the declared memory as their `--memory` cgroup limit, clamped to the
+machine's total the same way (a rule declaring `memory = "72G"` on a 4G
+box runs with `--memory 4G`, not a limit the kernel can never back).
+cgroup-aware tools (picard, STAR, Cell Ranger) therefore see an honest
+limit on every machine size.
+
+**Existing environments are verified before setup** — when the
+environment cache is cold (e.g. after `--rerun` wipes the checkpoint)
+but the conda environment already exists, oxo-flow verifies it in place
+and marks it ready instead of re-running the setup, whose `conda env
+update` fallback re-resolves every dependency over the network.
+
 **Array-valued `{config.*}`** — a `[config]` key holding an array renders
 as a space-joined list in the shell (`["a", "b"]` → `a b`), matching the
 `{input}` convention; iterate with `for x in {config.tools}`.

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -432,6 +432,7 @@ output = ["finish.txt"]
             rule,
             &values,
             &config.workflow.interpreter_map,
+            oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
         ) else {
             continue;
         };

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -432,7 +432,10 @@ output = ["finish.txt"]
             rule,
             &values,
             &config.workflow.interpreter_map,
-            oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
+            oxo_flow_core::scheduler::ResourceLimits {
+                threads: 4,
+                memory_mb: 8192,
+            },
         ) else {
             continue;
         };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1310,7 +1310,10 @@ fn render_shell_command_substitution() {
         rule.shell.as_ref().unwrap(),
         &rule,
         &wildcards,
-        oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
+        oxo_flow_core::scheduler::ResourceLimits {
+            threads: 4,
+            memory_mb: 8192,
+        },
     );
     assert!(rendered.contains("raw/sample_R1.fastq.gz"));
     assert!(rendered.contains("aligned/sample.bam"));
@@ -1337,7 +1340,10 @@ fn render_shell_command_effective_resource_placeholders() {
         ..Default::default()
     };
     let wildcards = HashMap::new();
-    let limits = oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 3723 };
+    let limits = oxo_flow_core::scheduler::ResourceLimits {
+        threads: 4,
+        memory_mb: 3723,
+    };
 
     let rendered = render_shell_command(rule.shell.as_ref().unwrap(), &rule, &wildcards, limits);
     // No declared resources: memory falls back to the whole machine,
@@ -1352,10 +1358,14 @@ fn render_shell_command_effective_resource_placeholders() {
             memory: Some("72G".to_string()),
             ..Default::default()
         },
-        shell: Some("STAR --runThreadN {effective_threads} --limitBAMsortRAM {effective_memory_mb}".to_string()),
+        shell: Some(
+            "STAR --runThreadN {effective_threads} --limitBAMsortRAM {effective_memory_mb}"
+                .to_string(),
+        ),
         ..Default::default()
     };
-    let rendered_over = render_shell_command(over.shell.as_ref().unwrap(), &over, &wildcards, limits);
+    let rendered_over =
+        render_shell_command(over.shell.as_ref().unwrap(), &over, &wildcards, limits);
     assert!(rendered_over.contains("--runThreadN 4"));
     assert!(rendered_over.contains("--limitBAMsortRAM 3723"));
 
@@ -1365,7 +1375,8 @@ fn render_shell_command_effective_resource_placeholders() {
         shell: Some("run --threads {effective_threads}".to_string()),
         ..Default::default()
     };
-    let rendered_unset = render_shell_command(unset.shell.as_ref().unwrap(), &unset, &wildcards, limits);
+    let rendered_unset =
+        render_shell_command(unset.shell.as_ref().unwrap(), &unset, &wildcards, limits);
     assert!(rendered_unset.contains("--threads 1"));
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1306,10 +1306,67 @@ fn render_shell_command_substitution() {
     let mut wildcards = HashMap::new();
     wildcards.insert("config.reference".to_string(), "/ref/hg38.fa".to_string());
 
-    let rendered = render_shell_command(rule.shell.as_ref().unwrap(), &rule, &wildcards);
+    let rendered = render_shell_command(
+        rule.shell.as_ref().unwrap(),
+        &rule,
+        &wildcards,
+        oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 8192 },
+    );
     assert!(rendered.contains("raw/sample_R1.fastq.gz"));
     assert!(rendered.contains("aligned/sample.bam"));
     assert!(rendered.contains("/ref/hg38.fa"));
+}
+
+/// `{effective_threads}` / `{effective_memory_mb}` clamp the declared
+/// request to the machine so tools can size their own flags (the hardcoded
+/// `-Xmx29491M`-class OOMs on small boxes).
+#[test]
+fn render_shell_command_effective_resource_placeholders() {
+    use oxo_flow_core::executor::process::render_shell_command;
+    use oxo_flow_core::rule::Rule;
+    use std::collections::HashMap;
+
+    let rule = Rule {
+        name: "markdup".to_string(),
+        input: vec![].into(),
+        output: vec!["a.bam".to_string()].into(),
+        shell: Some(
+            "picard -Xmx{effective_memory_mb}m -XX:ActiveProcessorCount={effective_threads} MarkDuplicates"
+                .to_string(),
+        ),
+        ..Default::default()
+    };
+    let wildcards = HashMap::new();
+    let limits = oxo_flow_core::scheduler::ResourceLimits { threads: 4, memory_mb: 3723 };
+
+    let rendered = render_shell_command(rule.shell.as_ref().unwrap(), &rule, &wildcards, limits);
+    // No declared resources: memory falls back to the whole machine,
+    // threads to the 1-unset sentinel.
+    assert!(rendered.contains("-Xmx3723m"));
+    assert!(rendered.contains("ActiveProcessorCount=1"));
+    // An over-declared rule clamps to the machine:
+    let over = Rule {
+        name: "star".to_string(),
+        resources: oxo_flow_core::rule::Resources {
+            threads: 12,
+            memory: Some("72G".to_string()),
+            ..Default::default()
+        },
+        shell: Some("STAR --runThreadN {effective_threads} --limitBAMsortRAM {effective_memory_mb}".to_string()),
+        ..Default::default()
+    };
+    let rendered_over = render_shell_command(over.shell.as_ref().unwrap(), &over, &wildcards, limits);
+    assert!(rendered_over.contains("--runThreadN 4"));
+    assert!(rendered_over.contains("--limitBAMsortRAM 3723"));
+
+    // Unset resources still produce usable numbers.
+    let unset = Rule {
+        name: "tool".to_string(),
+        shell: Some("run --threads {effective_threads}".to_string()),
+        ..Default::default()
+    };
+    let rendered_unset = render_shell_command(unset.shell.as_ref().unwrap(), &unset, &wildcards, limits);
+    assert!(rendered_unset.contains("--threads 1"));
 }
 
 /// Test sanitize_shell_command detects dangerous patterns.


### PR DESCRIPTION
conda/mamba's create/update can exit 0 while leaving a broken env behind, AND concurrent rule instances sharing one env ran un-serialized creates whose losing transaction removes the winner's packages (live evidence from the tx-ubuntu 24-workflow campaign: an env history showing +fq then -fq 12s later; rules then dying with 'tool: command not found').

- EnvironmentBackend gains verify_command(): conda/mamba check the env's own prefix via CONDA_PREFIX; other backends None.
- ensure_environment_ready(): per-environment setup mutex + double-checked cache (race prevention), post-setup verification + teardown-and-retry once (broken-env repair).
- EnvironmentResolver gains verify/teardown/setup_lock delegations.
- Reference builds now render {source} (STAR died on the literal '{source}' placeholder) and map {input} to the source.

Tests: setup-lock identity, verify command construction; full workspace gate green; live on tx-ubuntu as build7.