### PR TITLE
fix: audit #136 tier-1 — dispatch regressions, log masking, core safety, CI release integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,15 @@ on:
         default: ''
 
 # Cancel in-progress runs for the same branch/PR; preserve tag releases.
+# A dispatch-driven release (tag input set) runs in its own concurrency
+# group so that a push to main — including the version-bump commit the
+# release itself pushes — cannot cancel it between the commit push and the
+# tag push (which previously left main bumped with no tag).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') &&
+         format('{0}-release-{1}', github.workflow, inputs.tag) ||
+         format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
@@ -41,6 +48,30 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate release tag format
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid release tag '${TAG}'. Expected v<major>.<minor>.<patch>, e.g. v0.14.0. Aborting before any commit or push."
+            exit 1
+          fi
+          echo "Release tag format OK: ${TAG}"
+
+      - name: Ensure release tag does not already exist
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          if [ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]; then
+            echo "::error::Tag ${TAG} already exists on origin. Never move a released tag — pick a new version for this release."
+            exit 1
+          fi
+          echo "Tag ${TAG} does not exist yet — safe to create"
 
       - name: Extract version from tag
         id: extract
@@ -132,10 +163,10 @@ jobs:
           [ -d docs/guide/src ] && git add docs/guide/src/*.md docs/guide/src/**/*.md
           # Re-tagging a version whose files are already synced leaves nothing
           # to commit (CITATION.cff/docs branches set CHANGED unconditionally).
-          # Tolerate it: keep the tag where it is and let the rest of the
-          # workflow proceed against the tag SHA.
+          # Tolerate it: the dedicated "Create and push release tag" step
+          # still creates the tag against the current tree.
           if git diff --cached --quiet; then
-            echo "Version already synced — nothing to commit; keeping tag at $GITHUB_SHA"
+            echo "Version already synced — nothing to commit"
             exit 0
           fi
           git commit -m "chore: bump version to ${{ steps.extract.outputs.version }} [skip ci]"
@@ -143,16 +174,63 @@ jobs:
           NEW_SHA=$(git rev-parse HEAD)
           echo "updated_sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
           echo "New commit: $NEW_SHA"
+
+      - name: Install git-cliff
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff@2.12.0
+
+      # The changelog commit is created and pushed BEFORE the tag so the tag
+      # tree (git checkout <tag>) contains its own changelog entry. The tag is
+      # created locally first so git-cliff labels the top section with this
+      # version instead of "[Unreleased]".
+      - name: Generate and commit CHANGELOG.md
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG_NAME="${{ env.RELEASE_TAG }}"
+          git tag -f "$TAG_NAME" "$(git rev-parse HEAD)"
+          git-cliff --config cliff.toml --output CHANGELOG.md
+          if ! git diff --quiet CHANGELOG.md; then
+            git add CHANGELOG.md
+            git commit -m "docs: update CHANGELOG.md for ${TAG_NAME} [skip ci]"
+            git push origin "HEAD:${{ github.event.repository.default_branch }}"
+            echo "CHANGELOG.md committed at $(git rev-parse HEAD)"
+          else
+            echo "CHANGELOG.md is already up-to-date"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+
+      # Unconditional within the dispatch release path (idempotent): creates
+      # the tag against the current HEAD — the changelog commit when one was
+      # made, otherwise the bump commit or the already-synced main tip — and
+      # pushes it. The interrupted state "main bumped, no tag" is therefore
+      # recoverable by re-dispatching the same version.
+      - name: Create and push release tag
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ env.RELEASE_TAG }}"
+          TARGET_SHA=$(git rev-parse HEAD)
           if git cat-file -t "$TAG_NAME" 2>/dev/null | grep -q '^tag$'; then
             TAG_MSG=$(git tag -l --format='%(contents)' "$TAG_NAME")
             git tag -d "$TAG_NAME"
-            git tag -a "$TAG_NAME" "$NEW_SHA" -m "$TAG_MSG"
+            git tag -a "$TAG_NAME" "$TARGET_SHA" -m "$TAG_MSG"
           else
-            git tag -f "$TAG_NAME" "$NEW_SHA"
+            git tag -f "$TAG_NAME" "$TARGET_SHA"
           fi
-          git push origin "$TAG_NAME" --force
-          echo "Tag $TAG_NAME moved to $NEW_SHA"
+          # No --force: the existence guard above already verified the tag is
+          # absent remotely, so a plain push fails safely if one appeared in
+          # between — a released tag is never moved.
+          git push origin "$TAG_NAME"
+          echo "Tag $TAG_NAME created at $TARGET_SHA"
 
   # ─── Quality gate: fmt + clippy + tests ────────────────────────────────────
   test:

--- a/cliff.toml
+++ b/cliff.toml
@@ -65,6 +65,10 @@ filter_unconventional = false
 split_commits = false
 
 commit_parsers = [
+  # Release machinery noise: version bumps and CHANGELOG regen commits are
+  # tooling artifacts, not user-facing changes.
+  { message = "^chore: bump version", skip = true },
+  { message = "^docs: update CHANGELOG", skip = true },
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^perf", group = "Performance" },

--- a/crates/oxo-flow-cli/src/commands/cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/cluster.rs
@@ -177,6 +177,7 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
             extra_args,
             output,
             target,
+            module,
             dry_run,
             with_dependencies,
         } => {
@@ -194,6 +195,32 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
 
             let dag =
                 WorkflowDag::from_rules(&config.rules).context("failed to build workflow DAG")?;
+
+            // --module partial runs (issue #112 elasticity) — the same
+            // resolution `run` and `dry-run` use: each module name resolves
+            // to its rules plus the host producers of its declared concrete
+            // inputs, unioned into --target for the ordering machinery below.
+            let mut target = target;
+            for m in &module {
+                match config.module_closure(m) {
+                    Some(names) => target.extend(names),
+                    None => {
+                        let known: Vec<&String> = config.module_rules.keys().collect();
+                        return Err(anyhow::anyhow!(
+                            "unknown module '{m}' — known modules: {}",
+                            if known.is_empty() {
+                                "(none — no [[include]] modules)".to_string()
+                            } else {
+                                known
+                                    .iter()
+                                    .map(|k| k.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            }
+                        ));
+                    }
+                }
+            }
 
             let order = if target.is_empty() {
                 dag.execution_order()?

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -478,6 +478,13 @@ pub async fn run_command(
 ) -> Result<()> {
     print_banner();
 
+    // `-j 0` means "no explicit concurrency limit": clamp once at the
+    // boundary so every downstream consumer — the scheduler submit cap,
+    // the run-loop semaphore, and the executor's own semaphore (which
+    // would otherwise be a zero-permit gate that hangs the first
+    // submission) — sees a consistent value (issue #136 fix 1).
+    let jobs = jobs.max(1);
+
     // ── Repository-URL workflows (nextflow-style `run <repo>`) ──────────
     // `oxo-flow run gh:owner/repo[@ref]` (or a *.git URL / local repo dir)
     // checks out into <cwd>/.oxo-flow/repos/<name> (reused on later runs).
@@ -600,19 +607,31 @@ pub async fn run_command(
     // own log under the workdir with numbered rotation; the header names
     // the exact workflow version (name, version, git HEAD) that produced
     // this record. Best-effort: a logging failure never fails the run.
+    // Sensitive values must be computed BEFORE the run-log header is built:
+    // the header embeds the raw command line, and `--arg KEY=secret` would
+    // otherwise land in plaintext in the run log and its rotated backups
+    // (issue #99 B1 / #136 fix 3). Computed once here; the executor's
+    // capture masking below reuses the same list.
+    let sensitive_values = sensitive_values_of(&config);
     let workflow_abs = absolutize(&workflow)?;
     let workflow_git_sha =
         oxo_flow_core::executor::checkpoint::CheckpointState::workflow_git_sha(&workflow_abs);
     let effective_workdir_log = workdir.as_ref().unwrap_or(&workdir_default);
     let run_log_path = match &log_file {
-        Some(p) => absolutize(p)?,
+        // Relative --log-file paths resolve against the workdir, matching
+        // the default log location (issue #136 fix 4).
+        Some(p) if p.is_absolute() => p.clone(),
+        Some(p) => effective_workdir_log.join(p),
         None => effective_workdir_log.join(".oxo-flow/logs/oxo-flow.log"),
     };
     let run_log_header = format!(
         "oxo-flow run log\nstarted_at: {}\noxo-flow: v{}\ncommand: {}\nworkflow: {}\nworkflow_name: {}\nworkflow_version: {}\ngit_sha: {}\nworkdir: {}\n\n",
         chrono::Local::now().to_rfc3339(),
         env!("CARGO_PKG_VERSION"),
-        std::env::args().collect::<Vec<_>>().join(" "),
+        oxo_flow_core::executor::process::mask_sensitive(
+            &std::env::args().collect::<Vec<_>>().join(" "),
+            &sensitive_values,
+        ),
         workflow_abs.display(),
         config.workflow.name,
         config.workflow.version,
@@ -697,10 +716,6 @@ pub async fn run_command(
         .filter(|(_, def)| def.sensitive)
         .map(|(key, _)| key.clone())
         .collect();
-    // The VALUES themselves, for runner-side output masking (issue #99 B1):
-    // they are redacted from captured stdout/stderr and recorded commands
-    // before anything reaches the checkpoint, report, AI recovery, or web.
-    let sensitive_values = sensitive_values_of(&config);
     let old_snapshot = {
         let ck = checkpoint.lock().await;
         ck.config_snapshot.clone()
@@ -1418,6 +1433,11 @@ pub async fn run_command(
     let semaphore = Arc::new(tokio::sync::Semaphore::new(jobs.max(1)));
     let mut join_set = tokio::task::JoinSet::new();
     let mut submitted: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Task id → rule name for panic attribution (issue #136 fix 2): a
+    // panicked task leaves the JoinSet without its payload, so the id is
+    // the only way to learn which rule died and release its scheduler slot.
+    let mut task_rule: std::collections::HashMap<tokio::task::Id, String> =
+        std::collections::HashMap::new();
 
     // Pre-process checkpoint-completed rules so they are never re-submitted.
     {
@@ -1507,6 +1527,8 @@ pub async fn run_command(
             &priority_map,
             &waited_rounds,
         );
+        // jobs was clamped to >= 1 at run_command entry, so a raw 0 can
+        // never silently suppress all submissions (issue #136 fix 1).
         let available = jobs.saturating_sub(sched.running_count());
         let to_submit: Vec<String> = ready.iter().take(available).cloned().collect();
         for name in ready.iter().skip(available) {
@@ -1585,7 +1607,10 @@ pub async fn run_command(
             }
 
             let typed_config = config.config.clone();
-            join_set.spawn(async move {
+            // Register the task name BEFORE the spawn: the closure moves
+            // `rule_name` in, so the id→name map needs its own clone.
+            let task_rule_name = rule_name.clone();
+            let handle = join_set.spawn(async move {
                 let _permit = semaphore.acquire().await;
 
                 // Snapshot the input file set BEFORE execution (issue #72):
@@ -1796,6 +1821,7 @@ pub async fn run_command(
                     }
                 }
             });
+            task_rule.insert(handle.id(), task_rule_name);
         }
 
         // ---- wait for completions -----------------------------------------
@@ -1806,8 +1832,8 @@ pub async fn run_command(
         }
 
         // Wait for the next rule to finish.
-        let (completed_rule, status, record) = match join_set.join_next().await {
-            Some(Ok(v)) => v,
+        let (completed_rule, status, record) = match join_set.join_next_with_id().await {
+            Some(Ok((_id, v))) => v,
             Some(Err(e)) => {
                 if e.is_panic() {
                     tracing::error!("Task panicked: {e}");
@@ -1819,7 +1845,58 @@ pub async fn run_command(
                 // the FIFO line hostage — live waiters re-register.
                 executor.clear_resource_waiters().await;
                 fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                continue;
+                // The task left the JoinSet without its payload, so the id
+                // is the only link back to the rule (issue #136 fix 2).
+                // Without marking it completed the rule would stay in the
+                // scheduler's running set forever, permanently shrinking
+                // the submit cap — with -j 1 every remaining rule would
+                // silently never run. Fall through to the common failure
+                // bookkeeping instead of `continue`, so dependents are
+                // blocked, the checkpoint records the engine fault, and
+                // the standard abort path fails the run loudly.
+                let Some(rule_name) = task_rule.remove(&e.id()) else {
+                    // Internal invariant: every spawned task registers its
+                    // name at spawn. Fail the run rather than leak the cap.
+                    return Err(anyhow::anyhow!(
+                        "internal error: task {} has no recorded rule",
+                        e.id()
+                    ));
+                };
+                {
+                    let mut frs = failed_rules_set.lock().await;
+                    frs.insert(rule_name.clone());
+                }
+                let record = oxo_flow_core::executor::JobRecord {
+                    rule: rule_name.clone(),
+                    status: oxo_flow_core::executor::JobStatus::Failed,
+                    started_at: None,
+                    finished_at: None,
+                    exit_code: Some(-1),
+                    stdout: None,
+                    stderr: Some(oxo_flow_core::executor::process::mask_sensitive(
+                        &e.to_string(),
+                        &sensitive_values,
+                    )),
+                    command: None,
+                    retries: 0,
+                    timeout: None,
+                    skip_reason: None,
+                    max_rss_mb: None,
+                    cpu_seconds: None,
+                };
+                let mut ck = checkpoint.lock().await;
+                ck.record_run(&record);
+                ck.mark_failed(&rule_name);
+                if let Err(save_err) = ck.save_to_file(&checkpoint_path) {
+                    tracing::warn!("Failed to save checkpoint: {save_err}");
+                }
+                let mut f = failures.lock().await;
+                f.push((rule_name.clone(), format!("task panicked: {e}")));
+                (
+                    rule_name,
+                    oxo_flow_core::executor::JobStatus::Failed,
+                    record,
+                )
             }
             None => break,
         };

--- a/crates/oxo-flow-cli/src/commands/samples.rs
+++ b/crates/oxo-flow-cli/src/commands/samples.rs
@@ -125,6 +125,17 @@ pub(crate) fn apply_samples_filter(
     // No subset filter: the sheet operation alone defines the run set.
     if did_sample_op && filter_specs.is_empty() {
         let total: usize = config.sample_groups.iter().map(|g| g.samples.len()).sum();
+        // A sheet whose rows select zero instances must fail loudly — the
+        // same empty-selection guard the filter path enforces below. The
+        // `+@` append path can reach this with a row whose samples cell is
+        // empty on a workflow that declares none, and a silent
+        // "Running 0 sample(s)" would be a zero-instance run (issue #136
+        // audit). `ready` can never reach this path, so an empty selection
+        // always bails when the flag demands it.
+        let selection_empty = total == 0 && config.pairs.is_empty();
+        if selection_empty && bail_on_empty {
+            anyhow::bail!("--samples matched no samples in this workflow");
+        }
         eprintln!(
             "  {} Running {} sample(s) via --samples (sheet selection)",
             "Samples:".cyan(),
@@ -345,6 +356,62 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         assert!(result.is_err(), "empty rows must fail");
         assert!(format!("{result:?}").contains("produced no samples"));
+    }
+
+    #[test]
+    fn zero_instance_append_sheet_fails_loudly_when_flag_demands_it() {
+        // `+@sheet` on a workflow that declares no samples: a row whose
+        // samples cell is empty leaves the selection with zero instances.
+        // The sheet-only path must honor the same empty-selection guard as
+        // name/first:N/ready — never a silent "Running 0 sample(s)".
+        let path = std::env::temp_dir().join("oxo_flow_zero_instance_samples.tsv");
+        std::fs::write(&path, "name\tsamples\ncohort\t\n").unwrap();
+
+        let mut config = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "template"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "analyze"
+            output = ["out/{sample}.txt"]
+            shell = "echo {sample} > {output}"
+            "#,
+        )
+        .unwrap();
+        let spec = format!("+@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            result.is_err(),
+            "zero-instance append must fail: {result:?}"
+        );
+        assert!(
+            format!("{result:?}").contains("matched no samples"),
+            "error must name the empty selection: {result:?}"
+        );
+
+        // The same append with a sample is a normal selection.
+        let path = std::env::temp_dir().join("oxo_flow_zero_instance_samples.tsv");
+        std::fs::write(&path, "name\tsamples\ncohort\tSRR1\n").unwrap();
+        let mut config = WorkflowConfig::parse(
+            r#"
+            [workflow]
+            name = "template"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "analyze"
+            output = ["out/{sample}.txt"]
+            shell = "echo {sample} > {output}"
+            "#,
+        )
+        .unwrap();
+        let spec = format!("+@{}", path.display());
+        let result = apply_samples_filter(&mut config, &[spec], true, std::path::Path::new("."));
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_ok(), "non-empty append must succeed: {result:?}");
     }
 
     #[test]

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -901,6 +901,7 @@ pub enum ClusterAction {
             long,
             help = "Run one include module and the producers of its declared inputs (repeatable; unions with --target). Module names are the include's `name` field or its file stem"
         )]
+        module: Vec<String>,
         #[arg(long, help = "Generate scripts without submitting")]
         dry_run: bool,
         /// Generate job scripts with dependency support and a wrapper script

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -2421,9 +2421,12 @@ impl WorkflowConfig {
         let includes = std::mem::take(&mut self.includes);
         for inc in &includes {
             let (content, inc_base_dir) = if let Some(repo) = &inc.repo {
-                // Pinned git include (issue #112): clone once into the
-                // module cache (keyed repo@ref), then resolve `path` inside
-                // the checkout. Cache hits skip the clone entirely.
+                // Pinned git include (issue #112): clone into the module
+                // cache (keyed repo@ref), then resolve `path` inside the
+                // checkout. ensure_pinned clones on a cache miss (healing
+                // partial dirs), re-fetches branch/tag refs on every
+                // activation, and pins full commit SHAs by fetch (issue
+                // #136).
                 let git_ref = inc.git_ref.as_deref().ok_or_else(|| OxoFlowError::Config {
                     message: format!(
                         "include '{}' declares `repo` without `ref` — pin the module version",
@@ -2432,20 +2435,18 @@ impl WorkflowConfig {
                 })?;
                 let cache_dir =
                     crate::git::module_cache_root().join(crate::git::cache_dir_name(repo, git_ref));
-                if !cache_dir.join(".git").exists() {
-                    std::fs::create_dir_all(cache_dir.parent().unwrap_or(&cache_dir)).map_err(
-                        |e| OxoFlowError::Config {
-                            message: format!("cannot create module cache: {e}"),
-                        },
-                    )?;
-                    crate::git::clone_pinned(repo, git_ref, &cache_dir).map_err(|e| {
-                        OxoFlowError::Config {
-                            message: format!(
-                                "failed to clone include repo '{repo}' at '{git_ref}': {e}"
-                            ),
-                        }
-                    })?;
-                }
+                std::fs::create_dir_all(cache_dir.parent().unwrap_or(&cache_dir)).map_err(|e| {
+                    OxoFlowError::Config {
+                        message: format!("cannot create module cache: {e}"),
+                    }
+                })?;
+                crate::git::ensure_pinned(repo, git_ref, &cache_dir).map_err(|e| {
+                    OxoFlowError::Config {
+                        message: format!(
+                            "failed to clone or refresh include repo '{repo}' at '{git_ref}': {e}"
+                        ),
+                    }
+                })?;
                 let inc_path = cache_dir.join(&inc.path);
                 let text = std::fs::read_to_string(&inc_path).map_err(|e| OxoFlowError::Parse {
                     path: inc_path.clone(),

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -216,6 +216,27 @@ impl CondaBackend {
         }
     }
 
+    /// Verify command with optional project-local prefix.
+    ///
+    /// A prefix install (`conda env create -p`) creates no named env, so the
+    /// plain `-n {name}` verify checks a different (nonexistent) env and
+    /// always fails — a healthy pre-existing prefix env then failed verify,
+    /// which sent the executor down the teardown-and-recreate path and
+    /// deleted the user's own env (issue #136).
+    pub fn verify_command_with_opts(
+        &self,
+        spec: &str,
+        prefix: Option<&str>,
+    ) -> Result<Option<String>> {
+        if let Some(prefix) = prefix {
+            Ok(Some(format!(
+                "conda run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\"'"
+            )))
+        } else {
+            self.verify_command(spec)
+        }
+    }
+
     /// Cache key with optional project-local prefix.
     pub fn cache_key_with_opts(&self, spec: &str, prefix: Option<&str>) -> String {
         if let Some(prefix) = prefix {
@@ -354,6 +375,23 @@ impl MambaBackend {
             Ok(Some(format!("{} env remove -p {prefix} -y", self.binary)))
         } else {
             self.teardown_command(spec)
+        }
+    }
+
+    /// Verify command with optional project-local prefix — same
+    /// prefix-vs-named-env rationale as [`CondaBackend::verify_command_with_opts`].
+    pub fn verify_command_with_opts(
+        &self,
+        spec: &str,
+        prefix: Option<&str>,
+    ) -> Result<Option<String>> {
+        if let Some(prefix) = prefix {
+            Ok(Some(format!(
+                "{} run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+                self.binary
+            )))
+        } else {
+            self.verify_command(spec)
         }
     }
 
@@ -911,6 +949,13 @@ pub struct EnvironmentResolver {
     cache: Arc<Mutex<EnvironmentCache>>,
     /// Per-cache-key setup mutexes (see [`Self::setup_lock`]).
     setup_locks: std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Per-cache-key record of environments this resolver issued a setup
+    /// for, with whether the env pre-existed before the setup (true = the
+    /// env was NOT created by this run). Teardown refuses to remove such
+    /// envs — a failed verify must never destroy a pre-existing prefix env
+    /// the user owns (issue #136). The resolver lives for one run, so this
+    /// is exactly "created this run".
+    setup_origins: std::sync::Mutex<HashMap<String, bool>>,
 }
 
 impl Default for EnvironmentResolver {
@@ -933,6 +978,7 @@ impl EnvironmentResolver {
             system: SystemBackend,
             cache: Arc::new(Mutex::new(EnvironmentCache::new())),
             setup_locks: std::sync::Mutex::new(HashMap::new()),
+            setup_origins: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -949,6 +995,7 @@ impl EnvironmentResolver {
             system: SystemBackend,
             cache: Arc::new(Mutex::new(EnvironmentCache::with_cache_dir(cache_dir))),
             setup_locks: std::sync::Mutex::new(HashMap::new()),
+            setup_origins: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -1044,13 +1091,31 @@ impl EnvironmentResolver {
 
     /// Get the setup command for an environment specification.
     /// This command creates/pulls the environment before first use.
+    ///
+    /// Records the setup origin per cache key (see `setup_origins`): for
+    /// prefix installs the snapshot is whether the prefix directory already
+    /// existed (relative prefixes resolve against the process CWD — the
+    /// executor runs conda in the workflow dir, and the standard invocation
+    /// runs from there too).
     pub fn setup_command(&self, env_spec: &EnvironmentSpec) -> Result<String> {
         if let Some(ref mamba) = env_spec.mamba {
+            let pre_existed = env_spec
+                .mamba_prefix
+                .as_deref()
+                .map(|p| std::path::Path::new(p).exists())
+                .unwrap_or(false);
+            self.record_setup(&self.cache_key(env_spec), pre_existed);
             return self
                 .mamba
                 .setup_command_with_opts(mamba, env_spec.mamba_prefix.as_deref());
         }
         if let Some(ref conda) = env_spec.conda {
+            let pre_existed = env_spec
+                .conda_prefix
+                .as_deref()
+                .map(|p| std::path::Path::new(p).exists())
+                .unwrap_or(false);
+            self.record_setup(&self.cache_key(env_spec), pre_existed);
             return self
                 .conda
                 .setup_command_with_opts(conda, env_spec.conda_prefix.as_deref());
@@ -1086,20 +1151,54 @@ impl EnvironmentResolver {
     }
 
     /// Post-setup usability check for the environment (conda/mamba verify
-    /// the env's `bin/` exists; other backends return `None`).
+    /// the env's `bin/` exists; other backends return `None`). Prefix
+    /// installs are verified against the prefix (`-p`), never the named-env
+    /// form — `conda env create -p` creates no named env, so the `-n` check
+    /// would always fail and drive the executor into the teardown path that
+    /// deletes the user's own pre-existing prefix env (issue #136).
     pub fn verify_command(&self, env_spec: &EnvironmentSpec) -> Result<Option<String>> {
         if let Some(ref mamba) = env_spec.mamba {
-            return self.mamba.verify_command(mamba);
+            return self
+                .mamba
+                .verify_command_with_opts(mamba, env_spec.mamba_prefix.as_deref());
         }
         if let Some(ref conda) = env_spec.conda {
-            return self.conda.verify_command(conda);
+            return self
+                .conda
+                .verify_command_with_opts(conda, env_spec.conda_prefix.as_deref());
         }
         Ok(None)
     }
 
     /// Get the teardown command for an environment specification
     /// (removes the env so a broken one can be recreated cleanly).
+    ///
+    /// Refuses to tear down anything this run did not create: an env whose
+    /// setup was never issued (verify failed before any setup) or whose
+    /// prefix directory pre-existed when setup was issued is the user's
+    /// own, and a failed verify must not destroy it. Returns `Ok(None)` in
+    /// those cases; the executor treats that as "no teardown" and skips the
+    /// recreate-retry.
     pub fn teardown_command(&self, env_spec: &EnvironmentSpec) -> Result<Option<String>> {
+        let key = self.cache_key(env_spec);
+        let origins = self.setup_origins.lock().unwrap();
+        match origins.get(&key) {
+            None => {
+                tracing::warn!(
+                    env = %key,
+                    "teardown skipped: no setup was issued for this environment in this run"
+                );
+                return Ok(None);
+            }
+            Some(true) => {
+                tracing::warn!(
+                    env = %key,
+                    "teardown skipped: the environment pre-existed before this run's setup — refusing to remove it"
+                );
+                return Ok(None);
+            }
+            Some(false) => {}
+        }
         if let Some(ref mamba) = env_spec.mamba {
             return self
                 .mamba
@@ -1111,6 +1210,15 @@ impl EnvironmentResolver {
                 .teardown_command_with_opts(conda, env_spec.conda_prefix.as_deref());
         }
         Ok(None)
+    }
+
+    /// Record that this run issued a setup for `key`, and whether the
+    /// target env pre-existed (see `setup_origins`).
+    fn record_setup(&self, key: &str, pre_existed: bool) {
+        self.setup_origins
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), pre_existed);
     }
 
     /// Check which environment backends are available on the system.
@@ -2054,6 +2162,123 @@ mod tests {
             .unwrap();
         assert!(result.contains("conda run --no-capture-output -p .oxo-conda bash -c 'export PATH=\"$CONDA_PREFIX/bin:$PATH\"; fastqc reads.fq'"));
         assert!(!result.contains(" -n "));
+    }
+
+    #[test]
+    fn conda_verify_command_with_prefix() {
+        let backend = CondaBackend;
+        let cmd = backend
+            .verify_command_with_opts("envs/qc.yaml", Some(".oxo-conda"))
+            .unwrap()
+            .unwrap();
+        assert!(
+            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'"),
+            "a prefix env must be verified with -p (the -n form checks a \
+             named env that `conda env create -p` never creates), got: {cmd}"
+        );
+        assert!(!cmd.contains(" -n "));
+    }
+
+    #[test]
+    fn conda_verify_command_without_prefix() {
+        let backend = CondaBackend;
+        let cmd = backend.verify_command("envs/qc.yaml").unwrap().unwrap();
+        assert!(cmd.contains("conda run -n qc bash -c 'test -d \"$CONDA_PREFIX/bin\"'"));
+        assert!(!cmd.contains(" -p "));
+    }
+
+    #[test]
+    fn mamba_verify_command_with_prefix() {
+        let backend = MambaBackend::new();
+        let cmd = backend
+            .verify_command_with_opts("envs/qc.yaml", Some(".oxo-conda"))
+            .unwrap()
+            .unwrap();
+        assert!(
+            cmd.contains(&format!(
+                "{} run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+                backend.binary
+            )),
+            "expected -p prefix form, got: {cmd}"
+        );
+        assert!(!cmd.contains(" -n "));
+    }
+
+    #[test]
+    fn resolver_verify_command_uses_prefix_for_conda_prefix_env() {
+        let resolver = EnvironmentResolver::new();
+        let spec = EnvironmentSpec {
+            conda: Some("envs/qc.yaml".to_string()),
+            conda_prefix: Some(".oxo-conda".to_string()),
+            ..Default::default()
+        };
+        let cmd = resolver.verify_command(&spec).unwrap().unwrap();
+        assert!(
+            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'"),
+            "the named-env verify checks the WRONG env for a prefix install, got: {cmd}"
+        );
+        assert!(!cmd.contains(" -n "));
+    }
+
+    #[test]
+    fn teardown_skips_preexisting_prefix_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("env");
+        std::fs::create_dir_all(&prefix).unwrap();
+        let resolver = EnvironmentResolver::new();
+        let spec = EnvironmentSpec {
+            conda: Some("envs/qc.yaml".to_string()),
+            conda_prefix: Some(prefix.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        // The cold-cache flow: verify failed, setup was issued (its update
+        // fallback exits 0), verify failed again — teardown must refuse to
+        // remove an env that pre-existed before this run's setup.
+        let _setup = resolver.setup_command(&spec).unwrap();
+        assert!(
+            resolver.teardown_command(&spec).unwrap().is_none(),
+            "a pre-existing prefix env (the user's own) must never be torn down"
+        );
+        assert!(
+            prefix.exists(),
+            "the user's pre-existing prefix env must survive"
+        );
+    }
+
+    #[test]
+    fn teardown_skips_when_verify_failed_before_any_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("env");
+        std::fs::create_dir_all(&prefix).unwrap();
+        let resolver = EnvironmentResolver::new();
+        let spec = EnvironmentSpec {
+            conda: Some("envs/qc.yaml".to_string()),
+            conda_prefix: Some(prefix.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        // Verify failed before any setup was issued this run — teardown must
+        // not remove the env.
+        assert!(resolver.teardown_command(&spec).unwrap().is_none());
+        assert!(prefix.exists());
+    }
+
+    #[test]
+    fn teardown_removes_env_created_this_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("env"); // does not exist before setup
+        let resolver = EnvironmentResolver::new();
+        let spec = EnvironmentSpec {
+            conda: Some("envs/qc.yaml".to_string()),
+            conda_prefix: Some(prefix.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let _setup = resolver.setup_command(&spec).unwrap();
+        let cmd = resolver
+            .teardown_command(&spec)
+            .unwrap()
+            .expect("an env this run created may be torn down");
+        assert!(cmd.contains("conda env remove -p"));
+        assert!(cmd.contains(&prefix.to_string_lossy().into_owned()));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/output_invalidation.rs
+++ b/crates/oxo-flow-core/src/executor/output_invalidation.rs
@@ -73,9 +73,20 @@ pub async fn invalidate_failed_outputs(snapshots: &[OutputSnapshot]) {
         };
         if !snapshot.existed {
             // Created during the failed attempt — remove outright.
-            if let Err(e) = tokio::fs::remove_file(&snapshot.path).await {
+            // Directories need `remove_dir_all`: `remove_file` EISDIRs on
+            // them (warned and swallowed), leaving a stale dir that the
+            // freshness gate then treats as a fresh output — the re-run is
+            // skipped and downstream rules consume the partial contents
+            // (#118's residual form).
+            let removal = if current_meta.is_dir() {
+                tokio::fs::remove_dir_all(&snapshot.path).await
+            } else {
+                tokio::fs::remove_file(&snapshot.path).await
+            };
+            if let Err(e) = removal {
                 tracing::warn!(
                     file = %snapshot.path.display(),
+                    is_dir = current_meta.is_dir(),
                     error = %e,
                     "failed to remove output created by a failed rule"
                 );
@@ -150,6 +161,27 @@ mod tests {
         std::fs::write(dir.path().join("out.txt"), b"partial").unwrap();
         invalidate_failed_outputs(&snapshots).await;
         assert!(!dir.path().join("out.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn created_directory_output_is_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let rule = rule_with_outputs(&["out/"]);
+        let values = HashMap::new();
+        // Snapshot before anything exists.
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        assert_eq!(snapshots.len(), 1);
+        assert!(!snapshots[0].existed);
+        // The failed attempt "writes" a directory output with content.
+        std::fs::create_dir_all(dir.path().join("out")).unwrap();
+        std::fs::write(dir.path().join("out/partial.txt"), b"partial").unwrap();
+        invalidate_failed_outputs(&snapshots).await;
+        assert!(
+            !dir.path().join("out").exists(),
+            "a directory created by a failed attempt must be removed — remove_file \
+             EISDIRs on directories, so the stale dir would look fresh to the \
+             freshness gate and the re-run would be skipped"
+        );
     }
 
     #[tokio::test]

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -837,14 +837,29 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
         // planner (live: auto-sra's dumps declared output = [] while writing
         // the FASTQs merges consume — the missing edges fed a priority
         // starvation incident).
-        if rule.output.is_empty() && (rule.shell.is_some() || rule.script.is_some()) {
+        //
+        // Skipped when the rule has dependents — they already order against
+        // it via depends_on (the only possible edge for an output-less
+        // rule), so the old suggestion ("add depends_on to every consumer")
+        // could never silence the warning — and when `when = "false"`: the
+        // rule can never execute, so its missing outputs are moot (mirrors
+        // the engine's evaluate_condition literal handling). Transform rules
+        // are included — `transform.map` executes even though the rule
+        // declares no outputs of its own.
+        let executes = rule.shell.is_some() || rule.script.is_some() || rule.transform.is_some();
+        let can_never_run = matches!(rule.when.as_deref().map(str::trim), Some("false"));
+        let has_dependents = dag
+            .as_ref()
+            .and_then(|d| d.dependents(&rule.name).ok())
+            .is_some_and(|deps| !deps.is_empty());
+        if rule.output.is_empty() && executes && !can_never_run && !has_dependents {
             diagnostics.push(Diagnostic {
                 severity: Severity::Warning,
                 message: "rule executes a command but declares no outputs".to_string(),
                 rule: Some(rule.name.clone()),
                 code: "W019".to_string(),
                 suggestion: Some(
-                    "declare output = [...] naming the files this rule produces, or add depends_on = [\"<this rule>\"] to every consumer".to_string(),
+                    "declare output = [...] naming the files this rule produces, or add a depends_on entry for this rule to each rule that consumes its files".to_string(),
                 ),
             });
         }
@@ -3326,5 +3341,99 @@ mod tests {
         let config = WorkflowConfig::parse(toml).unwrap();
         let diagnostics = lint_format(&config);
         assert!(!diagnostics.iter().any(|d| d.code == "W019"));
+    }
+
+    #[test]
+    fn lint_no_w019_for_rule_with_dependents() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "produce"
+            shell = "echo data > sra/x.fastq"
+
+            [[rules]]
+            name = "consume"
+            input = ["sra/x.fastq"]
+            output = ["out.txt"]
+            shell = "cat sra/x.fastq > out.txt"
+            depends_on = ["produce"]
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W019"),
+            "an output-less rule with dependents already orders against them via \
+             depends_on — W019's suggestion could never silence the warning: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_no_w019_when_condition_is_false() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "never_runs"
+            when = "false"
+            shell = "echo data > sra/x.fastq"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W019"),
+            "a rule with when = \"false\" can never execute — missing outputs are moot: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_w019_for_transform_map_without_outputs() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "split_qc"
+
+            [rules.transform]
+            split = { by = "chr", values = ["1", "2"] }
+            map = "echo processing {chr}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            diagnostics.iter().any(|d| d.code == "W019"),
+            "a transform rule executes `map` but declares no outputs — it must warn: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_w019_suggestion_matches_new_semantics() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "produce"
+            shell = "echo data > sra/x.fastq"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        let w019 = diagnostics
+            .iter()
+            .find(|d| d.code == "W019")
+            .expect("shell rule without outputs and without dependents must warn");
+        let suggestion = w019.suggestion.as_deref().unwrap_or_default();
+        assert!(
+            suggestion.contains("declare output = [...]"),
+            "the suggestion must lead with declaring outputs, got: {suggestion}"
+        );
+        assert!(
+            !suggestion.contains("every consumer"),
+            "the old suggestion ('add depends_on to every consumer') could not silence \
+             the warning once dependents skip it: {suggestion}"
+        );
     }
 }

--- a/crates/oxo-flow-core/src/git.rs
+++ b/crates/oxo-flow-core/src/git.rs
@@ -1,4 +1,11 @@
 //! Git helpers shared by workflow pulling and module includes (issue #112).
+//!
+//! Pinned module includes (config.rs) use [`ensure_pinned`], which manages
+//! the cache lifecycle: clone on miss, re-fetch branch/tag refs on every
+//! activation, full-SHA pins fetched by SHA, cross-process locking, and
+//! cleanup of partial clones (issue #136).
+
+use fs2::FileExt;
 
 /// China-friendly clone mirrors tried after the official GitHub URL fails
 /// (github.com URLs only — other hosts are left untouched).
@@ -39,29 +46,265 @@ pub fn mirror_candidates(repo_url: &str) -> Vec<String> {
         .collect()
 }
 
+/// Classify a pinned ref: a full 40-hex commit SHA must be fetched by SHA —
+/// `git clone --branch <sha>` fails with "Remote branch <sha> not found
+/// upstream" because SHAs are not advertised refs. Anything else (branch,
+/// tag, short SHA) goes through the regular `--branch` clone.
+pub fn is_full_sha(git_ref: &str) -> bool {
+    git_ref.len() == 40 && git_ref.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Command plan for cloning an unadvertised commit SHA: `git init`, add the
+/// origin, `git fetch origin <sha>`, detached checkout of FETCH_HEAD.
+/// Extracted so tests exercise the production command strings without
+/// touching the network.
+fn clone_sha_commands(dest: &std::path::Path, url: &str, sha: &str) -> [Vec<String>; 4] {
+    let dir = dest.to_string_lossy().into_owned();
+    [
+        vec!["init".to_string(), dir.clone()],
+        vec![
+            "-C".to_string(),
+            dir.clone(),
+            "remote".to_string(),
+            "add".to_string(),
+            "origin".to_string(),
+            url.to_string(),
+        ],
+        vec![
+            "-C".to_string(),
+            dir.clone(),
+            "fetch".to_string(),
+            "--depth".to_string(),
+            "1".to_string(),
+            "origin".to_string(),
+            sha.to_string(),
+        ],
+        vec![
+            "-C".to_string(),
+            dir,
+            "checkout".to_string(),
+            "--detach".to_string(),
+            "FETCH_HEAD".to_string(),
+        ],
+    ]
+}
+
+/// Command plan for cloning a branch/tag ref with a shallow `--branch`.
+fn clone_ref_commands(url: &str, git_ref: &str, dest: &std::path::Path) -> Vec<String> {
+    vec![
+        "clone".to_string(),
+        "--depth".to_string(),
+        "1".to_string(),
+        "--branch".to_string(),
+        git_ref.to_string(),
+        url.to_string(),
+        dest.to_string_lossy().into_owned(),
+    ]
+}
+
+/// Command plan for bringing a cached clone up to date with `git_ref`:
+/// re-fetch on every activation (branch/tag pins must track the remote
+/// instead of freezing at the first snapshot) and activate the new state.
+/// Full-SHA pins skip the refresh entirely — they are immutable, and
+/// `ensure_pinned` guards them with a readability check instead.
+fn refresh_commands(dest: &std::path::Path, git_ref: &str) -> [Vec<String>; 2] {
+    let dir = dest.to_string_lossy().into_owned();
+    [
+        vec![
+            "-C".to_string(),
+            dir.clone(),
+            "fetch".to_string(),
+            "--depth".to_string(),
+            "1".to_string(),
+            "origin".to_string(),
+            git_ref.to_string(),
+        ],
+        vec![
+            "-C".to_string(),
+            dir,
+            "reset".to_string(),
+            "--hard".to_string(),
+            "FETCH_HEAD".to_string(),
+        ],
+    ]
+}
+
+/// Sibling lock file for a cache dir. flock semantics: the OS releases the
+/// lock when the holder process dies, so a SIGKILLed clone cannot wedge the
+/// cache — the lock file itself may stay behind, harmlessly.
+fn lock_path_for(dest: &std::path::Path) -> std::path::PathBuf {
+    std::path::PathBuf::from(format!("{}.lock", dest.display()))
+}
+
+/// Remove a partial clone directory. Tolerates an already-missing dir so
+/// callers can clean up unconditionally after a failed attempt.
+fn remove_partial_clone(dest: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(dest) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => {
+            tracing::warn!(dir = %dest.display(), error = %e, "failed to remove partial clone");
+            Err(e)
+        }
+    }
+}
+
+/// Bounded-wait exclusive lock around one module-cache entry's clone or
+/// refresh. Two concurrent runs cloning into the same dir race: the loser's
+/// `git clone` fails on the non-empty dir and its cleanup can then delete
+/// the winner's completed checkout (issue #136).
+struct CloneLock {
+    file: std::fs::File,
+}
+
+/// How long a clone/refresh holder may hold the lock before contenders give
+/// up: depth-1 clones of typical module repos take seconds; a holder stuck
+/// on a hung network clone must not block every other run forever.
+const CLONE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+impl CloneLock {
+    fn acquire(dest: &std::path::Path) -> std::io::Result<CloneLock> {
+        let path = lock_path_for(dest);
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)?;
+        let deadline = std::time::Instant::now() + CLONE_LOCK_TIMEOUT;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(CloneLock { file }),
+                Err(_) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::other(format!(
+                        "timed out waiting for module cache lock {path:?}: {e}"
+                    )));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for CloneLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+/// Run one git command from a plan, returning its stderr on failure.
+fn run_git_plan(plan: &[String]) -> std::io::Result<()> {
+    let out = std::process::Command::new("git").args(plan).output()?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let display = plan.join(" ");
+    if stderr.is_empty() {
+        Err(std::io::Error::other(format!(
+            "`git {display}` failed (exit {})",
+            out.status.code().unwrap_or(-1)
+        )))
+    } else {
+        Err(std::io::Error::other(format!(
+            "`git {display}` failed: {stderr}"
+        )))
+    }
+}
+
 /// Clone `repo` at `git_ref` (tag/branch/commit) into `dest`, with mirror
-/// fallback. A partial directory left by a failed attempt is removed so
-/// callers can retry cleanly.
+/// fallback. Full commit SHAs are fetched by SHA (see [`is_full_sha`]); any
+/// other ref uses `git clone --depth 1 --branch`. A partial directory left
+/// by a failed attempt is removed so callers can retry cleanly.
 pub fn clone_pinned(repo_url: &str, git_ref: &str, dest: &std::path::Path) -> std::io::Result<()> {
     let mut failures: Vec<String> = Vec::new();
     for (index, candidate) in mirror_candidates(repo_url).iter().enumerate() {
         if index > 0 {
             tracing::info!("official clone failed — trying mirror {candidate}");
         }
-        let out = std::process::Command::new("git")
-            .args(["clone", "--depth", "1", "--branch", git_ref, candidate])
-            .arg(dest)
-            .output()?;
-        if out.status.success() {
+        let plan: Vec<Vec<String>> = if is_full_sha(git_ref) {
+            clone_sha_commands(dest, candidate, git_ref).to_vec()
+        } else {
+            vec![clone_ref_commands(candidate, git_ref, dest)]
+        };
+        let mut failed = false;
+        for command in &plan {
+            if let Err(e) = run_git_plan(command) {
+                failures.push(e.to_string());
+                failed = true;
+                break;
+            }
+        }
+        if !failed {
             return Ok(());
         }
-        failures.push(String::from_utf8_lossy(&out.stderr).trim().to_string());
-        let _ = std::fs::remove_dir_all(dest);
+        let _ = remove_partial_clone(dest);
     }
     Err(std::io::Error::other(format!(
         "failed to clone '{repo_url}' at '{git_ref}': {}",
         failures.join("; ")
     )))
+}
+
+/// Bring an existing cached clone up to date with `git_ref` (see
+/// [`refresh_commands`]).
+fn refresh_pinned(dest: &std::path::Path, git_ref: &str) -> std::io::Result<()> {
+    for command in refresh_commands(dest, git_ref) {
+        run_git_plan(&command)?;
+    }
+    Ok(())
+}
+
+/// Ensure a usable pinned clone of `repo@git_ref` exists at `dest`: clone
+/// on a cache miss (healing any partial dir a killed clone left behind),
+/// re-fetch branch/tag refs on every activation (branch pins must not
+/// freeze at their first snapshot), and heal a cache entry whose checkout
+/// is unreadable (e.g. a SIGKILLed clone that left `.git` behind with a
+/// truncated checkout — that must not poison the cache permanently).
+/// Full-SHA pins are immutable: no re-fetch on activation — a commit
+/// force-pushed away upstream must not break a locally complete checkout —
+/// only the readability guard. Serialized across processes by [`CloneLock`].
+pub fn ensure_pinned(repo_url: &str, git_ref: &str, dest: &std::path::Path) -> std::io::Result<()> {
+    let _lock = CloneLock::acquire(dest)?;
+    if !dest.join(".git").exists() {
+        let _ = remove_partial_clone(dest);
+        return clone_pinned(repo_url, git_ref, dest);
+    }
+    // Full-SHA pins are immutable — no re-fetch (a commit force-pushed away
+    // upstream must not break a locally complete checkout); branch/tag refs
+    // are re-fetched on every activation so they don't freeze at their first
+    // snapshot.
+    let refreshed = if is_full_sha(git_ref) {
+        Ok(())
+    } else {
+        refresh_pinned(dest, git_ref)
+    };
+    match refreshed {
+        Ok(()) => Ok(()),
+        Err(refresh_err) => {
+            // A truncated checkout (`rev-parse` fails) is cache poison from
+            // a killed clone — remove and re-clone. A plain network failure
+            // on a healthy checkout must surface, not silently re-clone.
+            if has_valid_head(dest) {
+                return Err(refresh_err);
+            }
+            let _ = remove_partial_clone(dest);
+            clone_pinned(repo_url, git_ref, dest)
+        }
+    }
+}
+
+/// Is the cache entry's checkout readable (`git rev-parse HEAD` succeeds)?
+/// Cheap guard against a SIGKILLed clone that left `.git` behind with a
+/// truncated checkout.
+fn has_valid_head(dest: &std::path::Path) -> bool {
+    let dir = dest.to_string_lossy();
+    std::process::Command::new("git")
+        .args(["-C", dir.as_ref(), "rev-parse", "--verify", "HEAD"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 /// Module cache root: `$OXO_FLOW_MODULE_CACHE` or `~/.cache/oxo-flow/modules`.
@@ -88,6 +331,114 @@ pub fn cache_dir_name(repo_url: &str, git_ref: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_full_sha_classifies_ref_kinds() {
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(sha.len(), 40);
+        assert!(is_full_sha(sha), "40-hex commit SHAs are fetchable by SHA");
+        assert!(!is_full_sha("main"));
+        assert!(!is_full_sha("v0.13.0"));
+        assert!(
+            !is_full_sha("a1b2c3"),
+            "short SHAs are not advertised refs either"
+        );
+        assert!(!is_full_sha(""));
+        assert!(
+            !is_full_sha(&format!("{sha}Z")),
+            "non-hex chars are not a SHA"
+        );
+        assert!(!is_full_sha(&format!("{sha}0")), "41 chars is not a SHA");
+    }
+
+    #[test]
+    fn sha_pin_clone_plan_fetches_by_sha_never_branch() {
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        let dest = std::path::Path::new(
+            "/cache/https_github.com_org_repo@0123456789abcdef0123456789abcdef01234567",
+        );
+        let commands = clone_sha_commands(dest, "https://github.com/org/repo", sha);
+        assert_eq!(
+            commands.len(),
+            4,
+            "init, remote add, fetch by sha, detached checkout"
+        );
+        let joined = commands
+            .iter()
+            .flatten()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            joined.contains(&format!("fetch --depth 1 origin {sha}")),
+            "an unadvertised SHA must be fetched by SHA: {joined}"
+        );
+        assert!(joined.contains("checkout --detach FETCH_HEAD"));
+        assert!(
+            !joined.contains("--branch"),
+            "git clone --branch <sha> fails with 'Remote branch not found': {joined}"
+        );
+    }
+
+    #[test]
+    fn branch_pin_clone_plan_uses_branch_flag() {
+        let dest = std::path::Path::new("/cache/x@main");
+        let cmd = clone_ref_commands("https://github.com/org/repo", "main", dest);
+        assert_eq!(
+            cmd,
+            vec![
+                "clone".to_string(),
+                "--depth".to_string(),
+                "1".to_string(),
+                "--branch".to_string(),
+                "main".to_string(),
+                "https://github.com/org/repo".to_string(),
+                "/cache/x@main".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn refresh_plan_refetches_the_ref_and_activates_it() {
+        let dest = std::path::Path::new("/cache/x@main");
+        let commands = refresh_commands(dest, "main");
+        let joined = commands
+            .iter()
+            .flatten()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            joined.contains("fetch --depth 1 origin main"),
+            "branch refs must be re-fetched on every activation, not frozen at the first snapshot: {joined}"
+        );
+        assert!(joined.contains("reset --hard FETCH_HEAD"));
+    }
+
+    #[test]
+    fn lock_path_is_sibling_lock_file() {
+        let dest = std::path::Path::new("/cache/https_github.com_org_repo@main");
+        assert_eq!(
+            lock_path_for(dest),
+            std::path::PathBuf::from("/cache/https_github.com_org_repo@main.lock")
+        );
+    }
+
+    #[test]
+    fn remove_partial_clone_cleans_incomplete_checkout() {
+        let dir = tempfile::tempdir().unwrap();
+        let clone = dir.path().join("partial");
+        std::fs::create_dir_all(clone.join(".git")).unwrap();
+        std::fs::write(clone.join(".git/HEAD"), "ref: refs/heads/main").unwrap();
+        std::fs::write(clone.join("wf.oxoflow"), "stale").unwrap();
+        remove_partial_clone(&clone).unwrap();
+        assert!(
+            !clone.exists(),
+            "a SIGKILLed clone's partial dir must be removed so the next run starts clean"
+        );
+        // Removing a missing dir is a no-op, not an error.
+        assert!(remove_partial_clone(&clone).is_ok());
+    }
 
     #[test]
     fn find_repo_root_resolves_cwd_relative_workflow() {

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -28,7 +28,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--jobs` | `-j` | `1` | Maximum number of concurrent jobs |
 | `--keep-going` | `-k` | — | Continue execution when a job fails |
 | `--workdir` | `-d` | Workflow file's directory | Working directory for execution |
-| `--log-file` | — | `.oxo-flow/logs/oxo-flow.log` in the workdir | Write the run log to a custom path instead (previous logs rotate to `PATH.1` … `PATH.9`) |
+| `--log-file` | — | `.oxo-flow/logs/oxo-flow.log` in the workdir | Write the run log to a custom path instead (relative paths resolve against the workdir; previous logs rotate to `PATH.1` … `PATH.9`) |
 | `--target` | `-t` | All rules | Run only specific target rules |
 | `--retry` | `-r` | `0` | Number of times to retry failed jobs |
 | `--timeout` | — | `0` (disabled) | Timeout per job in seconds |
@@ -353,9 +353,8 @@ The closure is: the module's rules + every host rule producing one of its
 declared concrete contract inputs; upstream DAG dependents come through
 the regular target machinery. Unknown module names fail with the known
 module list. `dry-run --module` previews the same set.
-: downstream
-instances submit in ready batches as array elements finish, which is
-correct but not as queue-efficient as true element-wise chaining.
+
+### Run directory layout
 
 Each run leaves a directory you can navigate with ordinary tools:
 

--- a/docs/guide/src/how-to/cohort-sample-groups.md
+++ b/docs/guide/src/how-to/cohort-sample-groups.md
@@ -200,7 +200,7 @@ pilot size, or readiness):
 | `--samples @sheet.tsv` | **Replace** — the sheet's groups become the run set, overwriting the workflow's inline / auto-discovered / file-loaded groups |
 | `--samples +@sheet.tsv` | **Append** — same-name groups merge (union, deduplicated); new group names are added. `[[pairs]]` are untouched: appending can only add samples |
 | `--samples S1,S2` | **Filter** on workflows with declared samples (unknown names fail — no phantom samples); **declare** on workflows that ship with no samples at all (the template-workflow invocation pattern) |
-| `--samples first:3` / `--samples ready` | **Filter** — narrow the (possibly replaced, appended, or declared) set to a subset / to samples whose entry inputs are complete (see [Incremental data arrival](#incremental-data-arrival-samples-ready)) |
+| `--samples first:3` / `--samples ready` | **Filter** — narrow the (possibly replaced, appended, or declared) set to a subset / to samples whose entry inputs are complete (see [Incremental data arrival](../commands/run.md#incremental-data-arrival-samples-ready)) |
 
 Sheet specs apply in order and can combine with filters:
 `--samples @real.tsv,first:2` replaces with `real.tsv` then runs the first

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -330,7 +330,7 @@ Resolve by giving each rule distinct output paths (e.g., `caller_a/{sample}.vcf`
 | `Duplicate rule name` | Two rules share the same `name` field | Rename one rule; use `namespace` with `[[include]]` to avoid conflicts |
 | `Rule not found: 'name'` | `-t` target references a non-existent rule | Check spelling; try prefix matching (`-t al` may match `align`); use `oxo-flow graph` to list all rule names (unknown `depends_on` references are caught by `oxo-flow validate`) |
 | `resource budget too small for N rule(s)` | A rule's request exceeds an explicit `--max-threads`/`--max-memory` budget | Increase the budget, lower the rule's declaration, or drop the flag (auto-detected capacity is soft — over-capacity rules are clamped and run alone) |
-| `resource group 'x' exhausted` | A rule's group requirement exceeds the declared `[resource_groups]` capacity | Raise the declared capacity or lower the rule's group requirement |
+| `resource exhausted: rule 'x' requires N of resource group 'g' (declared capacity: M)` | A rule's group requirement exceeds the declared `[resource_groups]` capacity | Raise the declared capacity or lower the rule's group requirement |
 
 ---
 
@@ -356,11 +356,16 @@ at priority 10).
 Three engine mechanisms address this — together they make priority
 starvation **impossible**, not merely unlikely:
 
-1. **Fair dispatch.** The scheduler caps each round's submissions to the
-   free `-j` slots and applies **priority aging**: every round a ready
-   rule is passed over, its effective priority gains +1 (`effective =
-   declared + rounds waited`). A starved producer therefore outranks
-   fresh high-priority rules after `priority gap` rounds.
+1. **Fair dispatch (the backlog).** The run loop caps each round's
+   submissions to the free `-j` slots and applies **priority aging** to
+   the ready rules it passes over: every round a ready rule left
+   unsubmitted by the cap gains +1 to its effective priority
+   (`effective = declared + rounds waited`). A starved producer in the
+   backlog therefore outranks fresh high-priority rules after `priority
+   gap` rounds. Aging acts only on the dispatch backlog — a rule
+   already handed to the executor is out of the ready list and never
+   ages; its wait happens inside the resource pool, which FIFO
+   acquisition (next) settles.
 2. **FIFO resource acquisition (the guarantee).** Inside the resource
    pool, capacity is granted strictly in arrival order: the oldest
    waiter is served first, everyone else holds the line. The guarantee
@@ -380,7 +385,7 @@ waiting for resources: group 'limit_merge': need 1, have 0 held by [merge_R1_dat
 For workflows that still wait: remove the shared-group claim (give each
 rule set its own group), restore the missing `depends_on` edge so
 downstream rules cannot start before their producers, or declare `output`
-on producer rules that execute commands but declare nothing (`validate`
+on producer rules that execute commands but declare nothing (`lint`
 flags these with warning W019).
 
 ### "A rule I expect to run is being skipped"

--- a/docs/guide/src/reference/versioning.md
+++ b/docs/guide/src/reference/versioning.md
@@ -38,7 +38,7 @@ repository URL plus a tag, branch, or commit) alongside `path`. Pinned
 includes are cloned once into `~/.cache/oxo-flow/modules/<repo>@<ref>`
 and reused — the module is frozen at that ref until the workflow author
 moves it deliberately. See
-[Workflow Format](workflow-format.md#include--modular-workflow-composition)
+[Workflow Format](workflow-format.md#include-modular-workflow-composition)
 for the include syntax and interface contracts.
 
 ## Pillar 3 — Ecosystem: the catalog is versioned

--- a/tests/dispatch_fairness.rs
+++ b/tests/dispatch_fairness.rs
@@ -1,0 +1,190 @@
+//! Dispatch-fairness and run-loop accounting integration tests (issue #136).
+//!
+//! Guards the scheduler's submit-cap accounting end-to-end via the compiled
+//! `oxo-flow` binary: `-j 0` must still execute rules, a failed rule must
+//! not leak the running-count cap, and run-log surfaces (header masking,
+//! `--log-file` resolution) must respect the masking/workdir contracts.
+//! Kept in a dedicated crate so parallel sessions can own
+//! `cli_integration.rs` independently (each integration-test crate
+//! compiles and links on its own).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+
+/// Locate a workspace binary by name from the target directory.
+///
+/// This handles the case where binaries are defined in workspace sub-crates
+/// rather than the root package, which means `CARGO_BIN_EXE_*` env vars
+/// are not automatically set.
+fn workspace_bin(name: &str) -> PathBuf {
+    // Cargo sets OUT_DIR for build scripts and CARGO_MANIFEST_DIR for the package.
+    // For integration tests, we can derive the target dir from the test binary location.
+    let mut target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+
+    // Try the binary directly in the target/debug (or target/release) directory.
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    // On Windows, binaries have a .exe extension.
+    let candidate_exe = target_dir.join(format!("{name}.exe"));
+    if candidate_exe.exists() {
+        return candidate_exe;
+    }
+
+    // Fall back to the deps subdirectory.
+    target_dir = target_dir.join("deps");
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+fn oxo_flow_cmd() -> Command {
+    Command::new(workspace_bin("oxo-flow"))
+}
+
+// ─── -j 0 (issue #136 fix 1) ────────────────────────────────────────
+
+/// `-j 0` must clamp to one concurrent job like the semaphore does, not
+/// silently run nothing: the submit-cap arithmetic used the raw `jobs`
+/// value, so zero jobs meant zero submissions and a fake "0 succeeded" run.
+#[test]
+fn cli_jobs_zero_still_executes_rules() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("j0.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"j0\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-j", "0"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Done: 1 succeeded"));
+
+    assert!(
+        dir.path().join("out.txt").exists(),
+        "the rule must execute under -j 0"
+    );
+}
+
+// ─── Submit-cap accounting after failures (issue #136 fix 2) ──────────
+
+/// With `-j 1 --keep-going`, a failed rule must release its scheduler slot
+/// so the remaining rules still run. Guards the running-count accounting:
+/// if a failure path ever forgets `mark_completed`, the leaked slot shrinks
+/// the submit cap to zero and every later rule silently never runs.
+///
+/// Note: the task-panic path in `run_command` (which previously leaked the
+/// cap for real) cannot be triggered from the CLI — the executor returns
+/// errors instead of panicking for reachable inputs — so this guard covers
+/// the observable contract (cap accounting after a failed rule) end-to-end,
+/// and the panic path itself is fixed + reasoned about in run.rs.
+#[test]
+fn cli_job1_keep_going_continues_after_rule_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("cap.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"cap\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"boom\"\noutput = [\"boom.txt\"]\nshell = \"exit 3\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    // Since #135, --keep-going still exits nonzero when any rule failed —
+    // the exit code reflects the failure, the run does not die early.
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-j", "1", "--keep-going"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+
+    assert!(
+        dir.path().join("out.txt").exists(),
+        "with -j 1 the second rule must still run after the first fails — \
+         a leaked running-count would permanently shrink the submit cap"
+    );
+}
+
+// ─── Run-log header masking (issue #136 fix 3) ───────────────────────
+
+/// The run-log header embeds the raw command line; sensitive values passed
+/// via `--arg KEY=secret` must be masked there exactly like every other
+/// captured surface (issue #99 B1), not written in plaintext.
+#[test]
+fn cli_run_log_header_masks_sensitive_arg_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("masklog.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"masklog\"\nversion = \"1.0.0\"\n\n[config]\nTOKEN = { default = \"not-used\", sensitive = true }\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--arg", "TOKEN=supersecret"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let log = fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log")).unwrap();
+    assert!(
+        !log.contains("supersecret"),
+        "run log must not contain the raw sensitive value: {log}"
+    );
+    assert!(
+        log.contains("TOKEN=***"),
+        "run log must contain the masked command line: {log}"
+    );
+}
+
+// ─── --log-file resolution (issue #136 fix 4) ─────────────────────────
+
+/// A relative `--log-file` must resolve against the workdir (like the
+/// default path), not against the current directory of the invocation.
+#[test]
+fn cli_log_file_relative_path_resolves_against_workdir() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf_dir = dir.path().join("wf");
+    fs::create_dir(&wf_dir).unwrap();
+    let wf = wf_dir.join("rellog.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"rellog\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    // Invoke from OUTSIDE the workdir so CWD-relative and workdir-relative
+    // resolution are distinguishable.
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--log-file", "logs/custom.log"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        wf_dir.join("logs/custom.log").exists(),
+        "relative --log-file must resolve against the workdir (the workflow's directory)"
+    );
+    assert!(
+        !dir.path().join("logs/custom.log").exists(),
+        "relative --log-file must NOT resolve against the current directory"
+    );
+}


### PR DESCRIPTION
## Summary

Tier-1 fixes from the unified audit issue #136 (8-agent review of the 111 commits between the real v0.13.1 release ab54f46 and origin/main; every HIGH finding verified by file:line before implementation). 16 files, 22 new tests, all RED-first.

**Silent-failure regressions (HIGH)**
- `-j 0` was both a silent no-op run (exit 0, nothing executed) and — deeper — a zero-permit executor semaphore that hung the first submission. Clamped once at the run boundary.
- A panicked task skipped `mark_completed`, leaking the scheduler running set and permanently shrinking the submit cap: with `-j 1` (the default) every remaining rule silently never ran. The panic arm now resolves the rule via a task→rule map, records the engine fault, and falls through to the common bookkeeping; unknown ids fail loudly.

**Security boundary (HIGH)**
- Run-log header embeds raw argv; sensitive values passed via `--arg KEY=secret` landed plaintext in `.oxo-flow/logs/oxo-flow.log` and its 9 rotations (bypassing the #99 B1 masking contract). The command line now passes through `mask_sensitive`.

**Core safety (HIGH)**
- Failed-rule *directory* outputs were never invalidated (`remove_file` EISDIR swallowed) — stale dirs looked fresh and skipped re-runs (the #118 residual). Now `remove_dir_all`.
- Conda prefix envs: prefix-aware verify added (`-p`); teardown no longer deletes pre-existing user environments after a verify failure (setup-origin tracking).
- Git-pinned includes: 40-hex SHA pins now work (fetch+checkout; `--branch <sha>` fails on GitHub for unadvertised SHAs); branch refs refresh per activation instead of freezing; flock-guarded clones + partial-dir cleanup.

**CLI surface**
- `cluster submit --module` was a declared-but-dead flag glued onto `--dry-run`; now a real field wired into module-closure target resolution.
- `--samples @sheet` empty selections now fail loudly under the existing guard.
- Relative `--log-file` resolves against the workdir (was CWD).
- W019: no longer fires when the rule already has dependents (its own suggestion now works), skips `when = false`, covers `transform.map`, suggestion updated.

**Release pipeline (ci.yml)** — the v0.13.1 tag re-point root causes
- Tag format validation + remote tag-exists guard (never re-point a released tag).
- Tag creation moved out of the version-changed guard → idempotent re-dispatch recovers the "main bumped, no tag" state.
- CHANGELOG generated and committed *before* the tag, so the tag tree describes itself.
- Dispatch release runs get their own concurrency group — the bump-commit push run was self-cancelling the release run (the deterministic root cause of the moved tag).

**Docs**: run.md dangling fragment + restored heading; two broken anchors; W019 attributed to `lint` (not `validate`); dag-engine error string verbatim; fair-dispatch scoped to the dispatch backlog (pool fairness = FIFO acquisition, #123). cliff.toml skips release-machinery commits.

## Tests

- 22 new tests (4 dispatch fairness incl. `-j 0` + masking + `--log-file`, 7 conda prefix, 6 git-include, 5 W019, 1 samples), all watched RED first.
- Full `make ci` gate on the exact tree: fmt + clippy `-D warnings` + build + full test suite + audit → exit 0.
- Live-verified: `-j 0` executes; `TOKEN` masked (0 raw occurrences in log); failed dir output removed; `cluster submit --module` parses and selects; relative `--log-file` lands in the workdir.

## Test plan for reviewers

- [ ] `make ci`
- [ ] `oxo-flow run wf.oxoflow -j 0` → rule executes, exit 0
- [ ] Workflow with `[config] TOKEN = { sensitive = true }` + `run --arg TOKEN=secret` → log header shows `TOKEN=***`
- [ ] Failing rule that creates a directory output → dir removed after failure; rerun re-executes
- [ ] `cluster submit --help` shows `--module`; `--module bogus` errors with known modules

## Deferred (tracked in #136, colliding with parallel lanes)

Multi-chunk array cmd clobber + element-id collision, non-SLURM element polling, max_submitted bypass, cluster checkpoint durability (driver.rs lane — 19's #134), web cancel fallback family, 60s diagnostics injection, LOW tail.

Fixes issue #136 (tier 1 of 2; remainder listed there).
