### PR TITLE
fix(core): {effective_memory_mb} stays RAM-only — swap counts for scheduling, not tool sizing

### DIFF
--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -514,8 +514,13 @@ pub fn detect_system_limits() -> ResourceLimits {
         let threads = std::thread::available_parallelism()
             .map(|n| n.get() as u32)
             .unwrap_or(1);
-        let memory_mb = crate::executor::process::detect_total_memory_mb()
-            + crate::executor::process::detect_swap_mb();
+        // Tool-facing: RAM only. The scheduling ceiling (pool + container
+        // clamps) counts swap separately — but tools that size themselves
+        // from this placeholder (JVM heaps, cellranger --localmem) must
+        // fit in what the kernel can give WITHOUT paging, or cgroup-aware
+        // job managers (live: cellranger count) demand stages the box can
+        // never satisfy.
+        let memory_mb = crate::executor::process::detect_total_memory_mb();
         ResourceLimits { threads, memory_mb }
     })
 }


### PR DESCRIPTION
Follow-up to the swap-aware ceiling (#91): the tool-facing placeholder must stay at physical RAM.

**Live evidence (tx-ubuntu, scrnaseq)**: with the ceiling at RAM+swap (9.7G), cellranger count's `--localmem` scaled to 9 and its jobmngr demanded 9GB-class stages the 3.7G box can never satisfy — the count hung indefinitely.

**Fix**: `detect_system_limits` (the placeholder feed) reverts to RAM; the executor's pool + container clamps keep counting swap. 1019 core tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)