### PR TITLE
feat: partial module runs (--module) + git-pinned includes (#112 elasticity)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/pull.rs
+++ b/crates/oxo-flow-cli/src/commands/pull.rs
@@ -75,34 +75,16 @@ fn repo_dir_name(spec: &str) -> String {
         .to_string()
 }
 
-/// GitHub clone mirrors tried when the official URL fails — ghproxy-style
-/// prefixes, matching docs/guide/src/how-to/china-mirrors.md. Only applied
-/// to github.com URLs; other hosts get no fallback.
-const GITHUB_CLONE_MIRRORS: &[&str] = &["https://ghfast.top/", "https://gh-proxy.com/"];
-
-/// Candidate clone URLs in fallback order: the official URL first, then the
-/// mirror-prefixed forms for github.com URLs.
-pub(crate) fn mirror_candidates(repo_url: &str) -> Vec<String> {
-    let official = repo_url.trim_end_matches('/').to_string();
-    if !official.starts_with("https://github.com/") {
-        return vec![official];
-    }
-    std::iter::once(official.clone())
-        .chain(
-            GITHUB_CLONE_MIRRORS
-                .iter()
-                .map(|prefix| format!("{prefix}{official}")),
-        )
-        .collect()
-}
-
 /// `git clone` with mirror fallback: the official URL is tried first, then
 /// each China mirror in turn (github.com URLs only). Every failure is
 /// reported; a partial clone directory left behind by a failed attempt is
 /// removed so callers can retry cleanly.
 pub(crate) async fn clone_repo(repo_url: &str, git_ref: Option<&str>, target: &Path) -> Result<()> {
     let mut failures: Vec<String> = Vec::new();
-    for (index, candidate) in mirror_candidates(repo_url).iter().enumerate() {
+    for (index, candidate) in oxo_flow_core::git::mirror_candidates(repo_url)
+        .iter()
+        .enumerate()
+    {
         if index > 0 {
             eprintln!(
                 "{} official clone failed — trying mirror {candidate}...",
@@ -433,13 +415,13 @@ mod tests {
 
     #[test]
     fn mirror_candidates_prefix_github_urls_only() {
-        let github = mirror_candidates("https://github.com/owner/repo.git");
-        assert_eq!(github.len(), 1 + GITHUB_CLONE_MIRRORS.len());
+        let github = oxo_flow_core::git::mirror_candidates("https://github.com/owner/repo.git");
+        assert_eq!(github.len(), 1 + 2); // official + ghfast.top + gh-proxy.com
         assert_eq!(github[0], "https://github.com/owner/repo.git");
-        assert!(github[1].starts_with(GITHUB_CLONE_MIRRORS[0]));
+        assert!(github[1].starts_with("https://ghfast.top/"));
         assert!(github[1].contains("github.com/owner/repo.git"));
 
-        let other = mirror_candidates("https://example.com/team/repo.git");
+        let other = oxo_flow_core::git::mirror_candidates("https://example.com/team/repo.git");
         assert_eq!(other.len(), 1, "non-GitHub URLs get no mirror fallback");
     }
 

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -455,6 +455,7 @@ pub async fn run_command(
     keep_going: bool,
     workdir: Option<PathBuf>,
     target: Vec<String>,
+    module: Vec<String>,
     retry: u32,
     timeout: String,
     resume_failed: bool,
@@ -568,6 +569,31 @@ pub async fn run_command(
     )
     .context("failed to build workflow DAG")?;
 
+    // --module partial runs (issue #112 elasticity): each module name
+    // resolves to its rules plus the host producers of its declared
+    // concrete inputs; upstream DAG dependents come via the target
+    // machinery below.
+    let mut target = target;
+    for m in &module {
+        match config.module_closure(m) {
+            Some(names) => target.extend(names),
+            None => {
+                let known: Vec<&String> = config.module_rules.keys().collect();
+                return Err(anyhow::anyhow!(
+                    "unknown module '{m}' — known modules: {}",
+                    if known.is_empty() {
+                        "(none — no [[include]] modules)".to_string()
+                    } else {
+                        known
+                            .iter()
+                            .map(|k| k.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    }
+                ));
+            }
+        }
+    }
     let mut order = if target.is_empty() {
         dag.execution_order()?
     } else {
@@ -2266,6 +2292,7 @@ pub async fn run_command(
 pub async fn dry_run_command(
     workflow: Option<PathBuf>,
     target: Vec<String>,
+    module: Vec<String>,
     verbose: bool,
     json: bool,
     ai: bool,
@@ -2363,6 +2390,25 @@ pub async fn dry_run_command(
     )
     .context("failed to build workflow DAG")?;
 
+    // --module partial runs (issue #112 elasticity) — same resolution as
+    // `run`.
+    let mut target = target;
+    for m in &module {
+        match config.module_closure(m) {
+            Some(names) => target.extend(names),
+            None => {
+                return Err(anyhow::anyhow!(
+                    "unknown module '{m}' — known modules: {}",
+                    config
+                        .module_rules
+                        .keys()
+                        .map(|k| k.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
     // Compute the execution set (respects --target), then display it in
     // parallel-group order — the same grouping `run` uses for scheduling.
     // Independent rules at the same level appear adjacent, so the listing
@@ -3497,6 +3543,7 @@ pub async fn resume_command(
         keep_going,        // keep_going (same semantics as `run`)
         effective_workdir, // workdir (recorded by the original run)
         Vec::new(),        // target
+        Vec::new(),        // module
         0,                 // retry
         timeout,           // timeout
         false,             // resume_failed (user can re-run with --resume-failed in 'run')

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -85,6 +85,11 @@ pub enum Commands {
         )]
         target: Vec<String>,
         #[arg(
+            long,
+            help = "Run one include module and the producers of its declared inputs (repeatable; unions with --target). Module names are the include's `name` field or its file stem"
+        )]
+        module: Vec<String>,
+        #[arg(
             short = 'r',
             long,
             default_value = "0",
@@ -232,6 +237,11 @@ pub enum Commands {
             help = "Run only specific target rules (repeatable, prefix matching)"
         )]
         target: Vec<String>,
+        #[arg(
+            long,
+            help = "Run one include module and the producers of its declared inputs (repeatable; unions with --target). Module names are the include's `name` field or its file stem"
+        )]
+        module: Vec<String>,
         /// Enable AI-powered analysis of the workflow.
         #[arg(long)]
         ai: bool,
@@ -880,6 +890,10 @@ pub enum ClusterAction {
             help = "Run only specific target rules (repeatable, prefix matching)"
         )]
         target: Vec<String>,
+        #[arg(
+            long,
+            help = "Run one include module and the producers of its declared inputs (repeatable; unions with --target). Module names are the include's `name` field or its file stem"
+        )]
         #[arg(long, help = "Generate scripts without submitting")]
         dry_run: bool,
         /// Generate job scripts with dependency support and a wrapper script
@@ -1003,6 +1017,7 @@ async fn main() -> Result<()> {
             keep_going,
             workdir,
             target,
+            module,
             retry,
             timeout,
             resume_failed,
@@ -1128,6 +1143,7 @@ async fn main() -> Result<()> {
                 keep_going,
                 wd,
                 target,
+                module,
                 retry,
                 timeout,
                 resume_failed,
@@ -1174,6 +1190,7 @@ async fn main() -> Result<()> {
         Commands::DryRun {
             workflow,
             target,
+            module,
             ai,
             ai_max_retries,
             samples_filter,
@@ -1192,6 +1209,7 @@ async fn main() -> Result<()> {
             dry_run_command(
                 workflow,
                 target,
+                module,
                 cli.verbose,
                 cli.json,
                 ai,
@@ -1446,6 +1464,7 @@ async fn main() -> Result<()> {
             dry_run_command(
                 Some(workflow.clone()),
                 target.clone(),
+                Vec::new(), // module
                 cli.verbose,
                 cli.json,
                 false,
@@ -1472,6 +1491,7 @@ async fn main() -> Result<()> {
                     jobs,
                     keep_going,      // keep_going
                     workdir.clone(), // workdir
+                    Vec::new(),      // module
                     target.clone(),  // target
                     retry,           // retry
                     timeout.clone(), // timeout

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -323,6 +323,31 @@ pub struct IncludeDirective {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+
+    /// Interface contract (issue #112 module slice): file patterns the HOST
+    /// must wire into the module. Validation fails when a concrete (no
+    /// `{`-wildcard) declared input is not produced by any rule.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<String>,
+
+    /// Interface contract: files the module exposes to the host. Validation
+    /// fails when a declared output is not produced by a module rule, and
+    /// warns when a host rule reads a module-internal file that is NOT
+    /// declared here (encapsulation).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outputs: Vec<String>,
+
+    /// Interface contract: defaults for config keys the module reads —
+    /// filled into the host config profile-style (host values win).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub params: HashMap<String, toml::Value>,
+}
+
+/// A resolved include contract, namespaced rule provenance attached.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedIncludeContract {
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
 }
 
 /// Execution mode for an execution group.
@@ -1432,6 +1457,14 @@ pub struct WorkflowConfig {
     /// their TEMPLATE, never by guessing name suffixes. Never serialized.
     #[serde(skip)]
     pub expansion_templates: HashMap<String, String>,
+    /// Resolved include contracts (issue #112 module slice): one entry per
+    /// `[[include]]` that declares an interface. Never serialized.
+    #[serde(skip)]
+    pub include_contracts: Vec<ResolvedIncludeContract>,
+    /// Rule → include-contract index provenance (which module a rule came
+    /// from). Never serialized.
+    #[serde(skip)]
+    pub module_of: HashMap<String, usize>,
 
     /// Engine-internal: the sample names each expanded rule came from.
     ///
@@ -2060,6 +2093,18 @@ impl WorkflowConfig {
 
         self.validate_execution_groups()?;
 
+        // Include interface contracts (issue #112): contract errors fail
+        // fast with the wiring gap named; encapsulation gaps warn.
+        let (contract_errors, contract_warnings) = self.check_include_contracts();
+        if let Some(first) = contract_errors.first() {
+            return Err(OxoFlowError::Config {
+                message: first.clone(),
+            });
+        }
+        for warning in &contract_warnings {
+            tracing::warn!("{warning}");
+        }
+
         // Validate [[references]] entries: builder template names must be
         // known, template builds must declare an output, names must be unique.
         crate::references::validate_reference_defs(&self.references)?;
@@ -2385,6 +2430,25 @@ impl WorkflowConfig {
 
             // Recursively resolve nested includes
             inc_config.resolve_includes_with_depth(&inc_base_dir, depth + 1)?;
+            // Nested contracts merge first (their provenance indices shift
+            // by the host's current contract count).
+            let offset = self.include_contracts.len();
+            self.include_contracts
+                .extend(std::mem::take(&mut inc_config.include_contracts));
+            for (rule, idx) in std::mem::take(&mut inc_config.module_of) {
+                self.module_of.insert(rule, idx + offset);
+            }
+            // Record THIS include's contract (issue #112) and its rules'
+            // provenance.
+            let contract_idx = if !inc.inputs.is_empty() || !inc.outputs.is_empty() {
+                self.include_contracts.push(ResolvedIncludeContract {
+                    inputs: inc.inputs.clone(),
+                    outputs: inc.outputs.clone(),
+                });
+                Some(self.include_contracts.len() - 1)
+            } else {
+                None
+            };
             // Collect original rule names from included file for dependency resolution
             let original_rule_names: std::collections::HashSet<String> =
                 inc_config.rules.iter().map(|r| r.name.clone()).collect();
@@ -2400,12 +2464,100 @@ impl WorkflowConfig {
                     }
                 }
                 if !self.rules.iter().any(|r| r.name == rule.name) {
+                    if let Some(idx) = contract_idx {
+                        self.module_of.insert(rule.name.clone(), idx);
+                    }
                     self.rules.push(rule);
                 }
+            }
+            // Contract params fill config keys in profile-style — host
+            // values win (or_insert).
+            for (key, value) in &inc.params {
+                self.config
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
             }
         }
         self.includes = includes;
         Ok(())
+    }
+
+    /// Check the resolved include contracts (issue #112 module slice).
+    ///
+    /// Returns `(errors, warnings)`. Errors cover the fail-fast contract:
+    /// a declared concrete input nobody produces, and a declared output no
+    /// module rule produces (or produced outside the module). Warnings
+    /// cover encapsulation: a host rule reading a module-internal file the
+    /// contract does not declare. Wildcarded patterns are skipped here —
+    /// their wiring is verified by DAG edge inference at run time.
+    pub fn check_include_contracts(&self) -> (Vec<String>, Vec<String>) {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+        if self.include_contracts.is_empty() {
+            return (errors, warnings);
+        }
+        // Producer map: output path → producing rule name (owned — rule
+        // outputs are borrowed across iterations).
+        let mut producers: HashMap<String, String> = HashMap::new();
+        for rule in &self.rules {
+            for out in rule.output.to_vec() {
+                producers.entry(out).or_insert_with(|| rule.name.clone());
+            }
+        }
+        for (idx, contract) in self.include_contracts.iter().enumerate() {
+            for input in &contract.inputs {
+                if input.contains('{') {
+                    continue; // wildcard wiring: DAG-time, documented
+                }
+                if !producers.contains_key(input) {
+                    errors.push(format!(
+                        "include contract: declared input '{input}' is not produced by any rule — wire it to a host rule output"
+                    ));
+                }
+            }
+            for output in &contract.outputs {
+                if output.contains('{') {
+                    continue;
+                }
+                match producers.get(output) {
+                    Some(producer)
+                        if self
+                            .module_of
+                            .get(producer)
+                            .is_some_and(|p| *p == idx) => {}
+                    Some(producer) => errors.push(format!(
+                        "include contract: declared output '{output}' is produced by '{producer}', which is outside the module — module outputs must come from module rules"
+                    )),
+                    None => errors.push(format!(
+                        "include contract: declared output '{output}' is not produced by any module rule"
+                    )),
+                }
+            }
+            // Encapsulation: host rules reading undeclared module-internal
+            // files.
+            let declared: std::collections::HashSet<&str> =
+                contract.outputs.iter().map(String::as_str).collect();
+            for rule in &self.rules {
+                if self.module_of.get(&rule.name).is_some_and(|p| *p == idx) {
+                    continue;
+                }
+                for inp in rule.input.to_vec() {
+                    if inp.contains('{') {
+                        continue;
+                    }
+                    let internal = producers
+                        .get(&inp)
+                        .is_some_and(|p| self.module_of.get(p).is_some_and(|mp| *mp == idx));
+                    if internal && !declared.contains(inp.as_str()) {
+                        warnings.push(format!(
+                            "rule '{}' reads module-internal file '{inp}' which the include contract does not declare — add it to `outputs` to keep the coupling explicit",
+                            rule.name
+                        ));
+                    }
+                }
+            }
+        }
+        (errors, warnings)
     }
 
     /// Validate that all execution group references point to existing rules.
@@ -5970,6 +6122,211 @@ shell = "echo {config.database} > {output[0]}"
 
         // A rule that never fanned out has no template entry.
         assert_eq!(config.template_of("plain"), None);
+    }
+
+    #[test]
+    fn include_contract_unwired_input_is_an_error() {
+        // Issue #112 module slice: a module that DECLARES an input nobody
+        // produces must fail validation with the wiring gap named — instead
+        // of the rule dying at runtime on a missing file.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("qc.oxoflow"),
+            r#"[workflow]
+name = "qc"
+version = "1.0.0"
+
+[[rules]]
+name = "fastqc"
+input = ["raw/sample.fq"]
+output = ["qc/sample.html"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/sample.fq"]
+outputs = ["qc/sample.html"]
+
+[[rules]]
+name = "final"
+input = ["qc/sample.html"]
+output = ["final.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let err = WorkflowConfig::from_file(&wf).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("raw/sample.fq"),
+            "the error must name the unwired input: {msg}"
+        );
+    }
+
+    #[test]
+    fn include_contract_checks_declared_outputs_and_encapsulation() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("qc.oxoflow"),
+            r#"[workflow]
+name = "qc"
+version = "1.0.0"
+
+[[rules]]
+name = "fastqc"
+input = ["raw/sample.fq"]
+output = ["qc/sample.html"]
+shell = "true"
+
+[[rules]]
+name = "internal"
+input = ["qc/sample.html"]
+output = ["qc/tmp.bin"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+        // (a) a declared output that no module rule produces = error
+        let bad_host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/sample.fq"]
+outputs = ["qc/nope.html"]
+
+[[rules]]
+name = "rawmaker"
+output = ["raw/sample.fq"]
+shell = "true"
+"#;
+        let wf = dir.path().join("bad.oxoflow");
+        std::fs::write(&wf, bad_host).unwrap();
+        let err = WorkflowConfig::from_file(&wf).unwrap_err();
+        assert!(
+            format!("{err}").contains("qc/nope.html"),
+            "the error must name the unproduced declared output"
+        );
+
+        // (b) host reading an UNDECLARED module-internal file = warning
+        let host2 = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/sample.fq"]
+outputs = ["qc/sample.html"]
+
+[[rules]]
+name = "rawmaker"
+output = ["raw/sample.fq"]
+shell = "true"
+
+[[rules]]
+name = "peeker"
+input = ["qc/tmp.bin"]
+output = ["peek.txt"]
+shell = "true"
+"#;
+        let wf2 = dir.path().join("ok.oxoflow");
+        std::fs::write(&wf2, host2).unwrap();
+        let config = WorkflowConfig::from_file(&wf2).unwrap();
+        let (errors, warnings) = config.check_include_contracts();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert!(
+            warnings.iter().any(|w| w.contains("qc/tmp.bin")),
+            "encapsulation warning must name the internal file: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn include_contract_params_fill_in_config_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mod.oxoflow"),
+            r#"[workflow]
+name = "mod"
+version = "1.0.0"
+
+[[rules]]
+name = "step"
+output = ["o.txt"]
+shell = "echo {config.threads} > o.txt"
+"#,
+        )
+        .unwrap();
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "mod.oxoflow"
+outputs = ["o.txt"]
+params = { threads = "8" }
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        assert_eq!(
+            config.config.get("threads").and_then(toml::Value::as_str),
+            Some("8"),
+            "params defaults must fill in config keys"
+        );
+    }
+
+    #[test]
+    fn include_without_contract_is_unchanged() {
+        // Backward compatibility: includes that declare no interface fields
+        // trigger none of the new checks.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mod.oxoflow"),
+            r#"[workflow]
+name = "mod"
+version = "1.0.0"
+
+[[rules]]
+name = "step"
+output = ["o.txt"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "mod.oxoflow"
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        let (errors, warnings) = config.check_include_contracts();
+        assert!(
+            errors.is_empty() && warnings.is_empty(),
+            "{errors:?} {warnings:?}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -324,6 +324,28 @@ pub struct IncludeDirective {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 
+    /// Module name for partial runs (`run --module <name>`, issue #112
+    /// elasticity). Defaults to the included file's stem (`rules/20_germline.oxoflow`
+    /// → `20_germline`), so existing composed workflows are addressable
+    /// without changes.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Git repository the included path lives in (issue #112): `path` is
+    /// resolved inside a checkout pinned at `ref`. Supports any git URL —
+    /// https, ssh, file:// — with the China-mirror fallback for github.com.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+
+    /// The git ref (tag/branch/commit) pinning the module version. Required
+    /// when `repo` is set — versioned modules are the point.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+
     /// Interface contract (issue #112 module slice): file patterns the HOST
     /// must wire into the module. Validation fails when a concrete (no
     /// `{`-wildcard) declared input is not produced by any rule.
@@ -1465,6 +1487,10 @@ pub struct WorkflowConfig {
     /// from). Never serialized.
     #[serde(skip)]
     pub module_of: HashMap<String, usize>,
+    /// Module name → its rule names (issue #112 elasticity: `--module`
+    /// partial runs). Built at include resolution; never serialized.
+    #[serde(skip)]
+    pub module_rules: HashMap<String, Vec<String>>,
 
     /// Engine-internal: the sample names each expanded rule came from.
     ///
@@ -2394,9 +2420,43 @@ impl WorkflowConfig {
         }
         let includes = std::mem::take(&mut self.includes);
         for inc in &includes {
-            let (content, inc_base_dir) = if inc.path.starts_with("http://")
-                || inc.path.starts_with("https://")
-            {
+            let (content, inc_base_dir) = if let Some(repo) = &inc.repo {
+                // Pinned git include (issue #112): clone once into the
+                // module cache (keyed repo@ref), then resolve `path` inside
+                // the checkout. Cache hits skip the clone entirely.
+                let git_ref = inc.git_ref.as_deref().ok_or_else(|| OxoFlowError::Config {
+                    message: format!(
+                        "include '{}' declares `repo` without `ref` — pin the module version",
+                        inc.path
+                    ),
+                })?;
+                let cache_dir =
+                    crate::git::module_cache_root().join(crate::git::cache_dir_name(repo, git_ref));
+                if !cache_dir.join(".git").exists() {
+                    std::fs::create_dir_all(cache_dir.parent().unwrap_or(&cache_dir)).map_err(
+                        |e| OxoFlowError::Config {
+                            message: format!("cannot create module cache: {e}"),
+                        },
+                    )?;
+                    crate::git::clone_pinned(repo, git_ref, &cache_dir).map_err(|e| {
+                        OxoFlowError::Config {
+                            message: format!(
+                                "failed to clone include repo '{repo}' at '{git_ref}': {e}"
+                            ),
+                        }
+                    })?;
+                }
+                let inc_path = cache_dir.join(&inc.path);
+                let text = std::fs::read_to_string(&inc_path).map_err(|e| OxoFlowError::Parse {
+                    path: inc_path.clone(),
+                    message: format!(
+                        "failed to read include '{}' from repo '{repo}': {e}",
+                        inc.path
+                    ),
+                })?;
+                let next_base = inc_path.parent().unwrap_or(&cache_dir).to_path_buf();
+                (text, next_base)
+            } else if inc.path.starts_with("http://") || inc.path.starts_with("https://") {
                 // Fetch remote include on a dedicated thread to avoid tokio runtime conflicts
                 tracing::info!(url = %inc.path, "fetching remote include");
                 let url = inc.path.clone();
@@ -2450,8 +2510,16 @@ impl WorkflowConfig {
                 None
             };
             // Collect original rule names from included file for dependency resolution
+            // Module identity: explicit `name` field, else the file stem.
+            let module_name = inc.name.clone().unwrap_or_else(|| {
+                Path::new(&inc.path)
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_else(|| inc.path.clone())
+            });
             let original_rule_names: std::collections::HashSet<String> =
                 inc_config.rules.iter().map(|r| r.name.clone()).collect();
+            let mut module_members: Vec<String> = Vec::new();
             for mut rule in inc_config.rules {
                 if let Some(ref ns) = inc.namespace {
                     // Prefix rule name with namespace
@@ -2467,9 +2535,14 @@ impl WorkflowConfig {
                     if let Some(idx) = contract_idx {
                         self.module_of.insert(rule.name.clone(), idx);
                     }
+                    module_members.push(rule.name.clone());
                     self.rules.push(rule);
                 }
             }
+            self.module_rules
+                .entry(module_name)
+                .or_default()
+                .extend(module_members);
             // Contract params fill config keys in profile-style — host
             // values win (or_insert).
             for (key, value) in &inc.params {
@@ -2480,6 +2553,42 @@ impl WorkflowConfig {
         }
         self.includes = includes;
         Ok(())
+    }
+
+    /// The rule-name closure of a module for partial runs (issue #112
+    /// elasticity): the module's own rules plus every HOST rule producing
+    /// one of its declared concrete inputs. Upstream DAG dependents are
+    /// added by the caller through the regular target machinery.
+    pub fn module_closure(&self, module: &str) -> Option<Vec<String>> {
+        let members = self.module_rules.get(module)?.clone();
+        let mut closure: Vec<String> = members.clone();
+        // Declared concrete inputs the module needs wired in.
+        for (idx, contract) in self.include_contracts.iter().enumerate() {
+            let module_uses_this_contract = members
+                .iter()
+                .any(|r| self.module_of.get(r).is_some_and(|p| *p == idx));
+            if !module_uses_this_contract {
+                continue;
+            }
+            let mut producers: HashMap<String, String> = HashMap::new();
+            for rule in &self.rules {
+                for out in rule.output.to_vec() {
+                    producers.entry(out).or_insert_with(|| rule.name.clone());
+                }
+            }
+            for input in &contract.inputs {
+                if input.contains('{') {
+                    continue;
+                }
+                if let Some(producer) = producers.get(input)
+                    && !members.contains(producer)
+                    && !closure.contains(producer)
+                {
+                    closure.push(producer.clone());
+                }
+            }
+        }
+        Some(closure)
     }
 
     /// Check the resolved include contracts (issue #112 module slice).
@@ -6122,6 +6231,126 @@ shell = "echo {config.database} > {output[0]}"
 
         // A rule that never fanned out has no template entry.
         assert_eq!(config.template_of("plain"), None);
+    }
+
+    #[test]
+    fn module_closure_includes_contract_input_producers() {
+        // Issue #112 elasticity: `--module` must include the host rules
+        // producing the module's declared concrete inputs, so a partial
+        // run of the module alone has everything it needs wired.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("m.oxoflow"),
+            r#"[workflow]
+name = "m"
+version = "1.0.0"
+
+[[rules]]
+name = "step"
+input = ["raw.fq"]
+output = ["out.bam"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "m.oxoflow"
+name = "mapper"
+inputs = ["raw.fq"]
+outputs = ["out.bam"]
+
+[[rules]]
+name = "fetch"
+output = ["raw.fq"]
+shell = "true"
+
+[[rules]]
+name = "unrelated"
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        let closure = config.module_closure("mapper").expect("module exists");
+        assert!(
+            closure.contains(&"step".to_string()),
+            "module rules: {closure:?}"
+        );
+        assert!(
+            closure.contains(&"fetch".to_string()),
+            "the declared-input producer must join the closure: {closure:?}"
+        );
+        assert!(
+            !closure.contains(&"unrelated".to_string()),
+            "unrelated rules must stay out: {closure:?}"
+        );
+    }
+
+    #[test]
+    fn include_from_git_repo_resolves_path_inside_checkout() {
+        // Issue #112: includes may come from a pinned git repository
+        // (repo + ref + path) — the versioned-module composition story.
+        // A LOCAL git repo keeps the test network-free (file:// clone).
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("mods");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(
+            repo.join("qc.oxoflow"),
+            r#"[workflow]
+name = "qc"
+version = "1.0.0"
+
+[[rules]]
+name = "fastqc"
+output = ["qc.html"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "t@t"]);
+        git(&["config", "user.name", "t"]);
+        git(&["add", "qc.oxoflow"]);
+        git(&["commit", "-m", "qc"]);
+        git(&["tag", "v1.0.0"]);
+
+        let host = format!(
+            r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+repo = "file://{}"
+ref = "v1.0.0"
+path = "qc.oxoflow"
+
+[[rules]]
+name = "use"
+input = ["qc.html"]
+output = ["u.txt"]
+shell = "true"
+"#,
+            repo.display()
+        );
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        assert!(
+            config.rules.iter().any(|r| r.name == "fastqc"),
+            "the module's rule must resolve from the pinned repo"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/git.rs
+++ b/crates/oxo-flow-core/src/git.rs
@@ -1,0 +1,66 @@
+//! Git helpers shared by workflow pulling and module includes (issue #112).
+
+/// China-friendly clone mirrors tried after the official GitHub URL fails
+/// (github.com URLs only — other hosts are left untouched).
+const GITHUB_CLONE_MIRRORS: &[&str] = &["https://ghfast.top/", "https://gh-proxy.com/"];
+
+/// Candidate clone URLs: the official URL first, then each mirror.
+pub fn mirror_candidates(repo_url: &str) -> Vec<String> {
+    let official = repo_url.trim_end_matches('/').to_string();
+    if !official.starts_with("https://github.com/") {
+        return vec![official];
+    }
+    std::iter::once(official.clone())
+        .chain(
+            GITHUB_CLONE_MIRRORS
+                .iter()
+                .map(|prefix| format!("{prefix}{official}")),
+        )
+        .collect()
+}
+
+/// Clone `repo` at `git_ref` (tag/branch/commit) into `dest`, with mirror
+/// fallback. A partial directory left by a failed attempt is removed so
+/// callers can retry cleanly.
+pub fn clone_pinned(repo_url: &str, git_ref: &str, dest: &std::path::Path) -> std::io::Result<()> {
+    let mut failures: Vec<String> = Vec::new();
+    for (index, candidate) in mirror_candidates(repo_url).iter().enumerate() {
+        if index > 0 {
+            tracing::info!("official clone failed — trying mirror {candidate}");
+        }
+        let out = std::process::Command::new("git")
+            .args(["clone", "--depth", "1", "--branch", git_ref, candidate])
+            .arg(dest)
+            .output()?;
+        if out.status.success() {
+            return Ok(());
+        }
+        failures.push(String::from_utf8_lossy(&out.stderr).trim().to_string());
+        let _ = std::fs::remove_dir_all(dest);
+    }
+    Err(std::io::Error::other(format!(
+        "failed to clone '{repo_url}' at '{git_ref}': {}",
+        failures.join("; ")
+    )))
+}
+
+/// Module cache root: `$OXO_FLOW_MODULE_CACHE` or `~/.cache/oxo-flow/modules`.
+pub fn module_cache_root() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("OXO_FLOW_MODULE_CACHE") {
+        return std::path::PathBuf::from(dir);
+    }
+    std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .join(".cache/oxo-flow/modules")
+}
+
+/// Filesystem-safe cache key for a repo@ref pair.
+pub fn cache_dir_name(repo_url: &str, git_ref: &str) -> String {
+    let mut name = repo_url
+        .trim_end_matches('/')
+        .replace("://", "_")
+        .replace('/', "_");
+    name.push_str(&format!("@{}", git_ref.replace('/', "_")));
+    name
+}

--- a/crates/oxo-flow-core/src/lib.rs
+++ b/crates/oxo-flow-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod environment;
 pub mod error;
 pub mod executor;
 pub mod format;
+pub mod git;
 pub mod plugin;
 pub mod readiness;
 pub mod reentry;

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -329,7 +329,26 @@ max_array_size = 1001   # optional — the scheduler's MaxArraySize; larger
 - Arrays are transport-level: the JobRecord set, checkpoint, and resume
   semantics are identical to per-job submission.
 
-Element-wise `aftercorr` chaining is not part of this slice: downstream
+Element-wise `aftercorr` chaining is not part of this slice### Partial module runs (`--module`)
+
+A composed workflow (clinical pipelines like clindet: several
+`[[include]]` modules chained together) can run just ONE module and the
+producers of its declared inputs:
+
+```bash
+# run only the germline module (rules/20_germline.oxoflow) of a composed
+# clinical pipeline — the module name defaults to the include's file stem
+oxo-flow run main.oxoflow --module 20_germline
+
+# multiple modules + rule targets union together
+oxo-flow run main.oxoflow --module 20_germline --module 30_vcf_norm -t report
+```
+
+The closure is: the module's rules + every host rule producing one of its
+declared concrete contract inputs; upstream DAG dependents come through
+the regular target machinery. Unknown module names fail with the known
+module list. `dry-run --module` previews the same set.
+: downstream
 instances submit in ready batches as array elements finish, which is
 correct but not as queue-efficient as true element-wise chaining.
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -157,6 +157,8 @@ shell = "true"
 | `inputs` | Array of String | File patterns the host must wire into the module. A concrete declared input (no `{`-wildcard) that no rule produces fails validation with the gap named; wildcarded patterns are verified by DAG edge inference at run time |
 | `outputs` | Array of String | Files the module exposes to the host. A declared output not produced by a module rule fails validation; a host rule reading a module-internal file that is **not** declared here produces an encapsulation warning |
 | `params` | Table | Defaults for config keys the module reads, filled in profile-style (`or_insert` — explicit host values win) |
+| `name` | String | Module identity for partial runs (`run --module <name>`). Defaults to the included file's stem (`rules/20_germline.oxoflow` → `20_germline`), so existing composed workflows are addressable without changes |
+| `repo` + `ref` | String pair | Pin the included path to a git repository at a tag/branch/commit: `repo = "https://github.com/org/oxo-flow-modules"`, `ref = "v1.2.0"`, `path = "rules/qc.oxoflow"`. Any git URL works (https/ssh/file://); github.com clones fall back to China mirrors. Checkouts are cached under `~/.cache/oxo-flow/modules/<repo>@<ref>` (`OXO_FLOW_MODULE_CACHE` overrides) — versioned modules, reproducible composition |
 
 ---
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -117,6 +117,47 @@ shell = "bwa mem ref.fa {input} > aligned/{sample}.bam"
 
 Resulting rules: `qc::fastqc`, `qc::trim`, `align`
 
+### Interface Contracts
+
+An `[[include]]` may declare a typed interface — what the host must wire
+in, what the module exposes, and config defaults it reads (issue #112).
+All checks run at **validation time**; execution semantics are unchanged,
+and includes without a contract behave exactly as before.
+
+```toml
+# qc.oxoflow
+[[rules]]
+name = "fastqc"
+input = ["raw/{sample}.fq.gz"]      # the module's NEED
+output = ["qc/{sample}_fastqc.html"]
+shell = "fastqc {input} -o {output}"
+
+[[rules]]
+name = "internal"
+input = ["qc/{sample}_fastqc.html"]
+output = ["qc/{sample}.bin"]        # internal — not declared below
+shell = "true"
+
+# main.oxoflow
+[[include]]
+path = "qc.oxoflow"
+namespace = "qc"
+inputs  = ["raw/{sample}.fq.gz"]    # host MUST produce these
+outputs = ["qc/{sample}_fastqc.html"]  # module EXPOSES these
+params  = { threads = "4" }         # config defaults (host values win)
+
+[[rules]]
+name = "download"
+output = ["raw/{sample}.fq.gz"]     # wires the declared input
+shell = "true"
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `inputs` | Array of String | File patterns the host must wire into the module. A concrete declared input (no `{`-wildcard) that no rule produces fails validation with the gap named; wildcarded patterns are verified by DAG edge inference at run time |
+| `outputs` | Array of String | Files the module exposes to the host. A declared output not produced by a module rule fails validation; a host rule reading a module-internal file that is **not** declared here produces an encapsulation warning |
+| `params` | Table | Defaults for config keys the module reads, filled in profile-style (`or_insert` — explicit host values win) |
+
 ---
 
 ## `[workflow]` — Metadata

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -6594,6 +6594,97 @@ shell = "cat {input} > {output}"
     );
 }
 
+// ─── #112 elasticity: --module runs one include module only ───────────────
+
+/// A composed workflow (two modules + host rules) runs ONLY the selected
+/// module plus the producers of its declared inputs — the clinical-pipeline
+/// partial-run scenario (clindet-style composition).
+#[test]
+fn cli_run_module_runs_only_that_module() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("germline.oxoflow"),
+        r#"[workflow]
+name = "germline"
+version = "1.0.0"
+
+[[rules]]
+name = "call"
+input = ["bam/n.bam"]
+output = ["vcf/n.vcf"]
+shell = "cp bam/n.bam vcf/n.vcf"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("somatic.oxoflow"),
+        r#"[workflow]
+name = "somatic"
+version = "1.0.0"
+
+[[rules]]
+name = "mutect"
+input = ["bam/n.bam"]
+output = ["vcf/somatic.vcf"]
+shell = "cp bam/n.bam vcf/somatic.vcf"
+"#,
+    )
+    .unwrap();
+    let wf = dir.path().join("main.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "composed"
+version = "1.0.0"
+
+[[include]]
+path = "germline.oxoflow"
+inputs = ["bam/n.bam"]
+outputs = ["vcf/n.vcf"]
+
+[[include]]
+path = "somatic.oxoflow"
+inputs = ["bam/n.bam"]
+outputs = ["vcf/somatic.vcf"]
+
+[[rules]]
+name = "align"
+output = ["bam/n.bam"]
+shell = "echo reads > bam/n.bam"
+"#,
+    )
+    .unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--module", "germline"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "module run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        dir.path().join("vcf/n.vcf").exists(),
+        "the module rule must run"
+    );
+    assert!(
+        !dir.path().join("vcf/somatic.vcf").exists(),
+        "rules outside the module must NOT run"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(stderr.contains("Running: call"), "module rule: {stderr}");
+    assert!(
+        stderr.contains("Running: align"),
+        "input producer: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Running: mutect"),
+        "outside-module rule must not execute: {stderr}"
+    );
+}
+
 // ─── #101: rule subprocesses never block on stdin ─────────────────────────
 
 /// Contract smoke test: rule shells must observe null stdin (issue #101).


### PR DESCRIPTION
feat: partial module runs (--module) + git-pinned includes (#112 elasticity)

Two composition capabilities on top of the include interface contracts:

1. `run --module <name>` (repeatable; dry-run supports it too): run one
   include module plus the host producers of its declared concrete
   inputs. The closure feeds the existing target machinery, so upstream
   DAG dependents, checkpoint, and resume semantics are unchanged.
   Module names come from the include's `name` field or default to the
   file stem — existing composed workflows (e.g. clindet's
   rules/20_germline.oxoflow) are addressable with zero changes.
   Unknown names fail with the known-module list. Live-verified on
   oxo-flow-clindet: `dry-run --module 20_germline` selects exactly the
   17 germline rules.

2. Git-pinned includes: `repo` + `ref` + `path` resolve the included
   file inside a checkout pinned at a tag/branch/commit — versioned
   modules, reproducible composition. Any git URL works (https/ssh/
   file://); github.com clones fall back to the China mirrors via a
   shared helper moved to `oxo_flow_core::git` (pull.rs reuses it, no
   duplication). Checkouts cache under `~/.cache/oxo-flow/modules/
   <repo>@<ref>` (OXO_FLOW_MODULE_CACHE overrides); `repo` without
   `ref` is an error — pinning is the point.

Tests: module_closure unit (module rules + declared-input producers,
unrelated rules excluded); --module integration (only the selected
module runs); git-include unit against a local file:// repo (network-free).
Full make ci green.

Refs #112
