### PR TITLE
fix(core): per-environment create locks with a bounded wait

### DIFF
--- a/crates/oxo-flow-core/src/executor/env_create_lock.rs
+++ b/crates/oxo-flow-core/src/executor/env_create_lock.rs
@@ -62,6 +62,15 @@ fn lock_timeout() -> Duration {
         .unwrap_or(DEFAULT_LOCK_TIMEOUT)
 }
 
+/// Lock file path for an environment cache key — stable per key, distinct
+/// across keys. Extracted so tests exercise the production derivation, not
+/// a re-typed copy of it.
+fn lock_path_for(dir: &Path, key: &str) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let digest = format!("{:x}", Sha256::digest(key.as_bytes()));
+    dir.join(format!("env-{}.lock", &digest[..16]))
+}
+
 impl EnvCreateLock {
     /// Acquire the per-environment exclusive lock for `key`, creating
     /// `~/.oxo-flow/locks` if needed.
@@ -78,9 +87,7 @@ impl EnvCreateLock {
         std::fs::create_dir_all(&dir).ok();
         // One lock file per environment cache key — different envs
         // never contend.
-        use sha2::{Digest, Sha256};
-        let digest = format!("{:x}", Sha256::digest(key.as_bytes()));
-        let path = dir.join(format!("env-{}.lock", &digest[..16]));
+        let path = lock_path_for(&dir, key);
         let file = match OpenOptions::new()
             .create(true)
             .write(true)
@@ -175,13 +182,15 @@ mod tests {
     }
 
     #[test]
-    fn lock_key_derives_from_the_environment_not_the_machine() {
-        // Different env keys must yield different lock paths — the whole
-        // point of the per-env design (a slow solve for one env must not
-        // block another env's creation).
-        use sha2::{Digest, Sha256};
-        let a = format!("{:x}", Sha256::digest(b"key-a"));
-        let b = format!("{:x}", Sha256::digest(b"key-b"));
-        assert_ne!(a, b);
+    fn lock_path_is_stable_per_key_and_distinct_across_keys() {
+        // The whole point of the per-env design: a slow solve for one env
+        // must not block another env's creation — same key always maps to
+        // the same lock file, different keys never do.
+        let dir = Path::new("/tmp/oxo-locks-test");
+        let a1 = lock_path_for(dir, "key-a");
+        let a2 = lock_path_for(dir, "key-a");
+        let b = lock_path_for(dir, "key-b");
+        assert_eq!(a1, a2, "same key must map to the same lock file");
+        assert_ne!(a1, b, "different keys must map to different lock files");
     }
 }

--- a/crates/oxo-flow-core/src/executor/env_create_lock.rs
+++ b/crates/oxo-flow-core/src/executor/env_create_lock.rs
@@ -112,14 +112,19 @@ impl EnvCreateLock {
                 }
                 Err(e) if e.kind() == ErrorKind::WouldBlock => {
                     if Instant::now() >= deadline {
+                        let holder = std::fs::read_to_string(&path)
+                            .ok()
+                            .and_then(|s| s.trim().parse::<u32>().ok());
+                        let holder_hint = holder
+                            .map(|pid| format!("holder pid: {pid}"))
+                            .unwrap_or_else(|| "holder pid: unknown".to_string());
                         return Err(Error::new(
                             ErrorKind::TimedOut,
                             format!(
-                                "env create lock {} still held after {}s (holder pid file: {}) — a previous env setup appears stuck; \
+                                "env create lock {} still held after {}s ({holder_hint}) — a previous env setup appears stuck; \
                                  kill the holder or raise OXO_ENV_LOCK_TIMEOUT_SECS if the solve is legitimately slow",
                                 path.display(),
                                 lock_timeout().as_secs(),
-                                path.display()
                             ),
                         ));
                     }

--- a/crates/oxo-flow-core/src/executor/env_create_lock.rs
+++ b/crates/oxo-flow-core/src/executor/env_create_lock.rs
@@ -1,20 +1,36 @@
-//! Cross-process serialization of environment creation.
+//! Cross-process serialization of environment creation, per environment.
 //!
-//! Two `oxo-flow run` processes on the same machine used to create conda
-//! envs concurrently: conda's package-cache/post-link contention plus the
-//! stacked memory peaks OOM-killed small boxes (live evidence: the
-//! tx-ubuntu campaign overload episodes, load 56-79). This advisory flock
-//! serializes the whole create+verify sequence across processes; the OS
-//! releases it automatically when the holder exits, so there are no stale
-//! locks to clean up.
+//! Two `oxo-flow run` processes creating the SAME conda env concurrently
+//! corrupt each other's transaction (live evidence: rnaseq's env history
+//! showed `+fq` followed by `-fq` 12s later — the loser's transaction
+//! removed the winner's packages). DIFFERENT envs are independent by
+//! conda/pixi semantics (conda's package cache has its own locking, pixi
+//! has pixi.lock), so the lock is keyed by the environment: one lock file
+//! per env cache key under `~/.oxo-flow/locks/`. A slow solve for env A
+//! therefore never blocks env B's creation (live evidence: a 3.5h
+//! bioconductor solve held the OLD global lock and stalled every rule
+//! needing ANY env setup for hours).
+//!
+//! The wait is bounded: after the timeout (default 2h, `OXO_ENV_LOCK_TIMEOUT_SECS`
+//! to override) the acquisition fails with a diagnostic instead of hanging
+//! forever. The OS releases the flock automatically when the holder exits,
+//! so there are no stale locks to clean up.
 
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
+use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
-/// An exclusive machine-wide lock for environment creation, held across the
-/// whole setup+verify sequence. Blocking by design: a concurrent run's env
-/// create waits for this one to finish instead of racing it.
+/// Default bounded wait for the per-env lock: legitimate env solves take
+/// tens of minutes; anything beyond this is a stuck holder and should
+/// fail fast with a diagnostic rather than hang the queue.
+const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
+/// How often the waiter logs while blocked.
+const WAIT_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// An exclusive machine-wide lock for ONE environment's creation, held
+/// across the whole setup+verify sequence.
 #[derive(Debug)]
 pub struct EnvCreateLock {
     file: File,
@@ -37,25 +53,80 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
+fn lock_timeout() -> Duration {
+    std::env::var("OXO_ENV_LOCK_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_LOCK_TIMEOUT)
+}
+
 impl EnvCreateLock {
-    /// Acquire the blocking exclusive lock, creating `~/.oxo-flow` if needed.
+    /// Acquire the per-environment exclusive lock for `key`, creating
+    /// `~/.oxo-flow/locks` if needed.
     ///
-    /// Best-effort: on filesystem errors returns `None` and env setup
-    /// proceeds unlocked rather than failing the run.
-    #[must_use]
-    pub fn acquire() -> Option<Self> {
-        let dir = home_dir()?.join(".oxo-flow");
-        std::fs::create_dir_all(&dir).ok()?;
-        let path = dir.join("env-create.lock");
-        let file = OpenOptions::new()
+    /// Blocking up to the timeout, logging periodically while waiting.
+    /// Best-effort on filesystem errors: returns `None` and env setup
+    /// proceeds unlocked rather than failing the run. A TIMEOUT is not
+    /// best-effort — it returns an error the caller surfaces (a stuck
+    /// holder must be visible, not silently swallowed).
+    pub fn acquire(key: &str) -> std::io::Result<Option<Self>> {
+        let Some(dir) = home_dir().map(|h| h.join(".oxo-flow").join("locks")) else {
+            return Ok(None);
+        };
+        std::fs::create_dir_all(&dir).ok();
+        // One lock file per environment cache key — different envs
+        // never contend.
+        use sha2::{Digest, Sha256};
+        let digest = format!("{:x}", Sha256::digest(key.as_bytes()));
+        let path = dir.join(format!("env-{}.lock", &digest[..16]));
+        let file = match OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(false)
             .open(&path)
-            .ok()?;
-        match file.lock_exclusive() {
-            Ok(()) => Some(Self { file, path }),
-            Err(_) => None,
+        {
+            Ok(f) => f,
+            Err(_) => return Ok(None),
+        };
+
+        let deadline = Instant::now() + lock_timeout();
+        let mut last_log = Instant::now() - WAIT_LOG_INTERVAL;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    let _ = file.set_len(0);
+                    let _ = std::io::Write::write_all(
+                        &mut &file,
+                        format!("{}\n", std::process::id()).as_bytes(),
+                    );
+                    return Ok(Some(Self { file, path }));
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(Error::new(
+                            ErrorKind::TimedOut,
+                            format!(
+                                "env create lock {} still held after {}s (holder pid file: {}) — a previous env setup appears stuck; \
+                                 kill the holder or raise OXO_ENV_LOCK_TIMEOUT_SECS if the solve is legitimately slow",
+                                path.display(),
+                                lock_timeout().as_secs(),
+                                path.display()
+                            ),
+                        ));
+                    }
+                    if last_log.elapsed() >= WAIT_LOG_INTERVAL {
+                        tracing::warn!(
+                            path = %path.display(),
+                            "waiting for env create lock held by another process"
+                        );
+                        last_log = Instant::now();
+                    }
+                    std::thread::sleep(Duration::from_secs(5));
+                }
+                Err(e) => return Err(e),
+            }
         }
     }
 
@@ -101,5 +172,16 @@ mod tests {
         drop(first);
         // After release the lock is acquirable again.
         assert!(second.try_lock_exclusive().is_ok());
+    }
+
+    #[test]
+    fn lock_key_derives_from_the_environment_not_the_machine() {
+        // Different env keys must yield different lock paths — the whole
+        // point of the per-env design (a slow solve for one env must not
+        // block another env's creation).
+        use sha2::{Digest, Sha256};
+        let a = format!("{:x}", Sha256::digest(b"key-a"));
+        let b = format!("{:x}", Sha256::digest(b"key-b"));
+        assert_ne!(a, b);
     }
 }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -598,16 +598,32 @@ impl LocalExecutor {
         } else {
             setup_cmd
         };
-        // Cross-process serialization: another oxo-flow run on this machine
-        // may be creating a different env right now (conda cache/post-link
-        // contention + stacked memory peaks — live evidence: tx-ubuntu
-        // overload episodes). The blocking flock waits for the other run's
-        // create+verify sequence; held until this function returns.
-        let cross_process_guard =
-            tokio::task::spawn_blocking(super::env_create_lock::EnvCreateLock::acquire)
-                .await
-                .ok()
-                .flatten();
+        // Cross-process serialization, PER ENVIRONMENT: another run on this
+        // machine creating the SAME env would corrupt the transaction
+        // (rnaseq +fq/-fq live evidence); DIFFERENT envs are independent by
+        // conda/pixi semantics and must not contend (the old global lock
+        // let a 3.5h bioconductor solve stall every env setup). The wait
+        // is bounded — a stuck holder fails fast with a diagnostic instead
+        // of hanging the queue (OXO_ENV_LOCK_TIMEOUT_SECS to tune).
+        let lock_key = key.clone();
+        let cross_process_guard = tokio::task::spawn_blocking(move || {
+            super::env_create_lock::EnvCreateLock::acquire(&lock_key)
+        })
+        .await;
+        let cross_process_guard = match cross_process_guard {
+            Ok(Ok(guard)) => guard,
+            Ok(Err(e)) => {
+                tracing::error!(error = %e, "env create lock acquisition failed");
+                return Err(OxoFlowError::Environment {
+                    kind: kind.to_string(),
+                    message: format!("env create lock acquisition failed: {e}"),
+                });
+            }
+            Err(join_err) => {
+                tracing::warn!(error = %join_err, "env lock task join failed — env setup proceeds unlocked");
+                None
+            }
+        };
         if cross_process_guard.is_none() {
             tracing::warn!(
                 "env-create cross-process lock unavailable — env setup proceeds unlocked"

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1164,6 +1164,17 @@ but the conda environment already exists, oxo-flow verifies it in place
 and marks it ready instead of re-running the setup, whose `conda env
 update` fallback re-resolves every dependency over the network.
 
+**Environment creation is serialized per environment, not per machine**
+— concurrent processes creating the *same* env would corrupt each
+other's transaction, so setup holds an exclusive lock keyed by the env
+cache key (`~/.oxo-flow/locks/env-<sha256>.lock`); *different* envs are
+independent by conda/pixi semantics and never contend. The wait is
+bounded (2h by default, `OXO_ENV_LOCK_TIMEOUT_SECS` to tune): the
+waiter logs every 60s and a timeout fails the rule with the lock path
+in the diagnostic instead of hanging the run. The holder's pid is
+written into the lock file for diagnosis. On shared accounts, one
+user's slow solve only blocks creators of that same environment.
+
 **Array-valued `{config.*}`** — a `[config]` key holding an array renders
 as a space-joined list in the shell (`["a", "b"]` → `a b`), matching the
 `{input}` convention; iterate with `for x in {config.tools}`.


### PR DESCRIPTION
Replaces the single machine-wide env-create flock with per-environment locks.

**Live evidence (tx-ubuntu 2026-08-18)**: a 3.5h bioconductor solve held the global lock and stalled every rule needing ANY env setup for ~4 hours (the queue-wide stall). conda/pixi semantics only require mutual exclusion for the SAME env — different envs are independent (conda's package cache has its own locking, pixi has pixi.lock).

**Change**: lock keyed by the env cache key (`~/.oxo-flow/locks/env-<sha256>.lock`); wait bounded at 2h (`OXO_ENV_LOCK_TIMEOUT_SECS` to tune) with per-60s waiting logs; timeout fails the rule with a diagnostic naming the lock path instead of hanging; the holder pid is written into the lock file. Multi-user shared accounts benefit directly: one user's slow env solve only blocks creators of that same env.

1020 core tests pass; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)