### PR TITLE
fix(cluster): a fresh dependency no longer stalls the driver (#74)

### DIFF
--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -171,7 +171,7 @@ impl BackendDriver {
                     if !to_run_set.contains(&name)
                         || done.contains_key(&name)
                         || inflight.values().any(|f| f.rule == name)
-                        || !deps_ok(&name, &done, plan)
+                        || !deps_ok(&name, &done, &to_run_set, plan)
                     {
                         continue;
                     }
@@ -452,11 +452,24 @@ impl BackendDriver {
     }
 }
 
-fn deps_ok(name: &str, done: &HashMap<String, JobStatus>, plan: &ScheduledPlan) -> bool {
+/// Is every dependency of `name` satisfied?
+///
+/// A dependency outside `to_run` is satisfied by definition: the caller's
+/// invalidation analysis decided it is already complete, so it is never
+/// submitted and never lands in `done`. Requiring it there would wedge every
+/// partial re-run — resume after a failure, an edit to a downstream rule,
+/// `--target` on a leaf — into the stall branch below with nothing submitted.
+fn deps_ok(
+    name: &str,
+    done: &HashMap<String, JobStatus>,
+    to_run: &HashSet<String>,
+    plan: &ScheduledPlan,
+) -> bool {
     plan.rules.get(name).is_none_or(|sr| {
-        sr.dependencies
-            .iter()
-            .all(|d| matches!(done.get(d), Some(JobStatus::Success | JobStatus::Skipped)))
+        sr.dependencies.iter().all(|d| {
+            !to_run.contains(d)
+                || matches!(done.get(d), Some(JobStatus::Success | JobStatus::Skipped))
+        })
     })
 }
 
@@ -755,6 +768,48 @@ mod tests {
         }
         assert!(max_seen <= 2, "max in-flight observed: {max_seen}");
         assert!(max_seen >= 1);
+    }
+
+    /// A dependency the caller left out of `to_run` is already complete, not
+    /// pending. Before this, `deps_ok` waited for it to appear in `done`, so
+    /// every partial re-run — resume after a failure, an edit to a downstream
+    /// rule — submitted nothing and died with "driver stall".
+    #[test]
+    fn driver_runs_a_rule_whose_dependency_is_outside_to_run() {
+        let fx = setup();
+        let (d, _) = driver(&fx);
+        let mut plan = chain_plan(
+            fx.workdir.path(),
+            &[
+                ("a", "echo a > a.txt", "a.txt"),
+                ("b", "cat a.txt && echo b > b.txt", "b.txt"),
+            ],
+        );
+        // `a` ran in an earlier run: its output is on disk and the caller's
+        // invalidation analysis kept it out of this run's work set.
+        std::fs::write(fx.workdir.path().join("a.txt"), "a\n").unwrap();
+        let to_run: HashSet<String> = ["b".to_string()].into_iter().collect();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let records = runtime
+            .block_on(d.run(
+                &mut plan,
+                &to_run,
+                DriverOptions {
+                    run_dir: fx.run_dir.path(),
+                    on_checkpoint: None,
+                    merge: None,
+                    sensitive_values: &[],
+                },
+            ))
+            .expect("a fresh dependency must not stall the driver");
+        assert_eq!(
+            records.len(),
+            1,
+            "only `b` belongs to this run: {records:?}"
+        );
+        assert_eq!(records[0].rule, "b");
+        assert_eq!(records[0].status, JobStatus::Success);
+        assert!(fx.workdir.path().join("b.txt").exists());
     }
 
     #[test]

--- a/tests/cluster_run_profile.rs
+++ b/tests/cluster_run_profile.rs
@@ -238,6 +238,53 @@ fn cluster_and_local_agree_on_rerun_set() {
     );
 }
 
+/// Resume after a cluster failure: fix the cause, run again. The upstream is
+/// fresh and stays out of the work set, so the driver has to treat it as
+/// satisfied rather than wait for it — otherwise the everyday recovery path
+/// submits nothing and dies with "driver stall".
+#[test]
+fn resume_after_failure_submits_only_the_failed_rule() {
+    let dir = tempfile::tempdir().unwrap();
+    setup(dir.path(), Some(CLUSTER_PROFILE));
+    // `gate` fails until the FLAG file exists — a stand-in for any fixable
+    // cause (a missing module, a bad path, a full filesystem).
+    std::fs::write(
+        dir.path().join("wf.oxoflow"),
+        r#"
+[workflow]
+name = "resume"
+
+[[rules]]
+name = "prep"
+output = ["prep.txt"]
+shell = "echo prepared > prep.txt"
+
+[[rules]]
+name = "gate"
+input = ["prep.txt"]
+output = ["gate.txt"]
+shell = "test -f FLAG && cp prep.txt gate.txt"
+"#,
+    )
+    .unwrap();
+
+    let first = run(dir.path(), &["--profile", "slurm"]);
+    assert!(!first.status.success(), "`gate` must fail on the first run");
+    assert_eq!(submitted_rules(dir.path()), vec!["gate", "prep"]);
+
+    std::fs::write(dir.path().join("FLAG"), "").unwrap();
+    let second = run(dir.path(), &["--profile", "slurm"]);
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(second.status.success(), "resume failed:\n{stderr}");
+    assert!(!stderr.contains("driver stall"), "{stderr}");
+    assert_eq!(
+        submitted_rules(dir.path()),
+        vec!["gate"],
+        "only the failed rule re-runs; `prep` is already complete"
+    );
+    assert!(dir.path().join("gate.txt").exists());
+}
+
 /// Condition 4: a profile without a `[cluster]` block keeps the local path,
 /// so existing config-only profiles are unaffected.
 #[test]


### PR DESCRIPTION
Found this while looking for cheap cluster-path wins I could exercise locally before booking cluster time. It's a one-line condition, but it takes out the most common cluster workflow there is.

## The bug

`BackendDriver`'s `deps_ok` required every dependency to be in `done` before a rule was ready. A dependency the caller left out of `to_run` is already complete — it's never submitted, so it never lands in `done`. The dependent stayed pending forever, the wave submitted nothing, and the run hit the stall branch:

```
Cluster: submitting 1 job(s) to slurm (max 50 in flight)
Error: cluster execution failed: config error: driver stall: no jobs in flight but rules remain pending (plan/dependency mismatch)
```

That's every partial re-run:

- **resume after a failed job** — the everyday recovery loop
- edit a downstream rule, re-run
- `--target` a rule whose upstream is already built

Reproduced end to end against the mock scheduler: two-rule workflow, second rule fails, fix the cause, re-run → nothing submitted, hard error. The local path handles all three correctly, so this was cluster-only — which is also why the existing suite missed it. `cluster_and_local_agree_on_rerun_set` re-runs a whole chain (`align_S2` → `stats_S2`), so the dependency was always inside `to_run`.

## The fix

A dependency outside `to_run` counts as satisfied. Failure propagation is unaffected: a failed dependency *is* in `to_run` and in `done`, so dependents are still skipped with "blocked by failed upstream" rather than sneaking through.

Two tests, one per layer, because the two failure modes read differently:

- `driver_runs_a_rule_whose_dependency_is_outside_to_run` — pins the driver contract directly, so a future `deps_ok` edit fails here rather than at the CLI.
- `resume_after_failure_submits_only_the_failed_rule` — pins the user-facing loop through `run --profile`, and asserts the *set*, not just success: only the failed rule resubmits.

`make ci` green. Note the workspace suite passes at `--test-threads=1` (what the Makefile uses) — the `oxo-flow-web` `test_personal_mode_health` flake I mentioned on #93 only shows up in parallel runs.

## Four more, same hunt

All mock-testable, no cluster hardware needed. Happy to take any of them, or to leave them if you'd rather I go straight at re-attach:

1. **A failed cluster job reports nothing usable.** No real exit code (`exit_code` is hardcoded `Some(1)` — a rule exiting 7 records 1), no stderr, no log path. The mock `sacct` already returns `JobID|State|ExitCode|Elapsed|MaxRSS`; `parse_accounting` reads the state and drops the rest. Widening it to a record also fills the `max_rss_mb`/`cpu_seconds` `None`s I left for phase 4.
2. **`started_at` is submit time**, so `benchmarks.wall_time_secs` is queue wait + runtime. On a busy cluster that number doesn't mean anything. Same `sacct` fix — `Elapsed` is the real one.
3. **`events.jsonl` has no timestamps.** The run dir is the declared source of truth, but you can't reconstruct a timeline or compute queue wait from it. One field, and re-attach needs it anyway.
4. **Logs are unreachable from the run dir.** `#SBATCH --output=logs/<rule>.out` resolves against the submit cwd and nothing points at it — this is the phase-1 note I flagged rather than quietly fixed. Pointing `--output` at `jobs/<rule>/stdout.log` makes the run dir self-contained, and it's one of the run-dir items you folded into re-attach.

My instinct is 1+2 next as one change (single `sacct` parse, and it's what makes a failed cluster run debuggable at all), then 3+4 as the run-dir groundwork re-attach sits on. Say the word if you'd rather reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
