### PR TITLE
fix(references): documented checkpoint path + legacy adoption persistence (#97 follow-up)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -987,7 +987,24 @@ pub async fn run_command(
         let ref_checkpoint = checkpoint_path
             .parent()
             .unwrap_or(Path::new("."))
+            .join("reference-checkpoint.json");
+        // Migration: versions before this fix wrote the state one level
+        // deeper (the checkpoint parent already ends in `.oxo-flow`, so
+        // the old join produced `.oxo-flow/.oxo-flow/`). Move the old file
+        // over once so stored fingerprints survive the upgrade.
+        let legacy_ref_checkpoint = ref_checkpoint
+            .parent()
+            .unwrap_or(Path::new("."))
             .join(".oxo-flow/reference-checkpoint.json");
+        if !ref_checkpoint.exists() && legacy_ref_checkpoint.exists() {
+            let _ = std::fs::rename(&legacy_ref_checkpoint, &ref_checkpoint);
+            // The rename runs under the workdir lock (acquired above); the
+            // now-empty nested directory is removed so no shadow path stays
+            // behind for a future reader to mistake for the real one.
+            if let Some(parent) = legacy_ref_checkpoint.parent() {
+                let _ = std::fs::remove_dir(parent);
+            }
+        }
         // name → fingerprint. Legacy checkpoints store a plain JSON array of
         // names; those entries are adopted with the current fingerprint
         // (no rebuild) — the same one-time window as rule config snapshots.
@@ -1047,8 +1064,19 @@ pub async fn run_command(
             let rebuild_reason = if !output_full.exists() {
                 Some("output missing")
             } else if stored.as_deref() == Some("") {
-                // Legacy entry: adopt the current fingerprint without rebuilding.
+                // Legacy entry: adopt the current fingerprint without
+                // rebuilding — and PERSIST the adoption. An in-memory-only
+                // adopt would leave the entry "" forever: every future run
+                // would silently re-adopt the CURRENT source state and the
+                // content guard could never engage.
                 ref_state.insert(ref_def.name.clone(), current_fp.clone());
+                if let Some(parent) = ref_checkpoint.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                let _ = std::fs::write(
+                    &ref_checkpoint,
+                    serde_json::to_string(&ref_state).unwrap_or_default(),
+                );
                 None
             } else if source_newer {
                 Some("source is newer than output")

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6454,6 +6454,146 @@ shell = "echo {config.api_token} > {output}"
     );
 }
 
+// ─── #97 follow-up: reference checkpoint lives at the documented path ──────
+
+/// Older builds wrote the reference checkpoint into a doubly-nested
+/// `.oxo-flow/.oxo-flow/` directory (the parent already ends in
+/// `.oxo-flow`). The fix reads/writes the documented single-level path and
+/// migrates an existing doubled file over once.
+#[test]
+fn cli_reference_checkpoint_uses_documented_path_and_migrates() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("path.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "path"
+version = "1.0.0"
+
+[[references]]
+name = "idx"
+source = "genome.fa"
+output = "genome.idx"
+build = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("genome.fa"), b"AAAA").unwrap();
+    fs::write(dir.path().join("genome.idx"), b"AAAA").unwrap();
+
+    // Seed the OLD doubled path with a stored fingerprint.
+    let doubled = dir.path().join(".oxo-flow/.oxo-flow");
+    fs::create_dir_all(&doubled).unwrap();
+    fs::write(
+        doubled.join("reference-checkpoint.json"),
+        r#"{"idx":"legacy-fp"}"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run.status.success());
+
+    // The doubled file is migrated to the documented single-level path.
+    assert!(
+        dir.path()
+            .join(".oxo-flow/reference-checkpoint.json")
+            .exists(),
+        "the documented single-level checkpoint path must be used"
+    );
+    assert!(
+        !doubled.join("reference-checkpoint.json").exists(),
+        "the doubled path must be migrated away"
+    );
+}
+
+// ─── #97 follow-up: legacy reference adoption must persist ─────────────────
+
+/// The legacy (array-format) checkpoint adopts the current fingerprint in
+/// memory only — the adoption never reached the file, so the entry stayed
+/// "" forever and each run silently re-adopted the CURRENT source state:
+/// the content guard could never fire. The adoption must persist.
+#[test]
+fn cli_reference_legacy_adoption_persists_fingerprint() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("legacy.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "legacy"
+version = "1.0.0"
+
+[[references]]
+name = "idx"
+source = "genome.fa"
+output = "genome.idx"
+build = "cat {input} > {output}"
+
+[[rules]]
+name = "use_idx"
+input = ["genome.idx"]
+output = ["result.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("genome.fa"), b">chr1\nAAAA").unwrap();
+    // Park the source mtime in the past so the freshness path (source newer
+    // than output) can never fire — only the fingerprint can catch the
+    // rewrite, which is what this test pins.
+    filetime::set_file_mtime(
+        dir.path().join("genome.fa"),
+        filetime::FileTime::from_unix_time(1_600_000_000, 0),
+    )
+    .unwrap();
+    // Pre-seed the artifact AND a legacy array-format checkpoint.
+    fs::write(dir.path().join("genome.idx"), b"AAAA").unwrap();
+    let ck_dir = dir.path().join(".oxo-flow");
+    fs::create_dir_all(&ck_dir).unwrap();
+    fs::write(ck_dir.join("reference-checkpoint.json"), r#"["idx"]"#).unwrap();
+
+    // Run 1: legacy adoption, no rebuild.
+    let run1 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run1.status.success());
+    assert!(
+        !String::from_utf8_lossy(&run1.stderr).contains("Building"),
+        "legacy adoption must not rebuild: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    // Same-path content rewrite with a PRESERVED mtime — the exact class
+    // the content guard exists to catch.
+    let mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(dir.path().join("genome.fa")).unwrap(),
+    );
+    fs::write(dir.path().join("genome.fa"), b">chr2\nBBBB").unwrap();
+    filetime::set_file_mtime(dir.path().join("genome.fa"), mtime).unwrap();
+
+    let run2 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(run2.status.success());
+    assert!(
+        String::from_utf8_lossy(&run2.stderr).contains("Building"),
+        "a persisted adoption must guard later rewrites: {}",
+        String::from_utf8_lossy(&run2.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("genome.idx")).unwrap(),
+        ">chr2\nBBBB",
+        "the rebuilt artifact must carry the new source content"
+    );
+}
+
 // ─── #101: rule subprocesses never block on stdin ─────────────────────────
 
 /// Contract smoke test: rule shells must observe null stdin (issue #101).


### PR DESCRIPTION
fix(references): use the documented checkpoint path + persist legacy adoption

Two pre-existing bugs surfaced by a peer review of the #97 content guard:

1. The reference checkpoint was written to a doubly-nested shadow path:
   `checkpoint_path.parent()` already ends in `.oxo-flow`, and the code
   joined `.oxo-flow/reference-checkpoint.json` onto it, producing
   `.oxo-flow/.oxo-flow/reference-checkpoint.json`. The documented
   single-level path never existed on disk — every stored fingerprint
   (including post-#97 content guards) lived on the shadow path. Fix:
   read/write `.oxo-flow/reference-checkpoint.json`; an existing shadow
   file is renamed over once (under the workdir lock, which the reference
   block already holds) and the emptied nested directory is removed.

2. The legacy array-format adoption (stored == "") inserted the adopted
   fingerprint in memory but never persisted it, so the entry stayed ""
   forever: every run silently re-adopted the CURRENT source state and
   the content guard could never engage — the exact same-path rewrite
   class #97 fixed remained undetectable for legacy entries. Fix: the
   adoption writes the checkpoint file.

Tests: legacy adoption persists and guards later same-mtime rewrites
(RED first — run 2 skipped without the fix); documented path + shadow
migration integration test. Full make ci green.
