### PR TITLE
feat(cluster): job arrays for scatter rules (#74 phase 3)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/cluster.rs
@@ -293,6 +293,10 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
                     .map_err(|e| anyhow::anyhow!("environment wrapping failed: {}", e))?;
                 let scheduled = oxo_flow_core::backend::ScheduledRule {
                     rule: rule.clone(),
+                    // The standalone `cluster submit` command has no
+                    // expansion templates to consult — an instance maps to
+                    // itself.
+                    template: rule_name.clone(),
                     shell_cmd: wrapped_cmd,
                     workdir: std::path::PathBuf::from("."),
                     dependencies: dag.dependencies(rule_name).unwrap_or_default(),

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -266,6 +266,10 @@ pub(crate) async fn run_on_cluster(
             .max_submitted
             .or(cluster.max_submitted)
             .unwrap_or(driver_defaults.max_submitted),
+        max_array_size: cluster
+            .max_array_size
+            .unwrap_or(driver_defaults.max_array_size),
+        no_arrays: false,
         poll_interval: cluster
             .poll_interval_secs()
             .map(std::time::Duration::from_secs)

--- a/crates/oxo-flow-core/src/backend/cluster.rs
+++ b/crates/oxo-flow-core/src/backend/cluster.rs
@@ -6,7 +6,9 @@
 //! array-index mapping need the same logic.
 
 use super::{BackendJobStatus, ScheduledRule};
-use crate::cluster::{ClusterBackend, ClusterJobConfig, generate_submit_script};
+use crate::cluster::{
+    ClusterBackend, ClusterJobConfig, generate_array_submit_script, generate_submit_script,
+};
 use crate::error::{OxoFlowError, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -208,6 +210,21 @@ impl super::ExecutorBackend for ClusterExecutor {
             &self.backend,
             &rule.rule,
             &rule.shell_cmd,
+            &self.cluster,
+        ))
+    }
+
+    fn render_array_script(
+        &self,
+        rule: &crate::rule::Rule,
+        cmd_dir: &str,
+        count: usize,
+    ) -> Result<String> {
+        Ok(generate_array_submit_script(
+            &self.backend,
+            rule,
+            cmd_dir,
+            count,
             &self.cluster,
         ))
     }

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -6,7 +6,7 @@
 //! [`JobRecord`]s — the same record type the local executor produces, so
 //! checkpoint semantics are identical.
 
-use super::{BackendJobStatus, ExecutorBackend, ScheduledPlan};
+use super::{BackendJobStatus, ExecutorBackend, ScheduledPlan, ScheduledRule};
 use crate::error::{OxoFlowError, Result};
 use crate::executor::{JobRecord, JobStatus};
 use chrono::{DateTime, Utc};
@@ -22,6 +22,13 @@ pub struct DriverConfig {
     /// Jobs in flight at once (pending + running). Submissions top up to
     /// this cap as slots free.
     pub max_submitted: usize,
+    /// Maximum scheduler array size (SLURM MaxArraySize, commonly 1001):
+    /// larger scatter groups are chunked into several arrays (issue #74
+    /// phase 3).
+    pub max_array_size: usize,
+    /// Disable automatic array grouping — every instance submits as its
+    /// own job (the pre-phase-3 behavior).
+    pub no_arrays: bool,
     /// Delay between scheduler polls.
     pub poll_interval: Duration,
     /// Overall wall-clock budget; `None` = run until terminal states.
@@ -32,6 +39,8 @@ impl Default for DriverConfig {
     fn default() -> Self {
         Self {
             max_submitted: 50,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: Duration::from_secs(5),
             poll_timeout: None,
         }
@@ -71,6 +80,33 @@ pub struct BackendDriver {
 struct InFlight {
     rule: String,
     submitted_at: DateTime<Utc>,
+}
+
+/// Scheduler-visible directive signature: two instances are array-eligible
+/// only when every directive a scheduler could split on agrees (issue #74
+/// phase 3). The environment is included — conda vs docker instances must
+/// never share an array.
+fn array_key(sr: &ScheduledRule) -> String {
+    format!(
+        "{}|{}|{}|{}|{}|{:?}|{}",
+        sr.rule.effective_threads(),
+        sr.rule.effective_memory().unwrap_or_default(),
+        sr.rule.resources.time_limit.as_deref().unwrap_or_default(),
+        sr.rule.resources.partition.as_deref().unwrap_or_default(),
+        sr.rule
+            .resources
+            .gpu_spec
+            .as_ref()
+            .map(|g| format!("{:?}", g))
+            .unwrap_or_else(|| sr
+                .rule
+                .resources
+                .gpu
+                .map(|n| n.to_string())
+                .unwrap_or_default()),
+        sr.rule.environment,
+        sr.workdir.display(),
+    )
 }
 
 impl BackendDriver {
@@ -204,44 +240,196 @@ impl BackendDriver {
                         continue;
                     }
                     let sr = plan.rules[&name].clone();
-                    let script = self.backend.render_script(&sr)?;
-                    let job_dir = opts.run_dir.join("jobs").join(sanitize(&name));
-                    std::fs::create_dir_all(&job_dir).map_err(|e| OxoFlowError::Config {
-                        message: format!("cannot create {}: {e}", job_dir.display()),
-                    })?;
-                    let script_path = job_dir.join("job.sh");
-                    std::fs::write(&script_path, &script).map_err(|e| OxoFlowError::Config {
-                        message: format!("cannot write {}: {e}", script_path.display()),
-                    })?;
-                    let job_id = match self.backend.submit(&script_path).await {
-                        Ok(id) => id,
-                        Err(e) => {
-                            // Submit failure mid-DAG: cancel what is in flight,
-                            // leave the rest consistent (skipped by the next
-                            // run's preview — nothing was marked done here).
-                            let jobs: Vec<(String, String)> = inflight
-                                .iter()
-                                .map(|(id, f)| (id.clone(), f.rule.clone()))
-                                .collect();
-                            self.cancel_inflight(&jobs).await?;
-                            return Err(e);
-                        }
+                    // Array grouping (issue #74 phase 3): batch every READY
+                    // sibling instance of the same template with an identical
+                    // directive signature into one scheduler array, chunked
+                    // at max_array_size. Instance-level records, dependency
+                    // gates, and resume semantics are unchanged — arrays are
+                    // transport-level (one submission, element-wise records).
+                    let siblings: Vec<(String, ScheduledRule)> = if self.config.no_arrays {
+                        vec![]
+                    } else {
+                        plan.order
+                            .iter()
+                            .filter(|o| {
+                                **o != name
+                                    && !done.contains_key(*o)
+                                    && to_run_set.contains(*o)
+                                    && !inflight.values().any(|f| f.rule == **o)
+                                    && deps_ok(o, &done, &to_run_set, plan)
+                                    && plan.rules.get(*o).is_some_and(|o_sr| {
+                                        o_sr.template == sr.template
+                                            && array_key(o_sr) == array_key(&sr)
+                                            && o_sr.dependencies == sr.dependencies
+                                    })
+                            })
+                            .map(|o| (o.clone(), plan.rules[o].clone()))
+                            .collect()
                     };
-                    std::fs::write(job_dir.join("job.id"), &job_id).map_err(|e| {
-                        OxoFlowError::Config {
-                            message: format!("cannot write {}: {e}", job_dir.display()),
+                    let mut batch: Vec<(String, ScheduledRule)> = vec![(name.clone(), sr.clone())];
+                    batch.extend(siblings);
+                    let chunks = batch.chunks(self.config.max_array_size.max(1));
+                    for chunk in chunks {
+                        if chunk.len() > 1 {
+                            // Array submission: one script + per-index
+                            // command files under the TEMPLATE's job dir.
+                            let job_dir = opts.run_dir.join("jobs").join(sanitize(&sr.template));
+                            std::fs::create_dir_all(&job_dir).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!("cannot create {}: {e}", job_dir.display()),
+                                }
+                            })?;
+                            for (i, (_, c_sr)) in chunk.iter().enumerate() {
+                                let cmd_path = job_dir.join(format!("cmd.{}.sh", i + 1));
+                                std::fs::write(&cmd_path, &c_sr.shell_cmd).map_err(|e| {
+                                    OxoFlowError::Config {
+                                        message: format!(
+                                            "cannot write {}: {e}",
+                                            cmd_path.display()
+                                        ),
+                                    }
+                                })?;
+                            }
+                            let script = self.backend.render_array_script(
+                                &sr.rule,
+                                &job_dir.to_string_lossy(),
+                                chunk.len(),
+                            )?;
+                            let script_path = job_dir.join("job.sh");
+                            std::fs::write(&script_path, &script).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!("cannot write {}: {e}", script_path.display()),
+                                }
+                            })?;
+                            let base_id = match self.backend.submit(&script_path).await {
+                                Ok(id) => id,
+                                Err(e) => {
+                                    let jobs: Vec<(String, String)> = inflight
+                                        .iter()
+                                        .map(|(id, f)| (id.clone(), f.rule.clone()))
+                                        .collect();
+                                    self.cancel_inflight(&jobs).await?;
+                                    return Err(e);
+                                }
+                            };
+                            std::fs::write(job_dir.join("job.id"), &base_id).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!(
+                                        "cannot write {}: {e}",
+                                        job_dir.join("job.id").display()
+                                    ),
+                                }
+                            })?;
+                            // index.json: array index → instance name, so the
+                            // array stays an implementation detail (issue #74
+                            // phase 3 — "an array index is meaningless on its
+                            // own").
+                            {
+                                let index_path = opts.run_dir.join("index.json");
+                                let mut index: HashMap<String, Vec<String>> =
+                                    std::fs::read_to_string(&index_path)
+                                        .ok()
+                                        .and_then(|raw| serde_json::from_str(&raw).ok())
+                                        .unwrap_or_default();
+                                index.insert(
+                                    base_id.clone(),
+                                    chunk.iter().map(|(n, _)| n.clone()).collect(),
+                                );
+                                if let Some(parent) = index_path.parent() {
+                                    let _ = std::fs::create_dir_all(parent);
+                                }
+                                let _ = std::fs::write(
+                                    &index_path,
+                                    serde_json::to_string_pretty(&index).unwrap_or_default(),
+                                );
+                            }
+                            for (i, (c_name, c_sr)) in chunk.iter().enumerate() {
+                                let element_id = format!("{}_{}", base_id, i + 1);
+                                // Per-INSTANCE dirs keep the run directory
+                                // greppable (jobs/<instance>/job.sh + job.id)
+                                // — the array stays an implementation detail
+                                // (issue #74 phase 3). job.sh is a copy of
+                                // the array script: it is exactly what ran
+                                // for this element.
+                                let inst_dir = opts.run_dir.join("jobs").join(sanitize(c_name));
+                                std::fs::create_dir_all(&inst_dir).map_err(|e| {
+                                    OxoFlowError::Config {
+                                        message: format!(
+                                            "cannot create {}: {e}",
+                                            inst_dir.display()
+                                        ),
+                                    }
+                                })?;
+                                std::fs::copy(&script_path, inst_dir.join("job.sh")).map_err(
+                                    |e| OxoFlowError::Config {
+                                        message: format!(
+                                            "cannot copy {}: {e}",
+                                            inst_dir.join("job.sh").display()
+                                        ),
+                                    },
+                                )?;
+                                std::fs::write(inst_dir.join("job.id"), &element_id).map_err(
+                                    |e| OxoFlowError::Config {
+                                        message: format!(
+                                            "cannot write {}: {e}",
+                                            inst_dir.join("job.id").display()
+                                        ),
+                                    },
+                                )?;
+                                write_status(&inst_dir, &element_id, &c_sr.shell_cmd, "PENDING")?;
+                                inflight.insert(
+                                    element_id.clone(),
+                                    InFlight {
+                                        rule: c_name.clone(),
+                                        submitted_at: Utc::now(),
+                                    },
+                                );
+                                emit(&mut events, "SUBMITTED", c_name, Some(&element_id), None);
+                            }
+                            submitted_this_round += chunk.len();
+                        } else {
+                            let (c_name, c_sr) = &chunk[0];
+                            let script = self.backend.render_script(c_sr)?;
+                            let job_dir = opts.run_dir.join("jobs").join(sanitize(c_name));
+                            std::fs::create_dir_all(&job_dir).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!("cannot create {}: {e}", job_dir.display()),
+                                }
+                            })?;
+                            let script_path = job_dir.join("job.sh");
+                            std::fs::write(&script_path, &script).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!("cannot write {}: {e}", script_path.display()),
+                                }
+                            })?;
+                            let job_id = match self.backend.submit(&script_path).await {
+                                Ok(id) => id,
+                                Err(e) => {
+                                    let jobs: Vec<(String, String)> = inflight
+                                        .iter()
+                                        .map(|(id, f)| (id.clone(), f.rule.clone()))
+                                        .collect();
+                                    self.cancel_inflight(&jobs).await?;
+                                    return Err(e);
+                                }
+                            };
+                            std::fs::write(job_dir.join("job.id"), &job_id).map_err(|e| {
+                                OxoFlowError::Config {
+                                    message: format!("cannot write {}: {e}", job_dir.display()),
+                                }
+                            })?;
+                            write_status(&job_dir, &job_id, &c_sr.shell_cmd, "PENDING")?;
+                            inflight.insert(
+                                job_id.clone(),
+                                InFlight {
+                                    rule: c_name.clone(),
+                                    submitted_at: Utc::now(),
+                                },
+                            );
+                            submitted_this_round += 1;
+                            emit(&mut events, "SUBMITTED", c_name, Some(&job_id), None);
                         }
-                    })?;
-                    write_status(&job_dir, &job_id, &sr.shell_cmd, "PENDING")?;
-                    inflight.insert(
-                        job_id.clone(),
-                        InFlight {
-                            rule: name.clone(),
-                            submitted_at: Utc::now(),
-                        },
-                    );
-                    submitted_this_round += 1;
-                    emit(&mut events, "SUBMITTED", &name, Some(&job_id), None);
+                    }
                 }
             }
 
@@ -639,6 +827,8 @@ mod tests {
             executor.clone(),
             DriverConfig {
                 max_submitted: 2,
+                max_array_size: 1001,
+                no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(50),
                 poll_timeout: Some(std::time::Duration::from_secs(30)),
             },
@@ -681,7 +871,14 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(records.len(), 2);
-        assert!(records.iter().all(|r| r.status == JobStatus::Success));
+        assert!(
+            records.iter().all(|r| r.status == JobStatus::Success),
+            "unexpected records: {:?}",
+            records
+                .iter()
+                .map(|r| (r.rule.clone(), r.status, r.stderr.clone()))
+                .collect::<Vec<_>>()
+        );
         assert!(fx.workdir.path().join("a.txt").exists());
         assert!(fx.workdir.path().join("b.txt").exists());
         let ev = events(&fx);
@@ -823,6 +1020,8 @@ mod tests {
             executor,
             DriverConfig {
                 max_submitted: 2,
+                max_array_size: 1001,
+                no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(50),
                 poll_timeout: None,
             },
@@ -891,6 +1090,120 @@ mod tests {
             noop.skip_reason.as_deref(),
             Some("no shell or script defined")
         );
+    }
+
+    #[test]
+    fn scatter_instances_submit_as_one_array_with_identical_records() {
+        // Issue #74 phase 3: same-template instances group into ONE array
+        // submission (chunked at max_array_size), element-wise tracking
+        // maps back to per-instance JobRecords, and index.json records the
+        // array-index → instance mapping.
+        let fx = setup();
+        let (d, _) = driver(&fx);
+        // Two instances of one template via [[values]] + a dependent rule.
+        let wf_toml = r#"
+[workflow]
+name = "arr"
+version = "1.0.0"
+
+[[values]]
+name = "assembler"
+values = ["spades", "megahit"]
+
+[[rules]]
+name = "asm"
+output = ["out/{assembler}.txt"]
+shell = "echo asm > out/{assembler}.txt"
+
+[[rules]]
+name = "merge"
+input = ["out/spades.txt", "out/megahit.txt"]
+output = ["merged.txt"]
+shell = "cat {input} > merged.txt"
+"#;
+        let wf = fx.workdir.path().join("arr.oxoflow");
+        std::fs::write(&wf, wf_toml).unwrap();
+        let mut config = WorkflowConfig::from_file(&wf).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let dag = WorkflowDag::from_rules(&config.rules).unwrap();
+        let mut plan = ScheduledPlan::build(
+            &config,
+            &dag,
+            fx.workdir.path(),
+            &EnvironmentResolver::new(),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let to_run: HashSet<String> = plan.order.iter().cloned().collect();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let records = runtime
+            .block_on(d.run(
+                &mut plan,
+                &to_run,
+                DriverOptions {
+                    sensitive_values: &[],
+                    run_dir: fx.run_dir.path(),
+                    on_checkpoint: None,
+                    merge: None,
+                },
+            ))
+            .unwrap();
+
+        // Both instances + the dependent rule completed.
+        let names: std::collections::BTreeSet<String> =
+            records.iter().map(|r| r.rule.clone()).collect();
+        assert_eq!(
+            names,
+            [
+                "asm_assembler_megahit".to_string(),
+                "asm_assembler_spades".to_string(),
+                "merge".to_string()
+            ]
+            .into_iter()
+            .collect(),
+            "per-instance records must match the per-job path: {names:?}"
+        );
+        assert!(
+            records.iter().all(|r| r.status == JobStatus::Success),
+            "unexpected records: {:?}",
+            records
+                .iter()
+                .map(|r| (r.rule.clone(), r.status, r.stderr.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        // ONE array submission: the events file records two element ids
+        // sharing a base.
+        let ev = events(&fx);
+        let submitted: Vec<serde_json::Value> = ev
+            .iter()
+            .filter(|e| e["t"] == "SUBMITTED")
+            .cloned()
+            .collect();
+        let element_ids: Vec<String> = submitted
+            .iter()
+            .filter(|e| e["rule"].as_str().is_some_and(|r| r.starts_with("asm_")))
+            .map(|e| e["job"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert_eq!(element_ids.len(), 2, "both instances submitted: {ev:?}");
+        let base = element_ids[0].split('_').next().unwrap_or("");
+        assert!(
+            element_ids
+                .iter()
+                .all(|id| id.starts_with(base) && id != base),
+            "both ids must be array elements of one base: {element_ids:?}"
+        );
+
+        // index.json maps the array index back to instance names.
+        let index: std::collections::HashMap<String, Vec<String>> = serde_json::from_str(
+            &std::fs::read_to_string(fx.run_dir.path().join("index.json")).unwrap(),
+        )
+        .unwrap();
+        let mapped = index.get(base).expect("array base must be indexed");
+        assert_eq!(mapped.len(), 2);
+        assert!(mapped.contains(&"asm_assembler_spades".to_string()));
+        assert!(mapped.contains(&"asm_assembler_megahit".to_string()));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/backend/mod.rs
+++ b/crates/oxo-flow-core/src/backend/mod.rs
@@ -57,6 +57,21 @@ pub trait ExecutorBackend: Send + Sync {
     /// Cancel a submitted job.
     async fn cancel(&self, job_id: &str) -> Result<()>;
 
+    /// Render an ARRAY submit script for `count` same-rule instances whose
+    /// per-index commands live in `cmd_dir` (issue #74 phase 3). Backends
+    /// without array support return an error — the driver then falls back
+    /// to per-job submission via the chunk-of-one path.
+    fn render_array_script(
+        &self,
+        _rule: &crate::rule::Rule,
+        _cmd_dir: &str,
+        _count: usize,
+    ) -> Result<String> {
+        Err(OxoFlowError::Config {
+            message: format!("backend '{}' does not support job arrays", self.name()),
+        })
+    }
+
     /// Fetch job logs / accounting output (raw text).
     async fn logs(&self, job_id: &str) -> Result<String>;
 
@@ -75,6 +90,10 @@ pub struct ScheduledRule {
     /// Expanded rule instance (post `expand_wildcards`): the single source
     /// for script rendering and resource directives.
     pub rule: Rule,
+    /// Template rule name this instance was expanded from (issue #74 phase
+    /// 3) — the array-grouping key. Equals the instance name for rules
+    /// that never fanned out.
+    pub template: String,
     /// Environment-wrapped command with `cd <workdir>` folded in.
     pub shell_cmd: String,
     /// Working directory the command runs in.
@@ -171,8 +190,13 @@ fn build_rule(
         })?;
     let dependencies = dag.dependencies(name).unwrap_or_default();
     let shell_cmd = format!("cd '{}' && {}", workdir.display(), wrapped);
+    let template = config
+        .template_of(name)
+        .map(str::to_string)
+        .unwrap_or_else(|| name.to_string());
     Ok(Some(ScheduledRule {
         rule: rule.clone(),
+        template,
         shell_cmd,
         workdir: workdir.to_path_buf(),
         dependencies,

--- a/crates/oxo-flow-core/src/cluster.rs
+++ b/crates/oxo-flow-core/src/cluster.rs
@@ -154,6 +154,62 @@ pub fn generate_submit_script_with_env(
     ))
 }
 
+/// Generate an ARRAY submit script for a group of same-rule instances
+/// (issue #74 phase 3).
+///
+/// The script carries the backend's array-range directive and dispatches on
+/// the backend's task-index variable to per-index command files the driver
+/// writes next to the script — `sh '<cmd_dir>/cmd.${INDEX}.sh'`. Per-index
+/// files (rather than an inline case table) keep arbitrary multi-line
+/// commands (shell preludes, environment-wrapped commands) valid.
+pub fn generate_array_submit_script(
+    backend: &ClusterBackend,
+    rule: &Rule,
+    cmd_dir: &str,
+    count: usize,
+    config: &ClusterJobConfig,
+) -> String {
+    let base = generate_submit_script(backend, rule, "", config);
+    let mut lines: Vec<String> = base.lines().map(str::to_string).collect();
+
+    let (range_directive, task_var) = match backend {
+        ClusterBackend::Slurm => ("#SBATCH --array=1-{count}", "SLURM_ARRAY_TASK_ID"),
+        ClusterBackend::Pbs => ("#PBS -J 1-{count}", "PBS_ARRAY_INDEX"),
+        ClusterBackend::Sge => ("#$ -t 1-{count}", "SGE_TASK_ID"),
+        ClusterBackend::Lsf => ("#BSUB -J \"{name}[1-{count}]\"", "LSB_JOBINDEX"),
+    };
+    let range = range_directive
+        .replace("{count}", &count.to_string())
+        .replace("{name}", &rule.name);
+
+    // Insert the range after the shebang; for LSF replace the base -J line
+    // so the array name wins instead of duplicating the flag.
+    match backend {
+        ClusterBackend::Lsf => {
+            if let Some(idx) = lines.iter().position(|l| l.starts_with("#BSUB -J ")) {
+                lines[idx] = range;
+            } else {
+                lines.insert(1, range);
+            }
+        }
+        _ => lines.insert(1, range),
+    }
+
+    // Replace the trailing (empty) command line with the dispatch body.
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    lines.push("set -e".to_string());
+    lines.push("mkdir -p logs".to_string());
+    lines.push(format!("INDEX=\"${task_var}\""));
+    // Double quotes so ${INDEX} expands (single quotes would pass the
+    // literal `${INDEX}` to sh). The run dir is engine-generated and never
+    // contains shell metacharacters.
+    lines.push(format!("sh \"{cmd_dir}/cmd.${{INDEX}}.sh\""));
+
+    lines.join("\n")
+}
+
 /// Returns the shell command used to submit a job to the given backend.
 pub fn submit_command(backend: &ClusterBackend) -> &'static str {
     match backend {
@@ -530,6 +586,46 @@ mod tests {
     use super::*;
     use crate::rule::{EnvironmentSpec, Resources};
     use std::collections::HashMap;
+
+    #[test]
+    fn array_script_carries_directive_and_dispatch() {
+        // Issue #74 phase 3: the array variant keeps the base directives,
+        // adds the backend's array range, and dispatches on the backend's
+        // task-index variable to per-index command files (multi-line-safe).
+        let rule = make_rule("align", 4, Some("8G"));
+        let config = ClusterJobConfig {
+            backend: ClusterBackend::Slurm,
+            queue: Some("compute".to_string()),
+            account: None,
+            walltime: None,
+            extra_args: vec![],
+        };
+        let script = generate_array_submit_script(
+            &ClusterBackend::Slurm,
+            &rule,
+            "/run/jobs/align",
+            3,
+            &config,
+        );
+        assert!(script.contains("#SBATCH --array=1-3"), "{script}");
+        assert!(
+            script.contains("--cpus-per-task=4"),
+            "directives must persist"
+        );
+        assert!(script.contains("SLURM_ARRAY_TASK_ID"), "{script}");
+        assert!(script.contains("/run/jobs/align/cmd."), "{script}");
+
+        // Other backends use their own range syntax + task variable.
+        for (backend, range, var) in [
+            (ClusterBackend::Pbs, "#PBS -J 1-3", "PBS_ARRAY_INDEX"),
+            (ClusterBackend::Sge, "#$ -t 1-3", "SGE_TASK_ID"),
+            (ClusterBackend::Lsf, "#BSUB -J", "LSB_JOBINDEX"),
+        ] {
+            let s2 = generate_array_submit_script(&backend, &rule, "/run/jobs/align", 3, &config);
+            assert!(s2.contains(range), "{backend:?}: {s2}");
+            assert!(s2.contains(var), "{backend:?}: {s2}");
+        }
+    }
 
     fn make_rule(name: &str, threads: u32, memory: Option<&str>) -> Rule {
         Rule {

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -415,6 +415,12 @@ pub struct ClusterProfile {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_submitted: Option<usize>,
+    /// Maximum scheduler array size (SLURM `MaxArraySize`, commonly 1001):
+    /// larger scatter groups are chunked into several arrays (issue #74
+    /// phase 3).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_array_size: Option<usize>,
     /// Delay between scheduler polls, as a duration string (`30s`, `2m`).
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1421,6 +1427,11 @@ pub struct WorkflowConfig {
     /// serialized — user TOML cannot set it.
     #[serde(skip)]
     pub expansion_values: HashMap<String, crate::wildcard::WildcardValues>,
+    /// Instance → template rule name for every fan-out expansion (issue #74
+    /// phase 3): the cluster driver groups instances into job arrays by
+    /// their TEMPLATE, never by guessing name suffixes. Never serialized.
+    #[serde(skip)]
+    pub expansion_templates: HashMap<String, String>,
 
     /// Engine-internal: the sample names each expanded rule came from.
     ///
@@ -2420,6 +2431,12 @@ impl WorkflowConfig {
         self.rules.iter().map(|r| r.name.as_str()).collect()
     }
 
+    /// The template rule a fanned-out instance was expanded from, if any
+    /// (issue #74 phase 3). Rules that never fan out have no entry.
+    pub fn template_of(&self, instance: &str) -> Option<&str> {
+        self.expansion_templates.get(instance).map(String::as_str)
+    }
+
     /// Apply global defaults to all rules that don't have explicit overrides.
     pub fn apply_defaults(&mut self) {
         for rule in &mut self.rules {
@@ -2848,6 +2865,8 @@ impl WorkflowConfig {
                             self.expansion_values
                                 .insert(expanded.name.clone(), value_combo.clone());
                         }
+                        self.expansion_templates
+                            .insert(expanded.name.clone(), orig_name.clone());
 
                         expanded_rules.push(expanded);
                     }
@@ -2969,6 +2988,8 @@ impl WorkflowConfig {
                             self.expansion_values
                                 .insert(expanded.name.clone(), value_combo.clone());
                         }
+                        self.expansion_templates
+                            .insert(expanded.name.clone(), orig_name.clone());
 
                         expanded_rules.push(expanded);
                     }
@@ -3017,6 +3038,8 @@ impl WorkflowConfig {
 
                     self.expansion_values
                         .insert(new_name.clone(), combo.clone());
+                    self.expansion_templates
+                        .insert(new_name.clone(), orig_name.clone());
                     expanded_rules.push(expanded);
                 }
                 name_map.insert(orig_name, expanded_names);
@@ -3152,6 +3175,8 @@ impl WorkflowConfig {
                     scatter_bindings.insert(scatter.variable.clone(), val.clone());
                     self.expansion_values
                         .insert(scattered_rule.name.clone(), scatter_bindings);
+                    self.expansion_templates
+                        .insert(scattered_rule.name.clone(), rule.name.clone());
 
                     scatter_outputs.extend(scattered_rule.output.to_vec());
                     final_rules.push(scattered_rule);
@@ -5874,6 +5899,65 @@ shell = "echo {config.database} > {output[0]}"
             Some(""),
             "no default: the runtime value is empty until overridden"
         );
+    }
+
+    #[test]
+    fn expansion_templates_track_the_fan_out_source() {
+        // Issue #74 phase 3: array grouping needs the TEMPLATE name each
+        // expanded instance came from. The expansion records it for every
+        // fan-out path (scatter, values, pairs) so the cluster driver never
+        // guesses from instance-name suffixes.
+        let toml = r#"
+            [workflow]
+            name = "t"
+            version = "1.0.0"
+
+            [[values]]
+            name = "assembler"
+            values = ["spades"]
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "E1"
+            control = "C1"
+
+            [[rules]]
+            name = "align"
+            output = ["out/{pair_id}/{assembler}.bam"]
+            shell = "echo hi"
+
+            [[rules]]
+            name = "qc"
+            scatter = { variable = "treatment", values = ["control", "treated"] }
+            output = ["qc/{treatment}.tsv"]
+            shell = "echo hi"
+
+            [[rules]]
+            name = "plain"
+            output = ["p.txt"]
+            shell = "echo hi"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        // The pair-expanded instance maps back to "align".
+        let align_instance = config
+            .rules
+            .iter()
+            .find(|r| r.name.starts_with("align_"))
+            .expect("pair instance must exist");
+        assert_eq!(
+            config.template_of(&align_instance.name),
+            Some("align"),
+            "pair-expanded instances must track their template"
+        );
+
+        // Scatter instances map back to "qc".
+        assert_eq!(config.template_of("qc_control"), Some("qc"));
+        assert_eq!(config.template_of("qc_treated"), Some("qc"));
+
+        // A rule that never fanned out has no template entry.
+        assert_eq!(config.template_of("plain"), None);
     }
 
     #[test]

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -303,6 +303,36 @@ checkpoint exactly as a local run does — `status`, `resume`, and re-run
 invalidation behave identically, and a second `run --profile slurm` with
 nothing changed submits nothing.
 
+### Job arrays
+
+Same-template instances that are ready together and agree on every
+scheduler-visible directive (threads, memory, time limit, partition,
+account, GPU spec, environment, workdir) are grouped into **one scheduler
+array** automatically (issue #74):
+
+```toml
+[cluster]
+backend        = "slurm"
+max_array_size = 1001   # optional — the scheduler's MaxArraySize; larger
+                        # scatter groups are chunked into several arrays
+```
+
+- One submission instead of N `sbatch`/`qsub` calls — one queue entry that
+  expands internally (SLURM `--array=1-N`, PBS `-J`, SGE `-t`,
+  LSF `-J "name[1-N]"`).
+- Array elements are tracked individually: per-instance job directories
+  stay greppable (`jobs/<instance>/job.sh` + `job.id` + `status.json`),
+  and `index.json` in the run directory maps each array index back to its
+  instance, so the array never leaks into the human-facing layout.
+- Instances that differ on any directive fall out of the group and submit
+  as single jobs — heterogeneity degrades gracefully.
+- Arrays are transport-level: the JobRecord set, checkpoint, and resume
+  semantics are identical to per-job submission.
+
+Element-wise `aftercorr` chaining is not part of this slice: downstream
+instances submit in ready batches as array elements finish, which is
+correct but not as queue-efficient as true element-wise chaining.
+
 Each run leaves a directory you can navigate with ordinary tools:
 
 ```console

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -207,6 +207,8 @@ fn local_run_and_backend_run_produce_same_checkpoint_semantics() {
         &to_run,
         DriverConfig {
             max_submitted: 4,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
         },
@@ -318,6 +320,8 @@ fn dry_run_will_run_set_equals_driver_submitted_set() {
         &to_run,
         DriverConfig {
             max_submitted: 4,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
         },
@@ -366,6 +370,8 @@ output = ["fail.done"]
         &to_run,
         DriverConfig {
             max_submitted: 2,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(1)),
         },
@@ -538,6 +544,8 @@ fn driver_settles_jobs_that_vanish_from_the_live_queue_via_accounting() {
         &to_run,
         DriverConfig {
             max_submitted: 4,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
         },

--- a/tests/fixtures/mock-scheduler/sbatch
+++ b/tests/fixtures/mock-scheduler/sbatch
@@ -19,6 +19,36 @@ id=$((id + 1))
 mkdir -p "$dir/jobs/$id"
 echo "PENDING" > "$dir/jobs/$id/state"
 cp "$script" "$dir/jobs/$id/job.sh"
+# Array support (issue #74 phase 3): a script carrying
+# `#SBATCH --array=1-N` (or #PBS -J / #$ -t) fans out into element dirs
+# `<id>_<i>`; each element runs the script with its task-index variable.
+array=$(sed -n 's/^#SBATCH --array=1-\([0-9][0-9]*\)$/\1/p' "$script" 2>/dev/null)
+array="${array:-$(sed -n 's/^#PBS -J 1-\([0-9][0-9]*\)$/\1/p' "$script" 2>/dev/null)}"
+array="${array:-$(sed -n 's/^#$ -t 1-\([0-9][0-9]*\)$/\1/p' "$script" 2>/dev/null)}"
+if [ -n "$array" ]; then
+  rm -rf "$dir/jobs/$id"
+  for i in $(seq 1 "$array"); do
+    mkdir -p "$dir/jobs/${id}_${i}"
+    echo "PENDING" > "$dir/jobs/${id}_${i}/state"
+    cp "$script" "$dir/jobs/${id}_${i}/job.sh"
+    (
+      set +e
+      echo "RUNNING" > "$dir/jobs/${id}_${i}/state"
+      echo $$ > "$dir/jobs/${id}_${i}/pid"
+      SLURM_ARRAY_TASK_ID=$i SGE_TASK_ID=$i PBS_ARRAY_INDEX=$i LSB_JOBINDEX=$i         bash "$script" > "$dir/jobs/${id}_${i}/stdout.log" 2> "$dir/jobs/${id}_${i}/stderr.log"
+      code=$?
+      if [ "$code" -eq 0 ]; then echo "COMPLETED" > "$dir/jobs/${id}_${i}/state"; else echo "FAILED" > "$dir/jobs/${id}_${i}/state"; fi
+      echo "$code" > "$dir/jobs/${id}_${i}/exit_code"
+    ) >/dev/null 2>&1 &
+  done
+  if [ "$parsable" -eq 1 ]; then
+    echo "$id"
+  else
+    echo "Submitted batch job $id" >&2
+    echo "$id"
+  fi
+  exit 0
+fi
 # The subshell redirects ALL its fds: without this it inherits sbatch's
 # stdout pipe, keeping it open until the job finishes — a caller waiting on
 # sbatch's output would block for the job duration. Real sbatch returns

--- a/tests/reentry_integration.rs
+++ b/tests/reentry_integration.rs
@@ -296,6 +296,8 @@ fn backend_driver_executes_reentry_rounds() {
         executor,
         DriverConfig {
             max_submitted: 4,
+            max_array_size: 1001,
+            no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
         },


### PR DESCRIPTION
feat(cluster): job arrays for scatter rules (issue #74 phase 3)

Same-template instances now group into ONE scheduler array at submit
time — auto-detected, chunked at max_array_size, and transport-level:
to_run stays rule-name-granular, per-instance JobRecords, dependency
gates, resume semantics, and the run-directory layout are unchanged
(the array parity test pins this: identical records, one submission).

- Template tracking: expand_wildcards records instance → template on
  all four fan-out paths (expansion_templates + WorkflowConfig::template_of),
  so grouping never guesses from name suffixes.
- Array eligibility: instances group only when the scheduler-visible
  directive signature agrees (threads/memory/time_limit/partition/gpu/
  environment/workdir) AND their dependency sets match. Chunks >1 submit
  as an array; chunks of one take the existing per-job path.
- Scripts: generate_array_submit_script emits the backend's array-range
  directive (SLURM --array / PBS -J / SGE -t / LSF -J name[1-N]) and
  dispatches on the backend's task-index variable to per-index command
  files (multi-line-safe: shell preludes and environment-wrapped
  commands stay valid).
- Tracking: element ids (base_idx) flow through the existing poll/settle
  path (SLURM squeue already emits them); per-instance job dirs keep the
  run directory greppable (job.sh copy + job.id + status.json), and
  index.json maps the array index back to instance names.
- Config: [cluster] max_array_size (default 1001, the common SLURM
  MaxArraySize); DriverConfig.no_arrays opts out.

Not in this slice (documented on the issue): element-wise aftercorr
chaining (partial ready batches already chunk-correctly; aftercorr is a
queue-efficiency refinement), per-rule `array = false`.

Tests: template tracking unit (RED first); array script directives per
backend; driver integration through the mock scheduler (RED first —
array path must emit the same JobRecord set as per-job, one submission,
index.json mapping); mock sbatch extended for array fan-out. Full make
ci green; cluster_run_profile 7/7.
