### PR TITLE
feat(run-log): per-run archived log with versioned header + report git sha

### DIFF
--- a/crates/oxo-flow-cli/src/commands/output.rs
+++ b/crates/oxo-flow-cli/src/commands/output.rs
@@ -711,6 +711,7 @@ pub fn build_report(
             .then(|| checkpoint_path.map(|p| p.display().to_string()))
             .flatten(),
     )
+    .workflow_git_sha(checkpoint.and_then(|c| c.workflow_git_sha.clone()))
     .generated_at(generated_at);
     for section in sections {
         report = report.section(section);

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -454,6 +454,7 @@ pub async fn run_command(
     jobs: usize,
     keep_going: bool,
     workdir: Option<PathBuf>,
+    log_file: Option<PathBuf>,
     target: Vec<String>,
     module: Vec<String>,
     retry: u32,
@@ -594,6 +595,48 @@ pub async fn run_command(
             }
         }
     }
+    // ── Run log + workflow provenance (issue #115 pillar 1) ────────────
+    // Every run (and `resume`, which re-enters this function) archives its
+    // own log under the workdir with numbered rotation; the header names
+    // the exact workflow version (name, version, git HEAD) that produced
+    // this record. Best-effort: a logging failure never fails the run.
+    let workflow_abs = absolutize(&workflow)?;
+    let workflow_git_sha =
+        oxo_flow_core::executor::checkpoint::CheckpointState::workflow_git_sha(&workflow_abs);
+    let effective_workdir_log = workdir.as_ref().unwrap_or(&workdir_default);
+    let run_log_path = match &log_file {
+        Some(p) => absolutize(p)?,
+        None => effective_workdir_log.join(".oxo-flow/logs/oxo-flow.log"),
+    };
+    let run_log_header = format!(
+        "oxo-flow run log\nstarted_at: {}\noxo-flow: v{}\ncommand: {}\nworkflow: {}\nworkflow_name: {}\nworkflow_version: {}\ngit_sha: {}\nworkdir: {}\n\n",
+        chrono::Local::now().to_rfc3339(),
+        env!("CARGO_PKG_VERSION"),
+        std::env::args().collect::<Vec<_>>().join(" "),
+        workflow_abs.display(),
+        config.workflow.name,
+        config.workflow.version,
+        workflow_git_sha
+            .as_deref()
+            .unwrap_or("(not inside a git repository)"),
+        effective_workdir_log.display(),
+    );
+    let _run_log_guard = match crate::logging::activate_run_log(&run_log_path, &run_log_header) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            tracing::warn!(error = %e, path = %run_log_path.display(), "failed to open run log; continuing without file logging");
+            None
+        }
+    };
+    tracing::info!(
+        workflow = %config.workflow.name,
+        version = %config.workflow.version,
+        git_sha = workflow_git_sha.as_deref().unwrap_or("(none)"),
+        workdir = %effective_workdir_log.display(),
+        "workflow run started (log: {})",
+        run_log_path.display()
+    );
+
     let mut order = if target.is_empty() {
         dag.execution_order()?
     } else {
@@ -635,14 +678,11 @@ pub async fn run_command(
     // invocation directory.
     {
         let mut ck = checkpoint.lock().await;
-        let workflow_abs = absolutize(&workflow)?;
         ck.set_workflow_path(&workflow_abs);
         // Record the workflow repository's HEAD SHA for provenance
         // (issue #115 pillar 1) — best-effort, never fails the run.
-        if let Some(sha) =
-            oxo_flow_core::executor::checkpoint::CheckpointState::workflow_git_sha(&workflow_abs)
-        {
-            ck.set_workflow_git_sha(sha);
+        if let Some(sha) = &workflow_git_sha {
+            ck.set_workflow_git_sha(sha.clone());
         }
         ck.set_workdir(&absolutize(workdir.as_deref().unwrap_or(&workdir_default))?);
     }
@@ -3550,6 +3590,7 @@ pub async fn resume_command(
         jobs,
         keep_going,        // keep_going (same semantics as `run`)
         effective_workdir, // workdir (recorded by the original run)
+        None,              // log_file (default path)
         Vec::new(),        // target
         Vec::new(),        // module
         0,                 // retry

--- a/crates/oxo-flow-cli/src/logging.rs
+++ b/crates/oxo-flow-cli/src/logging.rs
@@ -1,0 +1,322 @@
+//! Run-log persistence: every `run` (and `resume`, which re-enters the same
+//! path) writes the engine's tracing stream into a per-workdir log file,
+//! rotating previous logs with numbered backups (`oxo-flow.log` →
+//! `oxo-flow.log.1` → …). Each run therefore leaves its own archived record,
+//! headed by the exact workflow version (name, version, git HEAD SHA) that
+//! produced it (issue #115 pillar 1 extension).
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Number of numbered backups kept per run log (`.1` … `.9`); the oldest
+/// backup is deleted on every rotation.
+pub const RUN_LOG_BACKUPS: u32 = 9;
+
+static ACTIVE_LOG: OnceLock<Arc<Mutex<Option<File>>>> = OnceLock::new();
+
+fn slot() -> &'static Arc<Mutex<Option<File>>> {
+    ACTIVE_LOG.get_or_init(|| Arc::new(Mutex::new(None)))
+}
+
+/// True while a run log file is armed (tracing events tee into it).
+#[cfg(test)]
+pub fn is_run_log_active() -> bool {
+    slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_some()
+}
+
+/// Disarm the tee and close the active run log file (the guard's `Drop`
+/// does this too; exposed for explicit completion).
+pub fn deactivate_run_log() {
+    if let Some(mut file) = slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take()
+    {
+        let _ = file.flush();
+    }
+}
+
+fn numbered_path(base: &Path, n: u32) -> PathBuf {
+    PathBuf::from(format!("{}.{}", base.display(), n))
+}
+
+/// Shift existing logs one slot up: `<base>` → `<base>.1`, `<base>.i` →
+/// `<base>.(i+1)`; backups beyond [`RUN_LOG_BACKUPS`] are deleted. No-op
+/// when neither the base nor any backup exists.
+pub fn rotate_run_log(base: &Path) -> io::Result<()> {
+    // Drop every overflow slot first so the shifts below never collide.
+    let mut j = RUN_LOG_BACKUPS + 1;
+    loop {
+        let overflow = numbered_path(base, j);
+        if overflow.exists() {
+            fs::remove_file(&overflow)?;
+            j += 1;
+        } else {
+            break;
+        }
+    }
+    // Shift from the highest kept backup down so each rename target is free.
+    for i in (1..=RUN_LOG_BACKUPS).rev() {
+        let from = if i == 1 {
+            base.to_path_buf()
+        } else {
+            numbered_path(base, i - 1)
+        };
+        if from.exists() {
+            fs::rename(&from, numbered_path(base, i))?;
+        }
+    }
+    Ok(())
+}
+
+/// Rotate previous logs, open `path` as the new current run log, and write
+/// `header` as its first content. Returns a guard that keeps the tee armed
+/// (tracing events are duplicated into the file) until it is dropped.
+pub fn activate_run_log(path: &Path, header: &str) -> io::Result<RunLogGuard> {
+    rotate_run_log(path)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    file.write_all(header.as_bytes())?;
+    let clone = file.try_clone()?;
+    *slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(file);
+    Ok(RunLogGuard { file: Some(clone) })
+}
+
+/// Keeps a run log armed. Dropping it disarms the tee (flush + close), so
+/// every early return from `run_command` still finalizes the log.
+pub struct RunLogGuard {
+    file: Option<File>,
+}
+
+impl Write for RunLogGuard {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match &mut self.file {
+            Some(f) => f.write(buf),
+            None => Ok(0),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match &mut self.file {
+            Some(f) => f.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for RunLogGuard {
+    fn drop(&mut self) {
+        if let Some(f) = &mut self.file {
+            let _ = f.flush();
+        }
+        deactivate_run_log();
+    }
+}
+
+/// The tracing writer installed in `main`: stderr only while no run log is
+/// armed; stderr + the active run log file once [`activate_run_log`] runs.
+/// File write failures are reported once to stderr and the tee degrades to
+/// stderr-only — a logging hiccup never fails the run.
+pub struct TeeWriter;
+
+impl<'a> MakeWriter<'a> for TeeWriter {
+    type Writer = Box<dyn Write + 'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        let file = slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .and_then(|f| f.try_clone().ok());
+        match file {
+            Some(f) => Box::new(Tee {
+                stderr: io::stderr(),
+                file: Some(f),
+            }),
+            None => Box::new(io::stderr()),
+        }
+    }
+}
+
+static FILE_WRITE_ERROR_REPORTED: AtomicBool = AtomicBool::new(false);
+
+struct Tee {
+    stderr: io::Stderr,
+    file: Option<File>,
+}
+
+/// Write `buf` to `out` with ANSI CSI escape sequences stripped — run-log
+/// files are plain text, colors stay on stderr only. `tracing` formats each
+/// event as one write, so sequences are never split across calls.
+fn write_plain(out: &mut File, buf: &[u8]) -> io::Result<()> {
+    let mut plain = Vec::with_capacity(buf.len());
+    let mut i = 0;
+    while i < buf.len() {
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'[' {
+            // CSI sequence: ESC '[' parameters final-byte.
+            i += 2;
+            while i < buf.len() && !(0x40..=0x7e).contains(&buf[i]) {
+                i += 1;
+            }
+            if i < buf.len() {
+                i += 1; // consume the final byte
+            }
+        } else if buf[i] == 0x1b {
+            i += 1; // stray escape — drop it
+        } else {
+            plain.push(buf[i]);
+            i += 1;
+        }
+    }
+    out.write_all(&plain)
+}
+
+impl Write for Tee {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let _ = self.stderr.write(buf);
+        if let Some(f) = &mut self.file
+            && let Err(e) = write_plain(f, buf)
+        {
+            if !FILE_WRITE_ERROR_REPORTED.swap(true, Ordering::Relaxed) {
+                let _ = writeln!(
+                    self.stderr,
+                    "warning: run log write failed ({e}); continuing without file logging"
+                );
+            }
+            self.file = None;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let _ = self.stderr.flush();
+        if let Some(f) = &mut self.file {
+            f.flush()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("oxo-runlog-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn rotate_shifts_numbered_backups_and_caps() {
+        let dir = scratch("rotate");
+        let base = dir.join("oxo-flow.log");
+        fs::write(&base, "latest").unwrap();
+        for i in 1..=(RUN_LOG_BACKUPS + 3) {
+            fs::write(dir.join(format!("oxo-flow.log.{i}")), format!("backup{i}")).unwrap();
+        }
+        rotate_run_log(&base).unwrap();
+        // The old current log becomes .1; every .i shifts one slot up.
+        assert_eq!(
+            fs::read_to_string(dir.join("oxo-flow.log.1")).unwrap(),
+            "latest"
+        );
+        for i in 2..=RUN_LOG_BACKUPS {
+            assert_eq!(
+                fs::read_to_string(dir.join(format!("oxo-flow.log.{i}"))).unwrap(),
+                format!("backup{}", i - 1)
+            );
+        }
+        // Oldest backups beyond the cap are deleted, never shifted further.
+        for i in (RUN_LOG_BACKUPS + 1)..=(RUN_LOG_BACKUPS + 3) {
+            assert!(!dir.join(format!("oxo-flow.log.{i}")).exists());
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rotate_without_existing_logs_is_a_noop() {
+        let dir = scratch("rotate-noop");
+        let base = dir.join("oxo-flow.log");
+        rotate_run_log(&base).unwrap();
+        assert!(!base.exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn activate_creates_parent_dirs_and_writes_header() {
+        let dir = scratch("activate");
+        let log = dir.join("nested/.oxo-flow/logs/oxo-flow.log");
+        let mut guard = activate_run_log(&log, "run header\nsecond line\n").unwrap();
+        let content = fs::read_to_string(&log).unwrap();
+        assert!(content.starts_with("run header\n"));
+        assert!(content.contains("second line"));
+        // The guard tees writes into the active file.
+        guard.write_all(b"event: rule x started\n").unwrap();
+        guard.flush().unwrap();
+        let content = fs::read_to_string(&log).unwrap();
+        assert!(content.contains("event: rule x started"));
+        assert!(is_run_log_active());
+        drop(guard);
+        // Deactivation on drop: no run log stays armed.
+        assert!(!is_run_log_active());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tee_strips_ansi_codes_from_file_writes() {
+        let dir = scratch("ansi");
+        let log = dir.join("run.log");
+        let _guard = activate_run_log(&log, "").unwrap();
+        let file = std::fs::OpenOptions::new().append(true).open(&log).unwrap();
+        let mut tee = Tee {
+            stderr: io::stderr(),
+            file: Some(file),
+        };
+        tee.write_all(b"\x1b[2m2026-08-21T14:54:11Z\x1b[0m \x1b[32m INFO\x1b[0m rule started\n")
+            .unwrap();
+        tee.flush().unwrap();
+        let content = fs::read_to_string(&log).unwrap();
+        assert!(content.contains(" INFO rule started"));
+        assert!(
+            !content.contains("\x1b["),
+            "run-log files must be plain text"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn activate_replaces_previous_run_log_after_rotation() {
+        let dir = scratch("replace");
+        let base = dir.join("oxo-flow.log");
+        fs::write(&base, "old run").unwrap();
+        let _guard = activate_run_log(&base, "new header\n").unwrap();
+        let content = fs::read_to_string(&base).unwrap();
+        assert!(content.starts_with("new header\n"));
+        assert!(!content.contains("old run"));
+        // The previous log was rotated into .1 before truncation.
+        assert_eq!(
+            fs::read_to_string(dir.join("oxo-flow.log.1")).unwrap(),
+            "old run"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -5,6 +5,7 @@
 
 pub mod banner;
 pub mod commands;
+mod logging;
 
 use crate::commands::ai_status::{ai_setup_command, ai_status_command, ai_test_command};
 use crate::commands::batch::batch_command;
@@ -78,6 +79,12 @@ pub enum Commands {
         keep_going: bool,
         #[arg(short = 'd', long, help = "Working directory for execution")]
         workdir: Option<PathBuf>,
+        #[arg(
+            long,
+            value_name = "PATH",
+            help = "Write the run log to PATH instead of the default .oxo-flow/logs/oxo-flow.log (previous logs rotate to PATH.1 .. PATH.9)"
+        )]
+        log_file: Option<PathBuf>,
         #[arg(
             short = 't',
             long,
@@ -1004,7 +1011,7 @@ async fn main() -> Result<()> {
         .with_target(false)
         // Logs go to stderr so machine-readable stdout (graph DOT output,
         // --json, pipes into dot/other tools) stays clean.
-        .with_writer(std::io::stderr)
+        .with_writer(crate::logging::TeeWriter)
         .init();
 
     // Suppress banner in quiet mode
@@ -1016,6 +1023,7 @@ async fn main() -> Result<()> {
             jobs,
             keep_going,
             workdir,
+            log_file,
             target,
             module,
             retry,
@@ -1142,6 +1150,7 @@ async fn main() -> Result<()> {
                 jobs,
                 keep_going,
                 wd,
+                log_file,
                 target,
                 module,
                 retry,
@@ -1491,8 +1500,9 @@ async fn main() -> Result<()> {
                     jobs,
                     keep_going,      // keep_going
                     workdir.clone(), // workdir
-                    Vec::new(),      // module
+                    None,            // log_file (default path)
                     target.clone(),  // target
+                    Vec::new(),      // module
                     retry,           // retry
                     timeout.clone(), // timeout
                     false,           // resume_failed

--- a/crates/oxo-flow-core/src/report.rs
+++ b/crates/oxo-flow-core/src/report.rs
@@ -174,6 +174,12 @@ pub struct Report {
     /// Provenance: path of the workflow file the report describes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_path: Option<String>,
+
+    /// Provenance: git HEAD SHA of the repository the workflow lives in,
+    /// recorded by the run that produced the checkpoint (issue #115
+    /// pillar 1). Absent when the workflow is not in a git repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_git_sha: Option<String>,
 }
 
 const REPORT_SCHEMA_VERSION: u32 = 1;
@@ -200,6 +206,7 @@ impl Report {
             metadata: HashMap::new(),
             checkpoint_path: None,
             workflow_path: None,
+            workflow_git_sha: None,
         }
     }
 
@@ -1011,6 +1018,13 @@ impl ReportBuilder {
     /// Provenance: the workflow file path the report describes.
     pub fn workflow_path(mut self, path: Option<String>) -> Self {
         self.report.workflow_path = path;
+        self
+    }
+
+    /// Provenance: the workflow repository's git HEAD SHA (issue #115
+    /// pillar 1) — which workflow version produced these results.
+    pub fn workflow_git_sha(mut self, sha: Option<String>) -> Self {
+        self.report.workflow_git_sha = sha;
         self
     }
 
@@ -2818,6 +2832,9 @@ impl ReportSectionGenerator for ProvenanceGenerator {
         if let Some(path) = ctx.checkpoint_path {
             pairs.push(("Checkpoint".into(), path.display().to_string()));
         }
+        if let Some(sha) = ctx.checkpoint.and_then(|c| c.workflow_git_sha.as_deref()) {
+            pairs.push(("Workflow git HEAD".into(), sha.into()));
+        }
         vec![ReportSection {
             title: "Provenance".into(),
             id: "provenance".into(),
@@ -2896,6 +2913,20 @@ fn task_summary_section(rules: &[crate::rule::Rule]) -> ReportSection {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn report_workflow_git_sha_provenance_roundtrip() {
+        // The builder records the workflow version that produced the
+        // results (issue #115 pillar 1); absent by default.
+        let report = ReportBuilder::new("t", "wf", "1.0.0")
+            .workflow_git_sha(Some("abc123".to_string()))
+            .build();
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"workflow_git_sha\":\"abc123\""));
+        let plain = ReportBuilder::new("t", "wf", "1.0.0").build();
+        let json = serde_json::to_string(&plain).unwrap();
+        assert!(!json.contains("workflow_git_sha"));
+    }
 
     #[test]
     fn create_report() {

--- a/docs/guide/src/commands/provenance.md
+++ b/docs/guide/src/commands/provenance.md
@@ -92,5 +92,7 @@ To get real integrity verification, re-run with `--provenance`.
 
 ## See Also
 
-- [oxo-flow run](run.md) — use `--provenance` to enable checksum tracking
+- [oxo-flow run](run.md) — use `--provenance` to enable checksum tracking;
+  the run log (`.oxo-flow/logs/oxo-flow.log`) and report snapshots carry the
+  same workflow version header
 - [REPRODUCIBILITY.md](https://github.com/Traitome/oxo-flow/blob/main/REPRODUCIBILITY.md)

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -28,6 +28,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--jobs` | `-j` | `1` | Maximum number of concurrent jobs |
 | `--keep-going` | `-k` | — | Continue execution when a job fails |
 | `--workdir` | `-d` | Workflow file's directory | Working directory for execution |
+| `--log-file` | — | `.oxo-flow/logs/oxo-flow.log` in the workdir | Write the run log to a custom path instead (previous logs rotate to `PATH.1` … `PATH.9`) |
 | `--target` | `-t` | All rules | Run only specific target rules |
 | `--retry` | `-r` | `0` | Number of times to retry failed jobs |
 | `--timeout` | — | `0` (disabled) | Timeout per job in seconds |
@@ -502,6 +503,25 @@ The lookup is best-effort — running outside a git repository simply omits
 the field and never fails the run. Commit your workflow before running to
 get fully version-audited results. See
 [Workflow Versioning](../reference/versioning.md) for the full model.
+
+### Run logs
+
+Every run — and `resume`, which re-enters the same path — archives its own
+log under the workdir:
+
+- **`.oxo-flow/logs/oxo-flow.log`** is always the *latest* run; on each new
+  run the previous log rotates to `.oxo-flow/logs/oxo-flow.log.1`, then
+  `.2`, … up to `.9` (the oldest backup is deleted). `--log-file PATH`
+  overrides the location; the same rotation applies to `PATH`.
+- The log header names the exact workflow version that produced the record:
+  timestamp, oxo-flow version, full command line, workflow path,
+  `workflow_name`, `workflow_version`, `git_sha` (the repository HEAD
+  recorded by the run — see [Workflow Versioning](../reference/versioning.md)),
+  and workdir.
+- The engine's tracing stream (rule start/finish verdicts, warnings, errors)
+  is written into the log alongside stderr. Logging is best-effort: if the
+  file cannot be opened or written, the run continues with stderr-only
+  logging and a warning. Dry-run remains stderr-only.
 
 ### Report snapshots
 

--- a/docs/guide/src/reference/versioning.md
+++ b/docs/guide/src/reference/versioning.md
@@ -21,6 +21,11 @@ thereby auditable to the exact workflow version that produced it.
 - `oxo-flow provenance verify` prints the recorded SHA alongside the
   workflow path (see [provenance](../commands/provenance.md)); the JSON
   field is there for programmatic use.
+- The version travels with every run artifact, closing the audit chain:
+  the **run log** (`.oxo-flow/logs/oxo-flow.log`, rotated per run, see
+  [run](../commands/run.md#run-logs)) carries the SHA in its header, and
+  **report snapshots** embed `workflow_git_sha` in their JSON and show it
+  in the HTML provenance section.
 - Practical guidance: **commit before you run**; tag milestones
   (`git tag v1.2.0`) so the bare SHA has a human-readable alias in your
   records.

--- a/tests/test_command.rs
+++ b/tests/test_command.rs
@@ -1,0 +1,84 @@
+//! Regression tests for the `test` command.
+//!
+//! `test --run -t <target>` must apply the target to the execution step:
+//! PR #114 (module composition) swapped `run_command`'s `target`/`module`
+//! positional arguments at this call site, which made `test --run -t` fail
+//! with "unknown module" before executing anything.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+
+/// Locate a workspace binary by name from the target directory.
+///
+/// This handles the case where binaries are defined in workspace sub-crates
+/// rather than the root package, which means `CARGO_BIN_EXE_*` env vars
+/// are not automatically set.
+fn workspace_bin(name: &str) -> PathBuf {
+    // Cargo sets OUT_DIR for build scripts and CARGO_MANIFEST_DIR for the package.
+    // For integration tests, we can derive the target dir from the test binary location.
+    let mut target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+
+    // Try the binary directly in the target/debug (or target/release) directory.
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    // On Windows, binaries have a .exe extension.
+    let candidate_exe = target_dir.join(format!("{name}.exe"));
+    if candidate_exe.exists() {
+        return candidate_exe;
+    }
+
+    // Fall back to the deps subdirectory.
+    target_dir = target_dir.join("deps");
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+fn oxo_flow_cmd() -> Command {
+    Command::new(workspace_bin("oxo-flow"))
+}
+
+/// `test --run -t gen` executes exactly the targeted rule. With the swapped
+/// arguments the command errored with "unknown module 'gen'" and produced
+/// no output file.
+#[test]
+fn cli_test_run_target_applies_to_execution() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("t.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"t\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    oxo_flow_cmd()
+        .args(["test", "--run", "-t", "gen", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Execution"));
+    assert!(
+        dir.path().join("out.txt").exists(),
+        "the targeted rule must have executed"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("out.txt")).unwrap(),
+        "hi\n"
+    );
+}

--- a/tests/workflow_versioning.rs
+++ b/tests/workflow_versioning.rs
@@ -149,3 +149,206 @@ fn cli_run_outside_git_repo_has_no_workflow_git_sha() {
     let v: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(v.get("workflow_git_sha").is_none());
 }
+
+// ─── Run-log persistence (issue #115 pillar 1 extension) ─────────────────
+
+fn git_head(dir: &std::path::Path) -> String {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Every run archives its own log under `.oxo-flow/logs/oxo-flow.log` with
+/// numbered rotation: the second run moves the first run's log to `.1`.
+/// The header names the exact workflow version (name, version, git HEAD),
+/// and the engine's tracing stream is teed into the file.
+#[test]
+fn cli_run_log_rotates_and_names_workflow_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    };
+    git(&["init", "-q"]);
+    let wf = dir.path().join("logged.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"logged\"\nversion = \"2.3.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    git(&["add", "logged.oxoflow"]);
+    git(&[
+        "-c",
+        "user.name=oxo-test",
+        "-c",
+        "user.email=test@oxo-flow.local",
+        "commit",
+        "-q",
+        "-m",
+        "v1",
+    ]);
+    let head = git_head(dir.path());
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let log1 = dir.path().join(".oxo-flow/logs/oxo-flow.log");
+    let content1 = fs::read_to_string(&log1).unwrap();
+    assert!(
+        content1.starts_with("oxo-flow run log\n"),
+        "log must start with the run-log header: {content1}"
+    );
+    assert!(content1.contains(&format!("git_sha: {head}")));
+    assert!(content1.contains("workflow_name: logged"));
+    assert!(content1.contains("workflow_version: 2.3.0"));
+    assert!(
+        content1.contains("workflow run started"),
+        "the tracing stream must be teed into the log"
+    );
+    assert!(!dir.path().join(".oxo-flow/logs/oxo-flow.log.1").exists());
+
+    // Second run: the previous log rotates to .1, the new run owns the base.
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let content2 = fs::read_to_string(&log1).unwrap();
+    assert!(content2.starts_with("oxo-flow run log\n"));
+    let rotated = dir.path().join(".oxo-flow/logs/oxo-flow.log.1");
+    let content_rotated = fs::read_to_string(&rotated).unwrap();
+    assert_eq!(
+        content_rotated, content1,
+        "the first run's log must survive in .1"
+    );
+}
+
+/// Outside a git repository the run log still exists — the git_sha header
+/// line says so explicitly and the run never fails.
+#[test]
+fn cli_run_log_outside_git_repo_still_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("plain.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"plain\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let log = dir.path().join(".oxo-flow/logs/oxo-flow.log");
+    let content = fs::read_to_string(&log).unwrap();
+    assert!(content.contains("git_sha: (not inside a git repository)"));
+}
+
+/// `--log-file` overrides the default location; the default path is then
+/// left untouched.
+#[test]
+fn cli_run_log_file_flag_uses_custom_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("custom.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"custom\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    let custom = dir.path().join("my-run.log");
+    oxo_flow_cmd()
+        .args([
+            "run",
+            wf.to_str().unwrap(),
+            "--log-file",
+            custom.to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    assert!(
+        fs::read_to_string(&custom)
+            .unwrap()
+            .starts_with("oxo-flow run log\n")
+    );
+    assert!(!dir.path().join(".oxo-flow/logs/oxo-flow.log").exists());
+}
+
+/// The automatic report snapshot carries the workflow git SHA, closing the
+/// audit chain: checkpoint → run log → report all name the version.
+#[test]
+fn cli_run_report_snapshot_carries_workflow_git_sha() {
+    let dir = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    };
+    git(&["init", "-q"]);
+    let wf = dir.path().join("reported.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"reported\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    git(&["add", "reported.oxoflow"]);
+    git(&[
+        "-c",
+        "user.name=oxo-test",
+        "-c",
+        "user.email=test@oxo-flow.local",
+        "commit",
+        "-q",
+        "-m",
+        "v1",
+    ]);
+    let head = git_head(dir.path());
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let index: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(dir.path().join(".oxo-flow/reports/index.json")).unwrap(),
+    )
+    .unwrap();
+    let report_path = index
+        .as_array()
+        .and_then(|a| a.last())
+        .and_then(|e| e.get("report"))
+        .and_then(|r| r.as_str())
+        .expect("index.json must name the newest report");
+    let report: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(dir.path().join(".oxo-flow/reports").join(report_path)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(report["workflow_git_sha"].as_str(), Some(head.as_str()));
+}


### PR DESCRIPTION
## Summary

Per-run archived logging with versioned headers — the second half of the auditability story from #115 (closed): results now name their workflow version **in the run record itself**, not just the checkpoint.

- **Every run (and `resume`) archives its own log** under the workdir: `.oxo-flow/logs/oxo-flow.log` is always the latest run; on each new run the previous log rotates to `.oxo-flow.log.1`, then `.2`, … up to `.9` (oldest deleted). `--log-file PATH` overrides the location with the same rotation. Dry-run stays stderr-only.
- **The header names the exact workflow version**: timestamp, oxo-flow version, full command line, workflow path, `workflow_name`, `workflow_version`, git HEAD SHA, workdir. The engine's tracing stream is teed into the file — ANSI codes stripped, so the log is plain text. Logging is best-effort: file failures warn once and never fail the run.
- **Report snapshots now embed `workflow_git_sha`** (JSON field + HTML provenance pair), closing the audit chain: checkpoint → run log → report all name the version.
- **Regression fix**: `test --run -t` passed its target as the *module* argument (positional args swapped at one call site by PR #114), failing with "unknown module". Corrected, with a regression test.

## Tests

- 5 unit (`logging.rs`): rotation shift + cap deletion, no-op rotation, header + parent-dir creation, tee into file + deactivation, ANSI stripping.
- 5 integration: log rotation across two runs (first run's log survives in `.1` byte-identical), no-repo header (`git_sha: (not inside a git repository)`), `--log-file` custom path, report snapshot carries the SHA, `test --run -t` executes the targeted rule (verified RED against the re-introduced bug, then GREEN).
- Full `make ci` gate green; live demo on a real git repo (rotation, header SHA = `rev-parse HEAD`, tee'd events, custom path, report SHA).

## Test plan for reviewers

- [ ] `make ci`
- [ ] Run any workflow twice in the same directory → `.oxo-flow/logs/oxo-flow.log` (2nd run) + `oxo-flow.log.1` (1st run); header contains `git_sha: <HEAD>`
- [ ] `run --log-file custom.log` → custom path written, default untouched
- [ ] `test --run -t <rule>` on a workflow → executes only that rule
