### PR TITLE
fix: reference source-content fingerprint (#97) + script/hook fan-out substitution (#98)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "filetime",
  "fs2",
  "glob",
  "globset",

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -996,40 +996,42 @@ pub async fn run_command(
                 &wildcard_values,
             );
             let output_full = ref_workdir.join(&output_path);
-            let current_fp =
-                oxo_flow_core::config_impact::reference_fingerprint(ref_def, &config.config);
+            // Resolved once: the fingerprint guards the source CONTENT
+            // (issue #97) and the freshness check below guards mtime vs
+            // the output — both need the same workdir-joined path.
+            let resolved_source = ref_def.source.as_ref().map(|source| {
+                ref_workdir.join(oxo_flow_core::executor::checkpoint::expand_config_in_path(
+                    source,
+                    &wildcard_values,
+                ))
+            });
+            let current_fp = oxo_flow_core::config_impact::reference_fingerprint(
+                ref_def,
+                &config.config,
+                resolved_source.as_deref(),
+            );
             let stored = ref_state.get(&ref_def.name).cloned();
 
-            // Decide whether the artifact must be (re)built. A fingerprint
-            // mismatch means the build/source/output definition — or a config
-            // value its build command references — changed since the last
-            // build, so the old artifact is silently stale.
+            // Decide whether the artifact must be (re)built. The freshness
+            // check comes FIRST so an mtime-only touch reports the accurate
+            // reason; a fingerprint mismatch then covers definition edits,
+            // referenced-config changes, and content changes the freshness
+            // check cannot see (same-path, timestamp-preserving rewrites).
+            let source_newer = resolved_source.as_deref().is_some_and(|p| {
+                p.exists() && oxo_flow_core::executor::checkpoint::file_is_newer(p, &output_full)
+            });
             let rebuild_reason = if !output_full.exists() {
                 Some("output missing")
             } else if stored.as_deref() == Some("") {
                 // Legacy entry: adopt the current fingerprint without rebuilding.
                 ref_state.insert(ref_def.name.clone(), current_fp.clone());
                 None
+            } else if source_newer {
+                Some("source is newer than output")
             } else if let Some(stored_fp) = stored.as_deref()
                 && stored_fp != current_fp
             {
-                Some("definition or referenced config changed")
-            } else if let Some(source) = ref_def.source.as_ref() {
-                let source_path =
-                    ref_workdir.join(oxo_flow_core::executor::checkpoint::expand_config_in_path(
-                        source,
-                        &wildcard_values,
-                    ));
-                if source_path.exists()
-                    && oxo_flow_core::executor::checkpoint::file_is_newer(
-                        &source_path,
-                        &output_full,
-                    )
-                {
-                    Some("source is newer than output")
-                } else {
-                    None
-                }
+                Some("definition, source content, or referenced config changed")
             } else {
                 None
             };
@@ -1120,7 +1122,19 @@ pub async fn run_command(
                     .status();
                 match status {
                     Ok(s) if s.success() => {
-                        ref_state.insert(ref_def.name.clone(), current_fp.clone());
+                        // Store the POST-build fingerprint: the decision
+                        // fingerprint above was computed before the build
+                        // ran, and a build that creates or rewrites its own
+                        // source (download-then-index) changes the source
+                        // state DURING the build — storing the pre-build
+                        // state would mismatch on every subsequent run and
+                        // rebuild forever.
+                        let post_fp = oxo_flow_core::config_impact::reference_fingerprint(
+                            ref_def,
+                            &config.config,
+                            resolved_source.as_deref(),
+                        );
+                        ref_state.insert(ref_def.name.clone(), post_fp);
                         rebuilt_outputs.push(output_path.clone());
                         if let Some(parent) = ref_checkpoint.parent() {
                             let _ = std::fs::create_dir_all(parent);

--- a/crates/oxo-flow-core/Cargo.toml
+++ b/crates/oxo-flow-core/Cargo.toml
@@ -57,6 +57,7 @@ nix = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 criterion = { workspace = true }
+filetime = "0.2.29"
 
 [[bench]]
 name = "wildcard_bench"

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1052,6 +1052,24 @@ fn expand_rule_shell(shell: &str, combo: &crate::wildcard::WildcardValues) -> St
     }
 }
 
+/// Bake per-instance fan-out values into the free-text command fields
+/// (issue #98): `script` plus the hook fields render through the same
+/// execution-time placeholder pass as `shell`/`log`, and that pass never
+/// sees pair/group/value/scatter names — so the values must be baked in
+/// here. The `expand` closure matches the surrounding block's expansion
+/// semantics (values-namespace-aware for the pair/group/value paths, plain
+/// wildcard expansion for the scatter path).
+fn expand_command_text_fields(
+    expanded: &mut crate::rule::Rule,
+    source: &crate::rule::Rule,
+    expand: impl Fn(&str) -> String,
+) {
+    expanded.script = source.script.as_deref().map(&expand);
+    expanded.pre_exec = source.pre_exec.as_deref().map(&expand);
+    expanded.on_success = source.on_success.as_deref().map(&expand);
+    expanded.on_failure = source.on_failure.as_deref().map(&expand);
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SampleGroup {
     /// Group name (available as `{group}`).
@@ -2637,7 +2655,12 @@ impl WorkflowConfig {
         let mut name_map: HashMap<String, Vec<String>> = HashMap::new();
 
         for rule in &self.rules {
-            // Collect all text fields that might contain wildcards
+            // Collect all text fields that might contain wildcards. The fan-out
+            // TRIGGER set is input/output/shell only — script and the hooks
+            // substitute per instance when the rule fans out, but never start
+            // a fan-out themselves (cloning on a hook-only wildcard would
+            // duplicate the whole rule execution, and `${name}` bash
+            // spellings inside script would false-trigger).
             let mut all_text: Vec<&str> = rule.input.iter().map(String::as_str).collect();
             all_text.extend(rule.output.iter().map(String::as_str));
             if let Some(ref shell) = rule.shell {
@@ -2766,6 +2789,12 @@ impl WorkflowConfig {
                         if let Some(ref log) = rule.log {
                             expanded.log = Some(expand_rule_shell(log, &combo));
                         }
+                        // Script and hooks carry the per-instance
+                        // substitution too (issue #98) — same class as
+                        // shell/log.
+                        expand_command_text_fields(&mut expanded, rule, |s| {
+                            expand_rule_shell(s, &combo)
+                        });
 
                         // Record which sample names this expansion belongs to
                         // (issue #63 readiness attribution).
@@ -2882,6 +2911,14 @@ impl WorkflowConfig {
                                 Some(log.clone())
                             };
                         }
+                        // Free-text command fields take the same per-instance
+                        // substitution as shell/log (issue #98): script and
+                        // the hooks render through the same placeholder pass
+                        // at execution time, which never sees pair/group
+                        // names, so the values must be baked in here.
+                        expand_command_text_fields(&mut expanded, rule, |s| {
+                            expand_rule_shell(s, &merged)
+                        });
 
                         // Record which sample this expansion belongs to
                         // (issue #63 readiness attribution).
@@ -2938,6 +2975,11 @@ impl WorkflowConfig {
                     if let Some(ref log) = rule.log {
                         expanded.log = Some(expand_rule_shell(log, combo));
                     }
+                    // Script and hooks carry the per-instance substitution
+                    // too (issue #98) — same class as shell/log.
+                    expand_command_text_fields(&mut expanded, rule, |s| {
+                        expand_rule_shell(s, combo)
+                    });
 
                     self.expansion_values
                         .insert(new_name.clone(), combo.clone());
@@ -3056,6 +3098,13 @@ impl WorkflowConfig {
                         scattered_rule.log =
                             Some(expand_pattern(log, &combo).unwrap_or_else(|_| log.clone()));
                     }
+                    // Script and hooks take the same substitution (issue #98):
+                    // a script whose path or content depends on the scatter
+                    // variable must resolve per instance (live: the pca rule
+                    // had to be split into three explicit rules).
+                    expand_command_text_fields(&mut scattered_rule, &rule, |text| {
+                        expand_pattern(text, &combo).unwrap_or_else(|_| text.to_string())
+                    });
 
                     // Carry the pre-scatter [[values]] bindings over to the
                     // scattered name and add the scatter variable, so
@@ -6274,6 +6323,174 @@ shell = "echo {config.database} > {output[0]}"
             .into_iter()
             .collect(),
             "every instance must own its log path: {logs:?}"
+        );
+    }
+
+    #[test]
+    fn scatter_expands_script_and_hooks_with_scatter_variable() {
+        // issue #98: the scatter variable must substitute into script (and
+        // the hook fields) per instance — shell/log were the only text
+        // fields covered before. Live: the star-deseq2 pca rule had to be
+        // split into three explicit rules because the per-treatment script
+        // invocation could not be expressed.
+        let toml = r#"
+            [workflow]
+            name = "t"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "pca"
+            scatter = { variable = "treatment", values = ["control", "treated"] }
+            output = ["pca/{treatment}.tsv"]
+            script = "scripts/pca_{treatment}.R --out {treatment}.tsv"
+            pre_exec = "mkdir -p tmp/{treatment}"
+            on_success = "echo done {treatment}"
+            on_failure = "echo failed {treatment}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        assert_eq!(
+            config.rules.len(),
+            2,
+            "scatter over 2 values must produce 2 instances"
+        );
+        for treatment in ["control", "treated"] {
+            let rule = config
+                .rules
+                .iter()
+                .find(|r| r.name == format!("pca_{treatment}"))
+                .unwrap_or_else(|| panic!("scattered instance pca_{treatment} must exist"));
+            assert_eq!(
+                rule.script.as_deref(),
+                Some(format!("scripts/pca_{treatment}.R --out {treatment}.tsv").as_str()),
+                "script must carry the per-instance scatter value"
+            );
+            assert_eq!(
+                rule.pre_exec.as_deref(),
+                Some(format!("mkdir -p tmp/{treatment}").as_str())
+            );
+            assert_eq!(
+                rule.on_success.as_deref(),
+                Some(format!("echo done {treatment}").as_str())
+            );
+            assert_eq!(
+                rule.on_failure.as_deref(),
+                Some(format!("echo failed {treatment}").as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn values_expansion_expands_script_per_instance() {
+        // Same class as issue #98 on the [[values]] fan-out path: script
+        // must carry the per-value substitution, not only shell/log.
+        let toml = r#"
+            [workflow]
+            name = "t"
+            version = "1.0.0"
+
+            [[values]]
+            name = "assembler"
+            values = ["spades", "megahit"]
+
+            [[rules]]
+            name = "asm"
+            output = ["out/{assembler}.fa"]
+            script = "scripts/asm_{assembler}.R"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+        let scripts: std::collections::BTreeSet<String> = config
+            .rules
+            .iter()
+            .filter_map(|r| r.script.clone())
+            .collect();
+        assert_eq!(
+            scripts,
+            [
+                "scripts/asm_megahit.R".to_string(),
+                "scripts/asm_spades.R".to_string()
+            ]
+            .into_iter()
+            .collect(),
+            "every value instance must own its script invocation: {scripts:?}"
+        );
+    }
+
+    #[test]
+    fn pair_expansion_expands_script_and_hooks_per_pair() {
+        // Same class as issue #98 on the pairs path: {pair_id} must
+        // substitute into script/hooks per instance.
+        let toml = r#"
+            [workflow]
+            name = "t"
+            version = "1.0.0"
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "E1"
+            control = "C1"
+
+            [[rules]]
+            name = "do"
+            output = ["out/{pair_id}.txt"]
+            script = "scripts/run_{pair_id}.R"
+            on_success = "echo ok {pair_id}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+        let scripts: std::collections::BTreeSet<String> = config
+            .rules
+            .iter()
+            .filter_map(|r| r.script.clone())
+            .collect();
+        assert_eq!(
+            scripts,
+            ["scripts/run_P1.R".to_string()].into_iter().collect(),
+            "the pair instance must own its script invocation: {scripts:?}"
+        );
+        let hooks: std::collections::BTreeSet<String> = config
+            .rules
+            .iter()
+            .filter_map(|r| r.on_success.clone())
+            .collect();
+        assert_eq!(hooks, ["echo ok P1".to_string()].into_iter().collect());
+    }
+
+    #[test]
+    fn script_only_wildcards_do_not_trigger_fan_out() {
+        // The fan-out trigger set is input/output/shell only. A rule whose
+        // ONLY wildcard use is the script field must stay a single rule —
+        // cloning it would duplicate the whole rule execution over
+        // identical paths, and `${name}` bash spellings inside script must
+        // never be mistaken for wildcards. Script substitution applies
+        // when the rule fans out through its path fields (issue #98).
+        let toml = r#"
+            [workflow]
+            name = "t"
+            version = "1.0.0"
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "E1"
+            control = "C1"
+
+            [[rules]]
+            name = "s"
+            script = "scripts/run_${pair_id}.R"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+        assert_eq!(
+            config.rules.len(),
+            1,
+            "script-only wildcard usage must not clone the rule"
+        );
+        assert_eq!(
+            config.rules[0].script.as_deref(),
+            Some("scripts/run_${pair_id}.R"),
+            "a non-fanned rule keeps its script untouched"
         );
     }
 

--- a/crates/oxo-flow-core/src/config_impact.rs
+++ b/crates/oxo-flow-core/src/config_impact.rs
@@ -16,6 +16,7 @@ use crate::executor::checkpoint::CheckpointState;
 use crate::rule::{FilePatterns, Rule};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
 
 /// Engine-injected config keys that churn on every run (rewritten by
 /// `--samples`/`--sample`, sample discovery, and pair consolidation).
@@ -249,7 +250,25 @@ pub fn rule_fingerprint(rule: &Rule, interpreter_map: &HashMap<String, String>) 
 ///
 /// A mismatch (build/source/output edited, or a referenced config key
 /// changed) means the artifact must be rebuilt.
-pub fn reference_fingerprint(def: &ReferenceDef, config: &HashMap<String, toml::Value>) -> String {
+///
+/// `resolved_source` is the source path with `{config.*}` already expanded
+/// (the caller resolves it against the workdir). When it names a readable
+/// local file, the file's size, mtime, and — below
+/// [`crate::executor::checkpoint::MANIFEST_HASH_MAX_BYTES`] — content hash
+/// join the fingerprint (issue #97): the source PATH string alone cannot
+/// detect a same-path replacement, which left artifacts silently stale
+/// (live: a regenerated genome.fa never rebuilt its STAR index). A missing
+/// or unreadable source degrades to the path-string-only fingerprint — the
+/// same policy as the freshness checks, so a first build in a pre-fetch
+/// state never errors out. Note the asymmetry: when the checkpoint already
+/// stores a content-bearing fingerprint, a later missing source mismatches
+/// and the rebuild fails loudly — the safe direction, never silently
+/// serving an artifact whose source state cannot be verified.
+pub fn reference_fingerprint(
+    def: &ReferenceDef,
+    config: &HashMap<String, toml::Value>,
+    resolved_source: Option<&Path>,
+) -> String {
     let mut hasher = Sha256::new();
     let mut add = |label: &str, content: &str| {
         hasher.update(label.as_bytes());
@@ -278,6 +297,24 @@ pub fn reference_fingerprint(def: &ReferenceDef, config: &HashMap<String, toml::
     }
     for (key, value) in referenced {
         add(&key, &value);
+    }
+
+    // Source content guard (issue #97): size + mtime + content hash, through
+    // the SAME helpers as input manifests (issue #72) so the two
+    // invalidation layers cannot drift. A directory or unreadable file
+    // contributes nothing beyond the path string hashed above.
+    if let Some(path) = resolved_source
+        && let Ok(md) = std::fs::metadata(path)
+        && md.is_file()
+    {
+        add("source:size", &md.len().to_string());
+        add(
+            "source:mtime",
+            &crate::executor::checkpoint::mtime_nanos(&md).to_string(),
+        );
+        if let Some(hash) = crate::executor::checkpoint::content_hash_if_small(path, &md) {
+            add("source:hash", &hash);
+        }
     }
 
     format!("sha256:{:x}", hasher.finalize())
@@ -719,13 +756,13 @@ mod tests {
             "ref_dir".to_string(),
             toml::Value::String("refs/v1".to_string()),
         );
-        let f1 = reference_fingerprint(&def, &config);
+        let f1 = reference_fingerprint(&def, &config, None);
 
         config.insert(
             "ref_dir".to_string(),
             toml::Value::String("refs/v2".to_string()),
         );
-        assert_ne!(f1, reference_fingerprint(&def, &config));
+        assert_ne!(f1, reference_fingerprint(&def, &config, None));
 
         let mut edited = def.clone();
         edited.build = "bwa index -p {config.ref_dir}/idx2 {input}".to_string();
@@ -734,8 +771,172 @@ mod tests {
             toml::Value::String("refs/v2".to_string()),
         );
         assert_ne!(
-            reference_fingerprint(&def, &config),
-            reference_fingerprint(&edited, &config)
+            reference_fingerprint(&def, &config, None),
+            reference_fingerprint(&edited, &config, None)
+        );
+    }
+
+    #[test]
+    fn reference_fingerprint_detects_same_path_source_content_replacement() {
+        // issue #97: replacing the source file at the SAME path must change
+        // the fingerprint — the path string alone cannot see it (live: STAR
+        // index silently stale after genome.fa regeneration, twice).
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("genome.fa");
+        let def = ReferenceDef {
+            name: "ref".to_string(),
+            source: Some("genome.fa".to_string()),
+            output: "genome.idx".to_string(),
+            build: "bwa index {input}".to_string(),
+            threads: None,
+            memory: None,
+            environment: None,
+            description: None,
+        };
+        let config = HashMap::new();
+
+        // Same-size content rewrite changes the fingerprint.
+        std::fs::write(&source, b">chr1\nAAAA").unwrap();
+        let before = reference_fingerprint(&def, &config, Some(&source));
+        std::fs::write(&source, b">chr1\nBBBB").unwrap();
+        let after = reference_fingerprint(&def, &config, Some(&source));
+        assert_ne!(
+            before, after,
+            "same-path content rewrite must change the fingerprint"
+        );
+    }
+
+    #[test]
+    fn reference_fingerprint_hashes_content_when_size_and_mtime_are_equal() {
+        // The content-hash branch is what catches a same-size rewrite that
+        // preserves mtime (cp -p, rsync -t, git checkouts) — pin it by
+        // forcing identical size AND mtime across a content change.
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("genome.fa");
+        let def = ReferenceDef {
+            name: "ref".to_string(),
+            source: Some("genome.fa".to_string()),
+            output: "genome.idx".to_string(),
+            build: "bwa index {input}".to_string(),
+            threads: None,
+            memory: None,
+            environment: None,
+            description: None,
+        };
+        let config = HashMap::new();
+        let fixed = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+
+        std::fs::write(&source, b">chr1\nAAAA").unwrap();
+        filetime::set_file_mtime(&source, fixed).unwrap();
+        let before = reference_fingerprint(&def, &config, Some(&source));
+
+        std::fs::write(&source, b">chr1\nBBBB").unwrap();
+        filetime::set_file_mtime(&source, fixed).unwrap();
+        let after = reference_fingerprint(&def, &config, Some(&source));
+
+        assert_ne!(
+            before, after,
+            "same size + same mtime + different content must differ (content hash)"
+        );
+    }
+
+    #[test]
+    fn reference_fingerprint_tracks_source_mtime() {
+        // Identical content at a different mtime must still change the
+        // fingerprint — the size+mtime policy for large files relies on it.
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("genome.fa");
+        let def = ReferenceDef {
+            name: "ref".to_string(),
+            source: Some("genome.fa".to_string()),
+            output: "genome.idx".to_string(),
+            build: "bwa index {input}".to_string(),
+            threads: None,
+            memory: None,
+            environment: None,
+            description: None,
+        };
+        let config = HashMap::new();
+
+        std::fs::write(&source, b">chr1\nAAAA").unwrap();
+        let before = reference_fingerprint(&def, &config, Some(&source));
+        let current =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&source).unwrap());
+        filetime::set_file_mtime(
+            &source,
+            filetime::FileTime::from_unix_time(current.unix_seconds() + 60, 0),
+        )
+        .unwrap();
+        let after = reference_fingerprint(&def, &config, Some(&source));
+
+        assert_ne!(
+            before, after,
+            "a source mtime change must change the fingerprint"
+        );
+    }
+
+    #[test]
+    fn reference_fingerprint_skips_content_hash_above_manifest_threshold() {
+        // Files above MANIFEST_HASH_MAX_BYTES contribute size+mtime only —
+        // fingerprinting stays metadata-cheap for genome-scale sources.
+        // Sparse file: set_len is metadata-only, the test stays instant.
+        let dir = tempfile::tempdir().unwrap();
+        let big = dir.path().join("big.fa");
+        let file = std::fs::File::create(&big).unwrap();
+        file.set_len(crate::executor::checkpoint::MANIFEST_HASH_MAX_BYTES + 1)
+            .unwrap();
+        drop(file);
+
+        let def = ReferenceDef {
+            name: "ref".to_string(),
+            source: Some("big.fa".to_string()),
+            output: "big.idx".to_string(),
+            build: "index {input}".to_string(),
+            threads: None,
+            memory: None,
+            environment: None,
+            description: None,
+        };
+        let config = HashMap::new();
+        let fp1 = reference_fingerprint(&def, &config, Some(&big));
+        let fp2 = reference_fingerprint(&def, &config, Some(&big));
+        assert_eq!(fp1, fp2, "unchanged large source must be deterministic");
+
+        let current =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&big).unwrap());
+        filetime::set_file_mtime(
+            &big,
+            filetime::FileTime::from_unix_time(current.unix_seconds() + 60, 0),
+        )
+        .unwrap();
+        let fp3 = reference_fingerprint(&def, &config, Some(&big));
+        assert_ne!(
+            fp1, fp3,
+            "large sources still detect mtime changes (size+mtime policy)"
+        );
+    }
+
+    #[test]
+    fn reference_fingerprint_degrades_to_path_only_when_source_unreadable() {
+        // A missing (pre-fetch, dry-run) or unreadable source must degrade
+        // to the historical path-string-only fingerprint — no error, same
+        // shape as `file_is_newer`'s degrade policy.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("not-there.fa");
+        let def = ReferenceDef {
+            name: "ref".to_string(),
+            source: Some("not-there.fa".to_string()),
+            output: "not-there.idx".to_string(),
+            build: "index {input}".to_string(),
+            threads: None,
+            memory: None,
+            environment: None,
+            description: None,
+        };
+        let config = HashMap::new();
+        assert_eq!(
+            reference_fingerprint(&def, &config, Some(&missing)),
+            reference_fingerprint(&def, &config, None)
         );
     }
 

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -464,6 +464,36 @@ pub fn compute_file_checksum(path: &Path) -> Result<String> {
     Ok(format!("sha256:{:x}", hash))
 }
 
+/// mtime in nanoseconds since the UNIX epoch, for change detection.
+///
+/// Shared by input manifests (issue #72) and reference fingerprints
+/// (issue #97): the two invalidation layers must agree on what counts as
+/// "changed". An unreadable mtime degrades to 0 — never an error — and is
+/// traced for diagnosis.
+pub fn mtime_nanos(md: &std::fs::Metadata) -> i128 {
+    match md
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    {
+        Some(d) => d.as_nanos() as i128,
+        None => {
+            tracing::debug!("mtime unavailable for change detection, degrading to 0");
+            0
+        }
+    }
+}
+
+/// Content hash for small files, under the shared input-manifest policy:
+/// `Some("sha256:…")` when the file is at most [`MANIFEST_HASH_MAX_BYTES`]
+/// and readable; `None` for larger files (guarded by size+mtime) and for
+/// unreadable files (best-effort degrade, never an error).
+pub fn content_hash_if_small(path: &Path, md: &std::fs::Metadata) -> Option<String> {
+    (md.len() <= MANIFEST_HASH_MAX_BYTES)
+        .then(|| compute_file_checksum(path).ok())
+        .flatten()
+}
+
 /// Snapshot the file set a rule's inputs resolve to (issue #72).
 ///
 /// Returns `Ok(None)` when the rule has no resolvable inputs: the input list
@@ -769,23 +799,14 @@ fn record_manifest_file(
         .unwrap_or(path)
         .to_string_lossy()
         .to_string();
-    let mtime_nanos = md
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_nanos() as i128)
-        .unwrap_or(0);
-    // Content-hash small files (best-effort: an unreadable file degrades to
-    // the size+mtime policy rather than failing the snapshot).
-    let hash = (md.len() <= MANIFEST_HASH_MAX_BYTES)
-        .then(|| compute_file_checksum(path).ok())
-        .flatten();
+    let mtime = mtime_nanos(md);
+    let hash = content_hash_if_small(path, md);
     entries.insert(
         rel.clone(),
         InputManifestEntry {
             path: rel,
             size: md.len(),
-            mtime_nanos,
+            mtime_nanos: mtime,
             hash,
             remote: None,
         },

--- a/docs/guide/src/gallery/scatter-gather.md
+++ b/docs/guide/src/gallery/scatter-gather.md
@@ -25,7 +25,7 @@ This is a classic parallel computing pattern:
 2. **Process**: Each scattered job runs GATK HaplotypeCaller restricted to a single chromosome (`-L {chr}`), producing one per-chromosome GVCF.
 3. **Gather**: The `gather_gvcf` rule receives the outputs of all scattered jobs as its `{input}` and merges them with GATK GatherVcfs.
 
-Scatter variables (`{chr}` here) are **not** wildcards — the fan-out comes from the `scatter` declaration, not from `{...}` in paths (see [Wildcards](../reference/wildcards.md) for the difference). When the pattern is split → map → combine within a single rule, use the [`transform` operator](../reference/workflow-format.md#transform-unified-scatter-gather-operator) — see the [Transform Operator](transform-operator.md) gallery.
+Scatter variables (`{chr}` here) are **not** wildcards — the fan-out comes from the `scatter` declaration, not from `{...}` in paths (see [Wildcards](../reference/wildcards.md) for the difference). Within each scattered job the variable substitutes into `input`, `output`, `shell`, `log`, `script`, and the hook fields (`pre_exec` / `on_success` / `on_failure`) — so a per-chromosome script invocation like `script = "scripts/call_{chr}.sh"` resolves per instance. When the pattern is split → map → combine within a single rule, use the [`transform` operator](../reference/workflow-format.md#transform-unified-scatter-gather-operator) — see the [Transform Operator](transform-operator.md) gallery.
 
 !!! info "Gather routing is declared, not inferred"
     Each scatter rule **explicitly names its gather rule** via the `gather = "..."` field — the engine routes outputs by that declaration, never by guessing:

--- a/docs/guide/src/reference/wildcards.md
+++ b/docs/guide/src/reference/wildcards.md
@@ -71,7 +71,7 @@ The most important concept when writing multi-sample workflows: **where you put 
 
 ### Rule-level fan-out: `{sample}` clones the rule
 
-If `{sample}` (or `{group}`, or a pair wildcard such as `{experiment}`) appears anywhere in a rule's `input`, `output`, or `shell`, oxo-flow **clones the entire rule once per value**:
+If `{sample}` (or `{group}`, or a pair wildcard such as `{experiment}`) appears anywhere in a rule's `input`, `output`, or `shell`, oxo-flow **clones the entire rule once per value**; inside each clone, the value also substitutes into `log`, `script`, and the hook fields (`pre_exec` / `on_success` / `on_failure`):
 
 ```toml
 [[rules]]
@@ -81,6 +81,8 @@ output = ["qc/{sample}_fastqc.html"]
 ```
 
 With samples `S1` and `S2`, this becomes **two tasks**: `fastqc_S1` (processing `S1`) and `fastqc_S2` (processing `S2`). This is what you want for per-sample steps — one definition, N tasks.
+
+`script` and the hook fields substitute per clone but never start a fan-out by themselves: a wildcard that appears *only* there keeps the rule as a single task (and `${sample}`-style shell-variable spellings inside `script` are never treated as wildcards).
 
 ### Input-level fan-in: `expand_inputs` fills the input list
 
@@ -113,7 +115,7 @@ output = ["variants/cohort.g.vcf.gz"]
 
 | Mechanism | Where | Effect | Use for |
 |---|---|---|---|
-| `{sample}` / `{group}` / pair wildcards | in `input`, `output`, or `shell` | clones the rule per value (fan-out) | per-sample steps |
+| `{sample}` / `{group}` / pair wildcards | in `input`, `output`, or `shell` | clones the rule per value (fan-out); per-clone values substitute into `log`, `script`, and hooks | per-sample steps |
 | `expand_inputs` | rule field | appends expanded paths to `input` (fan-in) | gather / combine steps |
 | `{config.x}` | any path or shell | single-value text substitution | reusing config values |
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -275,11 +275,15 @@ Declare reference artifacts (indexes, data files) that the engine auto-builds
 when missing. Each `[[references]]` entry specifies a source, output, and build
 command. The engine tracks built state in `.oxo-flow/reference-checkpoint.json`
 and never rebuilds unnecessarily: each entry stores a fingerprint of the
-definition plus the config values its build command references. Editing the
-build/source/output, changing a referenced config value, or touching the
-source file triggers a rebuild, and rules that consume the artifact through
-declared `input` paths (plus their downstream) are invalidated so their
-outputs are regenerated.
+definition plus the config values its build command references. The source
+file's **content state** joins the fingerprint: size and mtime for every
+source, plus a content hash for files up to 64 MiB — so for those files even
+a timestamp-preserving same-path replacement (`cp -p`, `rsync -t`, `git
+checkout`) triggers a rebuild; larger sources are guarded by size + mtime.
+Editing the build/source/output, changing a referenced config value, or
+touching the source file also triggers a rebuild, and rules that consume the
+artifact through declared `input` paths (plus their downstream) are
+invalidated so their outputs are regenerated.
 
 When `reference_dir` is set, four standard indexes are auto-derived without
 explicit `[[references]]` blocks: BWA, Bowtie2, STAR, and HISAT2.

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6130,7 +6130,7 @@ shell = "cat {input} > {output}"
     );
     let stderr3 = String::from_utf8_lossy(&run3.stderr);
     assert!(
-        stderr3.contains("definition or referenced config changed"),
+        stderr3.contains("definition, source content, or referenced config changed"),
         "expected rebuild: {stderr3}"
     );
     assert!(
@@ -6140,6 +6140,119 @@ shell = "cat {input} > {output}"
     assert_eq!(
         fs::read_to_string(dir.path().join("result.txt")).unwrap(),
         "built-v2\n"
+    );
+}
+
+#[test]
+fn cli_reference_self_writing_build_does_not_rebuild_loop() {
+    // A build that creates/rewrites its own source (download-then-index)
+    // changes the source mtime DURING the build. The checkpoint must store
+    // the POST-build fingerprint, or every subsequent run sees a
+    // pre-build-vs-post-build mismatch and rebuilds forever.
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("selffetch.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "selffetch"
+version = "1.0.0"
+
+[[references]]
+name = "self_idx"
+source = "genome.fa"
+output = "genome.idx"
+build = "cat seed.fa > genome.fa && cat genome.fa > genome.idx"
+
+[[rules]]
+name = "use_ref"
+input = ["genome.idx"]
+output = ["result.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("seed.fa"), b"AAAA").unwrap();
+
+    let run1 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run1.status.success(),
+        "run1 failed: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+    assert!(String::from_utf8_lossy(&run1.stderr).contains("Building"));
+
+    // Runs 2 and 3: the source state after run1's build matches the stored
+    // fingerprint — no rebuild, no loop.
+    for i in 2..=3 {
+        let run = oxo_flow_cmd()
+            .args(["run", wf.to_str().unwrap()])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(run.status.success(), "run{i} failed");
+        let stderr = String::from_utf8_lossy(&run.stderr);
+        assert!(
+            !stderr.contains("Building"),
+            "run{i} must not rebuild: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn cli_reference_touch_reports_freshness_not_content_change() {
+    // Touching the source (mtime moves, content identical) must report
+    // "source is newer than output" — the freshness branch — not the
+    // generic definition/content message.
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("touchref.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "touchref"
+version = "1.0.0"
+
+[[references]]
+name = "t_idx"
+source = "genome.fa"
+output = "genome.idx"
+build = "cat {input} > {output}"
+
+[[rules]]
+name = "use_ref"
+input = ["genome.idx"]
+output = ["result.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("genome.fa"), b"AAAA").unwrap();
+
+    let run1 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run1.status.success());
+
+    // Move the mtime forward WITHOUT changing content or size.
+    let src = dir.path().join("genome.fa");
+    let now = std::time::SystemTime::now() + std::time::Duration::from_secs(30);
+    filetime::set_file_mtime(&src, filetime::FileTime::from_system_time(now)).unwrap();
+
+    let run2 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run2.status.success());
+    let stderr2 = String::from_utf8_lossy(&run2.stderr);
+    assert!(
+        stderr2.contains("source is newer than output"),
+        "expected freshness reason, got: {stderr2}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the two engine gaps surfaced by the community live-test campaign (rnaseq / star-deseq2), hardened through a 5-angle adversarial review (40+ candidates triaged, 4 fixes landed).

### #97 — `[[references]]` fingerprint ignored source file CONTENT

`reference_fingerprint` hashed the source **path string**, output, build, environment, and referenced config values — never the file itself. Replacing `genome.fa` at the same path changed none of the hashed fields, so the auto-built STAR index stayed `up-to-date` and downstream alignment silently used the old index (hit twice, deterministically).

The fingerprint now joins the resolved source file's **size, mtime, and — below the input-manifest threshold (`MANIFEST_HASH_MAX_BYTES`, 64 MiB, issue #72) — its SHA-256 content hash**, through shared helpers extracted into `checkpoint.rs` (`mtime_nanos` + `content_hash_if_small`) so the manifest and reference invalidation layers cannot drift.

Two decision-chain fixes that fell out of review:

- **Post-build fingerprint storage**: a build that creates/rewrites its own source (download-then-index) changes the source state *during* the build — storing the pre-build fingerprint would mismatch on every subsequent run and rebuild forever. The checkpoint now stores the post-build state.
- **Freshness check first**: `source is newer than output` is evaluated before the fingerprint comparison, so an mtime-only `touch` reports the accurate reason instead of the generic content message.

### #98 — fan-out expansion substituted `{variable}` into shell/log but not `script`

Scatter expansion baked the per-value combo into input/output/shell/log only. A scatter rule whose `script` depends on the scatter variable could not be written — the star-deseq2 `pca` rule had to be split into three explicit rules (79c1cd0). The execution-time placeholder pass only knows `config.*` values, so expansion time is the only mechanism for per-instance values.

All four fan-out paths — `pair_id` pairs, group/sample, `[[values]]`, and the scatter block — now bake per-instance values into `script`, `pre_exec`, `on_success`, and `on_failure` via one shared `expand_command_text_fields` helper.

**Design decisions** (from the review, documented in code + guide):

- The fan-out **trigger** set stays `input/output/shell`. Script/hooks substitute per clone but never start a fan-out: cloning on a hook-only wildcard would duplicate the whole rule execution over identical paths, and `${sample}`-style shell-variable spellings inside `script` must never be mistaken for wildcards. Pinned by test.
- `when` excluded: `evaluate_condition` resolves only `config.*` keys — fan-out variables there would be dead syntax.
- `benchmark`/`input_function`/`interpreter` excluded: not consumed through the wildcard rendering pass.
- Large sources (>64 MiB) are guarded by size+mtime only, exactly like input manifests — the docs state the boundary precisely.

### Known tradeoffs (documented)

- **One-time rebuild on upgrade**: checkpoints written before this change store path-only fingerprints, so each reference with a readable source rebuilds once (the safe direction — pre-upgrade state cannot prove artifact-source match); wildcarded-script rules re-run once for the same reason.
- **mtime in the fingerprint** makes checkpoints machine-local and git-checkout-sensitive (spurious rebuilds, never stale reuse) — the tradeoff issue #97 itself prescribes, matching input manifests: rebuild correctness over cross-machine byte equality.
- **Missing source after a content-bearing checkpoint** fails loudly in the rebuild rather than silently serving the artifact.

## Evidence

- **13 new tests**, all watched RED first: 5 fingerprint units (same-path rewrite; same size+mtime different content via `filetime`-pinned mtimes; mtime-only change; >64 MiB threshold skip; missing-source degrade), 4 fan-out substitution units (scatter/values/pairs + script-only-no-fan-out), 2 reference integration tests (self-writing build must not rebuild-loop; touch reports freshness reason), plus the updated legacy-format test.
- **Full CI gate** (`make ci`: fmt + clippy `-D warnings` + build + workspace tests + audit) green on the final tree.
- **Live** (local, dev binary):
  - **#97**: run 1 builds index; run 2 idempotent; replace `genome.fa` with different content **and mtime set to 2020 (older than the index — invisible to the old `file_is_newer` check)**; run 3 rebuilds (`definition, source content, or referenced config changed`), invalidates the consumer, new content lands; run 4 idempotent.
  - **#98**: scatter `script = "scripts/pca_{treatment}.sh"` with `pre_exec`/`on_success`/`on_failure` hooks — both instances run their own script, outputs contain per-treatment markers, hooks write `pre-control`/`pre-treated` and `ok-control`/`ok-treated`, zero literal-brace artifacts, re-run fully skipped.

## Test plan

- [x] 13 new tests green (RED→GREEN recorded)
- [x] Full local CI gate green
- [x] Live #97: old-mtime same-path replacement rebuilds + invalidates consumers; idempotent re-runs
- [x] Live #98: scatter script/hooks resolve per instance; idempotent re-run
- [x] Docs: wildcards.md (trigger/substitution semantics), scatter-gather.md (per-instance script example), workflow-format.md (content guard with the 64 MiB boundary stated)

Closes #97, closes #98
