### PR TITLE
feat: sensitive-value masking + rule-level required=false (#99 B1/B2)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -610,6 +610,16 @@ pub async fn run_command(
         .filter(|(_, def)| def.sensitive)
         .map(|(key, _)| key.clone())
         .collect();
+    // The VALUES themselves, for runner-side output masking (issue #99 B1):
+    // they are redacted from captured stdout/stderr and recorded commands
+    // before anything reaches the checkpoint, report, AI recovery, or web.
+    let sensitive_values: Vec<String> = config
+        .config_meta
+        .iter()
+        .filter(|(_, def)| def.sensitive)
+        .filter_map(|(key, _)| config.config.get(key))
+        .map(oxo_flow_core::config_impact::config_value_string)
+        .collect();
     let old_snapshot = {
         let ck = checkpoint.lock().await;
         ck.config_snapshot.clone()
@@ -853,6 +863,7 @@ pub async fn run_command(
         max_jobs: jobs,
         dry_run: false,
         workdir: workdir.clone().unwrap_or_else(|| workdir_default.clone()),
+        sensitive_values: sensitive_values.clone(),
         keep_going,
         retry_count: retry,
         timeout: if timeout_secs > 0 {
@@ -933,6 +944,9 @@ pub async fn run_command(
     let executor = Arc::new(LocalExecutor::new(exec_config));
     let success_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let fail_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Failures of `required = false` rules (issue #99 B2): counted
+    // separately, surfaced in the summary, but exempt from failing the run.
+    let non_required_fail_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let skipped_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let failed_rules_set: Arc<Mutex<std::collections::HashSet<String>>> =
         Arc::new(Mutex::new(std::collections::HashSet::new()));
@@ -1150,7 +1164,10 @@ pub async fn run_command(
                             "failed to build reference '{}' (exit {}). Command: {}",
                             ref_def.name,
                             s.code().unwrap_or(-1),
-                            build_cmd
+                            oxo_flow_core::executor::process::mask_sensitive(
+                                &build_cmd,
+                                &sensitive_values
+                            )
                         );
                     }
                     Err(e) => {
@@ -1422,6 +1439,7 @@ pub async fn run_command(
             let failures = failures.clone();
             let success_count = success_count.clone();
             let fail_count = fail_count.clone();
+            let non_required_fail_count = non_required_fail_count.clone();
             let skipped_count = skipped_count.clone();
             let wildcard_values = wildcard_values.clone();
             let workdir_actual = workdir_actual.clone();
@@ -1518,7 +1536,15 @@ pub async fn run_command(
                             }
                             (rule_name, oxo_flow_core::executor::JobStatus::Skipped, record)
                         } else {
-                            fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // A failed `required = false` rule is recorded and
+                            // blocks its dependents, but does not fail the
+                            // run (issue #99 B2).
+                            if rule.required {
+                                fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            } else {
+                                non_required_fail_count
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
                             {
                                 let mut frs = failed_rules_set.lock().await;
                                 frs.insert(rule_name.clone());
@@ -1540,7 +1566,10 @@ pub async fn run_command(
                                 err_msg.push_str(&format!("\nexit code: {}", code));
                             }
                             eprintln!("  {} {}", "✗".red(), err_msg);
-                            if keep_going {
+                            // List in the final "Failed rules:" summary when
+                            // the run continues past the failure (keep_going,
+                            // or a non-required rule in either mode).
+                            if keep_going || !rule.required {
                                 let mut reason = String::new();
                                 if let Some(code) = record.exit_code {
                                     reason.push_str(&format!("exit code {}", code));
@@ -1560,6 +1589,9 @@ pub async fn run_command(
                                 if reason.is_empty() {
                                     reason.push_str("failed");
                                 }
+                                if !rule.required {
+                                    reason.push_str(" (non-required)");
+                                }
                                 let mut f = failures.lock().await;
                                 f.push((rule_name.clone(), reason));
                             }
@@ -1571,7 +1603,12 @@ pub async fn run_command(
                         }
                     }
                     Err(e) => {
-                        fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if rule.required {
+                            fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        } else {
+                            non_required_fail_count
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
                         {
                             let mut frs = failed_rules_set.lock().await;
                             frs.insert(rule_name.clone());
@@ -1603,9 +1640,14 @@ pub async fn run_command(
                         if !keep_going {
                             eprintln!("  {} rule '{}' failed: {}", "✗".red(), rule_name, e);
                         }
-                        if keep_going {
+                        if keep_going || !rule.required {
                             let mut f = failures.lock().await;
-                            f.push((rule_name.clone(), e.to_string()));
+                            let reason = if rule.required {
+                                e.to_string()
+                            } else {
+                                format!("{} (non-required)", e)
+                            };
+                            f.push((rule_name.clone(), reason));
                         }
                         (rule_name, oxo_flow_core::executor::JobStatus::Failed, record)
                     }
@@ -1627,6 +1669,9 @@ pub async fn run_command(
                 if e.is_panic() {
                     tracing::error!("Task panicked: {e}");
                 }
+                // A panicked task is an ENGINE fault, not a rule-level
+                // best-effort failure — always counts as required (the run
+                // fails), regardless of the rule's `required` flag.
                 fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 continue;
             }
@@ -1688,9 +1733,18 @@ pub async fn run_command(
             }
             {
                 let mut f = failures.lock().await;
-                f.push((completed_rule.clone(), format!("re-entry manifest: {e}")));
+                let reason = if cp_rule.required {
+                    format!("re-entry manifest: {e}")
+                } else {
+                    format!("re-entry manifest: {e} (non-required)")
+                };
+                f.push((completed_rule.clone(), reason));
             }
-            fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if cp_rule.required {
+                fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            } else {
+                non_required_fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
             sched.mark_completed(record);
         }
 
@@ -1734,11 +1788,14 @@ pub async fn run_command(
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
 
-        // With keep_going, propagate failure transitively: every rule that
-        // (transitively) depends on a failed rule is marked as skipped/blocked.
-        // Uses a worklist to ensure transitive propagation (grandchild of a
-        // failed rule is also blocked).
-        if fc > 0 && keep_going {
+        // Propagate failure transitively: every rule that (transitively)
+        // depends on a failed rule is marked as skipped/blocked. Uses a
+        // worklist to ensure transitive propagation (grandchild of a
+        // failed rule is also blocked). Runs when the loop continues past
+        // failures: keep_going with any failure, or a non-required failure
+        // in either mode (issue #99 B2).
+        let nrf = non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed);
+        if (fc > 0 && keep_going) || nrf > 0 {
             // Seed the worklist with every rule that directly depends on a
             // failed rule and has not been submitted yet.
             let frs = failed_rules_set.lock().await;
@@ -1821,6 +1878,8 @@ pub async fn run_command(
 
     let success_count = success_count.load(std::sync::atomic::Ordering::Relaxed);
     let fail_count = fail_count.load(std::sync::atomic::Ordering::Relaxed);
+    let non_required_fail_count =
+        non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed);
     let skipped_count = skipped_count.load(std::sync::atomic::Ordering::Relaxed);
     let mut checkpoint = checkpoint.lock().await;
     let failures = failures.lock().await;
@@ -1853,13 +1912,24 @@ pub async fn run_command(
         }
     }
 
-    eprintln!(
-        "\n{} {} succeeded, {} skipped, {} failed",
-        "Done:".bold(),
-        success_count,
-        skipped_count,
-        fail_count
-    );
+    if non_required_fail_count > 0 {
+        eprintln!(
+            "\n{} {} succeeded, {} skipped, {} failed, {} non-required failed",
+            "Done:".bold(),
+            success_count,
+            skipped_count,
+            fail_count,
+            non_required_fail_count
+        );
+    } else {
+        eprintln!(
+            "\n{} {} succeeded, {} skipped, {} failed",
+            "Done:".bold(),
+            success_count,
+            skipped_count,
+            fail_count
+        );
+    }
 
     // Automatic report snapshot (issue #83 P1-14): capture the final
     // checkpoint as a JSON report plus an index.json entry. One call site
@@ -2110,6 +2180,7 @@ pub async fn run_command(
                 "succeeded": success_count,
                 "skipped": skipped_count,
                 "failed": fail_count,
+                "non_required_failed": non_required_fail_count,
                 "blocked": blocked.len(),
             }),
         });

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1506,7 +1506,10 @@ impl WorkflowConfig {
             let toml::Value::Table(t) = val else {
                 continue;
             };
-            if (t.contains_key("default") || t.contains_key("required") || t.contains_key("help"))
+            if (t.contains_key("default")
+                || t.contains_key("required")
+                || t.contains_key("help")
+                || t.contains_key("sensitive"))
                 && let Ok(def) = toml::Value::Table(t.clone()).try_into::<ConfigDef>()
             {
                 self.config_meta.insert(key.clone(), def);
@@ -5810,6 +5813,35 @@ shell = "echo {config.database} > {output[0]}"
         assert_eq!(
             config.config.get("threshold").and_then(|v| v.as_str()),
             Some("1e-5")
+        );
+    }
+
+    #[test]
+    fn sensitive_only_inline_config_registers_metadata() {
+        // issue #99 B1: the declarative-config promotion trigger was
+        // default/required/help only, so a sensitive-ONLY declaration
+        // silently stayed an unparsed inline table and the value was never
+        // masked. The declaration must register its metadata; the value
+        // itself comes from a CLI override or profile at run time.
+        let config = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [config]
+            api_token = { sensitive = true }
+            "#,
+        )
+        .unwrap();
+        assert!(
+            config.config_meta["api_token"].sensitive,
+            "sensitive flag must register in config_meta"
+        );
+        assert_eq!(
+            config.config.get("api_token").and_then(|v| v.as_str()),
+            Some(""),
+            "no default: the runtime value is empty until overridden"
         );
     }
 

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -284,6 +284,10 @@ pub struct ExecutorConfig {
     /// Storage backends for remote input staging / output upload
     /// (issue #80 item 2). Defaults to the local backend only.
     pub storage_resolver: StorageResolver,
+    /// Values of `[config_meta.*] sensitive = true` config keys — masked out
+    /// of captured stdout/stderr and the recorded command before they reach
+    /// the checkpoint/report (issue #99 B1). Empty = no masking.
+    pub sensitive_values: Vec<String>,
 }
 
 impl Default for ExecutorConfig {
@@ -304,6 +308,7 @@ impl Default for ExecutorConfig {
             cache_dir: None,
             interpreter_map: HashMap::new(),
             storage_resolver: StorageResolver::with_local(),
+            sensitive_values: Vec::new(),
         }
     }
 }
@@ -1116,7 +1121,10 @@ impl LocalExecutor {
 
         let resolved_commands =
             vec![self.resolve_command(&base_cmd, &rule, scratch_dir.as_deref())];
-        record.command = resolved_commands.first().cloned();
+        record.command = resolved_commands
+            .first()
+            .cloned()
+            .map(|c| mask_sensitive(&c, &self.config.sensitive_values));
 
         validate_wildcard_injection(wildcard_values)?;
         for cmd in &resolved_commands {
@@ -1394,8 +1402,17 @@ impl LocalExecutor {
 
         record.finished_at = Some(Utc::now());
         record.exit_code = last_exit_code;
-        record.stdout = Some(combined_stdout);
-        record.stderr = Some(combined_stderr);
+        // Mask sensitive values at the capture boundary (issue #99 B1):
+        // everything downstream — checkpoint stderr_tail, report, AI
+        // recovery, web UI — derives from this record.
+        record.stdout = Some(mask_sensitive(
+            &combined_stdout,
+            &self.config.sensitive_values,
+        ));
+        record.stderr = Some(mask_sensitive(
+            &combined_stderr,
+            &self.config.sensitive_values,
+        ));
         if peak_bytes > 0 {
             record.max_rss_mb = Some(peak_bytes.div_ceil(1024 * 1024));
         }
@@ -1938,6 +1955,29 @@ async fn remove_tree(path: &Path) -> std::io::Result<()> {
 
 /// Append a diagnostic note to a job record's stderr, creating the field
 /// when the rule produced no stderr at all.
+/// Mask sensitive values in captured output (issue #99 B1).
+///
+/// Runner-side masking, GitHub-Actions-style: every occurrence of each
+/// value is replaced with `***` before the text lands in the job record
+/// (checkpoint, report, AI recovery, web). Values shorter than 4
+/// characters are not masked — the same threshold GitHub Actions uses, so
+/// common short strings (thresholds, counts) are not mass-redacted.
+/// Structured forms of a secret (JSON/YAML serialization, base64) do not
+/// match the exact value and pass through — the documented limitation of
+/// exact-match masking.
+pub fn mask_sensitive(text: &str, values: &[String]) -> String {
+    if text.is_empty() || values.is_empty() {
+        return text.to_string();
+    }
+    let mut masked = text.to_string();
+    for value in values {
+        if value.chars().count() >= 4 {
+            masked = masked.replace(value.as_str(), "***");
+        }
+    }
+    masked
+}
+
 fn push_stderr_note(record: &mut JobRecord, note: &str) {
     if let Some(ref mut stderr) = record.stderr {
         stderr.push_str(note);
@@ -2399,6 +2439,26 @@ pub fn hostname() -> String {
 mod tests {
     use super::*;
     use crate::rule::{EnvironmentSpec, Resources};
+
+    #[test]
+    fn mask_sensitive_redacts_matching_values_only() {
+        // Values >= 4 chars are masked; short/empty values are skipped (the
+        // same threshold GitHub Actions uses, to avoid mass-redacting common
+        // short strings like thresholds). Overlapping values are masked
+        // independently of order.
+        let values = vec!["s3cr3t-token-42".to_string(), "ab".to_string()];
+        let text = "token is s3cr3t-token-42 and again s3cr3t-token-42; ab stays";
+        let masked = mask_sensitive(text, &values);
+        assert_eq!(
+            masked, "token is *** and again ***; ab stays",
+            "long values mask, short values stay"
+        );
+        assert!(!masked.contains("s3cr3t-token-42"));
+
+        // Empty input and empty value list are no-ops.
+        assert_eq!(mask_sensitive("plain", &[]), "plain");
+        assert_eq!(mask_sensitive("plain", &["".to_string()]), "plain");
+    }
 
     fn executor_with(max_threads: u32, max_memory_mb: u64) -> LocalExecutor {
         LocalExecutor::new(ExecutorConfig {

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -159,6 +159,16 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
+fn is_true(b: &bool) -> bool {
+    *b
+}
+
+/// `required` defaults to true: only `required = false` (best-effort) rules
+/// are exempt from failing the run (issue #99 B2).
+fn default_required() -> bool {
+    true
+}
+
 fn is_zero<T>(n: &T) -> bool
 where
     T: Default + PartialEq,
@@ -818,8 +828,13 @@ pub struct Rule {
     pub checkpoint_manifest: Option<String>,
 
     /// Whether this rule is required (pipeline fails if this rule fails).
-    #[serde(default)]
-    #[serde(skip_serializing_if = "is_false")]
+    ///
+    /// Defaults to true: rules fail the pipeline unless explicitly marked
+    /// `required = false`, the best-effort/continue-on-error form (issue
+    /// #99 B2) — its failure is recorded and blocks dependents, but the
+    /// run still succeeds.
+    #[serde(default = "default_required")]
+    #[serde(skip_serializing_if = "is_true")]
     pub required: bool,
 
     /// Explicit rule-level dependencies (rule names that must complete first).

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -225,7 +225,7 @@ samples   = { required = true, type = "path", must_exist = true }
 | `default` | String | Default value when not provided via CLI |
 | `required` | Bool | If `true`, the value must be provided at runtime (default: `false`) |
 | `help` | String | Human-readable description shown in error messages |
-| `sensitive` | Bool | Mask the value as `****` in logs, `--help`, and errors (default: `false`) |
+| `sensitive` | Bool | Mask the value as `***` in captured rule output, recorded commands, checkpoint/report snapshots, and error summaries — before they reach the web UI or AI recovery (default: `false`). Values shorter than 4 characters are not masked, and structured or derived forms of the value (JSON/base64) pass through — exact-match masking only |
 | `type` | String | Expected value type for validation: `"string"`, `"int"`, `"float"`, `"bool"`, `"path"` |
 | `choices` | Array of String | Allowed values (requires `type = "string"`) |
 | `range` | String | Numeric range `"min..max"` (requires `type = "int"` or `"float"`) |
@@ -980,13 +980,13 @@ target = true   # Included when running without -t
 | Field | Type | Description |
 |-------|------|-------------|
 | `optional` | Boolean | If `true`, missing inputs become warnings instead of errors |
-| `required` | Boolean | If `true`, pipeline fails if this rule fails even without dependents |
+| `required` | Boolean | If `false`, a failure of this rule does not fail the run: the failure is recorded and listed, its dependents are blocked, and the run exits 0 (best-effort / continue-on-error, e.g. QC steps). Defaults to `true` — required failures fail the run (or, with `--keep-going`, keep it running but exit 0 with failures listed) |
 
 ```toml
 [[rules]]
 name = "experimental"
-optional = true    # Skip if input data is absent
-required = true    # But if it runs, failure stops the pipeline
+optional = true     # Skip if input data is absent
+required = false    # Failure is reported but does not fail the run
 ```
 
 ### Logging and Benchmarking

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6256,6 +6256,165 @@ shell = "cat {input} > {output}"
     );
 }
 
+// ─── #99 B1: sensitive values are masked in captured output ────────────────
+
+/// Values of `[config_meta.*] sensitive = true` keys must never reach the
+/// checkpoint, the report snapshot, or the failure output — they are masked
+/// at the executor capture boundary (issue #99 B1).
+#[test]
+fn cli_sensitive_values_masked_in_checkpoint_and_report() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("mask.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "mask"
+version = "1.0.0"
+
+[config]
+api_token = { default = "s3cr3t-token-42", sensitive = true }
+
+[[rules]]
+name = "leak"
+output = ["leak.txt"]
+shell = "echo 'token is s3cr3t-token-42' && echo 'token is s3cr3t-token-42' >&2 && echo done > {output}"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run.status.success());
+
+    let cp = fs::read_to_string(dir.path().join(".oxo-flow/checkpoint.json")).unwrap();
+    assert!(
+        !cp.contains("s3cr3t-token-42"),
+        "checkpoint must not contain the raw sensitive value"
+    );
+    assert!(
+        cp.contains("***"),
+        "checkpoint must contain the masked marker: {cp}"
+    );
+
+    let snaps = snapshot_files(dir.path());
+    assert!(!snaps.is_empty(), "run must produce a report snapshot");
+    let snap = fs::read_to_string(&snaps[0]).unwrap();
+    assert!(
+        !snap.contains("s3cr3t-token-42"),
+        "report snapshot must not contain the raw sensitive value"
+    );
+}
+
+// ─── #99 B2: rule-level `required = false` (continue-on-error) ─────────────
+
+/// A failed non-required rule must not fail the run: dependents are blocked,
+/// the failure is surfaced in the summary, and the exit code stays 0.
+#[test]
+fn cli_non_required_rule_failure_does_not_fail_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("besteffort.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "besteffort"
+version = "1.0.0"
+
+[[rules]]
+name = "qc"
+output = ["qc.txt"]
+required = false
+shell = "echo 'qc is broken' >&2 && exit 1"
+
+[[rules]]
+name = "analyze"
+input = ["qc.txt"]
+output = ["analyze.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "non-required failure must not fail the run: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("non-required"),
+        "summary must surface the non-required failure: {stderr}"
+    );
+    assert!(
+        stderr.contains("Blocked rules") && stderr.contains("analyze"),
+        "dependents of a failed rule must be blocked: {stderr}"
+    );
+    assert!(
+        !dir.path().join("analyze.txt").exists(),
+        "blocked dependent must not produce output"
+    );
+
+    // JSON mode: the run status is completed, with the non-required failure
+    // counted separately from required failures.
+    let json_run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(json_run.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&json_run.stdout).expect("valid JSON output");
+    assert_eq!(parsed["status"], "completed");
+    assert_eq!(parsed["results"]["failed"], 0);
+    assert_eq!(
+        parsed["results"]["non_required_failed"], 1,
+        "non-required failures must be counted separately: {parsed}"
+    );
+}
+
+/// Control: a required (default) rule failure keeps failing the run.
+#[test]
+fn cli_required_rule_failure_still_fails_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("strict.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "strict"
+version = "1.0.0"
+
+[[rules]]
+name = "qc"
+output = ["qc.txt"]
+shell = "exit 1"
+
+[[rules]]
+name = "analyze"
+input = ["qc.txt"]
+output = ["analyze.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !run.status.success(),
+        "required rule failure must fail the run"
+    );
+}
+
 // ─── #71: run flags after positional overrides get actionable errors ───────
 
 /// clap's trailing config_overrides positional (allow_hyphen_values) cannot


### PR DESCRIPTION
## Summary

Lands issue #99's two P0 ideas (from the GitHub/Gitee Actions research): **B1 sensitive-value masking** and **B2 rule-level continue-on-error**. The other 12 candidates stay open in the issue with a status note.

### B1 — Sensitive config values are masked in captured output

`sensitive = true` in a declarative `[config]` entry (e.g. `api_token = { default = "...", sensitive = true }`) was only honored in the config-change diff print — rule stdout/stderr and recorded commands flowed raw into the checkpoint, report snapshots, AI recovery, and web UI (multi-tenant/clinical leak surface).

- New `mask_sensitive` (executor/process.rs) redacts every occurrence at the **capture boundary** — `JobRecord.stdout/stderr` and `record.command` — so every downstream copy (checkpoint `stderr_tail`, report snapshot, AI context, web execution.log) is masked at the source.
- The reference-build failure message masks the embedded build command too.
- GitHub-Actions-style limitations, documented: values shorter than 4 characters are not masked (avoids mass-redacting common short strings); structured/derived forms (JSON/base64) don't match exact values and pass through.
- **Found and fixed a pre-existing config bug**: `extract_declarative_config` only promoted inline `[config]` tables carrying `default/required/help`, so a sensitive-only declaration silently stayed an unparsed table and was never masked.

### B2 — `required = false` is rule-level continue-on-error

The `Rule.required` field existed but was **never wired** (failure handling only knew global `--keep-going`). Now:

- `required` defaults to **true** (rules fail the run — current behavior, GH-aligned). `required = false` marks a best-effort rule (e.g. QC steps): its failure is recorded in the checkpoint, listed under "Failed rules:" with a `(non-required)` tag, its dependents are blocked (same transitive worklist as `--keep-going`), and the run **exits 0**.
- `Done:` summary and `--json` output count non-required failures separately (`non_required_failed`).
- Task panics stay required: an engine fault fails the run regardless of the rule flag.

**Semantics matrix** (live-verified):

| required | keep_going | exit | behavior |
|---|---|---|---|
| false | false | 0 | failure listed (non-required), dependents blocked |
| false | true | 0 | same |
| true (default) | false | non-zero | existing abort |
| true (default) | true | 0 | existing keep_going contract |

## Evidence

- **6 new tests, all watched RED first**: mask_sensitive unit (threshold, overlap, empty); sensitive-only config promotion unit (pinned the pre-existing bug); B1 integration (raw secret absent from checkpoint + report snapshot, masked marker present); B2 integration (exit 0, blocked dependents, JSON counters); required control (still fails).
- Full `make ci` green (fmt, clippy `-D warnings`, build, workspace + integration tests, audit).
- **Live** (dev binary): failing rule printing a secret → console error shows `token is ***`, checkpoint/report contain zero raw occurrences; B2 matrix above exercised end-to-end incl. `--json`.

## Notes

- `Rule`'s serde default for `required` is now true; the derived `Default` impl still yields false for programmatic construction (no production path runs failure handling on a `Default`-built rule — noted for future readers).
- `ExecutionEvent::RuleStarted` carries `command` but is currently un-emitted (dead event). If wired later, it must route through the same masking.

Refs #99
