### PR TITLE
fix(core): invalidate failed rules' outputs — stale files never skip a re-run (#118)

### DIFF
--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -9,6 +9,7 @@ use sysinfo::System;
 
 pub mod checkpoint;
 pub mod env_create_lock;
+pub mod output_invalidation;
 pub mod process;
 pub mod rss;
 pub mod security;

--- a/crates/oxo-flow-core/src/executor/output_invalidation.rs
+++ b/crates/oxo-flow-core/src/executor/output_invalidation.rs
@@ -1,0 +1,196 @@
+//! Output invalidation for failed rules (issue #118).
+//!
+//! A rule that fails mid-write leaves its declared outputs on disk. Without
+//! cleanup, the freshness gate (`should_skip_rule` — outputs exist and are
+//! newer than inputs) treats the failed rule as up-to-date on the next run
+//! and skips it, so downstream rules consume partial or garbage files (live:
+//! a failed postprocess left a 0-byte BAM; the re-run skipped the rule and
+//! the downstream sort died reading the header).
+//!
+//! Fix: before executing, snapshot each declared output's existence and
+//! mtime; on failure, invalidate only what THIS attempt produced:
+//!
+//! - created during the attempt → deleted;
+//! - pre-existing but modified during the attempt → moved aside as
+//!   `<name>.oxo-failed` (recoverable, never silently destroyed);
+//! - pre-existing and untouched → left alone (user data survives a
+//!   failure that never reached the file).
+
+use crate::rule::Rule;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Pre-execution snapshot of one declared output path.
+#[derive(Debug, Clone)]
+pub struct OutputSnapshot {
+    path: PathBuf,
+    existed: bool,
+    mtime: Option<std::time::SystemTime>,
+}
+
+/// Snapshot a rule's declared outputs (config placeholders expanded using
+/// `wildcard_values`, mirroring `should_skip_rule`'s expansion rules).
+/// Paths that still contain wildcard patterns after expansion are skipped —
+/// the same conservative behavior as the freshness gate.
+pub fn snapshot_outputs(
+    rule: &Rule,
+    workdir: &Path,
+    wildcard_values: &HashMap<String, String>,
+) -> Vec<OutputSnapshot> {
+    rule.output
+        .iter()
+        .filter_map(|output| {
+            let expanded = super::checkpoint::expand_config_in_path(output, wildcard_values);
+            if expanded.contains('{') {
+                return None;
+            }
+            let path = workdir.join(expanded);
+            let meta = std::fs::metadata(&path).ok();
+            let existed = meta.is_some();
+            let mtime = meta.and_then(|m| m.modified().ok());
+            Some(OutputSnapshot {
+                path,
+                existed,
+                mtime,
+            })
+        })
+        .collect()
+}
+
+/// Invalidate the outputs a failed rule attempt produced or modified.
+///
+/// Deletes files created during the attempt; moves pre-existing files the
+/// attempt modified aside to `<name>.oxo-failed` so the failure is
+/// recoverable and the freshness gate no longer sees a "fresh" output.
+/// Pre-existing files whose mtime is unchanged are left alone. Every step
+/// is best-effort with a warning — cleanup must never mask the rule's own
+/// failure.
+pub async fn invalidate_failed_outputs(snapshots: &[OutputSnapshot]) {
+    for snapshot in snapshots {
+        let current_meta = match tokio::fs::metadata(&snapshot.path).await {
+            Ok(meta) => meta,
+            Err(_) => continue, // gone already — nothing to invalidate
+        };
+        if !snapshot.existed {
+            // Created during the failed attempt — remove outright.
+            if let Err(e) = tokio::fs::remove_file(&snapshot.path).await {
+                tracing::warn!(
+                    file = %snapshot.path.display(),
+                    error = %e,
+                    "failed to remove output created by a failed rule"
+                );
+            } else {
+                tracing::debug!(
+                    file = %snapshot.path.display(),
+                    "removed output created by a failed rule"
+                );
+            }
+            continue;
+        }
+        // Pre-existing: invalidate only if the attempt modified it.
+        let modified = match (&snapshot.mtime, current_meta.modified().ok()) {
+            (Some(before), Some(after)) => after != *before,
+            // Unreadable mtime: be conservative and leave the file alone.
+            _ => false,
+        };
+        if modified {
+            let aside = aside_path(&snapshot.path);
+            if let Err(e) = tokio::fs::rename(&snapshot.path, &aside).await {
+                tracing::warn!(
+                    file = %snapshot.path.display(),
+                    error = %e,
+                    "failed to move aside output modified by a failed rule"
+                );
+            } else {
+                tracing::warn!(
+                    file = %snapshot.path.display(),
+                    aside = %aside.display(),
+                    "moved aside pre-existing output modified by a failed rule"
+                );
+            }
+        }
+    }
+}
+
+/// `<path>.oxo-failed` sibling for a moved-aside output. A previous failure
+/// already holding that name is overwritten by `rename`.
+fn aside_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".oxo-failed");
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rule::Rule;
+    use std::collections::HashMap;
+
+    fn rule_with_outputs(outputs: &[&str]) -> Rule {
+        Rule {
+            name: "r".to_string(),
+            output: outputs.iter().map(|o| o.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn created_output_is_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let rule = rule_with_outputs(&["out.txt"]);
+        let values = HashMap::new();
+        // Snapshot before anything exists.
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        assert_eq!(snapshots.len(), 1);
+        assert!(!snapshots[0].existed);
+        // The failed attempt "writes" the output, then we invalidate.
+        std::fs::write(dir.path().join("out.txt"), b"partial").unwrap();
+        invalidate_failed_outputs(&snapshots).await;
+        assert!(!dir.path().join("out.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn untouched_preexisting_output_survives() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("out.txt"), b"user-data").unwrap();
+        let rule = rule_with_outputs(&["out.txt"]);
+        let values = HashMap::new();
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        assert!(snapshots[0].existed);
+        // No modification — the file must survive byte-identical.
+        invalidate_failed_outputs(&snapshots).await;
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+            "user-data"
+        );
+    }
+
+    #[tokio::test]
+    async fn modified_preexisting_output_is_moved_aside() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("out.txt"), b"user-data").unwrap();
+        let rule = rule_with_outputs(&["out.txt"]);
+        let values = HashMap::new();
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        // The attempt overwrites the pre-existing file.
+        std::fs::write(dir.path().join("out.txt"), b"corrupt").unwrap();
+        invalidate_failed_outputs(&snapshots).await;
+        assert!(!dir.path().join("out.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("out.txt.oxo-failed")).unwrap(),
+            "corrupt",
+            "the failed content must be preserved for recovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn wildcard_outputs_are_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let rule = rule_with_outputs(&["results/{sample}.txt"]);
+        let values = HashMap::new();
+        assert!(snapshot_outputs(&rule, dir.path(), &values).is_empty());
+    }
+}

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1135,6 +1135,16 @@ impl LocalExecutor {
         // so pre-flight failures never leak empty dirs.
         let scratch_dir = rule.scratch.then(|| self.scratch_dir_for(&rule.name));
 
+        // Pre-execution snapshot of the declared outputs: on failure, only
+        // files this attempt creates or modifies are invalidated (issue
+        // #118) — a failed rule must never leave partial outputs that the
+        // freshness gate would treat as up-to-date on the next run.
+        let output_snapshot = super::output_invalidation::snapshot_outputs(
+            &rule,
+            &self.config.workdir,
+            wildcard_values,
+        );
+
         let resolved_commands =
             vec![self.resolve_command(&base_cmd, &rule, scratch_dir.as_deref())];
         record.command = resolved_commands
@@ -1455,6 +1465,7 @@ impl LocalExecutor {
                 push_stderr_note(&mut record, &format!("\n[oxo-flow] {e}"));
                 push_stderr_note(&mut record, &scratch_preserved_note(scratch));
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
+                super::output_invalidation::invalidate_failed_outputs(&output_snapshot).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
                         &render_shell_command(
@@ -1563,6 +1574,7 @@ impl LocalExecutor {
                     push_stderr_note(&mut record, &scratch_preserved_note(scratch));
                 }
                 cleanup_temp_outputs(&rule, &self.config.workdir).await;
+                super::output_invalidation::invalidate_failed_outputs(&output_snapshot).await;
                 if let Some(ref hook_cmd) = rule.on_failure {
                     run_hook(
                         &render_shell_command(
@@ -1587,6 +1599,7 @@ impl LocalExecutor {
                 push_stderr_note(&mut record, &scratch_preserved_note(scratch));
             }
             cleanup_temp_outputs(&rule, &self.config.workdir).await;
+            super::output_invalidation::invalidate_failed_outputs(&output_snapshot).await;
             if let Some(ref hook_cmd) = rule.on_failure {
                 run_hook(
                     &render_shell_command(

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -782,6 +782,7 @@ oxo-flow automatically cleans up temporary outputs:
 |---|---|---|
 | Success + `temp_output` | Cleaned after successful completion |
 | Failure + `temp_output` | Cleaned to prevent stale partial files |
+| Failure + declared `output` | Partial outputs created by the failed attempt are deleted; pre-existing files the attempt modified are moved aside as `<name>.oxo-failed`; untouched pre-existing files are preserved |
 | Transform with `cleanup=true` | Chunk files cleaned after the whole run finishes successfully (kept on failed runs for debugging; re-runs recompute the map rules) |
 | Success + `temporary = true` | Outputs deleted after the run once every dependent rule has completed; a tombstone is recorded in the checkpoint so a later run that needs the outputs regenerates the rule first (lazy cascade-up). Leaf rules (no dependents) keep their outputs. |
 
@@ -789,6 +790,20 @@ oxo-flow automatically cleans up temporary outputs:
 only until the queue-level callers finish): the deletion is checkpoint-aware,
 so a plain re-run skips the rule and does NOT regenerate the file — it comes
 back only when a dependent actually needs it again.
+
+**Failed-rule output invalidation.** A rule that fails mid-write must never
+leave partial outputs that the freshness gate would mistake for a completed
+run. Before executing, the engine snapshots each declared output's existence
+and modification time; when the rule fails (non-zero exit, timeout, or
+missing outputs after an exit-0 shell), only what THIS attempt produced is
+invalidated: files created during the attempt are deleted, pre-existing
+files the attempt modified are moved aside as `<name>.oxo-failed` (the
+failed content stays recoverable), and untouched pre-existing files are
+left alone — a failure that never reached a file never destroys user data.
+The next run then re-executes the rule instead of skipping it as
+up-to-date. Note this covers failures the engine observes; a hard kill
+(`SIGKILL`) mid-rule can still leave outputs behind, since no cleanup code
+runs — the `--rerun` flag is the escape hatch for that case.
 
 ### Timeout Enforcement
 

--- a/tests/output_invalidation.rs
+++ b/tests/output_invalidation.rs
@@ -1,0 +1,127 @@
+//! Issue #118: failed rules must not leave partial outputs behind, and
+//! pre-existing user files at declared output paths must survive untouched.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_bin(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target/debug");
+    path.push(name);
+    path
+}
+
+fn oxo_flow_cmd() -> Command {
+    Command::new(workspace_bin("oxo-flow"))
+}
+
+/// A failed rule's partial outputs must not make the next run treat it as
+/// up-to-date. Run 1 fails after writing a partial output; run 2 (with the
+/// gate enabled so the shell can succeed) must EXECUTE the rule instead of
+/// skipping it, and must not keep the stale partial content.
+#[test]
+fn failed_rule_outputs_are_invalidated_and_rerun() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("fail-once.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"fail-once\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"if [ -f ok.flag ]; then echo done > {output}; else echo partial > {output}; exit 1; fi\"\n",
+    )
+    .unwrap();
+
+    let run1 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!run1.status.success(), "run 1 must fail");
+    assert!(
+        !dir.path().join("out.txt").exists(),
+        "the failed run must not leave partial outputs behind"
+    );
+
+    // Let the same shell succeed from now on.
+    fs::write(dir.path().join("ok.flag"), b"").unwrap();
+
+    let run2 = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run2.status.success(),
+        "run 2 must succeed: {}",
+        String::from_utf8_lossy(&run2.stderr)
+    );
+    let stderr2 = String::from_utf8_lossy(&run2.stderr);
+    assert!(
+        stderr2.contains("1 succeeded"),
+        "the failed rule must re-execute, not skip on stale outputs: {stderr2}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "done\n",
+        "the re-executed rule must produce fresh content"
+    );
+}
+
+/// A failed run must not corrupt pre-existing files at declared output
+/// paths that the rule never touched: an untouched pre-existing output
+/// survives the failure byte-identical.
+#[test]
+fn failed_rule_preserves_untouched_preexisting_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("preserve.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"preserve\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"exit 1\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("out.txt"), b"user-data").unwrap();
+
+    // --rerun forces execution past the freshness gate; the rule then
+    // fails without touching the file.
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--rerun"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!run.status.success());
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "user-data",
+        "an untouched pre-existing output must survive a failed run"
+    );
+}
+
+/// A pre-existing output that a failed rule MODIFIES is moved aside as
+/// `<name>.oxo-failed` (recoverable) instead of being silently destroyed —
+/// and the freshness gate then re-runs the rule on the next attempt.
+#[test]
+fn failed_rule_moves_aside_modified_preexisting_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("modify.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"modify\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo corrupt > {output}; exit 1\"\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("out.txt"), b"user-data").unwrap();
+
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--rerun"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!run.status.success());
+    assert!(
+        !dir.path().join("out.txt").exists(),
+        "the modified pre-existing output must not sit at its declared path"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt.oxo-failed")).unwrap(),
+        "corrupt\n",
+        "the failed content must be preserved for recovery"
+    );
+}


### PR DESCRIPTION
## Problem (issue #118, live evidence)

varlociraptor campaign: a failed postprocess rule left a 0-byte BAM. The next run's freshness gate (outputs exist + newer than inputs) treated the rule as up-to-date and SKIPPED it; the downstream sort then died reading the BAM header. Port-side workaround was `rm -f {output}` in every shell.

## Design

Snapshot each declared output's existence + mtime **before** executing; on failure (non-zero exit, timeout, or missing outputs after an exit-0 shell) invalidate only what THIS attempt produced:

| output state | action |
|---|---|
| created during the attempt | deleted |
| pre-existing, modified by the attempt | moved aside as `<name>.oxo-failed` (recoverable) |
| pre-existing, untouched | left alone — user data survives |

- Cleanup is best-effort with warnings; never masks the rule's own failure.
- Hard kills (SIGKILL) can still leave outputs (no cleanup code runs) — documented escape hatch: `--rerun`.
- Wildcard outputs are skipped conservatively (same rule as the freshness gate).
- Remote outputs unaffected: the freshness gate already requires uploaded objects to be present.

## Implementation

- New module `executor/output_invalidation.rs` (4 unit tests: created/deleted, untouched-survives, modified-moved-aside, wildcard-skip).
- Wired at the three Failed/TimedOut exits of `run_one` (command failure, scratch-move failure, exit-0-but-missing-outputs).
- Integration tests in a dedicated `tests/output_invalidation.rs` crate (per-crate test convention; shared `cli_integration.rs` deliberately untouched — the concurrent #115 session owns it).
- Docs: `workflow-format.md` cleanup contract table + failure-invalidation paragraph.

## Verification

- TDD: tests written first, confirmed RED, then GREEN.
- `cargo test -p oxo-flow-core`: 1065 tests green.
- `cargo test --test output_invalidation`: 3/3 green (includes a live two-run repro of the reported bug: fail → re-run must EXECUTE, not skip).
- rustfmt (edition 2024) + clippy clean on all touched files.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)