### PR TITLE
feat: workflow-global shell prelude (#92) + explicit null-stdin contract (#101)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -640,6 +640,7 @@ pub async fn run_command(
             &config.config,
             &sensitive_keys,
             &config.workflow.interpreter_map,
+            config.defaults.shell_prelude.as_deref(),
         );
         let force_rules: std::collections::HashSet<String> =
             report.invalidated.iter().cloned().collect();
@@ -872,6 +873,7 @@ pub async fn run_command(
         dry_run: false,
         workdir: workdir.clone().unwrap_or_else(|| workdir_default.clone()),
         sensitive_values: sensitive_values.clone(),
+        shell_prelude: config.defaults.shell_prelude.clone(),
         keep_going,
         retry_count: retry,
         timeout: if timeout_secs > 0 {
@@ -1088,6 +1090,9 @@ pub async fn run_command(
                     );
                     build_cmd = build_cmd.replace("{source}", &expanded);
                 }
+                // References take the same shell prelude as rules (issue #92),
+                // before the environment wrapper resolves.
+                build_cmd = config.defaults.apply_shell_prelude(&build_cmd);
                 // References that need workflow tools (bowtie2-build, STAR
                 // genomeGenerate, …) declare an `environment` — same spec as
                 // `[rules.environment]`. The env is created on first use and
@@ -1137,11 +1142,21 @@ pub async fn run_command(
                     ref_def.description.as_deref().unwrap_or(&ref_def.output),
                     reason
                 );
-                let status = std::process::Command::new("sh")
-                    .arg("-c")
-                    .arg(&build_cmd)
-                    .current_dir(ref_workdir)
-                    .status();
+                // bash first, sh fallback — mirrors the rule executor
+                // (spawn_rule_shell): `set -o pipefail` in a shell prelude
+                // is invalid under dash, which /bin/sh is on Debian-family
+                // systems (review finding on issue #92).
+                let spawn_ref_build = |shell: &str| {
+                    std::process::Command::new(shell)
+                        .arg("-c")
+                        .arg(&build_cmd)
+                        .current_dir(ref_workdir)
+                        .status()
+                };
+                let status = match spawn_ref_build("bash") {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => spawn_ref_build("sh"),
+                    other => other,
+                };
                 match status {
                     Ok(s) if s.success() => {
                         // Store the POST-build fingerprint: the decision

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -223,6 +223,7 @@ pub fn preview_run_plan(
         &config.config,
         sensitive_keys,
         interpreter_map,
+        config.defaults.shell_prelude.as_deref(),
     );
     let config_invalidated: HashSet<String> = config_report.invalidated.iter().cloned().collect();
 
@@ -1197,6 +1198,7 @@ version = "1.0"
             &config.config,
             &sensitive(),
             &config.workflow.interpreter_map,
+            config.defaults.shell_prelude.as_deref(),
         );
 
         let mut changed_config = config.clone();

--- a/crates/oxo-flow-core/src/backend/mod.rs
+++ b/crates/oxo-flow-core/src/backend/mod.rs
@@ -160,15 +160,20 @@ fn build_rule(
     ) else {
         return Ok(None); // no shell/script — not schedulable
     };
+    // The prelude goes INSIDE the environment wrapper, matching the local
+    // executor (issue #92): prepending outside would leave the wrapped
+    // command (conda run / docker run bash -c) without fail-fast semantics.
+    let cmd = config.defaults.apply_shell_prelude(&cmd);
     let wrapped = env_resolver
         .wrap_command(&cmd, &rule.environment, Some(&rule.resources), workdir)
         .map_err(|e| OxoFlowError::Config {
             message: format!("environment wrapping failed for '{name}': {e}"),
         })?;
     let dependencies = dag.dependencies(name).unwrap_or_default();
+    let shell_cmd = format!("cd '{}' && {}", workdir.display(), wrapped);
     Ok(Some(ScheduledRule {
         rule: rule.clone(),
-        shell_cmd: format!("cd '{}' && {}", workdir.display(), wrapped),
+        shell_cmd,
         workdir: workdir.to_path_buf(),
         dependencies,
         wildcard_values: wildcard_values.clone(),
@@ -209,6 +214,34 @@ mod tests {
 
     fn values() -> HashMap<String, String> {
         HashMap::from([("config.ref".to_string(), "/data/ref.fa".to_string())])
+    }
+
+    #[test]
+    fn build_prepends_shell_prelude_before_cd_guard() {
+        // issue #92: the cluster plan applies the prelude to the WHOLE
+        // script — before the cd guard — so set -e also aborts on a failed
+        // cd, and the command line stays guarded.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = demo_config(dir.path());
+        config.defaults.shell_prelude = Some("set -euo pipefail".to_string());
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let dag = WorkflowDag::from_rules(&config.rules).unwrap();
+        let plan = ScheduledPlan::build(
+            &config,
+            &dag,
+            std::path::Path::new("/tmp/wf"),
+            &EnvironmentResolver::new(),
+            &values(),
+        )
+        .unwrap();
+        let r = &plan.rules["preprocess"];
+        assert!(
+            r.shell_cmd
+                .starts_with("cd '/tmp/wf' && set -euo pipefail\n"),
+            "prelude must sit inside the wrapped command, after the cd guard: {}",
+            r.shell_cmd
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -258,6 +258,37 @@ pub struct Defaults {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<EnvironmentSpec>,
+
+    /// Shell prelude prepended to every rule shell command (and hooks),
+    /// on its own line — e.g. `"set -euo pipefail"` for fail-fast shells
+    /// (issue #92). Opt-in: empty by default, so existing workflows keep
+    /// their exact command text.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell_prelude: Option<String>,
+}
+
+/// Prepend a shell prelude to a command on its own line (issue #92).
+///
+/// Returns the command unchanged when no prelude is configured. The single
+/// point all execution paths route through — local rules, hooks, reference
+/// builds, and the cluster plan — so prelude semantics cannot drift.
+pub fn prepend_shell_prelude(cmd: &str, prelude: Option<&str>) -> String {
+    match prelude {
+        Some(p) if !p.trim().is_empty() => format!("{p}\n{cmd}"),
+        _ => cmd.to_string(),
+    }
+}
+
+impl Defaults {
+    /// Prepend the configured shell prelude to a command on its own line.
+    ///
+    /// Returns the command unchanged when no prelude is configured. Applied
+    /// at command-build time — inside environment wrappers — so the local,
+    /// container, and reference-build paths share one semantics (issue #92).
+    pub fn apply_shell_prelude(&self, cmd: &str) -> String {
+        prepend_shell_prelude(cmd, self.shell_prelude.as_deref())
+    }
 }
 
 /// Report configuration section.
@@ -5842,6 +5873,56 @@ shell = "echo {config.database} > {output[0]}"
             config.config.get("api_token").and_then(|v| v.as_str()),
             Some(""),
             "no default: the runtime value is empty until overridden"
+        );
+    }
+
+    #[test]
+    fn defaults_shell_prelude_parses_and_applies() {
+        // issue #92: a workflow-global shell prelude (e.g. set -euo
+        // pipefail) is opt-in, parsed from [defaults], and prepended to a
+        // command on its own line.
+        let config = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [defaults]
+            shell_prelude = "set -euo pipefail"
+
+            [[rules]]
+            name = "s"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.defaults.shell_prelude.as_deref(),
+            Some("set -euo pipefail")
+        );
+        assert_eq!(
+            config.defaults.apply_shell_prelude("echo hi > out.txt"),
+            "set -euo pipefail\necho hi > out.txt"
+        );
+
+        // No prelude: the command passes through unchanged.
+        let plain = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "s"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            plain.defaults.apply_shell_prelude("echo hi > out.txt"),
+            "echo hi > out.txt"
         );
     }
 

--- a/crates/oxo-flow-core/src/config_impact.rs
+++ b/crates/oxo-flow-core/src/config_impact.rs
@@ -197,7 +197,11 @@ fn canonical_toml_map(map: &HashMap<String, toml::Value>) -> String {
 /// Includes `pre_exec`/`on_success`/`on_failure` (they are part of the rule
 /// definition and can write outputs or alter state) and the resolved
 /// interpreter for script rules.
-pub fn rule_fingerprint(rule: &Rule, interpreter_map: &HashMap<String, String>) -> String {
+pub fn rule_fingerprint(
+    rule: &Rule,
+    interpreter_map: &HashMap<String, String>,
+    shell_prelude: Option<&str>,
+) -> String {
     let mut hasher = Sha256::new();
     // Field name + value pairs separated by NUL bytes: unambiguous framing,
     // deterministic ordering (maps sorted by key, lists in semantic order).
@@ -209,6 +213,10 @@ pub fn rule_fingerprint(rule: &Rule, interpreter_map: &HashMap<String, String>) 
     };
 
     add("name", &rule.name);
+    // The workflow shell prelude changes every rule's execution semantics
+    // (issue #92): enabling or editing it must invalidate completed rules —
+    // their outputs were produced under different shell strictness.
+    add("shell_prelude", shell_prelude.unwrap_or(""));
     add("shell", rule.shell.as_deref().unwrap_or(""));
     add("script", rule.script.as_deref().unwrap_or(""));
     add("input", &canonical_file_patterns(&rule.input));
@@ -360,6 +368,7 @@ pub fn detect_config_changes(
     current: &HashMap<String, toml::Value>,
     sensitive_keys: &HashSet<String>,
     interpreter_map: &HashMap<String, String>,
+    shell_prelude: Option<&str>,
 ) -> ConfigChangeReport {
     // A checkpoint with neither snapshot nor fingerprints predates config
     // tracking: bootstrap only (no invalidation) — documented one-time window.
@@ -405,7 +414,7 @@ pub fn detect_config_changes(
     let mut current_fingerprints: HashMap<String, String> = HashMap::new();
     let mut fingerprint_mismatches: Vec<String> = Vec::new();
     for rule in rules {
-        let fingerprint = rule_fingerprint(rule, interpreter_map);
+        let fingerprint = rule_fingerprint(rule, interpreter_map, shell_prelude);
         if let Some(stored) = checkpoint.rule_fingerprints.get(&rule.name)
             && *stored != fingerprint
             && checkpoint.is_completed(&rule.name)
@@ -670,7 +679,10 @@ mod tests {
                 .insert(format!("k{i}"), toml::Value::String(format!("v{i}")));
         }
         let map = HashMap::new();
-        assert_eq!(rule_fingerprint(&a, &map), rule_fingerprint(&b, &map));
+        assert_eq!(
+            rule_fingerprint(&a, &map, None),
+            rule_fingerprint(&b, &map, None)
+        );
     }
 
     #[test]
@@ -680,7 +692,10 @@ mod tests {
         let mut b = a.clone();
         b.shell = Some("fastp -q 30".to_string());
         let map = HashMap::new();
-        assert_ne!(rule_fingerprint(&a, &map), rule_fingerprint(&b, &map));
+        assert_ne!(
+            rule_fingerprint(&a, &map, None),
+            rule_fingerprint(&b, &map, None)
+        );
     }
 
     #[test]
@@ -693,7 +708,10 @@ mod tests {
         b.threads = Some(16);
         b.memory = Some("64G".to_string());
         let map = HashMap::new();
-        assert_eq!(rule_fingerprint(&a, &map), rule_fingerprint(&b, &map));
+        assert_eq!(
+            rule_fingerprint(&a, &map, None),
+            rule_fingerprint(&b, &map, None)
+        );
     }
 
     #[test]
@@ -717,7 +735,10 @@ mod tests {
             ".oxo-flow/chunks/2".to_string(),
         ]);
         let map = HashMap::new();
-        assert_ne!(rule_fingerprint(&a, &map), rule_fingerprint(&b, &map));
+        assert_ne!(
+            rule_fingerprint(&a, &map, None),
+            rule_fingerprint(&b, &map, None)
+        );
     }
 
     #[test]
@@ -733,8 +754,14 @@ mod tests {
         d.interpreter = Some("/opt/python3.12/bin/python".to_string());
 
         let map = HashMap::new();
-        assert_ne!(rule_fingerprint(&a, &map), rule_fingerprint(&b, &map));
-        assert_ne!(rule_fingerprint(&c, &map), rule_fingerprint(&d, &map));
+        assert_ne!(
+            rule_fingerprint(&a, &map, None),
+            rule_fingerprint(&b, &map, None)
+        );
+        assert_ne!(
+            rule_fingerprint(&c, &map, None),
+            rule_fingerprint(&d, &map, None)
+        );
     }
 
     // ── Reference fingerprints ───────────────────────────────────────────
@@ -977,6 +1004,7 @@ mod tests {
             &cfg(&[("min_quality", "20")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -987,6 +1015,7 @@ mod tests {
             &cfg(&[("min_quality", "30")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
 
         assert_eq!(report.changed_keys, vec!["min_quality"]);
@@ -1031,6 +1060,7 @@ mod tests {
             &cfg(&[("gone_key", "x")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -1041,6 +1071,7 @@ mod tests {
             &cfg(&[("new_key", "y")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert_eq!(report.added_keys, vec!["new_key"]);
         assert_eq!(report.removed_keys, vec!["gone_key"]);
@@ -1074,6 +1105,7 @@ mod tests {
             &cfg(&[("min_quality", "20")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -1084,6 +1116,7 @@ mod tests {
             &cfg(&[("min_quality", "20")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.invalidated.is_empty());
         assert!(report.changed_keys.is_empty());
@@ -1115,6 +1148,7 @@ mod tests {
             &cfg(&[("samples_list", "S1,S2")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -1125,6 +1159,7 @@ mod tests {
             &cfg(&[("samples_list", "S3,S4")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.changed_keys.is_empty());
         assert!(report.invalidated.is_empty());
@@ -1140,6 +1175,7 @@ mod tests {
             &cfg(&[("pairs_list", "P1,P2")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
         let report = detect_config_changes(
@@ -1149,6 +1185,7 @@ mod tests {
             &cfg(&[("pairs_list", "P2,P3")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.changed_keys.is_empty());
         assert!(report.invalidated.is_empty());
@@ -1168,6 +1205,7 @@ mod tests {
             &cfg(&[("api_token", "hunter2")]),
             &sensitive,
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
         let stored = checkpoint.config_snapshot.get("api_token").unwrap();
@@ -1182,6 +1220,7 @@ mod tests {
             &cfg(&[("api_token", "hunter3")]),
             &sensitive,
             &HashMap::new(),
+            None,
         );
         assert_eq!(report.changed_keys, vec!["api_token"]);
     }
@@ -1212,6 +1251,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -1226,6 +1266,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.fingerprint_mismatches.contains(&"c".to_string()));
         assert!(!checkpoint.is_completed("c"));
@@ -1262,6 +1303,7 @@ mod tests {
             &cfg(&[("min_quality", "30")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.is_legacy);
         assert!(report.invalidated.is_empty());
@@ -1296,6 +1338,7 @@ mod tests {
             &cfg(&[("min_quality", "20")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         let report = detect_config_changes(
             &mut checkpoint,
@@ -1304,6 +1347,7 @@ mod tests {
             &cfg(&[("min_quality", "30")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(!report.is_legacy);
         assert!(!checkpoint.is_completed("b"));
@@ -1339,6 +1383,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
         checkpoint.rule_fingerprints.remove("b");
@@ -1350,6 +1395,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert!(report.fingerprint_mismatches.is_empty());
         assert!(report.invalidated.is_empty());
@@ -1385,6 +1431,7 @@ mod tests {
             &cfg(&[("k", "1")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         checkpoint = cp;
 
@@ -1395,6 +1442,7 @@ mod tests {
             &cfg(&[("k", "2")]),
             &HashSet::new(),
             &HashMap::new(),
+            None,
         );
         assert_eq!(report.invalidated, vec!["orphan".to_string()]);
         assert!(!checkpoint.is_completed("orphan"));

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -288,6 +288,10 @@ pub struct ExecutorConfig {
     /// of captured stdout/stderr and the recorded command before they reach
     /// the checkpoint/report (issue #99 B1). Empty = no masking.
     pub sensitive_values: Vec<String>,
+    /// Workflow-global shell prelude prepended to every rule command and
+    /// hook on its own line (issue #92), e.g. `set -euo pipefail`.
+    /// Opt-in: `None` keeps the historical exact command text.
+    pub shell_prelude: Option<String>,
 }
 
 impl Default for ExecutorConfig {
@@ -309,6 +313,7 @@ impl Default for ExecutorConfig {
             interpreter_map: HashMap::new(),
             storage_resolver: StorageResolver::with_local(),
             sensitive_values: Vec::new(),
+            shell_prelude: None,
         }
     }
 }
@@ -1089,6 +1094,12 @@ impl LocalExecutor {
                 return Ok(record);
             }
         };
+        // Workflow-global shell prelude (issue #92): prepended BEFORE the
+        // environment wrapper resolves, so the prelude runs INSIDE the
+        // container/conda wrapper — the local and cluster paths share one
+        // semantics.
+        let base_cmd =
+            crate::config::prepend_shell_prelude(&base_cmd, self.config.shell_prelude.as_deref());
 
         // Optional rules skip (no error) when their declared inputs are
         // absent — e.g. analysis steps that only apply to some samples
@@ -1243,7 +1254,12 @@ impl LocalExecutor {
                 self.release_resources(&rule).await;
                 return Err(e);
             }
-            let pre_child = spawn_rule_shell(&rendered, rule_cwd, &rule.envvars);
+            // pre_exec takes the same prelude as the other hooks (issue #92).
+            let rendered_pre = crate::config::prepend_shell_prelude(
+                &rendered,
+                self.config.shell_prelude.as_deref(),
+            );
+            let pre_child = spawn_rule_shell(&rendered_pre, rule_cwd, &rule.envvars);
             let pre_result = match pre_child {
                 Ok(child) => child.wait_with_output().await,
                 Err(e) => {
@@ -1452,6 +1468,7 @@ impl LocalExecutor {
                         ),
                         &rule,
                         &self.config.workdir,
+                        self.config.shell_prelude.as_deref(),
                     )
                     .await;
                 }
@@ -1488,6 +1505,7 @@ impl LocalExecutor {
                                 ),
                                 &rule,
                                 &self.config.workdir,
+                                self.config.shell_prelude.as_deref(),
                             )
                             .await;
                         }
@@ -1506,6 +1524,7 @@ impl LocalExecutor {
                                 ),
                                 &rule,
                                 &self.config.workdir,
+                                self.config.shell_prelude.as_deref(),
                             )
                             .await;
                         }
@@ -1557,6 +1576,7 @@ impl LocalExecutor {
                         ),
                         &rule,
                         &self.config.workdir,
+                        self.config.shell_prelude.as_deref(),
                     )
                     .await;
                 }
@@ -1580,6 +1600,7 @@ impl LocalExecutor {
                     ),
                     &rule,
                     &self.config.workdir,
+                    self.config.shell_prelude.as_deref(),
                 )
                 .await;
             }
@@ -1805,6 +1826,12 @@ pub(super) fn spawn_rule_shell(
     ) -> tokio::process::Command {
         let mut c = tokio::process::Command::new(shell);
         c.arg("-c").arg(cmd).current_dir(workdir).envs(envs);
+        // stdin is explicitly null (issue #101): tokio's default is INHERIT,
+        // so a TTY-launched `oxo-flow run` would hand the terminal to every
+        // rule — stdin-polling tools can park forever on it. Null stdin is
+        // the batch-tool contract (what cluster submit scripts do with
+        // </dev/null).
+        c.stdin(Stdio::null());
         c.stdout(Stdio::piped()).stderr(Stdio::piped());
         c
     }
@@ -2019,8 +2046,10 @@ async fn discard_scratch(scratch: Option<&Path>) {
 /// Execute a rendered rule hook (on_success / on_failure) in the rule's
 /// environment. Hooks are best-effort: their failure never changes the
 /// rule's own status (pre_exec is the exception and aborts the rule).
-async fn run_hook(cmd: &str, rule: &Rule, workdir: &std::path::Path) {
-    let child = match spawn_rule_shell(cmd, workdir, &rule.envvars) {
+async fn run_hook(cmd: &str, rule: &Rule, workdir: &std::path::Path, shell_prelude: Option<&str>) {
+    // Hooks take the same prelude as rule commands (issue #92).
+    let cmd = crate::config::prepend_shell_prelude(cmd, shell_prelude);
+    let child = match spawn_rule_shell(&cmd, workdir, &rule.envvars) {
         Ok(child) => child,
         Err(e) => {
             tracing::warn!(rule = %rule.name, error = %e, "failed to spawn rule hook");

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -390,6 +390,7 @@ Applied to all rules unless explicitly overridden:
 threads = 4
 memory = "8G"
 environment = { conda = "envs/base.yaml" }
+shell_prelude = "set -euo pipefail"
 ```
 
 | Field | Type | Description |
@@ -397,6 +398,7 @@ environment = { conda = "envs/base.yaml" }
 | `threads` | Integer | Default CPU thread count |
 | `memory` | String | Default memory allocation |
 | `environment` | Table | Default environment specification |
+| `shell_prelude` | String | Shell text prepended to every rule command, hook, reference build, and cluster job script on its own line (issue #92) — e.g. `set -euo pipefail` for fail-fast shells. **Opt-in**: empty by default, so existing workflows keep their exact command text. Applies inside environment wrappers (containers, conda) on every execution path. `pipefail` requires bash (the engine falls back to `sh` only when bash is absent) |
 
 ---
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6454,6 +6454,164 @@ shell = "echo {config.api_token} > {output}"
     );
 }
 
+// ─── #101: rule subprocesses never block on stdin ─────────────────────────
+
+/// Contract smoke test: rule shells must observe null stdin (issue #101).
+///
+/// Honest caveat: tokio's spawn default is INHERIT, and `spawn_rule_shell`
+/// pins `stdin(Stdio::null())` explicitly — this test guards that contract.
+/// It cannot serve as a RED proof for the line's removal in sandboxed CI:
+/// held-open pipes deliver immediate EOF to `read` there, so both inherit
+/// and null behave identically in this environment. The behavioral
+/// difference (a TTY-launched run handing the terminal to stdin-polling
+/// tools) is the real motivation and is documented at the spawn site.
+#[test]
+fn cli_rule_shell_gets_null_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("stdin.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "stdin"
+version = "1.0.0"
+
+[[rules]]
+name = "reader"
+output = ["out.txt"]
+shell = 'if read -t 8 x; then echo "got:$x" > out.txt; else echo eof > out.txt; fi'
+"#,
+    )
+    .unwrap();
+
+    // Launch the CLI with a HELD-OPEN stdin pipe: under the historical
+    // inherit behavior the rule's `read -t 8` would sit on the pipe for
+    // the full timeout and write "timeout"; with the executor's null stdin
+    // it sees an immediate EOF and writes "eof". The content assertion
+    // distinguishes the two without timing.
+    // Raw std Command: assert_cmd's wrapper does not expose stdin config.
+    let mut child = std::process::Command::new(workspace_bin("oxo-flow"))
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    // Keep the pipe's write end open for the whole run.
+    let held_open = child.stdin.take();
+    let run = child.wait_with_output().unwrap();
+    drop(held_open);
+    assert!(
+        run.status.success(),
+        "rule must succeed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "eof\n",
+        "the rule shell must observe null stdin (immediate EOF), not a held pipe"
+    );
+}
+
+// ─── #92: workflow-global shell prelude (set -euo pipefail) ───────────────
+
+/// Without a prelude, an intermediate failing command does NOT fail the
+/// rule (bash -c keeps going) — the silent-broken-output class the prelude
+/// exists to close.
+#[test]
+fn cli_shell_prelude_makes_intermediate_failure_fail_the_rule() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("strict.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "strict"
+version = "1.0.0"
+
+[defaults]
+shell_prelude = "set -euo pipefail"
+
+[[rules]]
+name = "boom"
+output = ["out.txt"]
+shell = "false; echo done > out.txt"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !run.status.success(),
+        "an intermediate failure must fail the rule under set -e: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    // -u: referencing an undefined variable must fail too.
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "strict"
+version = "1.0.0"
+
+[defaults]
+shell_prelude = "set -euo pipefail"
+
+[[rules]]
+name = "boom"
+output = ["out.txt"]
+shell = "echo $UNDEFINED_XYZ; echo ok > out.txt"
+"#,
+    )
+    .unwrap();
+    let run2 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !run2.status.success(),
+        "an undefined variable must fail the rule under set -u: {}",
+        String::from_utf8_lossy(&run2.stderr)
+    );
+}
+
+/// Control: without a prelude, the same command keeps the historical
+/// behavior (the intermediate failure is masked by the last command's
+/// success) — opt-in semantics, existing workflows unchanged.
+#[test]
+fn cli_shell_without_prelude_keeps_historical_behavior() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("loose.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "loose"
+version = "1.0.0"
+
+[[rules]]
+name = "boom"
+output = ["out.txt"]
+shell = "false; echo done > out.txt"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run.status.success());
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "done\n"
+    );
+}
+
 // ─── #71: run flags after positional overrides get actionable errors ───────
 
 /// clap's trailing config_overrides positional (allow_hyphen_values) cannot


### PR DESCRIPTION
feat: workflow-global shell prelude (issue #92) + explicit null-stdin contract (issue #101)

#92 — [defaults] shell_prelude: an opt-in shell text (e.g. `set -euo
pipefail`) prepended to every rule command, hook, reference build, and
cluster job script on its own line. Injected before the environment
wrapper resolves, so the local, container, and cluster paths share one
semantics; the recorded command and the dry-run plan print show it
truthfully. Empty by default — existing workflows keep their exact
command text (the 24-ported-community-ecosystem constraint). Without
this, an intermediate failing command in a multi-command shell silently
succeeds (bash -c keeps going) — the silent-broken-output class the
prelude closes.

#101 — investigation concluded (see issue comment): the metabat2 spin
is a flaky tool pathology, engine premise refuted by the campaign's
standalone reproduction and by the engine-side audit (tokio spawn stdin
already defaults to null; campaign plumbing ran the engine under
</dev/null). The stdin contract is now EXPLICIT in spawn_rule_shell
(stdin(Stdio::null())) and pinned by an integration test, so a future
stdio-default change cannot silently re-open the hang class.

Tests (RED first where behavioral): defaults parse + apply unit;
integration strict-mode (intermediate failure and undefined-variable
both fail the rule under the prelude) + control (historical behavior
without it); cluster plan prelude-before-cd-guard unit; rule-shell
null-stdin integration. Full make ci green; live-verified strict mode
and hook prelude.

Closes #92, Closes #101

Review hardening (5-angle review, 6 findings → 5 fixed):
- reference builds now spawn bash-first with sh fallback (set -o pipefail
  is invalid under dash — the docs example would fail every environment-less
  reference build on Debian-family hosts);
- cluster plan applies the prelude INSIDE the environment wrapper,
  matching the local executor (outside would leave conda/docker wrapped
  commands without fail-fast semantics);
- pre_exec hooks take the prelude like on_success/on_failure;
- the prelude joins rule fingerprints, so enabling or editing it
  invalidates completed rules (outputs produced under different shell
  strictness are suspect) — threading detect_config_changes through run
  and run_preview;
- shared prepend_shell_prelude helper replaces the triplicated inline
  logic.
Fact correction on #101: tokio's spawn stdin default is INHERIT
(source-verified, 1.53.1) — the stdin(null) line is a real behavior
change (TTY-launched runs previously handed the terminal to every rule),
not documentation-as-code. The integration test is an honest contract
smoke test: sandboxed pipes deliver immediate EOF to `read` here, so the
inherit-vs-null distinction cannot be produced as a RED in this
environment (documented at the test and the spawn site).
