### PR TITLE
feat(info): derive workflow git provenance in info --json (#124)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -130,7 +130,7 @@ fn derive_meta(
         .collect();
     references.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
 
-    json!({
+    let mut meta = json!({
         "command": "info",
         "workflow": workflow.display().to_string(),
         "name": cfg.workflow.name,
@@ -152,7 +152,58 @@ fn derive_meta(
         "references": references,
         "input_dirs": top_level_dirs(cfg.rules.iter().flat_map(|rule| rule.input.to_vec())),
         "output_dirs": top_level_dirs(cfg.rules.iter().flat_map(|rule| rule.output.to_vec())),
-    })
+    });
+    // Git provenance (issue #124 pillar 3): a workflow inside a git
+    // repository is uniquely addressable as repo + git ref. Keys are
+    // omitted entirely when unavailable — catalog consumers test presence.
+    if let Some((git_sha, git_remote, git_describe)) = git_provenance(workflow) {
+        meta["git_sha"] = json!(git_sha);
+        if let Some(remote) = git_remote {
+            meta["git_remote"] = json!(remote);
+        }
+        if let Some(describe) = git_describe {
+            meta["git_describe"] = json!(describe);
+        }
+    }
+    meta
+}
+
+/// Git identity of the workflow's repository: `(HEAD sha, origin remote
+/// URL, nearest tag)`. `None` when the workflow is not inside a git
+/// repository — `info --json` then omits the git keys entirely (issue
+/// #124 pillar 3, contract with the community catalog; field names agreed
+/// with the community lane: git_sha / git_remote / git_describe).
+fn git_provenance(workflow: &Path) -> Option<(String, Option<String>, Option<String>)> {
+    let root = oxo_flow_core::git::find_repo_root(workflow)?;
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if sha.is_empty() {
+        return None;
+    }
+    let git_output = |args: &[&str]| -> Option<String> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if value.is_empty() { None } else { Some(value) }
+    };
+    Some((
+        sha,
+        git_output(&["remote", "get-url", "origin"]),
+        git_output(&["describe", "--tags", "--always"]),
+    ))
 }
 
 /// `[config]` parameter records for the catalog parameter table: the default
@@ -524,6 +575,43 @@ mod tests {
             image_name("localhost:5000/biocontainers/star:2.7.10"),
             "star"
         );
+    }
+
+    #[test]
+    fn git_provenance_keys_present_inside_repo() {
+        // oxo-flow's own workspace is a git repository with an origin
+        // remote: deriving metadata for a workflow inside it must carry
+        // the git identity keys (issue #124 pillar 3). The real path is
+        // passed as both display and fixture so the walk-up finds .git.
+        let fixture = "../../examples/gallery/05_conda_environments.oxoflow";
+        let meta = meta(fixture, fixture);
+        assert_eq!(meta["git_sha"].as_str().map(|s| !s.is_empty()), Some(true));
+        assert_eq!(
+            meta["git_remote"].as_str().map(|s| !s.is_empty()),
+            Some(true)
+        );
+        assert_eq!(
+            meta["git_describe"].as_str().map(|s| !s.is_empty()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn git_provenance_keys_absent_outside_repo() {
+        let dir = std::env::temp_dir().join(format!("oxo-info-git-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wf = dir.join("wf.oxoflow");
+        std::fs::write(
+            &wf,
+            "[workflow]\nname = \"n\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"r\"\noutput = [\"o.txt\"]\nshell = \"echo hi > {output}\"\n",
+        )
+        .unwrap();
+        let meta = meta(wf.to_str().unwrap(), wf.to_str().unwrap());
+        assert!(meta.get("git_sha").is_none());
+        assert!(meta.get("git_remote").is_none());
+        assert!(meta.get("git_describe").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -283,24 +283,17 @@ impl CheckpointState {
     /// find `.git`, then runs `git rev-parse HEAD`. Returns `None` when the
     /// workflow is not in a git repository or git is unavailable.
     pub fn workflow_git_sha(workflow_path: &Path) -> Option<String> {
-        let start = workflow_path.parent().unwrap_or(workflow_path);
-        let mut dir = Some(start);
-        while let Some(d) = dir {
-            if d.join(".git").exists() {
-                let out = std::process::Command::new("git")
-                    .args(["rev-parse", "HEAD"])
-                    .current_dir(d)
-                    .output()
-                    .ok()?;
-                if out.status.success() {
-                    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                    if !sha.is_empty() {
-                        return Some(sha);
-                    }
-                }
-                return None;
+        let root = crate::git::find_repo_root(workflow_path)?;
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .output()
+            .ok()?;
+        if out.status.success() {
+            let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !sha.is_empty() {
+                return Some(sha);
             }
-            dir = d.parent();
         }
         None
     }

--- a/crates/oxo-flow-core/src/git.rs
+++ b/crates/oxo-flow-core/src/git.rs
@@ -5,6 +5,26 @@
 const GITHUB_CLONE_MIRRORS: &[&str] = &["https://ghfast.top/", "https://gh-proxy.com/"];
 
 /// Candidate clone URLs: the official URL first, then each mirror.
+/// Locate the root of the git repository containing `path`, if any: the
+/// nearest ancestor directory holding a `.git` entry. Walks up from
+/// `path`'s parent (when `path` is a file) or `path` itself (when it is a
+/// directory). Shared by checkpoint provenance (issue #115 pillar 1) and
+/// catalog metadata derivation (`info --json`, issue #124 pillar 3).
+pub fn find_repo_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Absolute first: lexical parent-walking on a shallow relative path
+    // (e.g. `examples/gallery/x.oxoflow` from the repo root) terminates at
+    // the empty path and would never reach the CWD's repository.
+    let start = std::path::absolute(path).ok()?;
+    let mut dir = Some(start.parent().unwrap_or(&start));
+    while let Some(d) = dir {
+        if d.join(".git").exists() {
+            return Some(d.to_path_buf());
+        }
+        dir = d.parent();
+    }
+    None
+}
+
 pub fn mirror_candidates(repo_url: &str) -> Vec<String> {
     let official = repo_url.trim_end_matches('/').to_string();
     if !official.starts_with("https://github.com/") {
@@ -63,4 +83,29 @@ pub fn cache_dir_name(repo_url: &str, git_ref: &str) -> String {
         .replace('/', "_");
     name.push_str(&format!("@{}", git_ref.replace('/', "_")));
     name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_repo_root_resolves_cwd_relative_workflow() {
+        // Regression: a shallow CWD-relative path (e.g. `examples/gallery/
+        // x.oxoflow` from the repo root) must still reach the repository —
+        // lexical parent-walking alone stops at the empty path and misses
+        // the CWD's repo. The core crate's test CWD is the workspace root.
+        let wf = std::path::Path::new("Cargo.toml");
+        let root = find_repo_root(wf).expect("workspace root is a git repo");
+        assert!(root.join(".git").exists());
+    }
+
+    #[test]
+    fn find_repo_root_returns_none_outside_repo() {
+        let dir = std::env::temp_dir().join(format!("oxo-gitroot-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(find_repo_root(&dir.join("wf.oxoflow")), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/docs/guide/src/commands/info.md
+++ b/docs/guide/src/commands/info.md
@@ -59,9 +59,21 @@ oxo-flow info [OPTIONS] <WORKFLOW>
   "pairs": [],
   "references": [],
   "input_dirs": ["raw"],
-  "output_dirs": ["aligned", "qc", "variants"]
+  "output_dirs": ["aligned", "qc", "variants"],
+  "git_sha": "8f005dab60a0ce024acc5048885d88e246119b5c",
+  "git_remote": "https://github.com/example/simple-variant-calling.git",
+  "git_describe": "v0.13.1"
 }
 ```
+
+- **`git_sha` / `git_remote` / `git_describe`** — the workflow's git
+  identity when it lives inside a git repository: the HEAD commit SHA, the
+  `origin` remote URL, and the nearest tag (`git describe --tags --always`,
+  falling back to an abbreviated SHA on untagged history). All three keys
+  are **omitted entirely** outside a git repository (never `null`), so
+  catalog consumers can test presence directly. The SHA matches the
+  `workflow_git_sha` recorded in run checkpoints (see
+  [Workflow Versioning](../reference/versioning.md)).
 
 - **`config`** — every `[config]` parameter with its default value, its
   derived type (`string` / `int` / `float` / `bool` / `array` / `table`), the

--- a/docs/guide/src/reference/versioning.md
+++ b/docs/guide/src/reference/versioning.md
@@ -44,11 +44,13 @@ for the include syntax and interface contracts.
 ## Pillar 3 — Ecosystem: the catalog is versioned
 
 Published workflows are referenced by repo + version, never by an
-unpinned "latest". The engine reads catalog metadata (`metadata.json`)
-when inspecting workflows (`oxo-flow info`); catalog entries and the
-community site record the repository and version of each published
-workflow, so a reference to a catalog entry resolves to a specific,
-reproducible artifact.
+unpinned "latest". `oxo-flow info --json` derives a workflow's git
+identity directly — `git_sha` (HEAD commit), `git_remote` (origin URL),
+and `git_describe` (nearest tag) — with the keys omitted outside a git
+repository (issue #124). Catalog generation consumes these fields to
+record the repository and version of each published workflow, so a
+reference to a catalog entry resolves to a specific, reproducible
+artifact.
 
 ## Comparison with other systems
 

--- a/tests/workflow_versioning.rs
+++ b/tests/workflow_versioning.rs
@@ -352,3 +352,94 @@ fn cli_run_report_snapshot_carries_workflow_git_sha() {
     .unwrap();
     assert_eq!(report["workflow_git_sha"].as_str(), Some(head.as_str()));
 }
+
+// ─── info --json git provenance (issue #124 pillar 3) ────────────────────
+
+/// `info --json` derives the workflow's git identity inside a repository
+/// (contract with the community catalog: keys omitted outside a repo).
+#[test]
+fn cli_info_json_carries_git_provenance_in_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    };
+    git(&["init", "-q"]);
+    git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/example/wf.git",
+    ]);
+    let wf = dir.path().join("wf.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"wf\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    git(&["add", "wf.oxoflow"]);
+    git(&[
+        "-c",
+        "user.name=oxo-test",
+        "-c",
+        "user.email=test@oxo-flow.local",
+        "commit",
+        "-q",
+        "-m",
+        "v1",
+    ]);
+    let head = git_head(dir.path());
+
+    let out = oxo_flow_cmd()
+        .args(["info", "--json", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let meta: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(meta["git_sha"].as_str(), Some(head.as_str()));
+    assert_eq!(
+        meta["git_remote"].as_str(),
+        Some("https://github.com/example/wf.git")
+    );
+    assert!(
+        meta["git_describe"].as_str().is_some_and(|s| !s.is_empty()),
+        "git_describe must fall back to an abbreviated SHA on untagged history"
+    );
+}
+
+/// Outside a git repository the git keys are omitted entirely — never null.
+#[test]
+fn cli_info_json_omits_git_provenance_outside_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("wf.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"wf\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    let out = oxo_flow_cmd()
+        .args(["info", "--json", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let meta: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(meta.get("git_sha").is_none());
+    assert!(meta.get("git_remote").is_none());
+    assert!(meta.get("git_describe").is_none());
+}


### PR DESCRIPTION
## Summary

Pillar 3 of the "git ref is the version" plan (#124): `oxo-flow info --json` derives the workflow's git identity directly from the repository it lives in, so any workflow is uniquely addressable as **repo + git ref** and catalog generation can record versions without hand-maintenance.

- New keys: `git_sha` (HEAD commit), `git_remote` (origin URL), `git_describe` (nearest tag via `git describe --tags --always`, falling back to an abbreviated SHA). **Keys are omitted entirely outside a git repository — never `null`** (contract with the community catalog; field names agreed with the community lane).
- `oxo_flow_core::git` gains `find_repo_root`, now shared with the checkpoint's `workflow_git_sha` resolver (DRY).
- Bug found by live verification and fixed: the repo-root walk terminated at the empty path for shallow CWD-relative workflow paths (e.g. `examples/gallery/x.oxoflow` from the repo root), so `info` missed the repository entirely. The walk now absolutizes the path first; regression test included.

## Tests

- 2 unit (`git.rs`): CWD-relative workflow resolves the repo root (the regression); outside a repo returns `None`.
- 2 unit (`info.rs`): git keys present for a workflow inside the oxo-flow repo itself; keys absent outside.
- 2 integration (`tests/workflow_versioning.rs`): `info --json` in a fresh git repo matches `rev-parse HEAD` / `remote get-url origin` / describe output; outside a repo all three keys are omitted.
- Full `make ci` gate green; live-verified against the oxo-flow repository — all three keys match git exactly.

## Test plan for reviewers

- [ ] `make ci`
- [ ] `oxo-flow info --json examples/gallery/05_conda_environments.oxoflow` (from the repo root) → `git_sha`/`git_remote`/`git_describe` match `git rev-parse HEAD` / `git remote get-url origin` / `git describe --tags --always`
- [ ] Same command on a workflow outside any git repo → keys absent

Part of #124 (engine side; community-site catalog entries are the community lane).
