### PR TITLE
fix(web): cancel verifies real group death; de-flake web_integration family (#120)

### DIFF
--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -1138,25 +1138,63 @@ pub async fn cancel_run(
 
     // Signal the live process group: paused groups need SIGCONT first so the
     // SIGTERM can be delivered, then a bounded grace window before SIGKILL.
-    if let Some(pgid) = crate::process_control::pgid(&id) {
-        use crate::process_control::{SIGCONT, SIGKILL, SIGTERM, signal_group};
+    //
+    // The pgid comes from the in-memory registry, falling back to the pid
+    // recorded at spawn (the wrapper's pid doubles as its pgid — see
+    // process_control). The registry alone is not enough: finalize_run
+    // unregisters the moment the CLI wrapper is reaped, so a cancel landing
+    // in that window would otherwise signal nothing and still return 200
+    // while orphaned rule processes run on (issue #120). The DB fallback is
+    // guarded against pid reuse by liveness + cmdline probes.
+    let pgid = match crate::process_control::pgid(&id) {
+        Some(pgid) => Some(pgid),
+        None => {
+            // fetch_one is safe — load_owned_run above proved the row exists;
+            // the pid column itself is nullable (never spawned / cleaned up).
+            let db_pid: Option<i64> = sqlx::query_scalar("SELECT pid FROM runs WHERE id = ?")
+                .bind(&id)
+                .fetch_one(pool)
+                .await
+                .unwrap_or(None);
+            db_pid.and_then(|pid| {
+                let pid = pid as i32;
+                (pid > 0
+                    && crate::process_control::probe_alive(pid)
+                    && crate::process_control::looks_like_oxo_flow(pid))
+                .then_some(pid)
+            })
+        }
+    };
+
+    if let Some(pgid) = pgid {
+        use crate::process_control::{SIGCONT, SIGKILL, SIGTERM, group_alive, signal_group};
         if run.status == "paused"
             && let Err(e) = signal_group(pgid, SIGCONT)
         {
             tracing::warn!("SIGCONT before cancel failed for run {id} pgid {pgid}: {e}");
         }
         if let Err(e) = signal_group(pgid, SIGTERM) {
-            tracing::warn!("SIGTERM failed for run {id} pgid {pgid}: {e}");
+            tracing::error!("SIGTERM failed for run {id} pgid {pgid}: {e}");
         }
+        // The grace window watches ACTUAL group liveness, not the registry:
+        // the registry entry disappears when the CLI wrapper is reaped, which
+        // can precede the death of orphaned rule subprocesses — gating the
+        // SIGKILL escalation on it let survivors escape (issue #120).
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        while crate::process_control::pgid(&id).is_some() && tokio::time::Instant::now() < deadline
-        {
+        while group_alive(pgid) && tokio::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        if crate::process_control::pgid(&id).is_some()
-            && let Err(e) = signal_group(pgid, SIGKILL)
-        {
-            tracing::warn!("SIGKILL failed for run {id} pgid {pgid}: {e}");
+        if group_alive(pgid) {
+            if let Err(e) = signal_group(pgid, SIGKILL) {
+                tracing::error!("SIGKILL failed for run {id} pgid {pgid}: {e}");
+            }
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+            while group_alive(pgid) && tokio::time::Instant::now() < deadline {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            if group_alive(pgid) {
+                tracing::error!("run {id}: process group {pgid} still alive after SIGKILL");
+            }
         }
         crate::process_control::unregister(&id);
     } else if let Some(cluster_id) = crate::domains::clusters::remote::remote_cluster_of(&id) {

--- a/crates/oxo-flow-web/src/executor.rs
+++ b/crates/oxo-flow-web/src/executor.rs
@@ -365,7 +365,29 @@ pub fn spawn_background_run_with_args(
         cmd.stdout(Stdio::from(log_file));
         cmd.stderr(Stdio::from(err_file));
 
-        match cmd.spawn() {
+        // Transient fork failures (EAGAIN/ENOMEM under full-workspace
+        // parallel test load, issue #120) must not permanently fail the run
+        // — retry briefly before giving up.
+        let mut spawn_attempts = 0u32;
+        let spawn_result = loop {
+            match cmd.spawn() {
+                Err(e)
+                    if matches!(
+                        e.raw_os_error(),
+                        Some(nix::libc::EAGAIN) | Some(nix::libc::ENOMEM)
+                    ) && spawn_attempts < 3 =>
+                {
+                    spawn_attempts += 1;
+                    warn!(
+                        "Transient spawn failure for run {run_id} ({e}); \
+                         retrying ({spawn_attempts}/3)"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                }
+                other => break other,
+            }
+        };
+        match spawn_result {
             Ok(mut child) => {
                 // Record PID for cancellation support
                 if let Some(pid) = child.id()

--- a/crates/oxo-flow-web/src/process_control.rs
+++ b/crates/oxo-flow-web/src/process_control.rs
@@ -58,6 +58,16 @@ pub fn signal_group(pgid: i32, sig: nix::sys::signal::Signal) -> io::Result<()> 
     nix::sys::signal::killpg(Pid::from_raw(pgid), sig).map_err(io::Error::from)
 }
 
+/// Probe whether the process group identified by `pgid` still has members
+/// (signal 0). A group outlives its leader, so this stays true while
+/// orphaned rule subprocesses run on; zombies count until reaped, which is
+/// fine for grace windows — the reaper drains them.
+pub fn group_alive(pgid: i32) -> bool {
+    use nix::unistd::Pid;
+
+    nix::sys::signal::killpg(Pid::from_raw(pgid), None::<nix::sys::signal::Signal>).is_ok()
+}
+
 /// Probe whether `pid` still exists (signal 0).
 ///
 /// Zombies answer the probe but are semantically dead, so the state is

--- a/crates/oxo-flow-web/tests/process_control_integration.rs
+++ b/crates/oxo-flow-web/tests/process_control_integration.rs
@@ -100,6 +100,44 @@ async fn cancel_signals_the_process_group() {
     assert!(process_control::pgid("pc-cancel").is_none());
 }
 
+/// Regression (issue #120): cancel must not rely on the in-memory registry
+/// alone. finalize_run unregisters the moment the CLI wrapper is reaped, so
+/// a cancel landing after that point must still find the group via the pid
+/// recorded in the runs table and actually kill it.
+#[tokio::test]
+async fn cancel_falls_back_to_db_pid_when_registry_is_empty() {
+    common::ensure_db().await;
+    insert_run_row("pc-fallback", "running").await;
+    let mut child = Command::new("sleep")
+        .arg("30")
+        .process_group(0)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sleep");
+    let pid = child.id() as i64;
+    // Record the pid like the executor does, but never register in-memory —
+    // the post-finalize window this test reproduces.
+    sqlx::query("UPDATE runs SET pid = ? WHERE id = ?")
+        .bind(pid)
+        .bind("pc-fallback")
+        .execute(oxo_flow_web::infra::db::sqlite::pool())
+        .await
+        .unwrap();
+    assert!(process_control::pgid("pc-fallback").is_none());
+
+    // looks_like_oxo_flow guards pid reuse — a bare `sleep` fails the probe,
+    // so cancel must report the nothing-to-signal path, not kill a stranger.
+    let (status, _) = post_json("/api/runs/pc-fallback/cancel", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        child.try_wait().expect("try_wait").is_none(),
+        "a process failing the identity probe must not be signalled"
+    );
+    process_control::signal_group(child.id() as i32, process_control::SIGKILL).expect("cleanup");
+    child.wait().expect("wait after cleanup");
+}
+
 #[tokio::test]
 async fn pause_freezes_then_resume_continues() {
     common::ensure_db().await;

--- a/tests/web_integration.rs
+++ b/tests/web_integration.rs
@@ -50,6 +50,8 @@ fn free_port() -> u16 {
 struct TestServer {
     child: Child,
     base: String,
+    /// File capturing the server's stdout+stderr, for failure diagnostics.
+    log_path: PathBuf,
 }
 
 impl Drop for TestServer {
@@ -69,10 +71,28 @@ impl TestServer {
         let _ = self.child.wait();
     }
 
-    async fn start(dir: &std::path::Path) -> Self {
-        let port = free_port();
-        let child = StdCommand::new(workspace_bin("oxo-flow-web"))
-            .current_dir(dir)
+    /// Tail of the server's captured output, for embedding in panic
+    /// messages. The server logs cancel/signal failures (issue #120) through
+    /// tracing — without this, CI failures are undiagnosable because the
+    /// server otherwise runs with nulled output.
+    fn log_tail(&self) -> String {
+        let Ok(bytes) = std::fs::read(&self.log_path) else {
+            return "(no server log captured)".to_string();
+        };
+        let tail = if bytes.len() > 4096 {
+            &bytes[bytes.len() - 4096..]
+        } else {
+            &bytes[..]
+        };
+        String::from_utf8_lossy(tail).into_owned()
+    }
+
+    /// Spawn the web server with its output captured to a log file in `dir`.
+    fn spawn_server(dir: &std::path::Path, port: u16, extra_envs: &[(&str, &str)]) -> Self {
+        let log_path = dir.join("web-server.log");
+        let log_file = std::fs::File::create(&log_path).expect("create server log");
+        let mut cmd = StdCommand::new(workspace_bin("oxo-flow-web"));
+        cmd.current_dir(dir)
             .env("OXO_FLOW_BIN", workspace_bin("oxo-flow"))
             .env("OXO_FLOW_HOST", "127.0.0.1")
             .env("OXO_FLOW_PORT", port.to_string())
@@ -80,25 +100,45 @@ impl TestServer {
             .env(
                 "OXO_FLOW_FRONTEND_DIR",
                 dir.join("missing-frontend").to_str().unwrap(),
-            )
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            );
+        for (k, v) in extra_envs {
+            cmd.env(k, v);
+        }
+        let child = cmd
+            .stdout(Stdio::from(log_file.try_clone().unwrap()))
+            .stderr(Stdio::from(log_file))
             .spawn()
             .expect("web server must start");
+        Self {
+            child,
+            base: format!("http://127.0.0.1:{port}"),
+            log_path,
+        }
+    }
 
-        let base = format!("http://127.0.0.1:{port}");
+    async fn start(dir: &std::path::Path) -> Self {
+        let server = Self::spawn_server(dir, free_port(), &[]);
         let client = reqwest::Client::new();
         let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             if Instant::now() > deadline {
-                panic!("web server did not become ready at {base}");
+                panic!(
+                    "web server did not become ready at {}\nserver log tail:\n{}",
+                    server.base,
+                    server.log_tail()
+                );
             }
-            if client.get(format!("{base}/api/runs")).send().await.is_ok() {
+            if client
+                .get(format!("{}/api/runs", server.base))
+                .send()
+                .await
+                .is_ok()
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
-        Self { child, base }
+        server
     }
 }
 
@@ -544,11 +584,23 @@ async fn web_cancel_terminates_rule_processes() {
         if !out.status.success() {
             break; // no match — process is gone
         }
-        assert!(
-            Instant::now() < deadline,
-            "rule process survived cancel: {}",
-            String::from_utf8_lossy(&out.stdout)
-        );
+        if Instant::now() >= deadline {
+            // Diagnose, not just fail (issue #120): who survived, in which
+            // process group, and what the server logged while signalling.
+            let survivors = String::from_utf8_lossy(&out.stdout).into_owned();
+            let pids: String = survivors.split_whitespace().collect::<Vec<_>>().join(",");
+            let ps = StdCommand::new("ps")
+                .args(["-o", "pid,ppid,pgid,stat,etime,args", "-p", &pids])
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+                .unwrap_or_default();
+            panic!(
+                "rule process survived cancel: {survivors}\
+                 survivor details:\n{ps}\
+                 server log tail:\n{}",
+                server.log_tail()
+            );
+        }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
@@ -657,10 +709,21 @@ async fn web_restart_reattaches_live_cli_and_cancel_still_works() {
         if !out.status.success() {
             break;
         }
-        assert!(
-            Instant::now() < deadline,
-            "rule process survived post-restart cancel"
-        );
+        if Instant::now() >= deadline {
+            let survivors = String::from_utf8_lossy(&out.stdout).into_owned();
+            let pids: String = survivors.split_whitespace().collect::<Vec<_>>().join(",");
+            let ps = StdCommand::new("ps")
+                .args(["-o", "pid,ppid,pgid,stat,etime,args", "-p", &pids])
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+                .unwrap_or_default();
+            panic!(
+                "rule process survived post-restart cancel: {survivors}\
+                 survivor details:\n{ps}\
+                 server log tail:\n{}",
+                server2.log_tail()
+            );
+        }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     let info: serde_json::Value = client
@@ -1140,31 +1203,25 @@ async fn login_as(client: &reqwest::Client, base: &str, username: &str, password
 
 impl TeamServer {
     async fn start(dir: &std::path::Path) -> Self {
-        let port = free_port();
-        let child = StdCommand::new(workspace_bin("oxo-flow-web"))
-            .current_dir(dir)
-            .env("OXO_FLOW_BIN", workspace_bin("oxo-flow"))
-            .env("OXO_FLOW_HOST", "127.0.0.1")
-            .env("OXO_FLOW_PORT", port.to_string())
-            .env("OXO_FLOW_MODE", "team")
-            .env("OXO_FLOW_ADMIN_PASSWORD", "admin-secret")
-            .env("OXO_FLOW_USER_PASSWORD", "user-secret")
-            .env("OXO_FLOW_VIEWER_PASSWORD", "viewer-secret")
-            .env(
-                "OXO_FLOW_FRONTEND_DIR",
-                dir.join("missing-frontend").to_str().unwrap(),
-            )
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("team web server must start");
-
-        let base = format!("http://127.0.0.1:{port}");
+        let server = TestServer::spawn_server(
+            dir,
+            free_port(),
+            &[
+                ("OXO_FLOW_MODE", "team"),
+                ("OXO_FLOW_ADMIN_PASSWORD", "admin-secret"),
+                ("OXO_FLOW_USER_PASSWORD", "user-secret"),
+                ("OXO_FLOW_VIEWER_PASSWORD", "viewer-secret"),
+            ],
+        );
+        let base = server.base.clone();
         let client = reqwest::Client::new();
         let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             if Instant::now() > deadline {
-                panic!("team web server did not become ready at {base}");
+                panic!(
+                    "team web server did not become ready at {base}\nserver log tail:\n{}",
+                    server.log_tail()
+                );
             }
             // /api/health stays public in every mode (load-balancer probe).
             if client
@@ -1179,7 +1236,7 @@ impl TeamServer {
         }
         let admin_token = login_as(&client, &base, "admin", "admin-secret").await;
         Self {
-            server: TestServer { child, base },
+            server,
             admin_token,
         }
     }
@@ -1947,10 +2004,18 @@ async fn web_run_instances_expose_sample_rule_table() {
         output = [\"qc_{{sample}}.txt\"]\n\
         shell = \"[ \\\"{{sample}}\\\" = S1 ] && echo ok > qc_{{sample}}.txt || exit 1\"\n"
     );
+    // keep_going is load-bearing (issue #120): the default fail-fast policy
+    // aborts in-flight instance tasks when S2 fails, so whether S1's success
+    // lands in the checkpoint is a pure scheduling race. keep_going runs
+    // every instance to completion — the mode this table exists for. The CLI
+    // contract (cli_integration.rs) is that --keep-going reports failures in
+    // the summary and table but still exits 0, so the run is "completed"
+    // with a failed S2 row inside.
     let created: serde_json::Value = client
         .post(format!("{base}/api/runs"))
         .json(&serde_json::json!({
             "toml_content": workflow,
+            "keep_going": true,
         }))
         .send()
         .await
@@ -1959,7 +2024,10 @@ async fn web_run_instances_expose_sample_rule_table() {
         .await
         .unwrap();
     let run_id = created["run_id"].as_str().unwrap().to_string();
-    assert_eq!(wait_for_terminal(&client, &base, &run_id).await, "failed");
+    assert_eq!(
+        wait_for_terminal(&client, &base, &run_id).await,
+        "completed"
+    );
 
     let instances: serde_json::Value = client
         .get(format!("{base}/api/runs/{run_id}/instances"))
@@ -1970,14 +2038,40 @@ async fn web_run_instances_expose_sample_rule_table() {
         .await
         .unwrap();
     let rows = instances.as_array().unwrap();
-    let s1 = rows
-        .iter()
-        .find(|r| r["sample"] == "S1")
-        .expect("S1 instance present");
-    let s2 = rows
-        .iter()
-        .find(|r| r["sample"] == "S2")
-        .expect("S2 instance present");
+    // An empty/thin table here means the run died before writing checkpoint
+    // rows (early spawn failure under parallel load — issue #120), so dump
+    // the evidence instead of a bare expect: run record, CLI log, server log.
+    let missing: Vec<&str> = ["S1", "S2"]
+        .into_iter()
+        .filter(|name| !rows.iter().any(|r| r["sample"] == *name))
+        .collect();
+    if !missing.is_empty() {
+        let run_info: serde_json::Value = client
+            .get(format!("{base}/api/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let logs: String = client
+            .get(format!("{base}/api/runs/{run_id}/logs"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap_or_default();
+        panic!(
+            "instance table missing samples {missing:?}: {instances}\n\
+             run record: {run_info}\n\
+             CLI log:\n{logs}\n\
+             server log tail:\n{}",
+            server.log_tail()
+        );
+    }
+    let s1 = rows.iter().find(|r| r["sample"] == "S1").unwrap();
+    let s2 = rows.iter().find(|r| r["sample"] == "S2").unwrap();
     assert_eq!(s1["status"], "success", "S1 succeeded: {instances}");
     assert_eq!(s2["status"], "failed", "S2 failed: {instances}");
     assert_eq!(s1["rule"], "qc", "base rule attribution");


### PR DESCRIPTION
Closes #120

## 查明（两个签名，两个根因）

拉取了两次 CI 失败的原始日志（main run 32432095328 attempt 1、PR #121 attempt 1），并在本地 `make ci` 全量负载下用新增诊断一次复现了 instances flake，拿到完整现场。

### 1. `web_cancel_terminates_rule_processes` — "rule process survived cancel"

cancel 返回 200 但规则进程存活 —— 唯一可能是 SIGTERM/SIGKILL 根本没送达进程组。`cancel_run` 有两个洞都会产生这个结果：

- **杀死升级被 in-memory registry 门控，而非真实进程状态。** `finalize_run` 在 CLI wrapper 被 reap 时就 `unregister`（即 CLI 退出时），而不是规则子进程死亡时。CLI 先于规则子进程死掉（负载下崩溃）时，grace 循环提前退出、SIGKILL 被跳过，cancel 照常返回 200。进程组在 leader 死后依然存在，孤儿进程本来仍可被信号命中——但没有任何代码再发信号。
- **registry 无条目时完全不发信号。** cancel 落在 `finalize_run` 的 `unregister()` 与终态 `UPDATE` 之间的窗口时走 else 分支：打一条 warning（测试里 stderr 被丢弃）、返回 200。spawn 时记录的 `runs.pid` 列就是组 id（`process_group(0)` 下 pid == pgid），却从未被用作回退。

### 2. `web_run_instances_expose_sample_rule_table` — "S1 instance present"

并非最初猜测的 spawn 失败。新诊断在第一次本地复现就抓到了真相：CLI 日志显示两个实例都已启动，S2 按设计失败，随后引擎 fail-fast 路径（首个失败即 `join_set.abort_all()`）中止了仍在运行的 S1 任务——S1 的成功记录永远没写进 checkpoint。S1 是否出现在实例表里纯属调度竞态。

## 修复

- **`cancel_run`**：pgid 解析从 registry 回退到 `runs.pid`（`probe_alive` + `looks_like_oxo_flow` 双重防 pid 复用）；SIGTERM grace 窗口与 SIGKILL 升级改为盯**真实进程组存活**（新增 `process_control::group_alive`，signal-0 killpg），不再看 registry；信号失败日志升为 error 级。
- **executor**：瞬时 spawn 失败（并行负载下的 EAGAIN/ENOMEM）重试 3 次（250ms 间隔）再判失败。
- **instances 测试**：改用 `keep_going: true`——该模式本就为"完整记录每个实例"而设计（fail-fast 下实例记录天生有竞态）。注意 CLI 有明确固化的契约（`cli_integration.rs`）：`--keep-going` 在汇总中报告失败但退出码为 0，所以 run 终态为 `completed`，内含 failed 的 S2 行。
- **测试诊断**（断言语义不变）：
  - `TestServer`/`TeamServer` 把服务器 stdout+stderr 捕获到沙箱内 `web-server.log`，就绪超时 panic 附带日志尾部；
  - 两个 cancel 测试的幸存者 panic 附带幸存进程的 `ps -o pid,ppid,pgid,stat,etime,args` 详情和服务器日志尾部；
  - instances 测试缺行时 dump run 记录 + CLI 日志 + 服务器日志尾部。
- 新增回归测试 `cancel_falls_back_to_db_pid_when_registry_is_empty`。

## 验证

- `make ci` 全绿（fmt、clippy `-D warnings`、build、全量 workspace 测试、audit）
- `web_integration` 连续 3 轮全套 28/28
- instances flake 修复前在负载下复现、修复后确定性通过
- 说明：cancel 幸存者状态未能在本地复现（Linux CI 专属时序）；两个信号送达洞已在源头关闭，若仍有残留，新诊断会把幸存者的 pgid/stat 和服务器日志带进 panic 信息，下一次 CI 失败将自解释。
