### PR TITLE
feat: resource-wait diagnostics + starvation-proof dispatch (aging & -j cap), W019 lint (#123)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1479,17 +1479,29 @@ pub async fn run_command(
         .iter()
         .map(|r| (r.name.clone(), r.priority))
         .collect();
+    // Fair-dispatch aging (issue #123): every dispatch round a rule spends
+    // ready-but-not-submitted adds AGING_STEP to its effective priority, so
+    // high-priority rules that keep failing/re-occupying slots cannot starve
+    // their lower-priority producers forever (live: auto-sra dumps at p10
+    // starved behind merges at p20 sharing the limit_merge group). Aging
+    // only matters under contention — with free slots everything submits
+    // immediately and the relative order is unchanged.
+    const AGING_STEP: i32 = 1;
+    let mut waited_rounds: std::collections::HashMap<String, i32> = Default::default();
     let compute_ready = |sched: &oxo_flow_core::scheduler::SchedulerState,
                          submitted: &std::collections::HashSet<String>,
                          dag: &WorkflowDag,
-                         order_set: &std::collections::HashSet<String>|
+                         order_set: &std::collections::HashSet<String>,
+                         waited: &std::collections::HashMap<String, i32>|
      -> Result<Vec<String>, anyhow::Error> {
         let mut ready = sched.ready_rules(dag)?;
         ready.retain(|name| order_set.contains(name) && !submitted.contains(name));
-        // Sort by priority (descending), then name.
+        // Sort by effective priority (declared + aging), then name.
         ready.sort_by(|a, b| {
-            let pa = priority_map.get(a).copied().unwrap_or(0);
-            let pb = priority_map.get(b).copied().unwrap_or(0);
+            let pa =
+                priority_map.get(a).copied().unwrap_or(0) + waited.get(a).copied().unwrap_or(0);
+            let pb =
+                priority_map.get(b).copied().unwrap_or(0) + waited.get(b).copied().unwrap_or(0);
             pb.cmp(&pa).then_with(|| a.cmp(b))
         });
         Ok(ready)
@@ -1503,9 +1515,16 @@ pub async fn run_command(
             sched.check_deadlock(&dag)?;
         }
 
-        // Submit every rule whose dependencies are now satisfied.
-        let ready = compute_ready(&sched, &submitted, &dag, &order_set)?;
-        for rule_name in &ready {
+        // Submit every rule whose dependencies are now satisfied — capped to
+        // the free -j slots so the semaphore queue never builds, and the
+        // ready list (aged by compute_ready) decides dispatch order fairly.
+        let ready = compute_ready(&sched, &submitted, &dag, &order_set, &waited_rounds)?;
+        let available = jobs.saturating_sub(sched.running_count());
+        let to_submit: Vec<String> = ready.iter().take(available).cloned().collect();
+        for name in ready.iter().skip(available) {
+            *waited_rounds.entry(name.clone()).or_insert(0) += AGING_STEP;
+        }
+        for rule_name in &to_submit {
             // Skip rules blocked by a failed upstream dependency.
             let blocked_by = {
                 let frs = failed_rules_set.lock().await;

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2343,10 +2343,10 @@ pub async fn run_command(
     Ok(())
 }
 
-/// Sorts the scheduler's ready list by effective priority (declared priority
-/// + rounds already waited, the aging counter of issue #123), ties broken by
-/// name. Pure and unit-tested: the dispatch loop feeds it the live ready list
-/// every round, so passed-over rules gain priority until they are submitted.
+/// Sorts the scheduler's ready list by effective priority: declared priority
+/// plus rounds already waited (the aging counter of issue #123), ties broken
+/// by name. Pure and unit-tested — the dispatch loop feeds it the live ready
+/// list every round, so passed-over rules gain priority until submitted.
 fn age_ready_list(
     mut ready: Vec<String>,
     order_set: &std::collections::HashSet<String>,

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1488,24 +1488,6 @@ pub async fn run_command(
     // immediately and the relative order is unchanged.
     const AGING_STEP: i32 = 1;
     let mut waited_rounds: std::collections::HashMap<String, i32> = Default::default();
-    let compute_ready = |sched: &oxo_flow_core::scheduler::SchedulerState,
-                         submitted: &std::collections::HashSet<String>,
-                         dag: &WorkflowDag,
-                         order_set: &std::collections::HashSet<String>,
-                         waited: &std::collections::HashMap<String, i32>|
-     -> Result<Vec<String>, anyhow::Error> {
-        let mut ready = sched.ready_rules(dag)?;
-        ready.retain(|name| order_set.contains(name) && !submitted.contains(name));
-        // Sort by effective priority (declared + aging), then name.
-        ready.sort_by(|a, b| {
-            let pa =
-                priority_map.get(a).copied().unwrap_or(0) + waited.get(a).copied().unwrap_or(0);
-            let pb =
-                priority_map.get(b).copied().unwrap_or(0) + waited.get(b).copied().unwrap_or(0);
-            pb.cmp(&pa).then_with(|| a.cmp(b))
-        });
-        Ok(ready)
-    };
 
     // ---- main event loop -------------------------------------------------
 
@@ -1517,8 +1499,14 @@ pub async fn run_command(
 
         // Submit every rule whose dependencies are now satisfied — capped to
         // the free -j slots so the semaphore queue never builds, and the
-        // ready list (aged by compute_ready) decides dispatch order fairly.
-        let ready = compute_ready(&sched, &submitted, &dag, &order_set, &waited_rounds)?;
+        // ready list (aged by age_ready_list) decides dispatch order fairly.
+        let ready = age_ready_list(
+            sched.ready_rules(&dag)?,
+            &order_set,
+            &submitted,
+            &priority_map,
+            &waited_rounds,
+        );
         let available = jobs.saturating_sub(sched.running_count());
         let to_submit: Vec<String> = ready.iter().take(available).cloned().collect();
         for name in ready.iter().skip(available) {
@@ -2353,6 +2341,26 @@ pub async fn run_command(
     }
 
     Ok(())
+}
+
+/// Sorts the scheduler's ready list by effective priority (declared priority
+/// + rounds already waited, the aging counter of issue #123), ties broken by
+/// name. Pure and unit-tested: the dispatch loop feeds it the live ready list
+/// every round, so passed-over rules gain priority until they are submitted.
+fn age_ready_list(
+    mut ready: Vec<String>,
+    order_set: &std::collections::HashSet<String>,
+    submitted: &std::collections::HashSet<String>,
+    priority_map: &std::collections::HashMap<String, i32>,
+    waited: &std::collections::HashMap<String, i32>,
+) -> Vec<String> {
+    ready.retain(|name| order_set.contains(name) && !submitted.contains(name));
+    ready.sort_by(|a, b| {
+        let pa = priority_map.get(a).copied().unwrap_or(0) + waited.get(a).copied().unwrap_or(0);
+        let pb = priority_map.get(b).copied().unwrap_or(0) + waited.get(b).copied().unwrap_or(0);
+        pb.cmp(&pa).then_with(|| a.cmp(b))
+    });
+    ready
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3636,11 +3644,87 @@ pub async fn resume_command(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_cli_overrides;
+    use super::{age_ready_list, parse_cli_overrides};
     use std::collections::HashSet;
 
     fn declared(keys: &[&str]) -> HashSet<String> {
         keys.iter().map(|k| k.to_string()).collect()
+    }
+
+    fn map_of(pairs: &[(&str, i32)]) -> std::collections::HashMap<String, i32> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    fn set_of(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn age_ready_list_orders_by_declared_priority_then_name() {
+        // Arrange
+        let priority = map_of(&[("high", 20), ("low", 10)]);
+        // Act
+        let ready = age_ready_list(
+            vec!["low".into(), "high".into()],
+            &set_of(&["high", "low"]),
+            &HashSet::new(),
+            &priority,
+            &std::collections::HashMap::new(),
+        );
+        // Assert
+        assert_eq!(ready, vec!["high", "low"]);
+    }
+
+    #[test]
+    fn age_ready_list_aged_rule_overtakes_higher_declared_priority() {
+        // The starvation cure (issue #123): a producer passed over for many
+        // rounds must eventually outrank the higher-priority rules that keep
+        // re-occupying the slots.
+        // Arrange
+        let priority = map_of(&[("merge", 20), ("dump", 10)]);
+        let waited = map_of(&[("dump", 15)]);
+        // Act
+        let ready = age_ready_list(
+            vec!["merge".into(), "dump".into()],
+            &set_of(&["merge", "dump"]),
+            &HashSet::new(),
+            &priority,
+            &waited,
+        );
+        // Assert
+        assert_eq!(ready, vec!["dump", "merge"]);
+    }
+
+    #[test]
+    fn age_ready_list_drops_submitted_and_out_of_scope_rules() {
+        // Arrange
+        let priority = map_of(&[("a", 5), ("b", 5), ("c", 5)]);
+        let submitted = set_of(&["b"]);
+        // Act
+        let ready = age_ready_list(
+            vec!["c".into(), "b".into(), "a".into()],
+            &set_of(&["a", "b", "c"]),
+            &submitted,
+            &priority,
+            &std::collections::HashMap::new(),
+        );
+        // Assert — b is already submitted, so it cannot be dispatched again.
+        assert_eq!(ready, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn age_ready_list_treats_missing_priority_and_waits_as_zero() {
+        // Arrange — neither rule appears in the maps.
+        // Act
+        let ready = age_ready_list(
+            vec!["z".into(), "a".into()],
+            &set_of(&["a", "z"]),
+            &HashSet::new(),
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+        );
+        // Assert — equal effective priority (0), name tie-break.
+        assert_eq!(ready, vec!["a", "z"]);
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -837,12 +837,37 @@ impl LocalExecutor {
             }
         }
 
+        // Wait diagnostics (issue #123): a rule parked here is invisible
+        // from the outside — it has printed "Running" but spawned nothing.
+        // Emit a throttled warning every 60s naming what the rule needs and
+        // WHO holds it, so priority-inversion starvation (live: auto-sra
+        // dumps starved by merges sharing the limit_merge group) is
+        // diagnosable from the log instead of hanging silently.
+        let wait_started = std::time::Instant::now();
+        let mut last_report = wait_started;
         loop {
             {
                 let mut pool = self.resource_pool.lock().await;
                 if pool.can_accommodate(rule, self.system_threads, self.system_memory_mb) {
                     pool.reserve(rule, self.system_threads, self.system_memory_mb);
+                    let waited = wait_started.elapsed().as_secs();
+                    if waited >= 60 {
+                        tracing::info!(
+                            rule = %rule.name,
+                            waited_secs = waited,
+                            "resource wait resolved"
+                        );
+                    }
                     return Ok(());
+                }
+                if last_report.elapsed().as_secs() >= 60 {
+                    tracing::warn!(
+                        rule = %rule.name,
+                        waited_secs = wait_started.elapsed().as_secs(),
+                        "waiting for resources: {}",
+                        pool.blockage_report(rule, self.system_threads, self.system_memory_mb)
+                    );
+                    last_report = std::time::Instant::now();
                 }
             }
             // Resources busy — wait for a release notification.

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -829,6 +829,26 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
             });
         }
 
+        // W019: Rule executes a command but declares no outputs. The engine's
+        // correctness machinery is output-driven — freshness checks, dataflow
+        // edges, failure invalidation (issue #118) — so an empty output list
+        // means downstream rules can only order against this rule via an
+        // explicit depends_on, and the produced files are invisible to the
+        // planner (live: auto-sra's dumps declared output = [] while writing
+        // the FASTQs merges consume — the missing edges fed a priority
+        // starvation incident).
+        if rule.output.is_empty() && (rule.shell.is_some() || rule.script.is_some()) {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                message: "rule executes a command but declares no outputs".to_string(),
+                rule: Some(rule.name.clone()),
+                code: "W019".to_string(),
+                suggestion: Some(
+                    "declare output = [...] naming the files this rule produces, or add depends_on = [\"<this rule>\"] to every consumer".to_string(),
+                ),
+            });
+        }
+
         // W009: Very high thread count (>32) without memory specification
         if rule.effective_threads() > 32 && rule.effective_memory().is_none() {
             diagnostics.push(Diagnostic {
@@ -3272,5 +3292,39 @@ mod tests {
         let config = WorkflowConfig::parse(toml).unwrap();
         let diagnostics = lint_format(&config);
         assert!(!diagnostics.iter().any(|d| d.code == "W022"));
+    }
+
+    #[test]
+    fn lint_executes_without_declared_outputs() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "produce"
+            shell = "echo data > sra/x.fastq"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "W019"),
+            "a rule executing a command with no declared outputs must warn: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_no_w019_for_declared_outputs() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "produce"
+            output = ["x.fastq"]
+            shell = "echo data > x.fastq"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(!diagnostics.iter().any(|d| d.code == "W019"));
     }
 }

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -537,6 +537,18 @@ pub fn effective_tool_resources(rule: &Rule, limits: ResourceLimits) -> (u32, u6
     (threads, memory_mb)
 }
 
+/// A rule's current holdings in the pool — the "who holds what" side of
+/// wait diagnostics (issue #123).
+#[derive(Debug, Clone, Default)]
+pub struct ActiveReservation {
+    /// Threads currently held.
+    pub threads: u32,
+    /// Memory currently held, in MB.
+    pub memory_mb: u64,
+    /// Per-group units currently held.
+    pub groups: HashMap<String, u32>,
+}
+
 /// Resource pool tracking available system resources and custom resource groups.
 #[derive(Debug, Clone)]
 pub struct ResourcePool {
@@ -548,6 +560,11 @@ pub struct ResourcePool {
 
     /// Available capacity for each resource group.
     pub groups: HashMap<String, u32>,
+
+    /// Per-rule active reservations — attribution for wait diagnostics.
+    /// A waiting rule holds nothing (reservations are atomic), so this map
+    /// never contains waiters; it is the holders-only side of the picture.
+    pub active: HashMap<String, ActiveReservation>,
 }
 
 impl ResourcePool {
@@ -557,6 +574,7 @@ impl ResourcePool {
             threads,
             memory_mb,
             groups: HashMap::new(),
+            active: HashMap::new(),
         }
     }
 
@@ -603,6 +621,14 @@ impl ResourcePool {
                 *available = available.saturating_sub(amount);
             }
         }
+
+        // Attribution for wait diagnostics (issue #123).
+        let reservation = ActiveReservation {
+            threads: reservation_threads(rule, max_threads),
+            memory_mb: reservation_memory_mb(rule, max_memory_mb),
+            groups: rule.resources.groups.clone(),
+        };
+        self.active.insert(rule.name.clone(), reservation);
     }
 
     /// Release resources after a rule completes.
@@ -627,6 +653,94 @@ impl ResourcePool {
                 *available = (*available + amount).min(max);
             }
         }
+
+        self.active.remove(&rule.name);
+    }
+
+    /// Human-readable explanation of why `rule` cannot be accommodated right
+    /// now, naming the top holders of whatever it needs (issue #123).
+    ///
+    /// Used by the executor's wait diagnostics — a rule stuck waiting on a
+    /// contended group (or on threads/memory) must surface WHO holds it, so
+    /// priority-inversion starvation is visible in the log instead of
+    /// manifesting as rules that print "Running" and never spawn.
+    ///
+    /// Note: requests beyond the pool's total capacity are clamped by
+    /// `can_accommodate`/`reserve` (an over-capacity rule runs alone), so a
+    /// threads/memory shortfall only ever arises from active holders —
+    /// the report is a contention picture, not an impossibility picture.
+    pub fn blockage_report(&self, rule: &Rule, max_threads: u32, max_memory_mb: u64) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        let need_threads = reservation_threads(rule, max_threads);
+        if self.threads < need_threads {
+            parts.push(format!(
+                "threads: need {need_threads}, have {}",
+                self.threads
+            ));
+        }
+        let need_memory = reservation_memory_mb(rule, max_memory_mb);
+        if self.memory_mb < need_memory {
+            parts.push(format!(
+                "memory: need {need_memory}MB, have {}MB",
+                self.memory_mb
+            ));
+        }
+        for (group_name, &required) in &rule.resources.groups {
+            let available = self.groups.get(group_name).copied().unwrap_or(0);
+            if available < required {
+                let holders: Vec<&str> = self
+                    .active
+                    .iter()
+                    .filter(|(_, r)| r.groups.get(group_name).copied().unwrap_or(0) > 0)
+                    .map(|(name, _)| name.as_str())
+                    .collect();
+                let holder_note = if holders.is_empty() {
+                    "(none active)".to_string()
+                } else {
+                    format!("held by [{}]", holders.join(", "))
+                };
+                parts.push(format!(
+                    "group '{group_name}': need {required}, have {available} {holder_note}"
+                ));
+            }
+        }
+        if parts.is_empty() {
+            parts.push("no single constraint found".to_string());
+        }
+
+        // Top thread/memory holders help even when a group is the blocker.
+        let mut by_threads: Vec<(&str, u32)> = self
+            .active
+            .iter()
+            .map(|(n, r)| (n.as_str(), r.threads))
+            .collect();
+        by_threads.sort_by_key(|(_, t)| std::cmp::Reverse(*t));
+        let mut by_memory: Vec<(&str, u64)> = self
+            .active
+            .iter()
+            .map(|(n, r)| (n.as_str(), r.memory_mb))
+            .collect();
+        by_memory.sort_by_key(|(_, m)| std::cmp::Reverse(*m));
+        let top_threads: Vec<String> = by_threads
+            .iter()
+            .take(3)
+            .filter(|(_, t)| *t > 0)
+            .map(|(n, t)| format!("{n}({t}t)"))
+            .collect();
+        let top_memory: Vec<String> = by_memory
+            .iter()
+            .take(3)
+            .filter(|(_, m)| *m > 0)
+            .map(|(n, m)| format!("{n}({m}MB)"))
+            .collect();
+        if !top_threads.is_empty() {
+            parts.push(format!("top thread holders: [{}]", top_threads.join(", ")));
+        }
+        if !top_memory.is_empty() {
+            parts.push(format!("top memory holders: [{}]", top_memory.join(", ")));
+        }
+        parts.join("; ")
     }
 }
 
@@ -1152,6 +1266,88 @@ mod tests {
         };
         // Unset threads -> 1 (safe default), unset memory -> whole machine.
         assert_eq!(effective_tool_resources(&rule, limits), (1, 32768));
+    }
+
+    fn rule_with_group(name: &str, group: &str, amount: u32) -> Rule {
+        let mut rule = Rule {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        rule.resources.groups.insert(group.to_string(), amount);
+        rule
+    }
+
+    #[test]
+    fn reserve_records_active_attribution_and_release_clears_it() {
+        let mut pool = ResourcePool::new(16, 32768);
+        pool.set_groups([("limit_merge".to_string(), 2)].into_iter().collect());
+        let rule = rule_with_group("merge_a", "limit_merge", 1);
+
+        pool.reserve(&rule, 16, 32768);
+        assert!(pool.active.contains_key("merge_a"));
+        assert_eq!(pool.groups["limit_merge"], 1);
+
+        pool.release(
+            &rule,
+            16,
+            32768,
+            &[("limit_merge".to_string(), 2)].into_iter().collect(),
+        );
+        assert!(!pool.active.contains_key("merge_a"));
+        assert_eq!(pool.groups["limit_merge"], 2);
+    }
+
+    #[test]
+    fn blockage_report_names_group_holders() {
+        let mut pool = ResourcePool::new(16, 32768);
+        pool.set_groups([("limit_merge".to_string(), 2)].into_iter().collect());
+        let holder = rule_with_group("merge_a", "limit_merge", 1);
+        let holder2 = rule_with_group("merge_b", "limit_merge", 1);
+        pool.reserve(&holder, 16, 32768);
+        pool.reserve(&holder2, 16, 32768);
+        // Group is now exhausted: both units held.
+        let waiter = rule_with_group("dump_x", "limit_merge", 1);
+        let report = pool.blockage_report(&waiter, 16, 32768);
+        assert!(
+            report.contains("group 'limit_merge': need 1, have 0"),
+            "report must state the group shortfall: {report}"
+        );
+        assert!(
+            report.contains("held by [merge_a, merge_b]")
+                || report.contains("held by [merge_b, merge_a]"),
+            "report must name the holders: {report}"
+        );
+    }
+
+    #[test]
+    fn blockage_report_covers_threads_and_memory_contention() {
+        // Over-capacity requests clamp to the whole pool (documented design),
+        // so a threads/memory shortfall only arises from CONTENTION — a
+        // holder consumes the capacity first.
+        let mut pool = ResourcePool::new(2, 4096);
+        let hog = Rule {
+            name: "hog".to_string(),
+            threads: Some(2),
+            memory: Some("3G".to_string()),
+            ..Default::default()
+        };
+        pool.reserve(&hog, 2, 4096);
+        let waiter = Rule {
+            name: "waiter".to_string(),
+            threads: Some(1),
+            memory: Some("2G".to_string()),
+            ..Default::default()
+        };
+        let report = pool.blockage_report(&waiter, 2, 4096);
+        assert!(
+            report.contains("threads: need 1, have 0"),
+            "threads shortfall: {report}"
+        );
+        assert!(
+            report.contains("memory: need 2048MB, have 1024MB"),
+            "memory shortfall: {report}"
+        );
+        assert!(report.contains("hog"), "top holders named: {report}");
     }
 }
 

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -353,19 +353,28 @@ high-priority side re-occupying the slots (e.g. merges at priority 20
 failing on missing inputs while the dumps that produce those inputs starve
 at priority 10).
 
-Since a waiting rule holds nothing (reservations are atomic), true
-deadlock cycles cannot form — the failure mode is livelock/starvation, and
-the engine now makes it **visible**: after 60 seconds of waiting, the run
-log emits, for each waiting rule:
+Two engine mechanisms address this:
+
+1. **Fair dispatch prevents it.** The scheduler caps each round's
+   submissions to the free `-j` slots and applies **priority aging**:
+   every round a ready rule is passed over, its effective priority gains
+   +1 (`effective = declared + rounds waited`). Starved producers
+   therefore outrank the higher-priority rules occupying the slots after
+   `priority gap` rounds — no manual priority rebalancing needed.
+2. **The wait is visible.** Since a waiting rule holds nothing
+   (reservations are atomic), true deadlock cycles cannot form — the
+   failure mode is livelock/starvation. After 60 seconds of waiting, the
+   run log emits, for each waiting rule:
 
 ```
 waiting for resources: group 'limit_merge': need 1, have 0 held by [merge_R1_data, merge_R2_data]; top thread holders: [...]
 ```
 
-Resolve by removing the shared-group claim (give each rule set its own
-group), restoring the missing `depends_on` edge so downstream rules cannot
-start before their producers, or rebalancing priorities so producers win
-the slots first.
+For workflows that still wait: remove the shared-group claim (give each
+rule set its own group), restore the missing `depends_on` edge so
+downstream rules cannot start before their producers, or declare `output`
+on producer rules that execute commands but declare nothing (`validate`
+flags these with warning W019).
 
 ### "A rule I expect to run is being skipped"
 

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -343,6 +343,30 @@ Resolve by giving each rule distinct output paths (e.g., `caller_a/{sample}.vcf`
 3. Check that rules at the same depth level don't have implicit file dependencies between them
 4. Resource constraints may serialize execution — check `--max-threads`/`--max-memory` aren't too restrictive
 
+### "Rules print Running but never spawn a process"
+
+A rule waiting for the resource pool is invisible from the outside — the
+run log shows `Running:` but no child process, no verdict. The most common
+cause is **shared resource-group starvation**: two rule sets claim the same
+`[resource_groups]` entry while a priority or dependency pattern keeps the
+high-priority side re-occupying the slots (e.g. merges at priority 20
+failing on missing inputs while the dumps that produce those inputs starve
+at priority 10).
+
+Since a waiting rule holds nothing (reservations are atomic), true
+deadlock cycles cannot form — the failure mode is livelock/starvation, and
+the engine now makes it **visible**: after 60 seconds of waiting, the run
+log emits, for each waiting rule:
+
+```
+waiting for resources: group 'limit_merge': need 1, have 0 held by [merge_R1_data, merge_R2_data]; top thread holders: [...]
+```
+
+Resolve by removing the shared-group claim (give each rule set its own
+group), restoring the missing `depends_on` edge so downstream rules cannot
+start before their producers, or rebalancing priorities so producers win
+the slots first.
+
 ### "A rule I expect to run is being skipped"
 
 1. Check `depends_on` — does the rule have unresolved explicit dependencies?


### PR DESCRIPTION
## Problem (issue #123, live evidence)

auto-sra campaign: dump rules printed `Running:` but never spawned a process — the pool's wait loop had no visibility, and a priority-inversion livelock (merges at p20 re-occupying the shared `limit_merge` group and failing on missing inputs, dumps at p10 starving forever) took days to diagnose. Manual priority rebalancing cured the workflow, but that cure belongs in the engine — most users would never find it.

## Part 1 — Make the wait visible (core)

- **Holder attribution**: `ResourcePool` now records active reservations per rule (threads/memory/groups). A waiting rule holds nothing (reservations are atomic), so wait-for cycles are impossible by construction; the failure mode is livelock, and this PR makes it *visible*.
- **`blockage_report()`**: why a rule cannot fit — per-constraint shortfalls, group holders named (`held by [merge_R1_data, merge_R2_data]`) + top thread/memory holders.
- **`check_resources`**: throttled warning every 60 s of waiting with the report; info line when a >60 s wait resolves.
- Scope-out documented in the issue: group-cycle detection was dropped — impossible by construction (waiters hold nothing); the observed starvation is priority livelock, now diagnosable from the log.

## Part 2 — Resolve the starvation automatically (cli)

Fairness à la OS scheduling, applied to the ready-queue:

- **Priority aging**: effective priority = declared priority + rounds waited. Every scheduling round a ready rule is passed over, it gains +1 — so starved rules eventually outrank the high-priority rules re-occupying the slots, without any workflow author intervention.
- **Submit cap**: each round submits at most the number of free `-j` slots. This gives aging its scheduling granularity: the ready list is re-evaluated every round instead of being drained all at once, which is what let a priority-inversion livelock persist indefinitely.
- **W019 lint**: `validate` now warns when a rule executes a command but declares no outputs — the classic footgun that leaves a producer invisible to the DAG, with a suggestion to declare `output` or add an explicit `depends_on`.

## Tests + docs

- 3 new pool unit tests (attribution, group-holder naming, contention shortfalls); scheduler suite green.
- 4 new `age_ready_list` unit tests (declared-priority order, aged overtake, submitted/scope filtering, zero defaults); the dispatch decision is now a pure, unit-tested function.
- dag-engine.md: troubleshooting entry "Rules print Running but never spawn a process" now documents both mechanisms (fair dispatch prevents, 60 s diagnostics reveal).

## Live A/B verification

Deterministic repro (30 merges at p20 becoming ready progressively, 1 producer at p10, shared capacity-1 group, `-j 2 --keep-going`), same workflow run by the pre-PR engine and this branch:

| engine | merges failed | producer position | merges succeeded |
|---|---|---|---|
| main (c62b060) | 18/30 | 19th (~41 s starved) | 12 |
| this PR | 1/30 | **2nd** | 29 |

Aging gains one step per scheduling round (which fires on every task completion), so the starved producer overtakes fresh p20 entrants after ~gap rounds — no workflow edits, no manual priority rebalancing.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
