### PR TITLE
fix(core): docker setup pulls only when the image is absent

### DIFF
--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -438,7 +438,14 @@ impl EnvironmentBackend for DockerBackend {
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
-        Ok(format!("docker pull {spec}"))
+        // Pull only when the image is absent: two rules sharing one
+        // image run their setup concurrently, and simultaneous
+        // `docker pull`s of the same image race in the daemon (live:
+        // fastqc x2 -> "failed to lease content: NotFound"). The
+        // per-key env lock serializes the truly-missing case.
+        Ok(format!(
+            "docker image inspect {spec} >/dev/null 2>&1 || docker pull {spec}"
+        ))
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
@@ -1331,7 +1338,10 @@ mod tests {
     fn docker_setup_command() {
         let backend = DockerBackend;
         let cmd = backend.setup_command("biocontainers/bwa:0.7.17").unwrap();
-        assert_eq!(cmd, "docker pull biocontainers/bwa:0.7.17");
+        assert_eq!(
+            cmd,
+            "docker image inspect biocontainers/bwa:0.7.17 >/dev/null 2>&1 || docker pull biocontainers/bwa:0.7.17"
+        );
     }
 
     #[test]

--- a/typescript
+++ b/typescript
@@ -1,0 +1,10 @@
+Script started on Wed Aug 19 18:32:13 2026
+^D[1m[7m%[27m[1m[0m                                                                                ]7;file://ShixiangWang-WorkSpacedeMacBook-Pro.local/Users/wsx/Documents/GitHub/oxo-flow[0m[27m[24m[J(base) wsx@ShixiangWang-WorkSpacedeMacBook-Pro oxo-flow % [K[?2004h[?2004l
+
+Saving session...
+...copying shared history...
+...saving history...truncating history files...
+...completed.
+Deleting expired sessions...none found.
+
+Script done on Wed Aug 19 18:32:14 2026


### PR DESCRIPTION
Live failure (tx-ubuntu, sarek live-run): two fastqc rules launch simultaneously and each runs `docker pull` for the same image — the second pull dies with

```
Error response from daemon: failed to lease content: NotFound: lease "…": not found
```

and the rule fails with an environment error. The per-key env lock does not save it when the lock join itself is cancelled during executor shutdown.

Fix: inspect-first setup (`docker image inspect {spec} >/dev/null 2>&1 || docker pull {spec}`) — the common case (image present) becomes a no-op; the truly-missing case is still serialized by the per-key env lock.

Test: `cargo test -p oxo-flow-core environment::` — 78 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)