### PR TITLE
fix: keep-going exits non-zero on required failures (#133)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2355,7 +2355,12 @@ pub async fn run_command(
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     }
 
-    if fail_count > 0 && !keep_going {
+    // The verdict is independent of --keep-going (issue #133): keep-going
+    // changes SCHEDULING (failures don't stop the run), never the verdict —
+    // a run with required failures exits non-zero so scripts and the web
+    // delegator (which classifies by exit code) see the truth.
+    // `required = false` failures keep exit 0 (issue #99 B2).
+    if fail_count > 0 {
         return Err(anyhow::anyhow!("workflow execution failed"));
     }
 

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -748,6 +748,11 @@ A progress bar shows execution progress with:
 - The DAG is built and validated before any rules execute
 - Rules are executed in topological order; independent rules may run in parallel up to the `-j` limit
 - If `--keep-going` is not set, execution stops at the first failure
+- **`--keep-going` changes scheduling, never the verdict:** it runs the
+  remaining rules past a failure, but the run still exits non-zero when a
+  `required` rule failed — scripts and the web UI (which classifies by
+  exit code) see the truth. Only `required = false` failures leave the
+  exit code at 0.
 - The `--retry` flag re-runs failed jobs up to N times before marking them as failed
 - A timeout of `0` means no timeout
 - Resource constraints (`threads`, `memory`) in rules are checked against available resources before execution

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1828,12 +1828,13 @@ fn cli_report_failed_moves_diagnosis_first() {
     )
     .unwrap();
 
-    // -k runs every rule and exits 0 while recording the failure.
+    // -k runs every rule while recording the failure; the verdict is still
+    // non-zero (issue #133 — required failures fail the run regardless).
     oxo_flow_cmd()
         .args(["run", "-k", wf.to_str().unwrap()])
         .current_dir(dir.path())
         .assert()
-        .success();
+        .failure();
 
     let section_ids = |args: &[&str]| -> Vec<String> {
         let out = oxo_flow_cmd()

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1603,13 +1603,14 @@ fn cli_report_sample_matrix_matches_named_group_instances() {
     )
     .unwrap();
 
-    // `--keep-going` runs every expanded instance to completion (exit 0
-    // even with failed jobs), so the checkpoint records align's success
-    // and call's failure for S1 and S2.
+    // `--keep-going` runs every expanded instance to completion; the
+    // verdict is still non-zero because a REQUIRED rule failed (issue
+    // #133 — keep-going changes scheduling, never the verdict). The
+    // checkpoint records align's success and call's failure for S1 and S2.
     oxo_flow_cmd()
         .args(["run", "-k", path.to_str().unwrap()])
         .assert()
-        .success();
+        .failure();
 
     let out = dir.path().join("report.json");
     oxo_flow_cmd()
@@ -3334,7 +3335,13 @@ shell = "echo 'I ran despite the failure' > {ok}"
         .output()
         .expect("failed to run");
 
-    // Should not hard-fail (keep-going), but stderr should mention the failure
+    // The verdict stays non-zero: keep-going changes scheduling, never the
+    // verdict (issue #133) — required failures must fail the run.
+    assert!(
+        !output.status.success(),
+        "keep-going must still exit non-zero when a required rule failed"
+    );
+    // Stderr mentions the failure + the consolidated summary.
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("fail_step") || stderr.contains("failed") || stderr.contains("✗"),
@@ -8209,12 +8216,13 @@ fn cli_run_snapshot_after_failed_run() {
          [[rules]]\nname = \"after\"\nshell = \"echo ok > after.txt\"\noutput = [\"after.txt\"]\n",
     );
 
-    // --keep-going runs report failures in the summary and exit 0 (existing
-    // semantics); the snapshot is taken before the summary completes.
+    // --keep-going runs report failures in the summary and exit non-zero
+    // (issue #133: required failures always fail the run); the snapshot is
+    // taken before the verdict.
     oxo_flow_cmd()
         .args(["run", wf.to_str().unwrap(), "--keep-going"])
         .assert()
-        .success();
+        .failure();
 
     let snapshots = snapshot_files(dir.path());
     assert_eq!(

--- a/tests/web_integration.rs
+++ b/tests/web_integration.rs
@@ -2007,10 +2007,10 @@ async fn web_run_instances_expose_sample_rule_table() {
     // keep_going is load-bearing (issue #120): the default fail-fast policy
     // aborts in-flight instance tasks when S2 fails, so whether S1's success
     // lands in the checkpoint is a pure scheduling race. keep_going runs
-    // every instance to completion — the mode this table exists for. The CLI
-    // contract (cli_integration.rs) is that --keep-going reports failures in
-    // the summary and table but still exits 0, so the run is "completed"
-    // with a failed S2 row inside.
+    // every instance to completion. Since issue #133, a run with a REQUIRED
+    // failure exits non-zero (keep-going changes scheduling, never the
+    // verdict), so the run is "failed" — but the instances table still
+    // carries the full per-sample picture (S1 succeeded, S2 failed).
     let created: serde_json::Value = client
         .post(format!("{base}/api/runs"))
         .json(&serde_json::json!({
@@ -2024,10 +2024,7 @@ async fn web_run_instances_expose_sample_rule_table() {
         .await
         .unwrap();
     let run_id = created["run_id"].as_str().unwrap().to_string();
-    assert_eq!(
-        wait_for_terminal(&client, &base, &run_id).await,
-        "completed"
-    );
+    assert_eq!(wait_for_terminal(&client, &base, &run_id).await, "failed");
 
     let instances: serde_json::Value = client
         .get(format!("{base}/api/runs/{run_id}/instances"))


### PR DESCRIPTION
## Problem (issue #133, live evidence)

clindet-RNA run 11 on tx-ubuntu: one required rule failed, the run continued under `--keep-going`, **exit code 0**. Scripts cannot tell a failed run from a clean one, and the web delegator (`final_status_from_exit`) recorded failed keep-going runs as **completed**.

The old behavior was an established tested contract (`cli_integration.rs` asserted `.success()` explicitly), so this changes it deliberately.

## New contract

- `--keep-going` continues to change SCHEDULING only: failures don't stop the run.
- The verdict: exit non-zero (1) when any **required** rule failed — regardless of `--keep-going` (make -k / Snakemake semantics).
- `required = false` failures keep exit 0 (issue #99 B2 unchanged).
- The JSON summary already reported `"status": "failed"` — only the exit code diverged; now they agree.

## Changes

- `run.rs`: the final verdict drops the `&& !keep_going` condition.
- Tests updated at all four sites encoding the old contract: two `cli_integration` tests, `web_integration`'s instances-table test (now expects `failed` with the full per-sample table intact), `cli_run_snapshot_after_failed_run`.
- `run.md`: documents the verdict contract.

The web path needs no code change: with the CLI now exiting truthfully, `final_status_from_exit` classifies correctly.

Closes #133.