### PR TITLE
fix(core): container setup pulls only when the image is absent (docker + singularity)

### DIFF
--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -438,7 +438,12 @@ impl EnvironmentBackend for DockerBackend {
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
-        Ok(format!("docker pull {spec}"))
+        // Pull only when the image is absent: two rules sharing one
+        // image run their setup concurrently, and simultaneous
+        // `docker pull`s of the same image race in the daemon (live:
+        // fastqc x2 -> "failed to lease content: NotFound"). The
+        // per-key env lock serializes the truly-missing case.
+        Ok(format!("docker image inspect {spec} >/dev/null 2>&1 || docker pull {spec}"))
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
@@ -1331,7 +1336,10 @@ mod tests {
     fn docker_setup_command() {
         let backend = DockerBackend;
         let cmd = backend.setup_command("biocontainers/bwa:0.7.17").unwrap();
-        assert_eq!(cmd, "docker pull biocontainers/bwa:0.7.17");
+        assert_eq!(
+            cmd,
+            "docker image inspect biocontainers/bwa:0.7.17 >/dev/null 2>&1 || docker pull biocontainers/bwa:0.7.17"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -443,7 +443,9 @@ impl EnvironmentBackend for DockerBackend {
         // `docker pull`s of the same image race in the daemon (live:
         // fastqc x2 -> "failed to lease content: NotFound"). The
         // per-key env lock serializes the truly-missing case.
-        Ok(format!("docker image inspect {spec} >/dev/null 2>&1 || docker pull {spec}"))
+        Ok(format!(
+            "docker image inspect {spec} >/dev/null 2>&1 || docker pull {spec}"
+        ))
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
@@ -522,7 +524,17 @@ impl EnvironmentBackend for SingularityBackend {
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
-        Ok(format!("{} pull {spec}", self.binary))
+        // Pull only when the image is absent: `{binary} pull` refuses
+        // to overwrite an existing SIF (live: "Image file already
+        // exists: ... - will not overwrite" when a previous run left
+        // the SIF in the workdir), and pulling per rule would rebuild
+        // the image every time. The SIF name follows the pull naming
+        // (last path segment, ':' -> '_'); the per-key env lock
+        // serializes the truly-missing case.
+        Ok(format!(
+            "IMG=$(printf '%s' '{spec}' | sed 's#^docker://##; s#.*/##; s#:#_#g').sif; [ -f \"$IMG\" ] || {b} pull {spec}",
+            b = self.binary,
+        ))
     }
 
     fn teardown_command(&self, _spec: &str) -> Result<Option<String>> {
@@ -1385,6 +1397,9 @@ mod tests {
         let backend = SingularityBackend::new();
         let cmd = backend.setup_command("docker://ubuntu:22.04").unwrap();
         assert!(cmd.contains(" pull docker://ubuntu:22.04"));
+        // inspect-first guard for the SIF naming
+        assert!(cmd.starts_with("IMG=$(printf '%s' 'docker://ubuntu:22.04'"));
+        assert!(cmd.contains("[ -f \"$IMG\" ] || "));
     }
 
     #[test]


### PR DESCRIPTION
Two live failures from the tx-ubuntu campaign (sarek live-run), same root family — the container backends' env setup unconditionally pulled per rule:

1. **docker**: two fastqc rules pull the same image simultaneously; the second pull dies with `Error response from daemon: failed to lease content: NotFound` and the rule fails. (Branch `fix-docker-setup-race` — inspect-first.)
2. **singularity**: a previous run's SIF left in the workdir makes the next `pull` die with `Image file already exists: ... - will not overwrite`. (This branch — derive the pull's SIF name and pull only when missing.)

Both keep the per-key env lock for the truly-missing case.

Tests: `cargo test -p oxo-flow-core environment::` — 78 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)