### PR TITLE
feat: run --profile submits to a scheduler when the profile declares [cluster] (#74 phase 2)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/mod.rs
+++ b/crates/oxo-flow-cli/src/commands/mod.rs
@@ -216,6 +216,7 @@ pub mod publish;
 pub mod pull;
 pub mod quality;
 pub mod run;
+pub mod run_cluster;
 pub mod run_preview;
 pub mod samples;
 pub mod web;

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -444,6 +444,7 @@ pub async fn run_command(
     samples_filter: Vec<String>,
     rerun: bool,
     no_report_snapshot: bool,
+    max_submitted: Option<usize>,
 ) -> Result<()> {
     print_banner();
 
@@ -791,6 +792,39 @@ pub async fn run_command(
             0
         })
     };
+
+    // ── Cluster path (issue #74 phase 2) ───────────────────────────────────
+    // A `[cluster]` block in effect plus a named profile routes execution to
+    // a scheduler instead of the local executor. Both conditions are
+    // required: a workflow carrying `[cluster]` keeps running locally until
+    // the user opts in with `--profile`, so no existing workflow starts
+    // submitting jobs because of this change.
+    if profile.is_some()
+        && let Some(cluster_profile) = config.cluster.clone()
+    {
+        let summary = crate::commands::run_cluster::run_on_cluster(
+            &cluster_profile,
+            crate::commands::run_cluster::ClusterRunArgs {
+                config: &config,
+                dag: &dag,
+                order: &order,
+                checkpoint: &checkpoint,
+                checkpoint_path: &checkpoint_path,
+                workdir: workdir_actual.as_ref(),
+                wildcard_values: wildcard_values.as_ref(),
+                sensitive_keys: &sensitive_keys,
+                force_rules: &force_rules,
+                max_submitted,
+                rerun,
+                resume_failed,
+            },
+        )
+        .await?;
+        if !summary.is_success() {
+            return Err(anyhow::anyhow!("workflow execution failed"));
+        }
+        return Ok(());
+    }
 
     let exec_config = ExecutorConfig {
         max_jobs: jobs,
@@ -3251,6 +3285,7 @@ pub async fn resume_command(
         Vec::new(), // samples_filter (resume restores checkpoint state as-is)
         false,      // rerun (resume skips completed rules by design)
         no_report_snapshot,
+        None, // max_submitted (cluster queue cap — resume keeps the profile's)
     )
     .await
 }

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -1,0 +1,296 @@
+//! `run --profile <NAME>` cluster path (issue #74 phase 2).
+//!
+//! Submission, tracking, and checkpoint bookkeeping for a workflow executed
+//! through a scheduler instead of the local executor. The engine's decisions
+//! are not re-derived here: the will-run set comes from `preview_run_plan` —
+//! the same producer `dry-run` uses, and the set `BackendDriver`'s #78
+//! acceptance test already pins submissions to — and job execution belongs to
+//! `BackendDriver`. This module is the glue between them.
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use oxo_flow_core::backend::ScheduledPlan;
+use oxo_flow_core::backend::cluster::ClusterExecutor;
+use oxo_flow_core::backend::driver::{BackendDriver, DriverConfig, DriverOptions};
+use oxo_flow_core::cluster::{ClusterBackend, ClusterJobConfig};
+use oxo_flow_core::config::{ClusterProfile, WorkflowConfig};
+use oxo_flow_core::dag::WorkflowDag;
+use oxo_flow_core::environment::EnvironmentResolver;
+use oxo_flow_core::executor::checkpoint::{BenchmarkRecord, CheckpointState};
+use oxo_flow_core::executor::{JobRecord, JobStatus};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Everything the cluster path needs from `run_command`'s scope.
+pub(crate) struct ClusterRunArgs<'a> {
+    pub config: &'a WorkflowConfig,
+    pub dag: &'a WorkflowDag,
+    pub order: &'a [String],
+    pub checkpoint: &'a Arc<Mutex<CheckpointState>>,
+    pub checkpoint_path: &'a Path,
+    pub workdir: &'a Path,
+    pub wildcard_values: &'a HashMap<String, String>,
+    pub sensitive_keys: &'a HashSet<String>,
+    /// Rules the run's invalidation analysis already forced. The local
+    /// executor receives this set to bypass its freshness gate; the cluster
+    /// path unions it into the submission set for the same reason.
+    pub force_rules: &'a HashSet<String>,
+    /// `--max-submitted`: a one-off override of the profile's queue cap.
+    pub max_submitted: Option<usize>,
+    pub rerun: bool,
+    pub resume_failed: bool,
+}
+
+/// Outcome of a cluster run, mirroring what the local loop reports.
+pub(crate) struct ClusterRunSummary {
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+}
+
+impl ClusterRunSummary {
+    pub fn is_success(&self) -> bool {
+        self.failed == 0
+    }
+}
+
+/// Translate a `[cluster]` profile into the job config the renderer uses.
+///
+/// `backend` is the only required key: without it there is no scheduler to
+/// submit to, and guessing one would submit real jobs to the wrong place.
+fn job_config(cluster: &ClusterProfile) -> Result<(ClusterBackend, ClusterJobConfig)> {
+    let backend_name = cluster.backend.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "profile has a [cluster] block without `backend` — set backend = \"slurm\" \
+             (or pbs/sge/lsf)"
+        )
+    })?;
+    let backend = ClusterBackend::from_str(backend_name).map_err(|_| {
+        anyhow::anyhow!(
+            "unknown cluster backend '{backend_name}' — expected slurm, pbs, sge, or lsf"
+        )
+    })?;
+    Ok((
+        backend,
+        ClusterJobConfig {
+            backend,
+            queue: cluster.partition.clone(),
+            account: cluster.account.clone(),
+            walltime: cluster.walltime.clone(),
+            extra_args: cluster.extra_args.clone(),
+        },
+    ))
+}
+
+/// Create `.oxo-flow/runs/<timestamp>/` and repoint the `latest` symlink.
+///
+/// The timestamp is the directory name so runs sort chronologically with
+/// `ls`; `latest` is a convenience for `cd`, not something the code reads.
+fn create_run_dir(workdir: &Path) -> Result<PathBuf> {
+    let runs_root = workdir.join(".oxo-flow").join("runs");
+    let stamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+    let run_dir = runs_root.join(&stamp);
+    std::fs::create_dir_all(&run_dir)
+        .with_context(|| format!("failed to create run directory {}", run_dir.display()))?;
+
+    #[cfg(unix)]
+    {
+        let latest = runs_root.join("latest");
+        // Replace rather than fail: `latest` points at the newest run, and a
+        // stale symlink from a previous run is expected, not an error.
+        let _ = std::fs::remove_file(&latest);
+        if let Err(e) = std::os::unix::fs::symlink(&stamp, &latest) {
+            tracing::debug!(error = %e, "could not update the runs/latest symlink");
+        }
+    }
+    Ok(run_dir)
+}
+
+/// Fold one driver-returned record into the checkpoint, mirroring the local
+/// loop's bookkeeping so `status`, `resume`, and re-runs cannot tell the two
+/// execution paths apart.
+async fn record_outcome(
+    args: &ClusterRunArgs<'_>,
+    record: &JobRecord,
+    summary: &mut ClusterRunSummary,
+) {
+    let duration = record
+        .finished_at
+        .and_then(|f| record.started_at.map(|s| f.signed_duration_since(s)))
+        .map(|d| d.num_milliseconds() as f64 / 1000.0)
+        .unwrap_or(0.0);
+    let mut ck = args.checkpoint.lock().await;
+    match record.status {
+        JobStatus::Success => {
+            summary.succeeded += 1;
+            let rule = args.config.get_rule(&record.rule);
+            let benchmark = BenchmarkRecord {
+                rule: record.rule.clone(),
+                wall_time_secs: duration,
+                // Real usage needs `sacct` polling — phase 4. Reporting a
+                // fabricated number here would be worse than reporting none.
+                max_memory_mb: None,
+                memory_limit_mb: rule
+                    .and_then(|r| r.effective_memory())
+                    .and_then(oxo_flow_core::scheduler::parse_memory_mb),
+                cpu_seconds: None,
+                retries: record.retries,
+            };
+            ck.record_run(record);
+            ck.mark_completed(&record.rule, benchmark);
+            if let Some(rule) = rule
+                && let Ok(Some(manifest)) =
+                    oxo_flow_core::executor::checkpoint::snapshot_input_manifest(
+                        rule,
+                        args.workdir,
+                        args.wildcard_values,
+                        &crate::commands::run_preview::storage_resolver(),
+                    )
+            {
+                ck.record_input_manifest(&record.rule, manifest);
+            }
+        }
+        JobStatus::Failed => {
+            summary.failed += 1;
+            ck.record_run(record);
+            ck.mark_failed(&record.rule);
+        }
+        _ => {
+            summary.skipped += 1;
+        }
+    }
+    if let Err(e) = ck.save_to_file(args.checkpoint_path) {
+        tracing::warn!("Failed to save checkpoint: {e}");
+    }
+}
+
+/// Submit and track this workflow through the scheduler named by `cluster`.
+pub(crate) async fn run_on_cluster(
+    cluster: &ClusterProfile,
+    args: ClusterRunArgs<'_>,
+) -> Result<ClusterRunSummary> {
+    let (backend, cluster_config) = job_config(cluster)?;
+
+    // The will-run set: the same computation `dry-run` reports.
+    //
+    // It is unioned with `force_rules` because by the time the cluster path
+    // runs, `run_command` has already applied and persisted its invalidation
+    // analysis — the cleared completion records and refreshed manifests the
+    // preview would need to re-derive a cascade are gone, so a cascaded rule
+    // whose outputs still look fresh classifies as a skip. `force_rules` is
+    // that analysis's own output, and the local executor gets it for exactly
+    // this purpose (see `ExecutorConfig.force_rules`), so consuming both here
+    // is what keeps the two paths deciding identically.
+    let mut to_run: HashSet<String> = {
+        let ck = args.checkpoint.lock().await;
+        let preview = crate::commands::run_preview::preview_run_plan(
+            &ck,
+            args.config,
+            args.dag,
+            args.order,
+            args.workdir,
+            args.wildcard_values,
+            args.sensitive_keys,
+            &args.config.workflow.interpreter_map,
+            args.checkpoint_path,
+            args.rerun,
+            args.resume_failed,
+        );
+        preview
+            .plan
+            .iter()
+            .filter(|p| !p.status.is_skip())
+            .map(|p| p.name.clone())
+            .collect()
+    };
+    // Forced rules are still constrained to this run's execution set — a
+    // `--target` subset must not pull in rules the user excluded.
+    to_run.extend(
+        args.order
+            .iter()
+            .filter(|name| args.force_rules.contains(*name))
+            .cloned(),
+    );
+
+    let mut summary = ClusterRunSummary {
+        succeeded: 0,
+        failed: 0,
+        skipped: 0,
+    };
+
+    if to_run.is_empty() {
+        eprintln!(
+            "{} everything is up to date — nothing to submit",
+            "Cluster:".bold().cyan()
+        );
+        return Ok(summary);
+    }
+
+    let env_resolver = EnvironmentResolver::new();
+    let mut plan = ScheduledPlan::build(
+        args.config,
+        args.dag,
+        args.workdir,
+        &env_resolver,
+        args.wildcard_values,
+    )
+    .map_err(|e| anyhow::anyhow!("failed to build the execution plan: {e}"))?;
+
+    let run_dir = create_run_dir(args.workdir)?;
+
+    let driver_defaults = DriverConfig::default();
+    let driver_config = DriverConfig {
+        // CLI flag beats the profile, which beats the driver default.
+        max_submitted: args
+            .max_submitted
+            .or(cluster.max_submitted)
+            .unwrap_or(driver_defaults.max_submitted),
+        poll_interval: cluster
+            .poll_interval_secs()
+            .map(std::time::Duration::from_secs)
+            .unwrap_or(driver_defaults.poll_interval),
+        // No wall-clock budget: cluster jobs legitimately sit in the queue
+        // for hours. Cancellation is the user's call (phase 2 follow-up).
+        poll_timeout: None,
+    };
+
+    eprintln!(
+        "{} submitting {} job(s) to {} (max {} in flight)",
+        "Cluster:".bold().cyan(),
+        to_run.len(),
+        backend,
+        driver_config.max_submitted
+    );
+    eprintln!("  run directory: {}", run_dir.display());
+
+    let executor = ClusterExecutor::new(backend, cluster_config);
+    let driver = BackendDriver::new(Arc::new(executor), driver_config);
+    let records = driver
+        .run(
+            &mut plan,
+            &to_run,
+            DriverOptions {
+                run_dir: &run_dir,
+                on_checkpoint: None,
+                merge: None,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("cluster execution failed: {e}"))?;
+
+    for record in &records {
+        record_outcome(&args, record, &mut summary).await;
+    }
+
+    eprintln!(
+        "\n{} {} succeeded, {} failed, {} skipped",
+        "Cluster:".bold(),
+        summary.succeeded,
+        summary.failed,
+        summary.skipped
+    );
+    Ok(summary)
+}

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -48,6 +48,19 @@ pub enum RuleStatus {
     SkippedFresh,
 }
 
+impl RuleStatus {
+    /// Whether this rule will be skipped rather than executed. The single
+    /// definition of the will-run boundary: the preview's `will_skip` count
+    /// and the cluster path's submission set both read it, so a new skip
+    /// variant cannot mean "skip" in one place and "run" in the other.
+    pub fn is_skip(&self) -> bool {
+        matches!(
+            self,
+            RuleStatus::Skipped | RuleStatus::SkippedByWhen | RuleStatus::SkippedFresh
+        )
+    }
+}
+
 /// One rule in the predicted plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreviewRule {
@@ -331,10 +344,7 @@ pub fn preview_run_plan(
         } else {
             RuleStatus::Skipped
         };
-        if matches!(
-            status,
-            RuleStatus::Skipped | RuleStatus::SkippedByWhen | RuleStatus::SkippedFresh
-        ) {
+        if status.is_skip() {
             will_skip += 1;
         }
         plan.push(PreviewRule {

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -168,6 +168,14 @@ pub enum Commands {
         /// Skip the automatic report snapshot after the run.
         #[arg(long, help = "Skip the automatic report snapshot after the run")]
         no_report_snapshot: bool,
+        /// Queue cap for cluster runs; overrides the profile's
+        /// `[cluster] max_submitted` for this invocation.
+        #[arg(
+            long,
+            value_name = "N",
+            help = "Cluster jobs in flight at once (overrides the profile's max_submitted)"
+        )]
+        max_submitted: Option<usize>,
     },
     /// Resume an interrupted workflow from a checkpoint.
     Resume {
@@ -1014,6 +1022,7 @@ async fn main() -> Result<()> {
             samples_filter,
             rerun,
             no_report_snapshot,
+            max_submitted,
         } => {
             use anyhow::Context as _;
             use colored::Colorize as _;
@@ -1136,6 +1145,7 @@ async fn main() -> Result<()> {
                 samples_filter,
                 rerun,
                 no_report_snapshot,
+                max_submitted,
             )
             .await?
         }
@@ -1480,6 +1490,7 @@ async fn main() -> Result<()> {
                     samples_filter.clone(),
                     false, // rerun (test mode: normal up-to-date checks)
                     false, // no_report_snapshot (test mode keeps the standard run behavior)
+                    None,  // max_submitted (cluster queue cap — test keeps the profile's)
                 )
                 .await?;
             }

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -355,6 +355,11 @@ pub struct CitationInfo {
 }
 
 /// Cluster execution profile for HPC deployment.
+///
+/// Declared as `[cluster]` in a workflow or in `profiles/<NAME>.toml`. Its
+/// presence is what makes `run --profile <NAME>` submit to a scheduler
+/// instead of executing locally (issue #74); a profile with only `[config]`
+/// keeps the local path.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ClusterProfile {
     /// Backend type (slurm, pbs, sge, lsf).
@@ -369,10 +374,60 @@ pub struct ClusterProfile {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<String>,
+    /// Default wall-time limit (`24h`, `2d`, or `24:00:00`). A rule's own
+    /// `time_limit` wins over this.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub walltime: Option<String>,
+    /// Jobs in flight at once (pending + running); submissions top up to
+    /// this cap as slots free.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_submitted: Option<usize>,
+    /// Delay between scheduler polls, as a duration string (`30s`, `2m`).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_interval: Option<String>,
     /// Additional arguments passed to the scheduler.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_args: Vec<String>,
+}
+
+impl ClusterProfile {
+    /// Poll interval in seconds, or `None` when unset/unparseable — the
+    /// caller supplies the driver default rather than guessing here.
+    pub fn poll_interval_secs(&self) -> Option<u64> {
+        self.poll_interval
+            .as_deref()
+            .and_then(crate::rule::parse_duration_secs)
+    }
+
+    /// Fold `other` into `self` for a profile merge. `override_mode`
+    /// mirrors [`ProfileMode`]: fill only sets fields this profile leaves
+    /// empty, override replaces any field `other` actually sets.
+    fn merge_from(&mut self, other: &ClusterProfile, override_mode: bool) {
+        macro_rules! merge_opt {
+            ($($field:ident),+ $(,)?) => {$(
+                if other.$field.is_some() && (override_mode || self.$field.is_none()) {
+                    self.$field = other.$field.clone();
+                }
+            )+};
+        }
+        merge_opt!(
+            backend,
+            partition,
+            account,
+            walltime,
+            max_submitted,
+            poll_interval
+        );
+        // Arrays replace wholesale in override mode, matching how
+        // `deep_merge_value` treats arrays elsewhere in the profile merge.
+        if !other.extra_args.is_empty() && (override_mode || self.extra_args.is_empty()) {
+            self.extra_args = other.extra_args.clone();
+        }
+    }
 }
 
 /// A declared configuration parameter with optional metadata.
@@ -2420,6 +2475,21 @@ impl WorkflowConfig {
                     }
                 }
             }
+        }
+        // `[cluster]` — the block whose presence routes `run --profile` to a
+        // scheduler (issue #74). Same fill/override semantics as the rest of
+        // the merge, so site config lives in one shared profile file.
+        if let Some(cluster_table) = profile_toml.get("cluster") {
+            let profile_cluster: ClusterProfile =
+                cluster_table
+                    .clone()
+                    .try_into()
+                    .map_err(|e| OxoFlowError::Config {
+                        message: format!("invalid [cluster] section in profile: {e}"),
+                    })?;
+            self.cluster
+                .get_or_insert_with(ClusterProfile::default)
+                .merge_from(&profile_cluster, mode == ProfileMode::Override);
         }
         Ok(())
     }

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -252,6 +252,67 @@ profile_mode = "override"   # fill | override (default: fill)
 If the named profile file does not exist, `run` prints a
 warning and proceeds with the workflow's own config.
 
+#### Cluster submission
+
+A profile that also carries a `[cluster]` block makes `run --profile` submit
+to a scheduler instead of executing locally:
+
+```toml
+# profiles/slurm.toml
+[cluster]
+backend       = "slurm"      # slurm | pbs | sge | lsf — required
+partition     = "compute"
+account       = "lab01"
+walltime      = "24h"
+max_submitted = 50           # jobs in flight at once
+poll_interval = "30s"
+
+[config]
+reference = "/data/ref/hg38.fa"
+```
+
+```bash
+oxo-flow run pipeline.oxoflow --profile slurm
+
+# one-off override of the profile's queue cap
+oxo-flow run pipeline.oxoflow --profile slurm --max-submitted 100
+```
+
+Profiles are looked up in the **workflow's own** `profiles/` directory —
+there is no user- or system-level profile location, so a site profile shared
+across a lab is copied into each workflow (or kept in the workflow
+repository) rather than installed once per machine.
+
+Both conditions are required: a `[cluster]` block must be in effect **and**
+a profile must be named. A profile with only `[config]` keeps the local
+path, and a workflow carrying its own `[cluster]` block still runs locally
+until you pass `--profile`, so adding one never changes an existing run.
+
+Rules become jobs after wildcard expansion, so a 100-sample scatter is 100
+jobs, and dependencies are chained per instance. The run submits at most
+`max_submitted` jobs at a time, tracks them to completion, and writes the
+checkpoint exactly as a local run does — `status`, `resume`, and re-run
+invalidation behave identically, and a second `run --profile slurm` with
+nothing changed submits nothing.
+
+Each run leaves a directory you can navigate with ordinary tools:
+
+```console
+.oxo-flow/runs/2026-08-17T14-30-05/   # `latest` symlinks to the newest
+  events.jsonl                        # append-only submit/complete/fail log
+  jobs/<rule>/job.sh                  # the exact script submitted
+  jobs/<rule>/job.id                  # scheduler job id
+  jobs/<rule>/status.json
+```
+
+Outputs, the working directory, and logs are assumed to live on storage
+shared between the submitting host and the compute nodes.
+
+> **Not yet implemented.** The driver polls until every job reaches a
+> terminal state; it does not yet re-attach to jobs still in flight if the
+> driver exits, and Ctrl-C does not yet cancel submitted jobs. Until then,
+> use `oxo-flow cluster cancel <JOB_ID>...` to clean up an interrupted run.
+
 Cluster scheduler submission (SLURM, PBS, SGE, LSF) is configured
 separately — see the [`cluster`](cluster.md) command.
 

--- a/docs/guide/src/how-to/run-on-cluster.md
+++ b/docs/guide/src/how-to/run-on-cluster.md
@@ -8,6 +8,15 @@ This guide explains how to execute oxo-flow workflows on HPC clusters using SLUR
 
 oxo-flow's cluster module translates each rule into a cluster job submission. Resource requirements declared in the `.oxoflow` file (`threads`, `memory`, `gpu`, `time_limit`) are mapped to the appropriate scheduler directives. The `disk` field is **not** mapped to any scheduler directive — it only produces a local warning during `oxo-flow run`.
 
+There are two ways to reach a scheduler, and they suit different jobs:
+
+| | What it does | Use when |
+|---|---|---|
+| `run --profile <NAME>` | Submits, tracks jobs to completion, and updates the checkpoint | Normal execution — you want the workflow to run |
+| `cluster submit` | Writes job scripts and stops | You want to inspect or hand-edit scripts before submitting |
+
+`run --profile` is the everyday path; it inherits everything `run` does — wildcard expansion, checkpoint/resume, `--samples`, `--rerun`, config-change invalidation. See [Cluster submission](../commands/run.md#cluster-submission) for the `[cluster]` profile block. `cluster submit` remains the escape hatch and is documented below.
+
 **Environment wrapping is applied automatically** — conda, mamba, docker, singularity, pixi, venv, and modules environments are wrapped in the generated scripts. Each rule applies **one** backend (the first declared in the resolver order), so declaring e.g. both `singularity` and `modules` silently drops `modules`.
 
 ---

--- a/docs/guide/src/reference/execution-backends.md
+++ b/docs/guide/src/reference/execution-backends.md
@@ -93,9 +93,17 @@ The P1 acceptance tests (`tests/cluster_backend.rs`) assert the core claim:
 - the dry-run preview's will-run set equals the set the driver submits,
 - poll timeouts cancel in-flight jobs.
 
+`run --profile <NAME>` now drives the backend when the profile carries a
+`[cluster]` block (see [Cluster submission](../commands/run.md#cluster-submission)).
+Its submission set is the dry-run preview's will-run set unioned with the
+run's `force_rules` — the same bypass set the local executor receives, since
+`run` has already applied and persisted its invalidation analysis by the time
+the cluster path runs. `tests/cluster_run_profile.rs` pins that combination to
+what the local executor actually executes from identical state.
+
 Real-cluster validation (SLURM scheduler matrix, version quirks) is tracked
-in the cluster testing checklist; wiring `run --profile slurm` on top of the
-driver, job arrays, and re-attach are follow-ups.
+in the cluster testing checklist; job arrays, re-attach to in-flight jobs, and
+`sacct`-based resource feedback are follow-ups.
 
 ## Assumptions
 

--- a/tests/cluster_run_profile.rs
+++ b/tests/cluster_run_profile.rs
@@ -1,0 +1,296 @@
+//! `run --profile <NAME>` cluster path (issue #74 phase 2).
+//!
+//! The load-bearing test here is `cluster_and_local_agree_on_rerun_set`: the
+//! cluster path derives its submission set from `preview_run_plan` plus the
+//! run's `force_rules`, and this pins that combination to what the local
+//! executor actually runs from identical state. If the two ever diverge,
+//! this goes red rather than a cluster run silently skipping work.
+
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+const WORKFLOW: &str = r#"
+[workflow]
+name = "cluster-profile"
+
+[[sample_groups]]
+name = "batch"
+samples = ["S1", "S2"]
+
+[[rules]]
+name = "align"
+input = ["data/{sample}.fq"]
+output = ["aln/{sample}.bam"]
+shell = "mkdir -p aln && cp data/{sample}.fq aln/{sample}.bam"
+
+[[rules]]
+name = "stats"
+input = ["aln/{sample}.bam"]
+output = ["stats/{sample}.txt"]
+shell = "mkdir -p stats && wc -l aln/{sample}.bam > stats/{sample}.txt"
+"#;
+
+const CLUSTER_PROFILE: &str = r#"
+[cluster]
+backend = "slurm"
+partition = "compute"
+max_submitted = 2
+poll_interval = "1s"
+"#;
+
+/// Locate a workspace binary (mirrors the helper in cluster_backend.rs).
+fn workspace_bin(name: &str) -> PathBuf {
+    let target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+    panic!(
+        "could not find binary '{name}' in target directory; run `cargo build --workspace` first"
+    );
+}
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock-scheduler")
+}
+
+/// A workflow directory with two samples and an optional `profiles/slurm.toml`.
+fn setup(dir: &Path, profile: Option<&str>) {
+    std::fs::write(dir.join("wf.oxoflow"), WORKFLOW).unwrap();
+    let data = dir.join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    for s in ["S1", "S2"] {
+        std::fs::write(data.join(format!("{s}.fq")), format!(">{s}\nACGT\n")).unwrap();
+    }
+    if let Some(body) = profile {
+        let profiles = dir.join("profiles");
+        std::fs::create_dir_all(&profiles).unwrap();
+        std::fs::write(profiles.join("slurm.toml"), body).unwrap();
+    }
+    std::fs::create_dir_all(dir.join("sched")).unwrap();
+}
+
+/// `oxo-flow run` with the mock scheduler ahead of the real one on PATH.
+/// Env goes to the child only — never `std::env::set_var`, which would race
+/// the other tests in this binary.
+fn run(dir: &Path, args: &[&str]) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        fixtures_dir().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut full: Vec<&str> = vec!["run", "wf.oxoflow"];
+    full.extend_from_slice(args);
+    StdCommand::new(workspace_bin("oxo-flow"))
+        .args(&full)
+        .current_dir(dir)
+        .env("PATH", path)
+        .env("MOCK_SCHEDULER_DIR", dir.join("sched"))
+        .output()
+        .unwrap()
+}
+
+/// Rules the cluster path submitted, read from the run directory's event log.
+fn submitted_rules(dir: &Path) -> Vec<String> {
+    let events =
+        std::fs::read_to_string(dir.join(".oxo-flow/runs/latest/events.jsonl")).expect("no events");
+    let mut names: Vec<String> = events
+        .lines()
+        .filter_map(|l| {
+            let v: serde_json::Value = serde_json::from_str(l).ok()?;
+            (v["t"] == "SUBMITTED").then(|| v["rule"].as_str().unwrap().to_string())
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+/// Rules the local executor actually ran, read from its per-rule success lines.
+fn executed_rules(output: &std::process::Output) -> Vec<String> {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut names: Vec<String> = stderr
+        .lines()
+        .filter_map(|l| {
+            let l = l.trim();
+            let rest = l.strip_prefix("✓ ")?;
+            // "✓ align_batch_S1 (0.1s)". The trailing duration is what
+            // separates a per-rule line from summary lines like
+            // "✓ 4 output files verified (42B total)".
+            let name = rest.split_whitespace().next()?;
+            rest.ends_with("s)").then(|| name.to_string())
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn run_profile_slurm_submits_tracks_and_records() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), Some(CLUSTER_PROFILE));
+
+    let out = run(dir.path(), &["--profile", "slurm"]);
+    assert!(
+        out.status.success(),
+        "cluster run failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Every rule instance was submitted, and the jobs really executed.
+    assert_eq!(
+        submitted_rules(dir.path()),
+        vec![
+            "align_batch_S1",
+            "align_batch_S2",
+            "stats_batch_S1",
+            "stats_batch_S2"
+        ]
+    );
+    for f in ["aln/S1.bam", "aln/S2.bam", "stats/S1.txt", "stats/S2.txt"] {
+        assert!(dir.path().join(f).exists(), "missing output {f}");
+    }
+
+    // The run directory is greppable and per-rule.
+    let jobs = dir.path().join(".oxo-flow/runs/latest/jobs");
+    for rule in ["align_batch_S1", "stats_batch_S2"] {
+        assert!(
+            jobs.join(rule).join("job.sh").exists(),
+            "no script for {rule}"
+        );
+        assert!(jobs.join(rule).join("job.id").exists(), "no id for {rule}");
+    }
+
+    // Checkpoint bookkeeping matches the local path's, so a second run is a
+    // no-op rather than a resubmission.
+    let ck: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.path().join(".oxo-flow/checkpoint.json")).unwrap(),
+    )
+    .unwrap();
+    let completed = ck["completed_rules"].as_array().unwrap();
+    assert_eq!(completed.len(), 4, "checkpoint: {completed:?}");
+    assert_eq!(ck["input_manifests"].as_object().unwrap().len(), 4);
+
+    let second = run(dir.path(), &["--profile", "slurm"]);
+    assert!(
+        String::from_utf8_lossy(&second.stderr).contains("nothing to submit"),
+        "second run should be a no-op:\n{}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+}
+
+/// The parity contract: from identical state, the cluster path submits
+/// exactly the set the local path executes.
+#[test]
+fn cluster_and_local_agree_on_rerun_set() {
+    let cluster_dir = tempfile::tempdir().unwrap();
+    let local_dir = tempfile::tempdir().unwrap();
+    setup(cluster_dir.path(), Some(CLUSTER_PROFILE));
+    setup(local_dir.path(), Some(CLUSTER_PROFILE));
+
+    // Both start from a completed run.
+    assert!(
+        run(cluster_dir.path(), &["--profile", "slurm"])
+            .status
+            .success()
+    );
+    assert!(run(local_dir.path(), &[]).status.success());
+
+    // The same input changes in both. `align_batch_S2` is invalidated
+    // directly; `stats_batch_S2` only through the cascade — and its outputs
+    // still look fresh at planning time, which is exactly the case a
+    // preview-only submission set gets wrong.
+    for d in [cluster_dir.path(), local_dir.path()] {
+        std::fs::write(d.join("data/S2.fq"), ">S2 CHANGED\nACGTACGT\n").unwrap();
+    }
+
+    let cluster_out = run(cluster_dir.path(), &["--profile", "slurm"]);
+    assert!(cluster_out.status.success());
+    let local_out = run(local_dir.path(), &[]);
+    assert!(local_out.status.success());
+
+    let submitted = submitted_rules(cluster_dir.path());
+    let executed = executed_rules(&local_out);
+    assert_eq!(
+        submitted, executed,
+        "cluster submitted {submitted:?} but local executed {executed:?}"
+    );
+    assert_eq!(
+        submitted,
+        vec!["align_batch_S2", "stats_batch_S2"],
+        "expected the changed sample's chain, cascade included"
+    );
+}
+
+/// Condition 4: a profile without a `[cluster]` block keeps the local path,
+/// so existing config-only profiles are unaffected.
+#[test]
+fn profile_without_cluster_block_stays_local() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), Some("[config]\nreference = \"/data/ref.fa\"\n"));
+
+    let out = run(dir.path(), &["--profile", "slurm"]);
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Cluster:"),
+        "config-only profile must not submit to a scheduler:\n{stderr}"
+    );
+    assert!(!dir.path().join(".oxo-flow/runs").exists());
+    assert_eq!(executed_rules(&out).len(), 4);
+}
+
+/// A workflow carrying `[cluster]` still runs locally until the user opts in
+/// with `--profile` — this change must not make existing workflows submit.
+#[test]
+fn cluster_block_without_profile_flag_stays_local() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), None);
+    let with_cluster = format!("{WORKFLOW}\n[cluster]\nbackend = \"slurm\"\n");
+    std::fs::write(dir.path().join("wf.oxoflow"), with_cluster).unwrap();
+
+    let out = run(dir.path(), &[]);
+    assert!(out.status.success());
+    assert!(!String::from_utf8_lossy(&out.stderr).contains("Cluster:"));
+    assert!(!dir.path().join(".oxo-flow/runs").exists());
+}
+
+/// `--max-submitted` is a one-off override of the profile's queue cap.
+#[test]
+fn max_submitted_flag_overrides_the_profile() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), Some(CLUSTER_PROFILE)); // profile says 2
+
+    let out = run(dir.path(), &["--profile", "slurm", "--max-submitted", "1"]);
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("max 1 in flight"),
+        "flag must beat the profile's max_submitted = 2:\n{stderr}"
+    );
+
+    // Without the flag, the profile's value stands.
+    let dir2 = tempfile::tempdir().unwrap();
+    setup(dir2.path(), Some(CLUSTER_PROFILE));
+    let out2 = run(dir2.path(), &["--profile", "slurm"]);
+    assert!(String::from_utf8_lossy(&out2.stderr).contains("max 2 in flight"));
+}
+
+#[test]
+fn cluster_profile_without_backend_is_an_actionable_error() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), Some("[cluster]\npartition = \"compute\"\n"));
+
+    let out = run(dir.path(), &["--profile", "slurm"]);
+    assert!(!out.status.success(), "missing backend must fail the run");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("backend") && stderr.contains("slurm"),
+        "error should name the missing key and a valid value:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Phase 2 of #74: `run --profile <NAME>` submits to a scheduler when the profile declares `[cluster]`. Built on #78's `BackendDriver` and `ClusterExecutor` — this is the glue, not a second engine.

```toml
# profiles/slurm.toml
[cluster]
backend       = "slurm"
partition     = "compute"
max_submitted = 50
poll_interval = "30s"
```

```bash
oxo-flow run wgs.oxoflow --profile slurm --max-submitted 100
```

Activation needs a named profile **and** a `[cluster]` block in effect, so config-only profiles keep the local path and a workflow carrying `[cluster]` keeps running locally until `--profile` is passed. Core `merge_profile` now merges `[cluster]` with the same fill/override semantics as the rest; `ClusterProfile` gains `walltime`, `max_submitted`, `poll_interval`.

Records rejoin the checkpoint at the same `mark_completed`/`mark_failed` + `save_to_file` seam the local loop uses, so `status`, `resume`, and re-run invalidation cannot tell the two paths apart.

## The `to_run` question, and what testing changed about it

I asked above which producer should feed `BackendDriver`'s `to_run` and went ahead rather than keep this blocked — easy to redo if you'd rather.

The set comes from `preview_run_plan` (the producer `dry-run` uses, and the one your #78 acceptance test already pins driver submissions to) **unioned with the run's `force_rules`**. The union is not tidiness — the preview alone is wrong, and the parity test caught it:

`run_command` applies *and persists* its invalidation analysis before the cluster path runs, so a later `preview_run_plan` can no longer re-derive the cascade. Complete a run, change one sample's input: local executes `align_S2` **and** `stats_S2`, but a preview-only submission set submits just `align_S2` — `stats_S2`'s outputs still look fresh relative to a `aln/S2.bam` that hasn't been rebuilt yet. A silently under-submitted cluster run. `force_rules` is that same analysis's output and is exactly what the local executor receives to bypass its freshness gate, so both paths now consume identical inputs.

`dry-run` alone does **not** have this bug — it runs on an un-mutated checkpoint. No parity defect to fix there.

`cluster_and_local_agree_on_rerun_set` pins the submitted set to what the local executor actually executes from identical state, so a future divergence fails a test instead of silently skipping work.

## Deliberately not here

- **Re-attach.** Verified the gap: kill the driver mid-run and jobs keep running, but tracking stops, and a re-run resubmits anything still in flight — two jobs writing the same outputs. The workdir lock does not save you (`flock`, released on process death). Documented as not-yet-implemented; `cluster cancel` is the manual escape.
- **Ctrl-C → `scancel`.** Same machinery. There is no signal handling anywhere in the CLI today, so this is greenfield.
- **Job arrays** — Phase 3, after the per-job path proves out.

## Two places this is narrower than the proposal

1. **No native scheduler dependencies.** `BackendDriver` holds dependents and submits them once upstreams complete; it never passes `--dependency=afterok`. So dependent jobs don't hold queue position and pay full queue wait at each stage boundary. That's your driver's design rather than something the glue layer decides — flagging it because it's measurable on real hardware and I expect it to dominate wall-clock on a busy cluster.
2. **Run directory is your "minimal phase-2 subset."** Present: timestamped dir + `latest`, `events.jsonl`, `jobs/<rule>/{job.sh,job.id,status.json}`. Not present: `index.json`, `jobs/<rule>/<key>=<value>/` nesting, per-job `stdout.log`/`stderr.log`, fingerprints in `status.json`. Completing it means changing the driver in core, so I left it alone.

## Testing

`tests/cluster_run_profile.rs` (6): submit/track/record end to end through the mock scheduler, second run is a no-op, cluster↔local parity on the re-run set, `--max-submitted` beats the profile, config-only profile stays local, `[cluster]` without `--profile` stays local, missing `backend` fails with an actionable error.

`make ci` clean. One caveat: `oxo-flow-web`'s `test_personal_mode_health` flakes in full parallel `cargo test --workspace` runs — I confirmed it fails the same way on unmodified `main`, so it's pre-existing and unrelated, but it may be hitting your CI too.

## Where I'd like direction

Re-attach next, or native dependency chaining first? Re-attach closes the correctness gap; dependency chaining is where the wall-clock win is. Happy to take either, and I can measure both on our cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
