### PR TITLE
fix: kill in-flight rule processes on abort — no more orphans (#131)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1900,6 +1900,19 @@ pub async fn run_command(
                 || status == oxo_flow_core::executor::JobStatus::Cancelled)
         {
             progress.finish_and_clear();
+            // Kill in-flight rule processes before cancelling their tasks —
+            // `abort_all()` alone orphans the OS children, which keep
+            // consuming the machine after the run exits (issue #131).
+            for (rule_name, pid) in executor.active_pids() {
+                if let Err(e) = oxo_flow_core::executor::timeout::kill_process_tree(pid) {
+                    tracing::warn!(
+                        rule = %rule_name,
+                        pid,
+                        error = %e,
+                        "failed to signal in-flight rule process during abort"
+                    );
+                }
+            }
             join_set.abort_all();
 
             // AI error recovery

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1815,6 +1815,9 @@ pub async fn run_command(
                 // A panicked task is an ENGINE fault, not a rule-level
                 // best-effort failure — always counts as required (the run
                 // fails), regardless of the rule's `required` flag.
+                // Its pool registration (if it was waiting) must not hold
+                // the FIFO line hostage — live waiters re-register.
+                executor.clear_resource_waiters().await;
                 fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 continue;
             }
@@ -1903,6 +1906,9 @@ pub async fn run_command(
             // Kill in-flight rule processes before cancelling their tasks —
             // `abort_all()` alone orphans the OS children, which keep
             // consuming the machine after the run exits (issue #131).
+            // Clear the pool's FIFO waiter queue first so cancelled waiters
+            // cannot hold the line hostage (issue #123 100% guarantee).
+            executor.clear_resource_waiters().await;
             for (rule_name, pid) in executor.active_pids() {
                 if let Err(e) = oxo_flow_core::executor::timeout::kill_process_tree(pid) {
                     tracing::warn!(

--- a/crates/oxo-flow-cli/src/logging.rs
+++ b/crates/oxo-flow-cli/src/logging.rs
@@ -218,6 +218,11 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    /// `activate_run_log` arms a PROCESS-GLOBAL slot; tests that arm it
+    /// must not interleave with each other (a parallel sibling deactivating
+    /// the slot mid-assertion was a recurring full-suite flake).
+    static GLOBAL_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn scratch(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("oxo-runlog-{tag}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
@@ -263,6 +268,7 @@ mod tests {
 
     #[test]
     fn activate_creates_parent_dirs_and_writes_header() {
+        let _guard = GLOBAL_STATE_LOCK.lock().unwrap();
         let dir = scratch("activate");
         let log = dir.join("nested/.oxo-flow/logs/oxo-flow.log");
         let mut guard = activate_run_log(&log, "run header\nsecond line\n").unwrap();
@@ -283,6 +289,7 @@ mod tests {
 
     #[test]
     fn tee_strips_ansi_codes_from_file_writes() {
+        let _guard = GLOBAL_STATE_LOCK.lock().unwrap();
         let dir = scratch("ansi");
         let log = dir.join("run.log");
         let _guard = activate_run_log(&log, "").unwrap();
@@ -305,6 +312,7 @@ mod tests {
 
     #[test]
     fn activate_replaces_previous_run_log_after_rotation() {
+        let _guard = GLOBAL_STATE_LOCK.lock().unwrap();
         let dir = scratch("replace");
         let base = dir.join("oxo-flow.log");
         fs::write(&base, "old run").unwrap();

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -331,6 +331,11 @@ pub struct LocalExecutor {
     system_memory_mb: u64,
     /// Shared per-run peak-RSS sampler (issue #67 §4).
     rss_sampler: Arc<super::rss::RssSampler>,
+    /// Currently spawned child pid per rule (issue #131) — the CLI's abort
+    /// path reads this to signal in-flight rule processes before cancelling
+    /// their tasks (`abort_all()` alone orphans them). `std::sync::Mutex`
+    /// because the registry is only ever touched for instant insert/remove.
+    active_pids: Arc<std::sync::Mutex<std::collections::HashMap<String, u32>>>,
 }
 
 /// Detect total system memory in MB using the most reliable method available
@@ -404,6 +409,22 @@ pub(crate) fn detect_swap_mb() -> u64 {
     0
 }
 
+/// Removes a rule's pid entry when `execute_rule_with_config` returns on
+/// any path — a rule with no in-flight child must not be signalable
+/// (issue #131). Drop cannot be async, hence the `std::sync::Mutex`.
+struct ActivePidGuard {
+    registry: Arc<std::sync::Mutex<std::collections::HashMap<String, u32>>>,
+    rule: String,
+}
+
+impl Drop for ActivePidGuard {
+    fn drop(&mut self) {
+        if let Ok(mut active) = self.registry.lock() {
+            active.remove(&self.rule);
+        }
+    }
+}
+
 impl LocalExecutor {
     pub fn new(config: ExecutorConfig) -> Self {
         let semaphore = Arc::new(Semaphore::new(config.max_jobs));
@@ -433,7 +454,18 @@ impl LocalExecutor {
             system_threads: max_threads,
             system_memory_mb: max_memory_mb,
             rss_sampler: Arc::new(super::rss::RssSampler::new()),
+            active_pids: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
+    }
+
+    /// Snapshot of the in-flight child pid per rule (issue #131). The
+    /// CLI's abort path signals these process trees before cancelling the
+    /// tasks, so a failed run never orphans running rules.
+    pub fn active_pids(&self) -> Vec<(String, u32)> {
+        self.active_pids
+            .lock()
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), *v)).collect())
+            .unwrap_or_default()
     }
 
     fn detect_system_resources(config: &ExecutorConfig) -> (u32, u64) {
@@ -1000,6 +1032,13 @@ impl LocalExecutor {
         wildcard_values: &HashMap<String, String>,
         config: &HashMap<String, toml::Value>,
     ) -> Result<JobRecord> {
+        // Covers every return path of this function: whatever the rule's
+        // outcome, once we leave here it no longer has an in-flight child
+        // (issue #131).
+        let _pid_guard = ActivePidGuard {
+            registry: Arc::clone(&self.active_pids),
+            rule: rule.name.clone(),
+        };
         let timeout = self.get_timeout(rule);
 
         let mut record = JobRecord {
@@ -1377,6 +1416,13 @@ impl LocalExecutor {
                 };
 
                 let child_id = child.id();
+                if let Some(pid) = child_id
+                    && let Ok(mut active) = self.active_pids.lock()
+                {
+                    // Latest spawn wins — a retry's earlier attempt is dead
+                    // (or being killed) by the time its successor starts.
+                    active.insert(rule.name.clone(), pid);
+                }
 
                 let rss_handle = child_id.map(|pid| self.rss_sampler.track(pid));
 

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -880,8 +880,10 @@ impl LocalExecutor {
         loop {
             {
                 let mut pool = self.resource_pool.lock().await;
-                if pool.can_accommodate(rule, self.system_threads, self.system_memory_mb) {
-                    pool.reserve(rule, self.system_threads, self.system_memory_mb);
+                // FIFO-gated acquisition (issue #123 100% guarantee): the
+                // pool serves waiters strictly in arrival order, so a senior
+                // waiter can never be leapfrogged by fresh arrivals.
+                if pool.try_acquire_fair(rule, self.system_threads, self.system_memory_mb) {
                     let waited = wait_started.elapsed().as_secs();
                     if waited >= 60 {
                         tracing::info!(
@@ -905,6 +907,14 @@ impl LocalExecutor {
             // Resources busy — wait for a release notification.
             self.resource_notify.notified().await;
         }
+    }
+
+    /// Clears the pool's waiter queue (issue #131): the CLI abort path calls
+    /// this before cancelling in-flight tasks, so cancelled waiters' entries
+    /// cannot hold the FIFO line hostage. Live waiters re-register on their
+    /// next acquisition attempt.
+    pub async fn clear_resource_waiters(&self) {
+        self.resource_pool.lock().await.clear_waiters();
     }
 
     async fn release_resources(&self, rule: &Rule) {

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -565,6 +565,11 @@ pub struct ResourcePool {
     /// A waiting rule holds nothing (reservations are atomic), so this map
     /// never contains waiters; it is the holders-only side of the picture.
     pub active: HashMap<String, ActiveReservation>,
+    /// Waiting rules in arrival order (issue #123, the 100% guarantee).
+    /// Acquisition is FIFO-gated on this queue: fresh arrivals can never
+    /// leapfrog a senior waiter, so priority-inversion starvation is
+    /// impossible, not merely unlikely.
+    pub waiters: std::collections::VecDeque<String>,
 }
 
 impl ResourcePool {
@@ -575,6 +580,7 @@ impl ResourcePool {
             memory_mb,
             groups: HashMap::new(),
             active: HashMap::new(),
+            waiters: std::collections::VecDeque::new(),
         }
     }
 
@@ -604,6 +610,40 @@ impl ResourcePool {
         }
 
         true
+    }
+
+    /// FIFO-gated acquisition (issue #123, the 100% guarantee): a rule may
+    /// reserve only when it is the OLDEST waiter. Fresh arrivals can never
+    /// leapfrog a senior waiter, so starvation by priority inversion is
+    /// impossible, not merely unlikely. Callers loop: `false` = registered
+    /// (or already registered) as a waiter, wait for the next release
+    /// notification and try again.
+    ///
+    /// Head-of-line semantics: when the oldest waiter cannot fit yet,
+    /// everyone behind it waits too. That can idle capacity briefly, but it
+    /// is the price of the guarantee — and it cannot deadlock: free capacity
+    /// only grows while waiters stand (holders always release), so the head
+    /// eventually fits and the line drains by induction.
+    pub fn try_acquire_fair(&mut self, rule: &Rule, max_threads: u32, max_memory_mb: u64) -> bool {
+        // An EMPTY queue means no one is ahead: the fast path for
+        // uncontended rules (and survivors after a clear).
+        let is_head = self.waiters.front().is_none_or(|head| head == &rule.name);
+        if is_head && self.can_accommodate(rule, max_threads, max_memory_mb) {
+            self.waiters.pop_front();
+            self.reserve(rule, max_threads, max_memory_mb);
+            return true;
+        }
+        if !self.waiters.iter().any(|w| w == &rule.name) {
+            self.waiters.push_back(rule.name.clone());
+        }
+        false
+    }
+
+    /// Drops every waiter entry — the CLI abort path clears cancelled
+    /// in-flight tasks so their registrations never hold the queue hostage
+    /// (issue #131 interplay). Live waiters re-register on their next try.
+    pub fn clear_waiters(&mut self) {
+        self.waiters.clear();
     }
 
     /// Reserve resources for a rule (clamped to the pool's total capacity).
@@ -1295,6 +1335,132 @@ mod tests {
         );
         assert!(!pool.active.contains_key("merge_a"));
         assert_eq!(pool.groups["limit_merge"], 2);
+    }
+
+    #[test]
+    fn fair_acquire_prevents_fresh_arrivals_leapfrogging_a_senior_waiter() {
+        // The 100% guarantee (issue #123): a senior waiter must be served
+        // before any LATER arrival, even when the later arrival wakes first.
+        let mut pool = ResourcePool::new(16, 32768);
+        pool.set_groups([("limit".to_string(), 1)].into_iter().collect());
+        let senior = rule_with_group("dump", "limit", 1);
+        let fresh = rule_with_group("merge", "limit", 1);
+        let holder = rule_with_group("holder", "limit", 1);
+
+        // Holder occupies the single slot; senior registers first.
+        pool.reserve(&holder, 16, 32768);
+        assert!(
+            !pool.try_acquire_fair(&senior, 16, 32768),
+            "senior must wait"
+        );
+        // Fresh arrival tries (and would win the free-for-all race) —
+        // must NOT acquire ahead of the senior.
+        assert!(!pool.try_acquire_fair(&fresh, 16, 32768), "fresh must wait");
+
+        // Holder releases. Simulate the adversarial wake order: FRESH wakes
+        // and tries first. FIFO must refuse it.
+        pool.release(
+            &holder,
+            16,
+            32768,
+            &[("limit".to_string(), 1)].into_iter().collect(),
+        );
+        assert!(
+            !pool.try_acquire_fair(&fresh, 16, 32768),
+            "fresh arrival must not leapfrog the senior waiter"
+        );
+        assert!(
+            pool.try_acquire_fair(&senior, 16, 32768),
+            "the senior waiter must acquire first"
+        );
+        // After the senior releases, the fresh arrival gets its turn.
+        pool.release(
+            &senior,
+            16,
+            32768,
+            &[("limit".to_string(), 1)].into_iter().collect(),
+        );
+        assert!(
+            pool.try_acquire_fair(&fresh, 16, 32768),
+            "fresh must be served next"
+        );
+    }
+
+    #[test]
+    fn fair_acquire_holds_the_line_behind_an_incompatible_head() {
+        // Head-of-line blocking is the price of the guarantee: a waiter that
+        // cannot fit yet parks everyone behind it (free capacity is monotone
+        // while waiters stand, so the head eventually fits — no deadlock).
+        let mut pool = ResourcePool::new(8, 32768);
+        let head = Rule {
+            name: "big".to_string(),
+            resources: crate::rule::Resources {
+                threads: 8,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let behind = Rule {
+            name: "small".to_string(),
+            resources: crate::rule::Resources {
+                threads: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let holder = Rule {
+            name: "holder".to_string(),
+            resources: crate::rule::Resources {
+                threads: 4,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        pool.reserve(&holder, 8, 32768); // free = 4
+        assert!(!pool.try_acquire_fair(&head, 8, 32768)); // needs 8, waits (head)
+        assert!(
+            !pool.try_acquire_fair(&behind, 8, 32768),
+            "a waiter behind an incompatible head must hold the line"
+        );
+
+        // Holder releases → free = 8 → the head fits and is served first.
+        pool.release(&holder, 8, 32768, &HashMap::new());
+        assert!(
+            pool.try_acquire_fair(&head, 8, 32768),
+            "head must fit after release"
+        );
+        pool.release(&head, 8, 32768, &HashMap::new());
+        assert!(
+            pool.try_acquire_fair(&behind, 8, 32768),
+            "the line must drain"
+        );
+    }
+
+    #[test]
+    fn clear_waiters_removes_stale_entries_from_cancelled_tasks() {
+        // The CLI abort path cancels in-flight tasks; their waiter entries
+        // must not hold the queue hostage (issue #131 interplay).
+        let mut pool = ResourcePool::new(16, 32768);
+        pool.set_groups([("limit".to_string(), 1)].into_iter().collect());
+        let stale = rule_with_group("cancelled", "limit", 1);
+        let holder = rule_with_group("holder", "limit", 1);
+
+        pool.reserve(&holder, 16, 32768);
+        assert!(!pool.try_acquire_fair(&stale, 16, 32768));
+        pool.clear_waiters();
+
+        let survivor = rule_with_group("survivor", "limit", 1);
+        pool.release(
+            &holder,
+            16,
+            32768,
+            &[("limit".to_string(), 1)].into_iter().collect(),
+        );
+        assert!(
+            pool.try_acquire_fair(&survivor, 16, 32768),
+            "a cleared queue must let fresh rules acquire immediately"
+        );
     }
 
     #[test]

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -353,18 +353,25 @@ high-priority side re-occupying the slots (e.g. merges at priority 20
 failing on missing inputs while the dumps that produce those inputs starve
 at priority 10).
 
-Two engine mechanisms address this:
+Three engine mechanisms address this — together they make priority
+starvation **impossible**, not merely unlikely:
 
-1. **Fair dispatch prevents it.** The scheduler caps each round's
-   submissions to the free `-j` slots and applies **priority aging**:
-   every round a ready rule is passed over, its effective priority gains
-   +1 (`effective = declared + rounds waited`). Starved producers
-   therefore outrank the higher-priority rules occupying the slots after
-   `priority gap` rounds — no manual priority rebalancing needed.
-2. **The wait is visible.** Since a waiting rule holds nothing
-   (reservations are atomic), true deadlock cycles cannot form — the
-   failure mode is livelock/starvation. After 60 seconds of waiting, the
-   run log emits, for each waiting rule:
+1. **Fair dispatch.** The scheduler caps each round's submissions to the
+   free `-j` slots and applies **priority aging**: every round a ready
+   rule is passed over, its effective priority gains +1 (`effective =
+   declared + rounds waited`). A starved producer therefore outranks
+   fresh high-priority rules after `priority gap` rounds.
+2. **FIFO resource acquisition (the guarantee).** Inside the resource
+   pool, capacity is granted strictly in arrival order: the oldest
+   waiter is served first, everyone else holds the line. The guarantee
+   is inductive — free capacity only grows while waiters stand (holders
+   always release), so the head eventually fits and the line drains. No
+   later arrival can ever leapfrog a senior waiter, and a waiting rule
+   holds nothing (reservations are atomic), so wait-for cycles cannot
+   form: **a ready rule always runs, in a bounded time, no matter the
+   priority pattern.**
+3. **The wait is visible.** After 60 seconds of waiting, the run log
+   emits, for each waiting rule:
 
 ```
 waiting for resources: group 'limit_merge': need 1, have 0 held by [merge_R1_data, merge_R2_data]; top thread holders: [...]

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -28,7 +28,7 @@ fn abort_kills_inflight_rule_processes() {
     fs::write(
         &wf,
         "[workflow]\nname = \"abort\"\n\n\
-         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 0.5\nexit 1\n\"\"\"\n\n\
+         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 2\nexit 1\n\"\"\"\n\n\
          [[rules]]\nname = \"slow\"\noutput = [\"slow.pid\"]\nshell = \"\"\"\n\
          echo $$ > slow.pid\nsleep 30\n\"\"\"\n",
     )

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -40,8 +40,8 @@ fn abort_kills_inflight_rule_processes() {
         .current_dir(dir.path())
         .output()
         .unwrap();
-    let run_log = fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log"))
-        .unwrap_or_default();
+    let run_log =
+        fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log")).unwrap_or_default();
     assert!(
         !run.status.success(),
         "the run must fail on 'bad':\n{}\n--- run log ---\n{}",

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -40,11 +40,19 @@ fn abort_kills_inflight_rule_processes() {
         .current_dir(dir.path())
         .output()
         .unwrap();
-    assert!(!run.status.success(), "the run must fail on 'bad'");
+    assert!(
+        !run.status.success(),
+        "the run must fail on 'bad':\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
 
     // Assert — slow spawned before the abort and must be dead after it.
     let pid_path = dir.path().join("slow.pid");
-    assert!(pid_path.exists(), "slow must have spawned before the abort");
+    assert!(
+        pid_path.exists(),
+        "slow must have spawned before the abort:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
     let pid: i32 = fs::read_to_string(&pid_path)
         .unwrap()
         .trim()

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -28,7 +28,7 @@ fn abort_kills_inflight_rule_processes() {
     fs::write(
         &wf,
         "[workflow]\nname = \"abort\"\n\n\
-         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 2\nexit 1\n\"\"\"\n\n\
+         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 10\nexit 1\n\"\"\"\n\n\
          [[rules]]\nname = \"slow\"\noutput = [\"slow.pid\"]\nshell = \"\"\"\n\
          echo $$ > slow.pid\nsleep 30\n\"\"\"\n",
     )
@@ -36,22 +36,26 @@ fn abort_kills_inflight_rule_processes() {
 
     // Act
     let run = oxo_flow_cmd()
-        .args(["run", wf.to_str().unwrap(), "-j", "2"])
+        .args(["run", wf.to_str().unwrap(), "-j", "2", "-v"])
         .current_dir(dir.path())
         .output()
         .unwrap();
+    let run_log = fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log"))
+        .unwrap_or_default();
     assert!(
         !run.status.success(),
-        "the run must fail on 'bad':\n{}",
-        String::from_utf8_lossy(&run.stderr)
+        "the run must fail on 'bad':\n{}\n--- run log ---\n{}",
+        String::from_utf8_lossy(&run.stderr),
+        run_log
     );
 
     // Assert — slow spawned before the abort and must be dead after it.
     let pid_path = dir.path().join("slow.pid");
     assert!(
         pid_path.exists(),
-        "slow must have spawned before the abort:\n{}",
-        String::from_utf8_lossy(&run.stderr)
+        "slow must have spawned before the abort:\n{}\n--- run log ---\n{}",
+        String::from_utf8_lossy(&run.stderr),
+        run_log
     );
     let pid: i32 = fs::read_to_string(&pid_path)
         .unwrap()

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -1,0 +1,68 @@
+//! Issue #131: when the run aborts on a required failure, in-flight rule
+//! processes must be killed — `abort_all()` alone cancels the tokio tasks
+//! but orphans the OS children (live: auto-sra v40 exited while 5 merges
+//! and 2 STAR kept running).
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_bin(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("target/debug");
+    path.push(name);
+    path
+}
+
+fn oxo_flow_cmd() -> Command {
+    Command::new(workspace_bin("oxo-flow"))
+}
+
+/// `bad` fails while `slow` is mid-sleep; the abort must signal `slow`'s
+/// process tree, not just cancel its task.
+#[test]
+fn abort_kills_inflight_rule_processes() {
+    // Arrange
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("abort.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"abort\"\n\n\
+         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 0.5\nexit 1\n\"\"\"\n\n\
+         [[rules]]\nname = \"slow\"\noutput = [\"slow.pid\"]\nshell = \"\"\"\n\
+         echo $$ > slow.pid\nsleep 30\n\"\"\"\n",
+    )
+    .unwrap();
+
+    // Act
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-j", "2"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!run.status.success(), "the run must fail on 'bad'");
+
+    // Assert — slow spawned before the abort and must be dead after it.
+    let pid_path = dir.path().join("slow.pid");
+    assert!(pid_path.exists(), "slow must have spawned before the abort");
+    let pid: i32 = fs::read_to_string(&pid_path)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .is_ok_and(|s| s.success());
+        if !alive {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("in-flight rule process {pid} survived the abort (orphaned)");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}

--- a/tests/abort_kills_inflight.rs
+++ b/tests/abort_kills_inflight.rs
@@ -5,7 +5,7 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn workspace_bin(name: &str) -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -19,7 +19,10 @@ fn oxo_flow_cmd() -> Command {
 }
 
 /// `bad` fails while `slow` is mid-sleep; the abort must signal `slow`'s
-/// process tree, not just cancel its task.
+/// process tree, not just cancel its task. The pid is captured WHILE the
+/// run is in flight — after the abort, the pid file itself is legitimately
+/// removed by failed-output invalidation (#118), so the surviving-file
+/// check would test the wrong property.
 #[test]
 fn abort_kills_inflight_rule_processes() {
     // Arrange
@@ -28,42 +31,42 @@ fn abort_kills_inflight_rule_processes() {
     fs::write(
         &wf,
         "[workflow]\nname = \"abort\"\n\n\
-         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 10\nexit 1\n\"\"\"\n\n\
+         [[rules]]\nname = \"bad\"\nshell = \"\"\"\nsleep 2\nexit 1\n\"\"\"\n\n\
          [[rules]]\nname = \"slow\"\noutput = [\"slow.pid\"]\nshell = \"\"\"\n\
          echo $$ > slow.pid\nsleep 30\n\"\"\"\n",
     )
     .unwrap();
 
-    // Act
-    let run = oxo_flow_cmd()
-        .args(["run", wf.to_str().unwrap(), "-j", "2", "-v"])
+    // Act — spawn the run in the background and capture slow's pid while
+    // it is still alive.
+    let mut child = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-j", "2"])
         .current_dir(dir.path())
-        .output()
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
         .unwrap();
-    let run_log =
-        fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log")).unwrap_or_default();
-    assert!(
-        !run.status.success(),
-        "the run must fail on 'bad':\n{}\n--- run log ---\n{}",
-        String::from_utf8_lossy(&run.stderr),
-        run_log
-    );
 
-    // Assert — slow spawned before the abort and must be dead after it.
     let pid_path = dir.path().join("slow.pid");
-    assert!(
-        pid_path.exists(),
-        "slow must have spawned before the abort:\n{}\n--- run log ---\n{}",
-        String::from_utf8_lossy(&run.stderr),
-        run_log
-    );
-    let pid: i32 = fs::read_to_string(&pid_path)
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
+    let pid_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let pid: i32 = loop {
+        if let Ok(content) = fs::read_to_string(&pid_path)
+            && let Ok(pid) = content.trim().parse()
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < pid_deadline,
+            "slow must have spawned before the abort"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let status = child.wait().unwrap();
+    assert!(!status.success(), "the run must fail on 'bad'");
+
+    // Assert — the abort must have killed slow's process tree.
+    let kill_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let alive = Command::new("kill")
             .args(["-0", &pid.to_string()])
@@ -72,7 +75,7 @@ fn abort_kills_inflight_rule_processes() {
         if !alive {
             break;
         }
-        if std::time::Instant::now() > deadline {
+        if std::time::Instant::now() > kill_deadline {
             panic!("in-flight rule process {pid} survived the abort (orphaned)");
         }
         std::thread::sleep(std::time::Duration::from_millis(100));


### PR DESCRIPTION
## Problem (issue #131, live evidence from the b6 campaign)

auto-sra v40: `dump_41` failed; the engine kept scheduling ~6 min, then `Error: workflow execution failed` — **5 merges + 2 STAR were still running when the run exited** and kept running as orphans (never reaped). clindet-RNA runs 3-8 repeated the pattern.

## Root cause (code-verified)

The abort path (`run.rs`: required failure + `!keep_going`) called `join_set.abort_all()` — cancelling the tokio tasks but never signaling the rule children. The executor spawns each rule's shell without `kill_on_drop`, so the OS child (and its subtree: conda run → python, STAR, …) survives the exit.

## Fix

- **Core**: `LocalExecutor` gains an `active_pids` registry (rule → currently spawned child pid), updated at each spawn and cleared by a Drop guard covering **every** return path of `execute_rule_with_config`; `pub fn active_pids()` snapshots it.
- **CLI abort path**: before `abort_all()`, each active pid's **process tree** is signaled via the existing `kill_process_tree` (subtree-aware — grandchildren included).

## Tests

- TDD: `tests/abort_kills_inflight.rs` — a failing rule aborts a run while a second rule is mid-`sleep 30`; the test reproduced the orphan on the pre-fix binary (RED: pid survived) and passes after (GREEN: pid dead on first probe).
- Full local gate pending: fmt + clippy + workspace tests.

Closes #131.