### PR TITLE
fix(core): conda run --no-capture-output kills capture-poll hang

### DIFF
--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -110,7 +110,19 @@ impl EnvironmentBackend for CondaBackend {
     ) -> Result<String> {
         let env_name = conda_env_name_from_spec(spec);
         let escaped = escape_for_sh_single_quote(command);
-        Ok(format!("conda run -n {env_name} bash -c '{escaped}'"))
+        // `--no-capture-output` (conda >= 4.13): without it, `conda run`
+        // buffers the wrapped process's stdout/stderr through its own
+        // internal pipes and polls them for EOF — when the wrapped
+        // command's grandchildren inherit those pipe write-ends (forked
+        // helpers, gzip/pigz workers, sra-tools daemons), the poll never
+        // sees EOF and the whole rule parks for 30+ minutes (live:
+        // auto-sra fasterq-dump rules on tx-ubuntu; the identical command
+        // ran instantly by hand). With the flag, conda forwards the child's
+        // fds straight through — the engine's own pipe draining
+        // (wait_with_output) is the capture mechanism.
+        Ok(format!(
+            "conda run --no-capture-output -n {env_name} bash -c '{escaped}'"
+        ))
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
@@ -169,11 +181,16 @@ impl CondaBackend {
         prefix: Option<&str>,
     ) -> Result<String> {
         let escaped = escape_for_sh_single_quote(command);
+        // Same --no-capture-output rationale as wrap_command above.
         if let Some(prefix) = prefix {
-            Ok(format!("conda run -p {prefix} bash -c '{escaped}'"))
+            Ok(format!(
+                "conda run --no-capture-output -p {prefix} bash -c '{escaped}'"
+            ))
         } else {
             let env_name = conda_env_name_from_spec(spec);
-            Ok(format!("conda run -n {env_name} bash -c '{escaped}'"))
+            Ok(format!(
+                "conda run --no-capture-output -n {env_name} bash -c '{escaped}'"
+            ))
         }
     }
 
@@ -1929,7 +1946,7 @@ mod tests {
             .wrap_command_with_opts("echo hi", "envs/qc.yaml", Some(".oxo-conda"))
             .unwrap();
         assert!(
-            result.contains("conda run -p .oxo-conda"),
+            result.contains("conda run --no-capture-output -p .oxo-conda"),
             "expected -p prefix form, got: {result}"
         );
         assert!(result.contains("echo hi"));
@@ -1941,7 +1958,7 @@ mod tests {
         let result = backend
             .wrap_command_with_opts("echo hi", "envs/qc.yaml", None)
             .unwrap();
-        assert!(result.contains("conda run -n qc"));
+        assert!(result.contains("conda run --no-capture-output -n qc"));
         assert!(!result.contains(" -p "));
     }
 
@@ -2026,7 +2043,7 @@ mod tests {
         let result = resolver
             .wrap_command("fastqc reads.fq", &spec, None, std::path::Path::new("."))
             .unwrap();
-        assert!(result.contains("conda run -p .oxo-conda"));
+        assert!(result.contains("conda run --no-capture-output -p .oxo-conda"));
         assert!(!result.contains(" -n "));
     }
 


### PR DESCRIPTION
## Problem (live evidence)

b6's auto-sra live run on tx-ubuntu: engine-spawned `conda run -n <env> bash -c ...` rules hang **randomly** — the child parks in conda's internal capture loop (do_poll reading its subprocess pipes) for 30+ minutes, while the identical command runs instantly by hand. Once hung, the -j slot is occupied and the whole queue wedges.

## Root cause

`conda run` (without flags) buffers the wrapped process's stdout/stderr through its own internal pipes and polls them for EOF. When the rule command's grandchildren inherit those pipe write-ends (forked helpers, gzip/pigz workers, sra-tools daemons), EOF never arrives — the poll waits forever. Random trigger = depends on which grandchild fork keeps the fd open.

The engine side is clean: `spawn_rule_shell` sets stdin=null (issue #101 contract) and drains both pipes via `wait_with_output`.

## Fix

`conda run --no-capture-output` (available since conda 4.13, 2022) on the three wrap sites (`wrap_command` + `wrap_command_with_opts` -n/-p): conda forwards the child fds straight through, and the engine's own pipe draining becomes the capture mechanism. `verify_command` keeps plain `conda run` (short-lived probe, no grandchildren).

## Tests

- 3 existing assertions updated to the new form (RED→GREEN)
- `cargo test -p oxo-flow-core` full suite + fmt + clippy clean locally

Reported by @b6's live testing; fix by the verification hub session. Suggest @andrewbudge-style review from the engine maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)