### PR TITLE
fix: #99 review follow-up — cluster masking/B2 parity, AI recovery target, error-path masking

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -34,6 +34,19 @@ fn config_placeholder_values(config: &HashMap<String, toml::Value>) -> HashMap<S
 /// `--rerun` everything is forced anyway, so the summary is suppressed —
 /// the snapshot/fingerprint refresh still happened silently.
 #[allow(clippy::too_many_arguments)]
+/// Values of `[config_meta.*] sensitive = true` keys, for runner-side
+/// output masking (issue #99 B1). Shared by the local run, the verbose
+/// plan print, and the cluster path.
+fn sensitive_values_of(config: &WorkflowConfig) -> Vec<String> {
+    config
+        .config_meta
+        .iter()
+        .filter(|(_, def)| def.sensitive)
+        .filter_map(|(key, _)| config.config.get(key))
+        .map(oxo_flow_core::config_impact::config_value_string)
+        .collect()
+}
+
 fn print_config_change_summary(
     report: &ConfigChangeReport,
     old_snapshot: &HashMap<String, String>,
@@ -613,13 +626,7 @@ pub async fn run_command(
     // The VALUES themselves, for runner-side output masking (issue #99 B1):
     // they are redacted from captured stdout/stderr and recorded commands
     // before anything reaches the checkpoint, report, AI recovery, or web.
-    let sensitive_values: Vec<String> = config
-        .config_meta
-        .iter()
-        .filter(|(_, def)| def.sensitive)
-        .filter_map(|(key, _)| config.config.get(key))
-        .map(oxo_flow_core::config_impact::config_value_string)
-        .collect();
+    let sensitive_values = sensitive_values_of(&config);
     let old_snapshot = {
         let ck = checkpoint.lock().await;
         ck.config_snapshot.clone()
@@ -835,6 +842,7 @@ pub async fn run_command(
                 workdir: workdir_actual.as_ref(),
                 wildcard_values: wildcard_values.as_ref(),
                 sensitive_keys: &sensitive_keys,
+                sensitive_values: &sensitive_values,
                 force_rules: &force_rules,
                 max_submitted,
                 rerun,
@@ -1440,6 +1448,7 @@ pub async fn run_command(
             let success_count = success_count.clone();
             let fail_count = fail_count.clone();
             let non_required_fail_count = non_required_fail_count.clone();
+            let sensitive_values = sensitive_values.clone();
             let skipped_count = skipped_count.clone();
             let wildcard_values = wildcard_values.clone();
             let workdir_actual = workdir_actual.clone();
@@ -1566,10 +1575,11 @@ pub async fn run_command(
                                 err_msg.push_str(&format!("\nexit code: {}", code));
                             }
                             eprintln!("  {} {}", "✗".red(), err_msg);
-                            // List in the final "Failed rules:" summary when
-                            // the run continues past the failure (keep_going,
-                            // or a non-required rule in either mode).
-                            if keep_going || !rule.required {
+                            // Always record: keep_going needs the final
+                            // listing, non-required failures are listed in
+                            // either mode, and the AI recovery path must be
+                            // able to find the ABORTING rule by name.
+                            {
                                 let mut reason = String::new();
                                 if let Some(code) = record.exit_code {
                                     reason.push_str(&format!("exit code {}", code));
@@ -1623,7 +1633,13 @@ pub async fn run_command(
                             finished_at: None,
                             exit_code: Some(-1),
                             stdout: None,
-                            stderr: Some(e.to_string()),
+                            // Staging/security errors embed config-expanded
+                            // URIs and full commands — mask them like every
+                            // other captured surface (issue #99 B1).
+                            stderr: Some(oxo_flow_core::executor::process::mask_sensitive(
+                                &e.to_string(),
+                                &sensitive_values,
+                            )),
                             command: None,
                             retries: 0,
                             timeout: None,
@@ -1640,15 +1656,18 @@ pub async fn run_command(
                         if !keep_going {
                             eprintln!("  {} rule '{}' failed: {}", "✗".red(), rule_name, e);
                         }
-                        if keep_going || !rule.required {
-                            let mut f = failures.lock().await;
-                            let reason = if rule.required {
-                                e.to_string()
-                            } else {
-                                format!("{} (non-required)", e)
-                            };
-                            f.push((rule_name.clone(), reason));
-                        }
+                        // Always record: keep_going needs the final
+                        // listing, non-required failures are listed in
+                        // either mode, and the AI recovery path must be able
+                        // to find the ABORTING rule by name (a non-required
+                        // failure recorded earlier must not shadow it).
+                        let mut f = failures.lock().await;
+                        let reason = if rule.required {
+                            e.to_string()
+                        } else {
+                            format!("{} (non-required)", e)
+                        };
+                        f.push((rule_name.clone(), reason));
                         (rule_name, oxo_flow_core::executor::JobStatus::Failed, record)
                     }
                 }
@@ -1764,7 +1783,13 @@ pub async fn run_command(
                 ai_recover || crate::commands::ai_template::should_use_ai(Some(&workflow), false);
             if should_recover {
                 let failures_guard = failures.lock().await;
-                if let Some((rule, error)) = failures_guard.first()
+                // Diagnose the rule that actually aborted the run — a
+                // non-required failure recorded earlier must not shadow it.
+                let failure = failures_guard
+                    .iter()
+                    .find(|(name, _)| name == &completed_rule)
+                    .or_else(|| failures_guard.first());
+                if let Some((rule, error)) = failure
                     && let Some(provider) =
                         crate::commands::ai_template::try_resolve_ai(Some(&workflow), true)
                 {
@@ -2361,6 +2386,8 @@ pub async fn dry_run_command(
         .filter(|(_, def)| def.sensitive)
         .map(|(key, _)| key.clone())
         .collect();
+    // The verbose plan print must not leak sensitive values (issue #99 B1).
+    let sensitive_values = sensitive_values_of(&config);
     let interpreter_map = config.workflow.interpreter_map.clone();
     let mut preview = crate::commands::run_preview::preview_run_plan(
         &checkpoint_state,
@@ -2593,6 +2620,10 @@ pub async fn dry_run_command(
                 &wildcard_values,
                 oxo_flow_core::scheduler::detect_system_limits(),
             );
+            // Mask sensitive values (issue #99 B1): the plan print is a log
+            // surface like any other.
+            let expanded =
+                oxo_flow_core::executor::process::mask_sensitive(&expanded, &sensitive_values);
             eprintln!("     command: {}", expanded);
         }
 

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -34,6 +34,9 @@ pub(crate) struct ClusterRunArgs<'a> {
     pub workdir: &'a Path,
     pub wildcard_values: &'a HashMap<String, String>,
     pub sensitive_keys: &'a HashSet<String>,
+    /// Sensitive config values masked out of recorded job commands
+    /// (issue #99 B1, cluster path).
+    pub sensitive_values: &'a [String],
     /// Rules the run's invalidation analysis already forced. The local
     /// executor receives this set to bypass its freshness gate; the cluster
     /// path unions it into the submission set for the same reason.
@@ -48,6 +51,9 @@ pub(crate) struct ClusterRunArgs<'a> {
 pub(crate) struct ClusterRunSummary {
     pub succeeded: usize,
     pub failed: usize,
+    /// Failures of `required = false` rules: recorded and reported, but
+    /// exempt from failing the run (issue #99 B2, cluster path).
+    pub non_required_failed: usize,
     pub skipped: usize,
 }
 
@@ -154,7 +160,18 @@ async fn record_outcome(
             }
         }
         JobStatus::Failed => {
-            summary.failed += 1;
+            // A failed `required = false` rule is recorded and reported but
+            // does not fail the run (issue #99 B2, cluster path) — the same
+            // contract as the local loop.
+            let is_required = args
+                .config
+                .get_rule(&record.rule)
+                .is_none_or(|r| r.required);
+            if is_required {
+                summary.failed += 1;
+            } else {
+                summary.non_required_failed += 1;
+            }
             ck.record_run(record);
             ck.mark_failed(&record.rule);
         }
@@ -218,6 +235,7 @@ pub(crate) async fn run_on_cluster(
     let mut summary = ClusterRunSummary {
         succeeded: 0,
         failed: 0,
+        non_required_failed: 0,
         skipped: 0,
     };
 
@@ -276,6 +294,7 @@ pub(crate) async fn run_on_cluster(
                 run_dir: &run_dir,
                 on_checkpoint: None,
                 merge: None,
+                sensitive_values: args.sensitive_values,
             },
         )
         .await
@@ -285,12 +304,23 @@ pub(crate) async fn run_on_cluster(
         record_outcome(&args, record, &mut summary).await;
     }
 
-    eprintln!(
-        "\n{} {} succeeded, {} failed, {} skipped",
-        "Cluster:".bold(),
-        summary.succeeded,
-        summary.failed,
-        summary.skipped
-    );
+    if summary.non_required_failed > 0 {
+        eprintln!(
+            "\n{} {} succeeded, {} failed, {} non-required failed, {} skipped",
+            "Cluster:".bold(),
+            summary.succeeded,
+            summary.failed,
+            summary.non_required_failed,
+            summary.skipped
+        );
+    } else {
+        eprintln!(
+            "\n{} {} succeeded, {} failed, {} skipped",
+            "Cluster:".bold(),
+            summary.succeeded,
+            summary.failed,
+            summary.skipped
+        );
+    }
     Ok(summary)
 }

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -55,6 +55,10 @@ pub struct DriverOptions<'a> {
     /// Merges newly created instances into the plan; called when
     /// `on_checkpoint` returns names.
     pub merge: Option<PlanMerge<'a>>,
+    /// Sensitive config values masked out of recorded job commands
+    /// (issue #99 B1, cluster path — mirrors the local executor's
+    /// capture-boundary masking).
+    pub sensitive_values: &'a [String],
 }
 
 /// Executes a static plan through a backend.
@@ -337,7 +341,10 @@ impl BackendDriver {
                                 exit_code: Some(0),
                                 stdout: None,
                                 stderr: None,
-                                command: Some(plan.rules[&f.rule].shell_cmd.clone()),
+                                command: Some(crate::executor::process::mask_sensitive(
+                                    &plan.rules[&f.rule].shell_cmd,
+                                    opts.sensitive_values,
+                                )),
                                 retries: 0,
                                 timeout: None,
                                 skip_reason: None,
@@ -360,7 +367,10 @@ impl BackendDriver {
                                 exit_code: Some(1),
                                 stdout: None,
                                 stderr: None,
-                                command: Some(plan.rules[&f.rule].shell_cmd.clone()),
+                                command: Some(crate::executor::process::mask_sensitive(
+                                    &plan.rules[&f.rule].shell_cmd,
+                                    opts.sensitive_values,
+                                )),
                                 retries: 0,
                                 timeout: None,
                                 skip_reason: None,
@@ -376,7 +386,10 @@ impl BackendDriver {
                             exit_code: None,
                             stdout: None,
                             stderr: None,
-                            command: Some(plan.rules[&f.rule].shell_cmd.clone()),
+                            command: Some(crate::executor::process::mask_sensitive(
+                                &plan.rules[&f.rule].shell_cmd,
+                                opts.sensitive_values,
+                            )),
                             retries: 0,
                             timeout: None,
                             skip_reason: Some("cancelled".into()),
@@ -650,6 +663,7 @@ mod tests {
                     run_dir: fx.run_dir.path(),
                     on_checkpoint: None,
                     merge: None,
+                    sensitive_values: &[],
                 },
             ))
             .unwrap();
@@ -684,6 +698,7 @@ mod tests {
                     run_dir: fx.run_dir.path(),
                     on_checkpoint: None,
                     merge: None,
+                    sensitive_values: &[],
                 },
             ))
             .unwrap();
@@ -723,6 +738,7 @@ mod tests {
                     run_dir: fx.run_dir.path(),
                     on_checkpoint: None,
                     merge: None,
+                    sensitive_values: &[],
                 },
             ))
             .unwrap();
@@ -767,6 +783,7 @@ mod tests {
                     run_dir: fx.run_dir.path(),
                     on_checkpoint: None,
                     merge: None,
+                    sensitive_values: &[],
                 },
             ))
             .unwrap_err();
@@ -809,6 +826,7 @@ mod tests {
                     run_dir: fx.run_dir.path(),
                     on_checkpoint: None,
                     merge: None,
+                    sensitive_values: &[],
                 },
             ))
             .unwrap();
@@ -818,5 +836,43 @@ mod tests {
             noop.skip_reason.as_deref(),
             Some("no shell or script defined")
         );
+    }
+
+    #[test]
+    fn cluster_job_record_command_masks_sensitive_values() {
+        // Review follow-up of #99 B1: the cluster driver recorded the fully
+        // expanded shell command (with {config.*} secrets baked in) into
+        // JobRecord.command, which flows into the checkpoint/report/web —
+        // bypassing the local executor's capture-boundary masking.
+        let fx = setup();
+        let (d, _) = driver(&fx);
+        let mut plan = chain_plan(
+            fx.workdir.path(),
+            &[("echo_secret", "echo token-is-s3cr3t-token-42", "out.txt")],
+        );
+        let to_run: HashSet<String> = plan.order.iter().cloned().collect();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let records = runtime
+            .block_on(d.run(
+                &mut plan,
+                &to_run,
+                DriverOptions {
+                    run_dir: fx.run_dir.path(),
+                    on_checkpoint: None,
+                    merge: None,
+                    sensitive_values: &["s3cr3t-token-42".to_string()],
+                },
+            ))
+            .unwrap();
+        let rec = records
+            .iter()
+            .find(|r| r.rule == "echo_secret")
+            .expect("rule must produce a record");
+        let command = rec.command.as_deref().unwrap_or("");
+        assert!(
+            !command.contains("s3cr3t-token-42"),
+            "cluster JobRecord.command must mask sensitive values: {command}"
+        );
+        assert!(command.contains("***"), "masked marker expected: {command}");
     }
 }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1044,7 +1044,12 @@ impl LocalExecutor {
                 record.status = JobStatus::Failed;
                 record.finished_at = Some(Utc::now());
                 record.exit_code = Some(-1);
-                record.stderr = Some(format!("\n[oxo-flow] {e}"));
+                // Staging errors embed config-expanded URIs — mask them
+                // like every other captured surface (issue #99 B1).
+                record.stderr = Some(mask_sensitive(
+                    &format!("\n[oxo-flow] {e}"),
+                    &self.config.sensitive_values,
+                ));
                 return Ok(record);
             }
         };

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6415,6 +6415,45 @@ shell = "cat {input} > {output}"
     );
 }
 
+// ─── #99 B1 review follow-up: the verbose plan print must not leak ────────
+
+/// `--verbose` prints the config-expanded shell command; sensitive values
+/// must be masked there like every other log surface.
+#[test]
+fn cli_verbose_plan_print_masks_sensitive_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("v.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "v"
+version = "1.0.0"
+
+[config]
+api_token = { default = "s3cr3t-token-42", sensitive = true }
+
+[[rules]]
+name = "step"
+output = ["out.txt"]
+shell = "echo {config.api_token} > {output}"
+"#,
+    )
+    .unwrap();
+
+    let out = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap(), "--verbose"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("s3cr3t-token-42") && !stderr.contains("s3cr3t-token-42"),
+        "the verbose plan print must mask sensitive values\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
 // ─── #71: run flags after positional overrides get actionable errors ───────
 
 /// clap's trailing config_overrides positional (allow_hyphen_values) cannot

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -135,6 +135,7 @@ fn run_driver_with_env(
             &mut plan,
             to_run,
             DriverOptions {
+                sensitive_values: &[],
                 run_dir,
                 on_checkpoint: None,
                 merge: None,

--- a/tests/reentry_integration.rs
+++ b/tests/reentry_integration.rs
@@ -307,6 +307,7 @@ fn backend_driver_executes_reentry_rounds() {
             &mut plan,
             &to_run,
             DriverOptions {
+                sensitive_values: &[],
                 run_dir: run_dir.path(),
                 on_checkpoint: Some(Box::new(|rule_name: &str| {
                     let manifest = dir.path().join("discover.toml");


### PR DESCRIPTION
fix: close #99 review gaps — cluster masking/B2 parity, AI recovery target, error-path masking

Follow-up on the #99 B1/B2 review findings (PR #102):

- Cluster path (--profile): DriverOptions now carries sensitive_values and
  the backend driver masks recorded job commands at all three outcome
  sites — the cluster JobRecord.command previously carried the fully
  expanded shell (with {config.*} secrets) straight into the checkpoint,
  report, and web UI. record_outcome also honors `required = false` now:
  non-required failures are counted separately (non_required_failed),
  printed in the Cluster summary, and no longer fail the run — the same
  contract as the local loop.
- AI error recovery targeted the wrong rule: a non-required failure
  recorded earlier shadowed the rule that actually aborted the run
  (failures.first()). Failures are now always recorded, and the recovery
  path finds the entry matching the aborting rule by name, falling back
  to the first entry.
- Error-path masking: staging errors (config-expanded URIs) and
  security-validation errors (full command text) bypassed the
  capture-boundary mask — both record sites now route through
  mask_sensitive. The verbose plan print (dry-run --verbose) masks the
  expanded shell command as well, via a shared sensitive_values_of
  helper used by run, dry-run, and the cluster path.
- Tests: cluster driver JobRecord.command masking via the mock-scheduler
  harness (RED first), verbose plan print integration test (RED first).
