### PR TITLE
fix: audit #136 tier-2 — web cancel integrity, wait-loop races, LOW tail

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -448,6 +448,40 @@ fn apply_cli_overrides(
     Ok(())
 }
 
+/// Quote a path for safe embedding in a reference build command (executed
+/// via `bash -c` / `sh -c`): wrap in single quotes and escape embedded
+/// quotes with the POSIX `'\''` sequence — the same idiom the environment
+/// wrapper uses when embedding commands into `sh -c '...'` and the cluster
+/// renderer uses for its `cd '...'`. Without the quoting, a source path
+/// containing spaces or shell metacharacters would be spliced bare into the
+/// command (issue #136 tier-2 audit).
+fn quote_shell_path(path: &str) -> String {
+    format!("'{}'", path.replace('\'', "'\\''"))
+}
+
+/// Substitute the reference builder's `{source}` placeholder with the
+/// expanded source path, shell-quoted so the path survives as one argument
+/// (issue #136 tier-2 audit — the raw splice broke on spaces/metacharacters).
+fn substitute_source_placeholder(build_cmd: &str, expanded_source: &str) -> String {
+    build_cmd.replace("{source}", &quote_shell_path(expanded_source))
+}
+
+/// Render the "known modules" list for an unknown-module error. `run` and
+/// `dry-run` share the phrasing — in particular the explicit empty-list
+/// hint, so a workflow without includes cannot print a trailing "known
+/// modules: " (issue #136 tier-2 audit).
+fn known_modules_hint(module_rules: &std::collections::HashMap<String, Vec<String>>) -> String {
+    if module_rules.is_empty() {
+        "(none — no [[include]] modules)".to_string()
+    } else {
+        module_rules
+            .keys()
+            .map(|k| k.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_command(
     workflow: Option<PathBuf>,
@@ -586,18 +620,9 @@ pub async fn run_command(
         match config.module_closure(m) {
             Some(names) => target.extend(names),
             None => {
-                let known: Vec<&String> = config.module_rules.keys().collect();
                 return Err(anyhow::anyhow!(
                     "unknown module '{m}' — known modules: {}",
-                    if known.is_empty() {
-                        "(none — no [[include]] modules)".to_string()
-                    } else {
-                        known
-                            .iter()
-                            .map(|k| k.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    }
+                    known_modules_hint(&config.module_rules)
                 ));
             }
         }
@@ -937,6 +962,12 @@ pub async fn run_command(
                 max_submitted,
                 rerun,
                 resume_failed,
+                // The cluster path honors --cache-dir (shared env cache);
+                // --skip-env-setup/--ai-recover are unsupported there and
+                // warned about at submit time (issue #136 tier-2 audit).
+                cache_dir: cache_dir.clone(),
+                skip_env_setup,
+                ai_recover,
             },
         )
         .await?;
@@ -1199,13 +1230,16 @@ pub async fn run_command(
                 // `{source}` is the builder-template spelling of the same
                 // thing; render it too (live evidence: tcasia's STAR
                 // genomeGenerate died with 'could not open genomeFastaFile:
-                // {source}' — the placeholder was never substituted).
+                // {source}' — the placeholder was never substituted). The
+                // path is shell-quoted — a bare splice breaks reference
+                // builds whose source path contains spaces (issue #136
+                // tier-2 audit).
                 if let Some(source) = ref_def.source.as_deref() {
                     let expanded = oxo_flow_core::executor::checkpoint::expand_config_in_path(
                         source,
                         &wildcard_values,
                     );
-                    build_cmd = build_cmd.replace("{source}", &expanded);
+                    build_cmd = substitute_source_placeholder(&build_cmd, &expanded);
                 }
                 // References take the same shell prelude as rules (issue #92),
                 // before the environment wrapper resolves.
@@ -1489,11 +1523,15 @@ pub async fn run_command(
         }
     }
 
-    // Returns rules that are ready to run: dependencies satisfied, not yet
-    // submitted, and not blocked by a failed upstream rule.  Sorted by
-    // priority (descending) then name for determinism.
-    // Priorities captured once: the closure may outlive config borrows
-    // across checkpoint re-entry (config mutates mid-run, issue #78 P3).
+    // Ready-list ordering (age_ready_list below, called every dispatch
+    // round): the scheduler's ready rules are filtered to this run's order
+    // set minus already-submitted rules, then sorted by EFFECTIVE priority
+    // — declared priority plus the rounds a rule has waited ready-but-not-
+    // submitted (the aging counter of issue #123, cluster-side issue #134)
+    // — descending, ties broken by name for determinism. Priorities are
+    // captured ONCE up front: the config mutates mid-run across checkpoint
+    // re-entry (issue #78 P3), and re-reading priorities per round would
+    // drift the ordering.
     let priority_map: std::collections::HashMap<String, i32> = config
         .rules
         .iter()
@@ -2575,12 +2613,7 @@ pub async fn dry_run_command(
             None => {
                 return Err(anyhow::anyhow!(
                     "unknown module '{m}' — known modules: {}",
-                    config
-                        .module_rules
-                        .keys()
-                        .map(|k| k.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    known_modules_hint(&config.module_rules)
                 ));
             }
         }
@@ -3745,7 +3778,9 @@ pub async fn resume_command(
 
 #[cfg(test)]
 mod tests {
-    use super::{age_ready_list, parse_cli_overrides};
+    use super::{
+        age_ready_list, known_modules_hint, parse_cli_overrides, substitute_source_placeholder,
+    };
     use std::collections::HashSet;
 
     fn declared(keys: &[&str]) -> HashSet<String> {
@@ -3906,5 +3941,46 @@ mod tests {
     fn rejects_bare_non_key_value_positional() {
         let err = parse_cli_overrides(vec!["naked".to_string()], &declared(&[])).unwrap_err();
         assert!(format!("{err}").contains("KEY=VALUE"), "{err:?}");
+    }
+
+    #[test]
+    fn source_placeholder_quotes_paths_with_spaces() {
+        // A `{source}` path containing spaces must survive the reference
+        // build as ONE shell argument (issue #136 tier-2 audit — the raw
+        // splice broke on spaces/metacharacters).
+        let rendered =
+            substitute_source_placeholder("STAR --genomeDir {source}", "refs/genome data/hg38");
+        assert_eq!(rendered, "STAR --genomeDir 'refs/genome data/hg38'");
+    }
+
+    #[test]
+    fn source_placeholder_escapes_embedded_quotes() {
+        // POSIX-safe: an embedded quote closes and reopens the quoting
+        // (the `'\''` idiom the environment wrapper also uses).
+        let rendered = substitute_source_placeholder("--in {source}", "dir/we'ird");
+        assert_eq!(rendered, "--in 'dir/we'\\''ird'");
+    }
+
+    #[test]
+    fn source_placeholder_without_placeholder_is_unchanged() {
+        let rendered = substitute_source_placeholder("echo built", "ignored");
+        assert_eq!(rendered, "echo built");
+    }
+
+    #[test]
+    fn known_modules_hint_names_the_empty_case() {
+        // Dry-run must print the same explicit "(none — no [[include]]
+        // modules)" hint `run` does instead of a trailing empty list
+        // (issue #136 tier-2 audit).
+        let empty: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        assert_eq!(
+            known_modules_hint(&empty),
+            "(none — no [[include]] modules)"
+        );
+        let mut map: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        map.insert("qc".to_string(), vec!["qc".to_string()]);
+        assert_eq!(known_modules_hint(&map), "qc");
     }
 }

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -45,6 +45,18 @@ pub(crate) struct ClusterRunArgs<'a> {
     pub max_submitted: Option<usize>,
     pub rerun: bool,
     pub resume_failed: bool,
+    /// `--cache-dir`: env cache location (falls back to the same
+    /// `workdir/.oxo-flow/env-cache` default the local executor uses, so
+    /// the two execution paths share env state — issue #136 tier-2 audit).
+    pub cache_dir: Option<PathBuf>,
+    /// `--skip-env-setup`: honored by the local executor. The cluster path
+    /// never auto-creates environments, so the flag is a no-op there — it
+    /// is announced at submit time, never silently accepted.
+    pub skip_env_setup: bool,
+    /// `--ai-recover`: supported by the local loop only; the cluster path
+    /// has no AI recovery. A request is announced at submit time, never
+    /// silently accepted.
+    pub ai_recover: bool,
 }
 
 /// Outcome of a cluster run, mirroring what the local loop reports.
@@ -113,6 +125,15 @@ fn create_run_dir(workdir: &Path) -> Result<PathBuf> {
         }
     }
     Ok(run_dir)
+}
+
+/// The env cache dir for a cluster run: `--cache-dir` when given, else the
+/// same `workdir/.oxo-flow/env-cache` default the local executor uses, so
+/// the two execution paths share env state (issue #136 tier-2 audit).
+fn cluster_env_cache_dir(cache_dir: Option<&Path>, workdir: &Path) -> PathBuf {
+    cache_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| workdir.join(".oxo-flow").join("env-cache"))
 }
 
 /// Fold one driver-returned record into the checkpoint, mirroring the local
@@ -247,7 +268,30 @@ pub(crate) async fn run_on_cluster(
         return Ok(summary);
     }
 
-    let env_resolver = EnvironmentResolver::new();
+    // The local path's cache default is `workdir/.oxo-flow/env-cache` (or
+    // --cache-dir); the cluster path must share it so env state is not
+    // split across two caches (issue #136 tier-2 audit — `EnvironmentResolver::new()`
+    // would silently use the process-global default instead).
+    let env_resolver = EnvironmentResolver::with_cache_dir(&cluster_env_cache_dir(
+        args.cache_dir.as_deref(),
+        args.workdir,
+    ));
+    // Flags the cluster path cannot honor are announced at submit time —
+    // never silently accepted (issue #136 tier-2 audit).
+    if args.skip_env_setup {
+        eprintln!(
+            "  {} --skip-env-setup has no effect on the cluster path — environments are \
+             never auto-created there (accepted for command-line parity)",
+            "Warning:".bold().yellow()
+        );
+    }
+    if args.ai_recover {
+        eprintln!(
+            "  {} --ai-recover is not supported on the cluster path — failed jobs are \
+             recorded for resume/--resume-failed instead of AI-repaired",
+            "Warning:".bold().yellow()
+        );
+    }
     let mut plan = ScheduledPlan::build(
         args.config,
         args.dag,
@@ -360,4 +404,27 @@ pub(crate) async fn run_on_cluster(
         );
     }
     Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cluster_env_cache_dir;
+
+    #[test]
+    fn env_cache_defaults_to_workdir_env_cache() {
+        // The cluster path must share the local executor's default cache
+        // dir (`workdir/.oxo-flow/env-cache`), not EnvironmentResolver's
+        // process-global default (issue #136 tier-2 audit).
+        let dir = cluster_env_cache_dir(None, std::path::Path::new("/wf"));
+        assert_eq!(dir, std::path::PathBuf::from("/wf/.oxo-flow/env-cache"));
+    }
+
+    #[test]
+    fn env_cache_flag_wins_over_default() {
+        let dir = cluster_env_cache_dir(
+            Some(std::path::Path::new("/custom/cache")),
+            std::path::Path::new("/wf"),
+        );
+        assert_eq!(dir, std::path::PathBuf::from("/custom/cache"));
+    }
 }

--- a/crates/oxo-flow-cli/src/commands/samples.rs
+++ b/crates/oxo-flow-cli/src/commands/samples.rs
@@ -94,7 +94,19 @@ pub(crate) fn apply_samples_filter(
                 filter_specs.push(part.to_string());
                 continue;
             };
-            let groups = SampleGroup::load_from_file(std::path::Path::new(path))
+            // Resolve relative sheet paths against base_dir — the SAME
+            // base the `ready` spec uses — never the process CWD, so a
+            // relative sheet does not silently resolve differently
+            // depending on where the CLI was invoked (issue #136 tier-2
+            // audit; `--workdir`/the workflow directory is the documented
+            // resolution base for --samples paths).
+            let sheet_path = std::path::Path::new(path);
+            let sheet_path = if sheet_path.is_absolute() {
+                sheet_path.to_path_buf()
+            } else {
+                base_dir.join(sheet_path)
+            };
+            let groups = SampleGroup::load_from_file(&sheet_path)
                 .with_context(|| format!("failed to load samplesheet '{path}'"))?;
             // A samplesheet with no data rows must fail loudly: silently
             // falling back to the discovered samples would run the WRONG
@@ -468,5 +480,25 @@ mod tests {
             std::path::Path::new("."),
         );
         assert!(result.is_err(), "unknown name must fail: {result:?}");
+    }
+
+    #[test]
+    fn relative_sheet_resolves_against_base_dir_not_cwd() {
+        // `@path` resolves against the workdir base — the SAME base the
+        // `ready` spec uses — never the process CWD (issue #136 tier-2
+        // audit: the two specs used to resolve differently, so a relative
+        // sheet silently depended on where the CLI was invoked).
+        let base = std::env::temp_dir().join("oxo_flow_sheet_base_test");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("sheet.tsv"), "name\tsamples\ncohort\tSRR1\n").unwrap();
+
+        let mut config = config_with_inline_samples();
+        let result = apply_samples_filter(&mut config, &["@sheet.tsv".to_string()], true, &base);
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(
+            result.is_ok(),
+            "sheet must resolve under base_dir, not the CWD: {result:?}"
+        );
+        assert_eq!(config.sample_groups[0].samples, vec!["SRR1".to_string()]);
     }
 }

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -730,12 +730,14 @@ pub enum Commands {
             help = "Maximum number of concurrent jobs"
         )]
         jobs: usize,
-        /// Filter to a subset of samples: `first:N` or explicit names
-        /// (repeatable, comma-separated).
+        /// Filter to a subset of samples: `@path`/`+@path` sheet
+        /// operations, `first:N`, explicit names, or `ready` — the SAME
+        /// unified selection `run`/`dry-run` use (the handler forwards the
+        /// specs to both, so the help text mirrors their wording).
         #[arg(
             long = "samples",
             value_name = "LIST",
-            help = "Test only these samples: first:N (pilot), explicit names, or ready (complete inputs; repeatable, comma-separated)"
+            help = "Sample selection: '@path' replaces the workflow's samples from a samplesheet, '+@path' appends (same-name groups merge); names, first:N (pilot), or ready (complete inputs) filter to a subset. Repeatable, comma-separated."
         )]
         samples_filter: Vec<String>,
         /// Run deep health checks (script files, environment definition files,

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -419,13 +419,25 @@ impl BackendDriver {
                                 base_id.clone(),
                                 chunk.iter().map(|(n, _)| n.clone()).collect(),
                             );
+                            // The array→instance map is what status/resume
+                            // read back — a lost write silently misleads
+                            // them, so it fails the run like the sibling
+                            // run-dir writes above (issue #136 tier-2
+                            // audit; the old `let _ =` swallowed it).
                             if let Some(parent) = index_path.parent() {
-                                let _ = std::fs::create_dir_all(parent);
+                                std::fs::create_dir_all(parent).map_err(|e| {
+                                    OxoFlowError::Config {
+                                        message: format!("cannot create {}: {e}", parent.display()),
+                                    }
+                                })?;
                             }
-                            let _ = std::fs::write(
+                            std::fs::write(
                                 &index_path,
                                 serde_json::to_string_pretty(&array_index).unwrap_or_default(),
-                            );
+                            )
+                            .map_err(|e| OxoFlowError::Config {
+                                message: format!("cannot write {}: {e}", index_path.display()),
+                            })?;
                             for (i, (c_name, c_sr)) in chunk.iter().enumerate() {
                                 let element_id = format!("{}_{}", base_id, i + 1);
                                 // Per-INSTANCE dirs keep the run directory
@@ -1415,6 +1427,67 @@ shell = "cat {input} > merged.txt"
         assert_eq!(mapped.len(), 2);
         assert!(mapped.contains(&"asm_assembler_spades".to_string()));
         assert!(mapped.contains(&"asm_assembler_megahit".to_string()));
+    }
+
+    #[test]
+    fn driver_errors_when_index_json_is_not_writable() {
+        // The array→instance map is what status/resume read back: a write
+        // failure must fail the run, not be swallowed by a `let _ =`
+        // (issue #136 tier-2 audit — a corrupt/missing mapping silently
+        // misleads status about which instance a job id belonged to).
+        let fx = setup();
+        let (d, _) = driver(&fx);
+        // A directory in place of the file makes the write fail.
+        std::fs::create_dir(fx.run_dir.path().join("index.json")).unwrap();
+        // Two instances of one template → one array submission (the only
+        // path that writes index.json).
+        let wf_toml = r#"
+[workflow]
+name = "arr"
+version = "1.0.0"
+
+[[values]]
+name = "assembler"
+values = ["spades", "megahit"]
+
+[[rules]]
+name = "asm"
+output = ["out/{assembler}.txt"]
+shell = "echo asm > out/{assembler}.txt"
+"#;
+        let wf = fx.workdir.path().join("arr.oxoflow");
+        std::fs::write(&wf, wf_toml).unwrap();
+        let mut config = WorkflowConfig::from_file(&wf).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let dag = WorkflowDag::from_rules(&config.rules).unwrap();
+        let mut plan = ScheduledPlan::build(
+            &config,
+            &dag,
+            fx.workdir.path(),
+            &EnvironmentResolver::new(),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let to_run: HashSet<String> = plan.order.iter().cloned().collect();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let err = runtime
+            .block_on(d.run(
+                &mut plan,
+                &to_run,
+                DriverOptions {
+                    run_dir: fx.run_dir.path(),
+                    on_checkpoint: None,
+                    merge: None,
+                    sensitive_values: &[],
+                    on_submit: None,
+                },
+            ))
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("index.json"),
+            "the error must name the index.json write: {err}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -57,11 +57,17 @@ pub trait EnvironmentBackend: Send + Sync {
     fn cache_key(&self, spec: &str) -> String;
 }
 
-/// Read a conda YAML spec and extract the `name:` field, falling back to file stem.
-fn conda_env_name_from_spec(spec: &str) -> String {
+/// Read a conda YAML spec and extract the `name:` field, falling back to
+/// file stem. The name is interpolated into a shell command string
+/// (`conda run -n <name>`), so it must be validated: an untrusted YAML
+/// `name:` could otherwise break out of the quoting and run arbitrary
+/// shell (issue #136). Fail fast with a clear error instead of emitting
+/// a command that does not do what it says. `kind` names the backend
+/// (conda/mamba) in the error.
+fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String> {
     // Try reading the YAML file to extract `name:` field
-    if let Ok(content) = std::fs::read_to_string(spec) {
-        for line in content.lines() {
+    let from_yaml = std::fs::read_to_string(spec).ok().and_then(|content| {
+        content.lines().find_map(|line| {
             let trimmed = line.trim();
             if trimmed.starts_with("name:") || trimmed.starts_with("name :") {
                 let name = trimmed
@@ -71,18 +77,33 @@ fn conda_env_name_from_spec(spec: &str) -> String {
                     .trim()
                     .trim_matches('"')
                     .trim_matches('\'');
-                if !name.is_empty() {
-                    return name.to_string();
-                }
+                (!name.is_empty()).then(|| name.to_string())
+            } else {
+                None
             }
-        }
-    }
+        })
+    });
     // Fall back to file stem
-    std::path::Path::new(spec)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(spec)
-        .to_string()
+    let name = from_yaml.unwrap_or_else(|| {
+        std::path::Path::new(spec)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(spec)
+            .to_string()
+    });
+    if name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        Ok(name)
+    } else {
+        Err(OxoFlowError::Environment {
+            kind: kind.to_string(),
+            message: format!(
+                "invalid environment name '{name}' derived from spec '{spec}': names may contain only alphanumerics, '_' and '-'"
+            ),
+        })
+    }
 }
 
 /// Conda environment backend.
@@ -108,7 +129,7 @@ impl EnvironmentBackend for CondaBackend {
         _resources: Option<&crate::rule::Resources>,
         _workdir: &std::path::Path,
     ) -> Result<String> {
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("conda", spec)?;
         let escaped = escape_for_sh_single_quote(command);
         // `--no-capture-output` (conda >= 4.13): without it, `conda run`
         // buffers the wrapped process's stdout/stderr through its own
@@ -139,14 +160,14 @@ impl EnvironmentBackend for CondaBackend {
         // or the file stem. Without `-n`, conda 25+ fails with "Unable to
         // determine environment" for YAMLs that declare no name (the common
         // nf-core style — found live: mixscape's seurat_lda.yaml).
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("conda", spec)?;
         Ok(format!(
             "conda env create -n {env_name} -f {spec} 2>/dev/null || conda env update -n {env_name} -f {spec} --prune"
         ))
     }
 
     fn teardown_command(&self, spec: &str) -> Result<Option<String>> {
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("conda", spec)?;
         Ok(Some(format!("conda env remove -n {env_name} -y")))
     }
 
@@ -154,9 +175,11 @@ impl EnvironmentBackend for CondaBackend {
         // `conda run` succeeds even when the env's own bin/ is missing
         // (tools then resolve from the system PATH), so the check must
         // target the env prefix itself — CONDA_PREFIX is set by `conda run`.
-        let env_name = conda_env_name_from_spec(spec);
+        // A present-but-empty bin/ (interrupted transaction) is just as
+        // broken: require at least one entry, not just the dir (issue #136).
+        let env_name = conda_env_name_from_spec("conda", spec)?;
         Ok(Some(format!(
-            "conda run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\"'"
+            "conda run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'"
         )))
     }
 
@@ -196,7 +219,7 @@ impl CondaBackend {
                 "conda run --no-capture-output -p {prefix} bash -c 'export PATH=\"$CONDA_PREFIX/bin:$PATH\"; {escaped}'"
             ))
         } else {
-            let env_name = conda_env_name_from_spec(spec);
+            let env_name = conda_env_name_from_spec("conda", spec)?;
             Ok(format!(
                 "conda run --no-capture-output -n {env_name} bash -c 'export PATH=\"$CONDA_PREFIX/bin:$PATH\"; {escaped}'"
             ))
@@ -230,7 +253,7 @@ impl CondaBackend {
     ) -> Result<Option<String>> {
         if let Some(prefix) = prefix {
             Ok(Some(format!(
-                "conda run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\"'"
+                "conda run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'"
             )))
         } else {
             self.verify_command(spec)
@@ -357,7 +380,7 @@ impl MambaBackend {
                 self.binary
             ))
         } else {
-            let env_name = conda_env_name_from_spec(spec);
+            let env_name = conda_env_name_from_spec("mamba", spec)?;
             Ok(format!(
                 "{} run -n {env_name} bash -c '{escaped}'",
                 self.binary
@@ -387,7 +410,7 @@ impl MambaBackend {
     ) -> Result<Option<String>> {
         if let Some(prefix) = prefix {
             Ok(Some(format!(
-                "{} run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+                "{} run -p {prefix} bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'",
                 self.binary
             )))
         } else {
@@ -424,7 +447,7 @@ impl EnvironmentBackend for MambaBackend {
         _resources: Option<&crate::rule::Resources>,
         _workdir: &std::path::Path,
     ) -> Result<String> {
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("mamba", spec)?;
         let escaped = escape_for_sh_single_quote(command);
         Ok(format!(
             "{} run -n {env_name} bash -c '{escaped}'",
@@ -435,7 +458,7 @@ impl EnvironmentBackend for MambaBackend {
     fn setup_command(&self, spec: &str) -> Result<String> {
         // Same name-consistency fix as CondaBackend (see there): mamba 2.x
         // refuses nameless YAMLs without `-n`.
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("mamba", spec)?;
         Ok(format!(
             "{} env create -n {env_name} -f {spec} 2>/dev/null || {} env update -n {env_name} -f {spec} --prune",
             self.binary, self.binary
@@ -443,14 +466,14 @@ impl EnvironmentBackend for MambaBackend {
     }
 
     fn teardown_command(&self, spec: &str) -> Result<Option<String>> {
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("mamba", spec)?;
         Ok(Some(format!("{} env remove -n {env_name} -y", self.binary)))
     }
 
     fn verify_command(&self, spec: &str) -> Result<Option<String>> {
-        let env_name = conda_env_name_from_spec(spec);
+        let env_name = conda_env_name_from_spec("mamba", spec)?;
         Ok(Some(format!(
-            "{} run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+            "{} run -n {env_name} bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'",
             self.binary
         )))
     }
@@ -593,14 +616,17 @@ impl EnvironmentBackend for SingularityBackend {
         //   when the derived SIF is absent — `pull` refuses to overwrite
         //   an existing SIF, and pulling per rule would rebuild the image
         //   every time. The SIF name follows the pull naming (last path
-        //   segment, ':' -> '_'); the per-key env lock serializes the
-        //   truly-missing case.
+        //   segment, ':' -> '_'); an https URI whose final segment already
+        //   ends in `.sif` must not get a second `.sif` appended — the
+        //   existence guard would then never match the pulled artifact
+        //   and every rule would re-pull (issue #136). The per-key env
+        //   lock serializes the truly-missing case.
         // - a local SIF path: already deployed (e.g. a shared site image
         //   store) — nothing to pull. `{binary} pull` accepts only URIs,
         //   so a path must bypass it entirely; a missing local file fails
         //   with a clear diagnostic instead of pull's URI parse error.
         Ok(format!(
-            "case '{spec}' in *://*) IMG=$(printf '%s' '{spec}' | sed 's#^docker://##; s#.*/##; s#:#_#g').sif; [ -f \"$IMG\" ] || {b} pull {spec} ;; *) [ -f '{spec}' ] || {{ echo \"singularity spec '{spec}' is neither a pull URI nor an existing file\" >&2; exit 1; }} ;; esac",
+            "case '{spec}' in *://*) IMG=$(printf '%s' '{spec}' | sed 's#^docker://##; s#.*/##; s#:#_#g'); case \"$IMG\" in *.sif) ;; *) IMG=\"$IMG.sif\" ;; esac; [ -f \"$IMG\" ] || {b} pull {spec} ;; *) [ -f '{spec}' ] || {{ echo \"singularity spec '{spec}' is neither a pull URI nor an existing file\" >&2; exit 1; }} ;; esac",
             b = self.binary,
         ))
     }
@@ -1464,6 +1490,59 @@ mod tests {
         assert_eq!(backend.cache_key("envs/qc.yaml"), "conda:envs/qc.yaml");
     }
 
+    #[test]
+    fn conda_env_name_validation_rejects_untrusted_yaml_names() {
+        // The env name is interpolated into `conda run -n <name>` inside a
+        // shell string, so an untrusted YAML `name:` could break out of the
+        // quoting and run arbitrary shell (issue #136). The derived name is
+        // validated and the failure is a clear environment error, not a
+        // silently emitted command that does not do what it says.
+        let dir = tempfile::tempdir().unwrap();
+        let evil = dir.path().join("evil.yaml");
+        std::fs::write(&evil, "name: \"x'; rm -rf ~ ;'\"\n").unwrap();
+        match conda_env_name_from_spec("conda", evil.to_str().unwrap()) {
+            Err(OxoFlowError::Environment { kind, message }) => {
+                assert_eq!(kind, "conda");
+                assert!(
+                    message.contains("invalid environment name"),
+                    "message must explain the rejection: {message}"
+                );
+                assert!(
+                    message.contains("alphanumerics"),
+                    "message must state the allowed alphabet: {message}"
+                );
+            }
+            other => panic!("expected an Environment error, got: {other:?}"),
+        }
+        // The mamba kind is surfaced through the same check.
+        assert!(matches!(
+            conda_env_name_from_spec("mamba", evil.to_str().unwrap()),
+            Err(OxoFlowError::Environment { kind, .. }) if kind == "mamba"
+        ));
+    }
+
+    #[test]
+    fn conda_env_name_validation_accepts_plain_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = dir.path().join("env.yaml");
+        std::fs::write(&yaml, "name: rnaseq_2\nchannels: [bioconda]\n").unwrap();
+        assert_eq!(
+            conda_env_name_from_spec("conda", yaml.to_str().unwrap()).unwrap(),
+            "rnaseq_2",
+            "a YAML name within the allowed alphabet passes"
+        );
+        assert_eq!(
+            conda_env_name_from_spec("conda", "envs/qc.yaml").unwrap(),
+            "qc",
+            "the file-stem fallback passes for plain stems"
+        );
+        assert_eq!(
+            conda_env_name_from_spec("conda", "my-env_1").unwrap(),
+            "my-env_1",
+            "a bare name spec passes"
+        );
+    }
+
     // ── DockerBackend ──────────────────────────────────────────────
 
     #[test]
@@ -1538,6 +1617,27 @@ mod tests {
         // inspect-first guard for the SIF naming
         assert!(cmd.starts_with("case 'docker://ubuntu:22.04' in *://*)"));
         assert!(cmd.contains("IMG=$(printf '%s' 'docker://ubuntu:22.04'"));
+        assert!(cmd.contains("[ -f \"$IMG\" ] || "));
+    }
+
+    #[test]
+    fn singularity_setup_https_uri_derives_final_segment_without_double_sif() {
+        let backend = SingularityBackend::new();
+        let cmd = backend
+            .setup_command("https://example.com/images/foo.sif")
+            .unwrap();
+        // The derived name is the final URI segment — `foo.sif`, not
+        // `foo.sif.sif`: the old unconditional `.sif` append made the
+        // existence guard look for the wrong artifact, so every rule
+        // re-pulled (issue #136).
+        assert!(
+            cmd.contains("IMG=$(printf '%s' 'https://example.com/images/foo.sif'"),
+            "the URI arm must derive the name from the spec: {cmd}"
+        );
+        assert!(
+            cmd.contains("case \"$IMG\" in *.sif) ;; *) IMG=\"$IMG.sif\" ;; esac;"),
+            "a final segment already ending in .sif must not get a second .sif: {cmd}"
+        );
         assert!(cmd.contains("[ -f \"$IMG\" ] || "));
     }
 
@@ -2172,9 +2272,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(
-            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'"),
+            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'"),
             "a prefix env must be verified with -p (the -n form checks a \
-             named env that `conda env create -p` never creates), got: {cmd}"
+             named env that `conda env create -p` never creates) and the \
+             check must require at least one entry in bin/, got: {cmd}"
         );
         assert!(!cmd.contains(" -n "));
     }
@@ -2183,7 +2284,11 @@ mod tests {
     fn conda_verify_command_without_prefix() {
         let backend = CondaBackend;
         let cmd = backend.verify_command("envs/qc.yaml").unwrap().unwrap();
-        assert!(cmd.contains("conda run -n qc bash -c 'test -d \"$CONDA_PREFIX/bin\"'"));
+        assert!(
+            cmd.contains("conda run -n qc bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'"),
+            "the named-env verify must also require at least one entry in bin/ \
+             (an empty bin/ is a broken env), got: {cmd}"
+        );
         assert!(!cmd.contains(" -p "));
     }
 
@@ -2196,10 +2301,10 @@ mod tests {
             .unwrap();
         assert!(
             cmd.contains(&format!(
-                "{} run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'",
+                "{} run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'",
                 backend.binary
             )),
-            "expected -p prefix form, got: {cmd}"
+            "expected -p prefix form with a non-empty bin/ check, got: {cmd}"
         );
         assert!(!cmd.contains(" -n "));
     }
@@ -2214,7 +2319,7 @@ mod tests {
         };
         let cmd = resolver.verify_command(&spec).unwrap().unwrap();
         assert!(
-            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\"'"),
+            cmd.contains("conda run -p .oxo-conda bash -c 'test -d \"$CONDA_PREFIX/bin\" && ls \"$CONDA_PREFIX/bin\" | head -1 | grep -q .'"),
             "the named-env verify checks the WRONG env for a prefix install, got: {cmd}"
         );
         assert!(!cmd.contains(" -n "));

--- a/crates/oxo-flow-core/src/executor/output_invalidation.rs
+++ b/crates/oxo-flow-core/src/executor/output_invalidation.rs
@@ -26,6 +26,7 @@ pub struct OutputSnapshot {
     path: PathBuf,
     existed: bool,
     mtime: Option<std::time::SystemTime>,
+    size: Option<u64>,
 }
 
 /// Snapshot a rule's declared outputs (config placeholders expanded using
@@ -47,11 +48,13 @@ pub fn snapshot_outputs(
             let path = workdir.join(expanded);
             let meta = std::fs::metadata(&path).ok();
             let existed = meta.is_some();
-            let mtime = meta.and_then(|m| m.modified().ok());
+            let mtime = meta.as_ref().and_then(|m| m.modified().ok());
+            let size = meta.map(|m| m.len());
             Some(OutputSnapshot {
                 path,
                 existed,
                 mtime,
+                size,
             })
         })
         .collect()
@@ -62,9 +65,11 @@ pub fn snapshot_outputs(
 /// Deletes files created during the attempt; moves pre-existing files the
 /// attempt modified aside to `<name>.oxo-failed` so the failure is
 /// recoverable and the freshness gate no longer sees a "fresh" output.
-/// Pre-existing files whose mtime is unchanged are left alone. Every step
-/// is best-effort with a warning — cleanup must never mask the rule's own
-/// failure.
+/// A pre-existing file is considered modified when its mtime or its size
+/// differs from the snapshot — the size check catches rewrites that
+/// restore the old timestamp. Files matching both are left alone. Every
+/// step is best-effort with a warning — cleanup must never mask the rule's
+/// own failure.
 pub async fn invalidate_failed_outputs(snapshots: &[OutputSnapshot]) {
     for snapshot in snapshots {
         let current_meta = match tokio::fs::metadata(&snapshot.path).await {
@@ -98,15 +103,31 @@ pub async fn invalidate_failed_outputs(snapshots: &[OutputSnapshot]) {
             }
             continue;
         }
-        // Pre-existing: invalidate only if the attempt modified it.
-        let modified = match (&snapshot.mtime, current_meta.modified().ok()) {
+        // Pre-existing: invalidate only if the attempt modified it. The
+        // mtime comparison alone misses rewrites that restore the old
+        // timestamp (tools doing that are rare but real, and coarse
+        // filesystems can share mtimes) — a size change catches those
+        // (issue #136).
+        let mtime_changed = match (&snapshot.mtime, current_meta.modified().ok()) {
             (Some(before), Some(after)) => after != *before,
             // Unreadable mtime: be conservative and leave the file alone.
             _ => false,
         };
-        if modified {
+        let size_changed = snapshot.size != Some(current_meta.len());
+        if mtime_changed || size_changed {
             let aside = aside_path(&snapshot.path);
-            if let Err(e) = tokio::fs::rename(&snapshot.path, &aside).await {
+            if tokio::fs::metadata(&aside).await.is_ok() {
+                // `rename` would silently overwrite a previous failure's
+                // evidence — skip it so recovery keeps every snapshot of
+                // what failed, and leave the current file in place (issue
+                // #136).
+                tracing::warn!(
+                    file = %snapshot.path.display(),
+                    aside = %aside.display(),
+                    "not moving failed output aside: the aside name is already \
+                     held by a previous failure — keeping the current file in place"
+                );
+            } else if let Err(e) = tokio::fs::rename(&snapshot.path, &aside).await {
                 tracing::warn!(
                     file = %snapshot.path.display(),
                     error = %e,
@@ -124,7 +145,8 @@ pub async fn invalidate_failed_outputs(snapshots: &[OutputSnapshot]) {
 }
 
 /// `<path>.oxo-failed` sibling for a moved-aside output. A previous failure
-/// already holding that name is overwritten by `rename`.
+/// already holding that name is never overwritten — the caller skips the
+/// rename with a warning so recovery evidence is never destroyed.
 fn aside_path(path: &Path) -> PathBuf {
     let mut name = path
         .file_name()
@@ -197,6 +219,61 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(dir.path().join("out.txt")).unwrap(),
             "user-data"
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_failed_aside_is_never_clobbered() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+        std::fs::write(&path, b"user-data").unwrap();
+        // A previous failure's evidence already holds the aside name.
+        let aside = dir.path().join("out.txt.oxo-failed");
+        std::fs::write(&aside, b"previous-failure-evidence").unwrap();
+        let rule = rule_with_outputs(&["out.txt"]);
+        let values = HashMap::new();
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        // The attempt overwrites the pre-existing output.
+        std::fs::write(&path, b"corrupt").unwrap();
+        invalidate_failed_outputs(&snapshots).await;
+        assert_eq!(
+            std::fs::read_to_string(&aside).unwrap(),
+            "previous-failure-evidence",
+            "a second failure must never destroy the first failure's evidence"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "corrupt",
+            "the current failure's output stays put when the aside name is taken"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_mtime_but_resized_output_is_moved_aside() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.txt");
+        std::fs::write(&path, b"user-data").unwrap();
+        // Pin the mtime so the failed attempt's rewrite can restore it —
+        // the old mtime-only check then sees no change at all.
+        let mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&path).unwrap());
+        let rule = rule_with_outputs(&["out.txt"]);
+        let values = HashMap::new();
+        let snapshots = snapshot_outputs(&rule, dir.path(), &values);
+        // The attempt overwrites the file with different content, then a
+        // coarse-grained filesystem (or a tool preserving timestamps)
+        // restores the original mtime.
+        std::fs::write(&path, b"partial-corrupt-output").unwrap();
+        filetime::set_file_mtime(&path, mtime).unwrap();
+        invalidate_failed_outputs(&snapshots).await;
+        assert!(
+            !path.exists(),
+            "a resized rewrite must invalidate even when the mtime matches"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("out.txt.oxo-failed")).unwrap(),
+            "partial-corrupt-output",
+            "the failed content must be preserved for recovery"
         );
     }
 

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -318,6 +318,13 @@ impl Default for ExecutorConfig {
     }
 }
 
+/// Default throttle for the resource-wait diagnostics (issue #123): a rule
+/// parked on the pool prints a "waiting for resources" warning at most this
+/// often, so priority-inversion starvation is diagnosable from the log
+/// without spamming it. Injectable per-executor for tests; production runs
+/// keep the 60s default (issue #136).
+pub const DEFAULT_WAIT_REPORT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub struct LocalExecutor {
     config: ExecutorConfig,
     semaphore: Arc<Semaphore>,
@@ -325,6 +332,9 @@ pub struct LocalExecutor {
     resource_pool: Arc<Mutex<ResourcePool>>,
     /// Wakes waiters when resources are released back to the pool.
     resource_notify: Arc<tokio::sync::Notify>,
+    /// Throttle interval for the "waiting for resources" diagnostics
+    /// (issue #123); defaults to [`DEFAULT_WAIT_REPORT_INTERVAL`].
+    wait_report_interval: std::time::Duration,
     /// Detected system thread count (respects cgroup limits on Linux).
     system_threads: u32,
     /// Detected system total memory in MB (respects cgroup limits on Linux).
@@ -451,11 +461,19 @@ impl LocalExecutor {
             env_resolver,
             resource_pool,
             resource_notify: Arc::new(tokio::sync::Notify::new()),
+            wait_report_interval: DEFAULT_WAIT_REPORT_INTERVAL,
             system_threads: max_threads,
             system_memory_mb: max_memory_mb,
             rss_sampler: Arc::new(super::rss::RssSampler::new()),
             active_pids: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
+    }
+
+    /// Override the resource-wait diagnostics throttle (issue #136): tests
+    /// drive a tiny interval to exercise the report path; production keeps
+    /// the 60s [`DEFAULT_WAIT_REPORT_INTERVAL`].
+    pub fn set_wait_report_interval(&mut self, interval: std::time::Duration) {
+        self.wait_report_interval = interval;
     }
 
     /// Snapshot of the in-flight child pid per rule (issue #131). The
@@ -792,6 +810,15 @@ impl LocalExecutor {
             .and_then(crate::scheduler::parse_memory_mb)
             && declared > container_ceiling_mb
         {
+            // Loud, not silent (issue #136 LOW): the clamp keeps the run
+            // alive but a tool that genuinely needs the declared amount
+            // will OOM inside the cgroup — the operator must see why.
+            tracing::warn!(
+                rule = %rule.name,
+                declared_memory_mb = declared,
+                ceiling_memory_mb = container_ceiling_mb,
+                "rule declares more memory than the machine provides — clamping the container --memory limit (OOM risk if the tool actually needs the declared amount)"
+            );
             resources.memory = Some(format!("{container_ceiling_mb}M"));
         }
         match self.env_resolver.wrap_command(
@@ -871,13 +898,29 @@ impl LocalExecutor {
 
         // Wait diagnostics (issue #123): a rule parked here is invisible
         // from the outside — it has printed "Running" but spawned nothing.
-        // Emit a throttled warning every 60s naming what the rule needs and
-        // WHO holds it, so priority-inversion starvation (live: auto-sra
-        // dumps starved by merges sharing the limit_merge group) is
-        // diagnosable from the log instead of hanging silently.
+        // Emit a throttled warning (every `wait_report_interval`, 60s by
+        // default) naming what the rule needs and WHO holds it, so
+        // priority-inversion starvation (live: auto-sra dumps starved by
+        // merges sharing the limit_merge group) is diagnosable from the log
+        // instead of hanging silently.
         let wait_started = std::time::Instant::now();
         let mut last_report = wait_started;
         loop {
+            // Lost-wakeup guard (issue #136): register the wakeup future
+            // BEFORE the acquisition check. `notify_waiters()` wakes only
+            // waiters that are already registered and stores nothing, so a
+            // waiter that registered only at park time could miss a release
+            // that lands between its failed check and its park — and if that
+            // was the last release, sleep forever. Registering first closes
+            // the window: a release after this point wakes this waiter; a
+            // release before it is visible to the check below (or was caught
+            // by the previous cycle's registration).
+            let notified = self.resource_notify.notified();
+            let mut notified = std::pin::pin!(notified);
+            let waker = std::task::Waker::noop();
+            let _ = notified
+                .as_mut()
+                .poll(&mut std::task::Context::from_waker(waker));
             {
                 let mut pool = self.resource_pool.lock().await;
                 // FIFO-gated acquisition (issue #123 100% guarantee): the
@@ -885,7 +928,7 @@ impl LocalExecutor {
                 // waiter can never be leapfrogged by fresh arrivals.
                 if pool.try_acquire_fair(rule, self.system_threads, self.system_memory_mb) {
                     let waited = wait_started.elapsed().as_secs();
-                    if waited >= 60 {
+                    if waited >= self.wait_report_interval.as_secs() {
                         tracing::info!(
                             rule = %rule.name,
                             waited_secs = waited,
@@ -894,7 +937,7 @@ impl LocalExecutor {
                     }
                     return Ok(());
                 }
-                if last_report.elapsed().as_secs() >= 60 {
+                if last_report.elapsed() >= self.wait_report_interval {
                     tracing::warn!(
                         rule = %rule.name,
                         waited_secs = wait_started.elapsed().as_secs(),
@@ -904,8 +947,10 @@ impl LocalExecutor {
                     last_report = std::time::Instant::now();
                 }
             }
-            // Resources busy — wait for a release notification.
-            self.resource_notify.notified().await;
+            // Resources busy — wait for a release notification. The future
+            // was already registered above, so this park cannot miss a
+            // release that happened between the check and the park.
+            notified.await;
         }
     }
 
@@ -2085,9 +2130,9 @@ async fn remove_tree(path: &Path) -> std::io::Result<()> {
 ///
 /// Runner-side masking, GitHub-Actions-style: every occurrence of each
 /// value is replaced with `***` before the text lands in the job record
-/// (checkpoint, report, AI recovery, web). Values shorter than 4
-/// characters are not masked — the same threshold GitHub Actions uses, so
-/// common short strings (thresholds, counts) are not mass-redacted.
+/// (checkpoint, report, AI recovery, web). Every NON-EMPTY value is
+/// masked — 3-character credentials are rare but real, and masking has no
+/// false-positive cost for keys the user declared sensitive (issue #136).
 /// Structured forms of a secret (JSON/YAML serialization, base64) do not
 /// match the exact value and pass through — the documented limitation of
 /// exact-match masking.
@@ -2097,7 +2142,7 @@ pub fn mask_sensitive(text: &str, values: &[String]) -> String {
     }
     let mut masked = text.to_string();
     for value in values {
-        if value.chars().count() >= 4 {
+        if !value.is_empty() {
             masked = masked.replace(value.as_str(), "***");
         }
     }
@@ -2570,18 +2615,19 @@ mod tests {
 
     #[test]
     fn mask_sensitive_redacts_matching_values_only() {
-        // Values >= 4 chars are masked; short/empty values are skipped (the
-        // same threshold GitHub Actions uses, to avoid mass-redacting common
-        // short strings like thresholds). Overlapping values are masked
+        // Every non-empty value is masked — 3-char credentials are rare but
+        // real, and masking has no false-positive cost for keys the user
+        // declared sensitive (issue #136). Overlapping values are masked
         // independently of order.
         let values = vec!["s3cr3t-token-42".to_string(), "ab".to_string()];
-        let text = "token is s3cr3t-token-42 and again s3cr3t-token-42; ab stays";
+        let text = "token is s3cr3t-token-42 and again s3cr3t-token-42; ab is short but masked";
         let masked = mask_sensitive(text, &values);
         assert_eq!(
-            masked, "token is *** and again ***; ab stays",
-            "long values mask, short values stay"
+            masked, "token is *** and again ***; *** is short but masked",
+            "every non-empty value masks, including short ones"
         );
         assert!(!masked.contains("s3cr3t-token-42"));
+        assert!(!masked.contains("ab"));
 
         // Empty input and empty value list are no-ops.
         assert_eq!(mask_sensitive("plain", &[]), "plain");
@@ -2625,5 +2671,236 @@ mod tests {
         let ex = executor_with(4, 2048);
         let cmd = ex.resolve_command("echo hi", &docker_rule("1G"), None);
         assert!(cmd.contains("--memory 1G"), "cmd: {cmd}");
+    }
+
+    // ── Resource-wait diagnostics (issue #123 / #136) ────────────────
+
+    /// Minimal tracing subscriber that captures formatted events (level +
+    /// fields) for assertions — avoids a tracing-subscriber dev-dependency.
+    struct CaptureSubscriber {
+        events: Arc<std::sync::Mutex<Vec<(tracing::Level, String)>>>,
+    }
+
+    impl tracing::Subscriber for CaptureSubscriber {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+        fn enter(&self, _span: &tracing::span::Id) {}
+        fn exit(&self, _span: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct Fields(String);
+            impl tracing::field::Visit for Fields {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if !self.0.is_empty() {
+                        self.0.push(' ');
+                    }
+                    self.0.push_str(field.name());
+                    self.0.push('=');
+                    self.0.push_str(&format!("{value:?}"));
+                }
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    if !self.0.is_empty() {
+                        self.0.push(' ');
+                    }
+                    self.0.push_str(field.name());
+                    self.0.push('=');
+                    self.0.push_str(value);
+                }
+                fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+                    if !self.0.is_empty() {
+                        self.0.push(' ');
+                    }
+                    self.0.push_str(field.name());
+                    self.0.push('=');
+                    self.0.push_str(&value.to_string());
+                }
+                fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+                    if !self.0.is_empty() {
+                        self.0.push(' ');
+                    }
+                    self.0.push_str(field.name());
+                    self.0.push('=');
+                    self.0.push_str(&value.to_string());
+                }
+                fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+                    if !self.0.is_empty() {
+                        self.0.push(' ');
+                    }
+                    self.0.push_str(field.name());
+                    self.0.push('=');
+                    self.0.push_str(&value.to_string());
+                }
+            }
+            let mut fields = Fields(String::new());
+            event.record(&mut fields);
+            self.events
+                .lock()
+                .unwrap()
+                .push((*event.metadata().level(), fields.0));
+        }
+    }
+
+    /// Recompute every callsite's cached interest under THIS test's
+    /// subscriber. tracing caches `Interest` globally per callsite; a
+    /// callsite is registered (and cached) on first use by whichever thread
+    /// executes it first. A parallel test that emits through a callsite
+    /// while no subscriber is active on its thread (the common case in this
+    /// binary) caches that callsite as `Interest::never` — and `event!`
+    /// then drops it process-wide, silently, forever. Rebuilding while our
+    /// `with_default` guard is live (and is the only registered dispatcher)
+    /// repins every callsite to `always`, so assertions on captured events
+    /// stop depending on global registration order.
+    fn repair_interest_cache() {
+        tracing::callsite::rebuild_interest_cache();
+    }
+
+    fn rule_with_resources(name: &str, threads: u32, memory_mb: u32) -> Rule {
+        Rule {
+            name: name.to_string(),
+            resources: Resources {
+                threads,
+                memory: Some(format!("{memory_mb}M")),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn wait_diagnostics_are_throttled_and_name_holders() {
+        // The report interval is injectable (issue #136): with a 20ms
+        // interval the throttled "waiting for resources" warn must fire
+        // naming the holder, and the "resource wait resolved" info must
+        // follow once the waiter acquires.
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        tracing::subscriber::with_default(
+            CaptureSubscriber {
+                events: Arc::clone(&events),
+            },
+            || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(async {
+                    let mut ex = executor_with(2, 2048);
+                    ex.set_wait_report_interval(std::time::Duration::from_millis(20));
+                    let ex = Arc::new(ex);
+                    // Occupy the whole pool with two holders so a partial
+                    // release keeps the waiter parked long enough to trip
+                    // the throttled report.
+                    let holder_a = rule_with_resources("holder_a", 1, 1024);
+                    let holder_b = rule_with_resources("holder_b", 1, 1024);
+                    {
+                        let mut pool = ex.resource_pool.lock().await;
+                        pool.reserve(&holder_a, 2, 2048);
+                        pool.reserve(&holder_b, 2, 2048);
+                    }
+                    let waiter = rule_with_resources("waiter", 2, 2048);
+                    let ex_task = Arc::clone(&ex);
+                    let task = tokio::spawn(async move { ex_task.check_resources(&waiter).await });
+                    // First iteration parks without reporting (below the
+                    // interval); the park itself is the wakeup registration.
+                    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+                    // Partial release: still not enough for the waiter —
+                    // the throttled warn fires now, naming holder_b. The
+                    // interest-cache repair is synchronous here, so the
+                    // waiter task (which only runs when we next await) sees
+                    // a cache that lets its events through.
+                    repair_interest_cache();
+                    {
+                        let mut pool = ex.resource_pool.lock().await;
+                        pool.release(&holder_a, 2, 2048, &HashMap::new());
+                    }
+                    ex.resource_notify.notify_waiters();
+                    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+                    // Full release: the waiter acquires and logs the
+                    // resolve info.
+                    repair_interest_cache();
+                    {
+                        let mut pool = ex.resource_pool.lock().await;
+                        pool.release(&holder_b, 2, 2048, &HashMap::new());
+                    }
+                    ex.resource_notify.notify_waiters();
+                    task.await
+                        .expect("waiter task joins")
+                        .expect("waiter acquires");
+                });
+            },
+        );
+        let events = events.lock().unwrap();
+        let report_warns: Vec<&str> = events
+            .iter()
+            .filter(|(level, text)| {
+                *level == tracing::Level::WARN && text.contains("waiting for resources")
+            })
+            .map(|(_, text)| text.as_str())
+            .collect();
+        assert!(
+            report_warns.iter().any(|text| text.contains("holder_b")),
+            "the throttled warn must name who holds the resources: {report_warns:?}"
+        );
+        assert!(
+            report_warns.len() <= 2,
+            "the warn must be throttled, not spammed: {report_warns:?}"
+        );
+        assert!(
+            events.iter().any(|(level, text)| {
+                *level == tracing::Level::INFO && text.contains("resource wait resolved")
+            }),
+            "the resolve info must be emitted: {events:?}"
+        );
+    }
+
+    #[test]
+    fn resource_wait_wakes_on_release_notification_after_park() {
+        // Reasoning test for the lost-wakeup ordering guarantee (issue
+        // #136): the wait loop registers its `notified()` future BEFORE
+        // the acquisition check, so a release landing after the check but
+        // before the park wakes the waiter — `notify_waiters()` stores
+        // nothing for unregistered waiters, so a waiter that registered
+        // only at park time could miss the LAST release and sleep forever.
+        // A deterministic reproduction of that scheduling window is not
+        // feasible in a unit test; this pins the observable contract: a
+        // waiter parked on a fully held pool must wake and acquire from a
+        // SINGLE release+notify, with no further notifications ever
+        // arriving.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let mut ex = executor_with(1, 1024);
+            ex.set_wait_report_interval(std::time::Duration::from_millis(1));
+            let ex = Arc::new(ex);
+            let holder = rule_with_resources("holder", 1, 1024);
+            {
+                let mut pool = ex.resource_pool.lock().await;
+                pool.reserve(&holder, 1, 1024);
+            }
+            let waiter = rule_with_resources("waiter", 1, 1024);
+            let ex_task = Arc::clone(&ex);
+            let task = tokio::spawn(async move { ex_task.check_resources(&waiter).await });
+            // Let the waiter register and park.
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            {
+                let mut pool = ex.resource_pool.lock().await;
+                pool.release(&holder, 1, 1024, &HashMap::new());
+            }
+            // Exactly one notification — no retries, no further releases.
+            ex.resource_notify.notify_waiters();
+            task.await
+                .expect("waiter task joins")
+                .expect("waiter must acquire from the single notification");
+        });
     }
 }

--- a/crates/oxo-flow-core/src/git.rs
+++ b/crates/oxo-flow-core/src/git.rs
@@ -12,26 +12,6 @@ use fs2::FileExt;
 const GITHUB_CLONE_MIRRORS: &[&str] = &["https://ghfast.top/", "https://gh-proxy.com/"];
 
 /// Candidate clone URLs: the official URL first, then each mirror.
-/// Locate the root of the git repository containing `path`, if any: the
-/// nearest ancestor directory holding a `.git` entry. Walks up from
-/// `path`'s parent (when `path` is a file) or `path` itself (when it is a
-/// directory). Shared by checkpoint provenance (issue #115 pillar 1) and
-/// catalog metadata derivation (`info --json`, issue #124 pillar 3).
-pub fn find_repo_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
-    // Absolute first: lexical parent-walking on a shallow relative path
-    // (e.g. `examples/gallery/x.oxoflow` from the repo root) terminates at
-    // the empty path and would never reach the CWD's repository.
-    let start = std::path::absolute(path).ok()?;
-    let mut dir = Some(start.parent().unwrap_or(&start));
-    while let Some(d) = dir {
-        if d.join(".git").exists() {
-            return Some(d.to_path_buf());
-        }
-        dir = d.parent();
-    }
-    None
-}
-
 pub fn mirror_candidates(repo_url: &str) -> Vec<String> {
     let official = repo_url.trim_end_matches('/').to_string();
     if !official.starts_with("https://github.com/") {
@@ -44,6 +24,33 @@ pub fn mirror_candidates(repo_url: &str) -> Vec<String> {
                 .map(|prefix| format!("{prefix}{official}")),
         )
         .collect()
+}
+
+/// Locate the root of the git repository containing `path`, if any: the
+/// nearest ancestor directory holding a `.git` entry. Walks up from
+/// `path`'s parent (when `path` is a file) or `path` itself (when it is a
+/// directory). Shared by checkpoint provenance (issue #115 pillar 1) and
+/// catalog metadata derivation (`info --json`, issue #124 pillar 3).
+pub fn find_repo_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Absolute first: lexical parent-walking on a shallow relative path
+    // (e.g. `examples/gallery/x.oxoflow` from the repo root) terminates at
+    // the empty path and would never reach the CWD's repository.
+    let start = std::path::absolute(path).ok()?;
+    // Walk starts at the directory itself when `path` is a directory, and
+    // at its parent when it is a file — the doc promised this, the code
+    // skipped the first step (issue #136).
+    let mut dir = if start.is_dir() {
+        Some(start.as_path())
+    } else {
+        Some(start.parent().unwrap_or(&start))
+    };
+    while let Some(d) = dir {
+        if d.join(".git").exists() {
+            return Some(d.to_path_buf());
+        }
+        dir = d.parent();
+    }
+    None
 }
 
 /// Classify a pinned ref: a full 40-hex commit SHA must be fetched by SHA —
@@ -319,13 +326,40 @@ pub fn module_cache_root() -> std::path::PathBuf {
 }
 
 /// Filesystem-safe cache key for a repo@ref pair.
+///
+/// The readable prefix preserves the old `_`-flattened form; the hash
+/// suffix is the identity. Flattening alone is lossy: `https://a/b` and
+/// `https://a_b` both become `https_a_b`, so unrelated modules would
+/// share a cache dir and clobber each other (issue #136). The FNV-1a
+/// 64-bit hash over `repo\0ref` separates confusable pairs while the
+/// prefix keeps the directory names human-readable.
 pub fn cache_dir_name(repo_url: &str, git_ref: &str) -> String {
-    let mut name = repo_url
+    let repo = repo_url
         .trim_end_matches('/')
         .replace("://", "_")
         .replace('/', "_");
-    name.push_str(&format!("@{}", git_ref.replace('/', "_")));
-    name
+    let reference = git_ref.replace('/', "_");
+    format!(
+        "{repo}@{reference}@{:016x}",
+        cache_dir_hash(repo_url, git_ref)
+    )
+}
+
+/// FNV-1a 64-bit over `repo_url\0git_ref` (NUL-separated so adjacent
+/// segments cannot run together — repo URLs and git refs cannot contain
+/// NUL, so the separator is unambiguous).
+fn cache_dir_hash(repo_url: &str, git_ref: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in repo_url
+        .trim_end_matches('/')
+        .bytes()
+        .chain(std::iter::once(0))
+        .chain(git_ref.bytes())
+    {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 #[cfg(test)]
@@ -457,6 +491,67 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         assert_eq!(find_repo_root(&dir.join("wf.oxoflow")), None);
+        // A directory outside any repository is also None.
+        assert_eq!(find_repo_root(&dir), None);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn find_repo_root_handles_directory_inputs() {
+        let dir = std::env::temp_dir().join(format!("oxo-gitdir-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let repo = dir.join("repo");
+        std::fs::create_dir_all(repo.join("sub/dir")).unwrap();
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        // The repo directory itself must be found — the doc promises
+        // "walk starts at the directory itself", but the code skipped the
+        // first step and walked from the parent (issue #136).
+        assert_eq!(
+            find_repo_root(&repo),
+            Some(repo.clone()),
+            "a repo passed as a directory must resolve to itself"
+        );
+        // A directory deep inside the repo resolves to the root.
+        assert_eq!(
+            find_repo_root(&repo.join("sub/dir")),
+            Some(repo),
+            "a nested directory must resolve to the containing repo"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_dir_names_are_injective_for_confusable_inputs() {
+        // The old scheme flattened both repo URL and ref with `_` —
+        // `https://github.com/a/b` and `https://github.com/a_b` collapsed
+        // to the same cache dir, so unrelated modules clobbered each other
+        // (issue #136). The pair now carries a hash suffix: identical
+        // inputs still hash identically, confusable inputs differ.
+        let a_b = cache_dir_name("https://github.com/a/b", "main");
+        let a_b_confusable = cache_dir_name("https://github.com/a_b", "main");
+        assert_ne!(
+            a_b, a_b_confusable,
+            "`a/b` and `a_b` must not share a cache dir"
+        );
+        assert_eq!(
+            cache_dir_name("https://github.com/a/b", "main"),
+            a_b,
+            "the name must be deterministic for the same pair"
+        );
+        // Trailing slashes on the repo URL are normalized before hashing.
+        assert_eq!(
+            cache_dir_name("https://github.com/a/b/", "main"),
+            a_b,
+            "a trailing slash must not change the cache dir"
+        );
+        // The prefix stays readable for humans.
+        assert!(
+            a_b.starts_with("https_github.com_a_b@main@"),
+            "the readable prefix must be preserved: {a_b}"
+        );
+        // Ref slashes are flattened like before, still hashed apart.
+        let with_slash = cache_dir_name("https://github.com/a/b", "feature/x");
+        assert!(with_slash.starts_with("https_github.com_a_b@feature_x@"));
+        assert_ne!(with_slash, a_b);
     }
 }

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -746,7 +746,28 @@ impl ResourcePool {
             }
         }
         if parts.is_empty() {
-            parts.push("no single constraint found".to_string());
+            // No constraint shortfall: the rule COULD fit right now, so the
+            // FIFO guarantee (issue #123) is what blocks it — an older
+            // waiter stands ahead in the queue. Name the line ahead; the
+            // previous "no single constraint found" fallback misdiagnosed
+            // this reachable contention state as an internal inconsistency
+            // (issue #136). When the queue is empty this is unreachable
+            // (an empty queue plus satisfiable needs always acquires), so
+            // the fallback below is purely defensive.
+            let ahead: Vec<&str> = self
+                .waiters
+                .iter()
+                .take_while(|w| *w != &rule.name)
+                .map(|w| w.as_str())
+                .collect();
+            if ahead.is_empty() {
+                parts.push("waiting for a release — head of the FIFO queue".to_string());
+            } else {
+                parts.push(format!(
+                    "queued behind [{}] — older waiters acquire first (FIFO)",
+                    ahead.join(", ")
+                ));
+            }
         }
 
         // Top thread/memory holders help even when a group is the blocker.
@@ -1482,6 +1503,50 @@ mod tests {
             report.contains("held by [merge_a, merge_b]")
                 || report.contains("held by [merge_b, merge_a]"),
             "report must name the holders: {report}"
+        );
+    }
+
+    #[test]
+    fn blockage_report_names_senior_waiters_when_rule_can_fit() {
+        // A junior rule whose own needs are satisfiable can still be blocked
+        // by the FIFO guarantee (issue #123): an older waiter stands ahead of
+        // it in the queue and cannot fit yet. The report must explain that
+        // contention state instead of claiming "no single constraint found"
+        // (issue #136) — that fallback misdiagnosed a real, reachable state
+        // as an internal inconsistency.
+        let mut pool = ResourcePool::new(8, 8192);
+        let holder = Rule {
+            name: "holder".to_string(),
+            threads: Some(1),
+            ..Default::default()
+        };
+        pool.reserve(&holder, 8, 8192); // 7 threads free
+        let senior = Rule {
+            name: "senior".to_string(),
+            threads: Some(8),
+            ..Default::default()
+        };
+        assert!(
+            !pool.try_acquire_fair(&senior, 8, 8192),
+            "senior needs all 8 threads; only 7 are free"
+        );
+        let junior = Rule {
+            name: "junior".to_string(),
+            threads: Some(1),
+            ..Default::default()
+        };
+        assert!(
+            !pool.try_acquire_fair(&junior, 8, 8192),
+            "junior fits on paper but the FIFO queue blocks it behind the senior"
+        );
+        let report = pool.blockage_report(&junior, 8, 8192);
+        assert!(
+            !report.contains("no single constraint found"),
+            "the old fallback misdiagnosed FIFO blocking as a bug: {report}"
+        );
+        assert!(
+            report.contains("queued behind") && report.contains("senior"),
+            "the report must name the senior waiter ahead: {report}"
         );
     }
 

--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -1146,6 +1146,16 @@ pub async fn cancel_run(
     // in that window would otherwise signal nothing and still return 200
     // while orphaned rule processes run on (issue #120). The DB fallback is
     // guarded against pid reuse by liveness + cmdline probes.
+    //
+    // The fallback must probe the process GROUP, not just the recorded pid
+    // (issue #136 tier-2): in exactly the window it exists for — wrapper
+    // leader reaped by the executor, registry already unregistered — the
+    // wrapper pid probes dead (`probe_alive` answers ESRCH), while
+    // `killpg(pgid, 0)` still answers because the orphaned CLI and rule
+    // subprocesses keep running under the same pgid. When the leader is
+    // gone, the identity guard is applied to the group's surviving members
+    // instead, so a recycled pgid belonging to unrelated processes is never
+    // signalled.
     let pgid = match crate::process_control::pgid(&id) {
         Some(pgid) => Some(pgid),
         None => {
@@ -1158,10 +1168,25 @@ pub async fn cancel_run(
                 .unwrap_or(None);
             db_pid.and_then(|pid| {
                 let pid = pid as i32;
-                (pid > 0
-                    && crate::process_control::probe_alive(pid)
-                    && crate::process_control::looks_like_oxo_flow(pid))
-                .then_some(pid)
+                if pid <= 0 {
+                    return None;
+                }
+                // Leader alive: probe + identity guard on the pid itself.
+                if crate::process_control::probe_alive(pid)
+                    && crate::process_control::looks_like_oxo_flow(pid)
+                {
+                    return Some(pid);
+                }
+                // Leader reaped but the GROUP outlived it: probe group
+                // liveness (the wrapper was the group leader, so pid ==
+                // pgid) and guard against pid reuse by scanning the
+                // surviving members' command lines.
+                if crate::process_control::group_alive(pid)
+                    && crate::process_control::group_looks_like_oxo_flow(pid)
+                {
+                    return Some(pid);
+                }
+                None
             })
         }
     };

--- a/crates/oxo-flow-web/src/executor.rs
+++ b/crates/oxo-flow-web/src/executor.rs
@@ -119,7 +119,10 @@ fn final_status_from_exit(success: bool) -> &'static str {
 /// attribute a run honestly after a web-server crash — the same pattern
 /// Nextflow uses (`.exitcode` files). Positional forwarding avoids any
 /// shell-quoting of user-controlled arguments.
-const EXIT_CODE_WRAPPER_SCRIPT: &str =
+///
+/// `pub` so the process-control integration tests can compose the exact
+/// same invocation (and the identity guard can recognize it).
+pub const EXIT_CODE_WRAPPER_SCRIPT: &str =
     r#"f="$1"; shift; "$@"; rc=$?; printf '%s' "$rc" > "$f"; exit "$rc""#;
 
 /// Execution options carried from the run request to the CLI subprocess.
@@ -367,10 +370,31 @@ pub fn spawn_background_run_with_args(
 
         // Transient fork failures (EAGAIN/ENOMEM under full-workspace
         // parallel test load, issue #120) must not permanently fail the run
-        // — retry briefly before giving up.
+        // — retry briefly before giving up. While retrying, the run row is
+        // 'running' with a NULL pid: a cancel landing in that window must
+        // win — abort the spawn rather than executing a workflow the user
+        // already stopped (issue #136 tier-2: without the check, the retry
+        // would eventually spawn and a cancelled run would silently execute).
+        //
+        // Test seam: OXO_FLOW_TEST_SPAWN_FAIL deterministically fails the
+        // first N spawn attempts (synthetic EAGAIN) so the retry contract
+        // is exercisable without inducing fork pressure.
+        let fail_first: u32 = std::env::var("OXO_FLOW_TEST_SPAWN_FAIL")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
         let mut spawn_attempts = 0u32;
         let spawn_result = loop {
-            match cmd.spawn() {
+            if run_is_cancelled(&run_id).await {
+                warn!("Run {run_id} cancelled during spawn retries — aborting spawn");
+                return;
+            }
+            let spawned = if spawn_attempts < fail_first {
+                Err(std::io::Error::from_raw_os_error(nix::libc::EAGAIN))
+            } else {
+                cmd.spawn()
+            };
+            match spawned {
                 Err(e)
                     if matches!(
                         e.raw_os_error(),
@@ -389,7 +413,30 @@ pub fn spawn_background_run_with_args(
         };
         match spawn_result {
             Ok(mut child) => {
-                // Record PID for cancellation support
+                // Register the process group FIRST so a cancel racing the
+                // spawn can signal it, then persist the pid for crash
+                // recovery.
+                if let Some(pid) = child.id() {
+                    crate::process_control::register(&run_id, pid as i32);
+                }
+                if run_is_cancelled(&run_id).await {
+                    // The cancel won the race against the final spawn
+                    // attempt: nothing was registered at cancel time, so the
+                    // group was never signalled — kill it here. A cancelled
+                    // run must not execute (issue #136 tier-2).
+                    info!("Run {run_id} cancelled while spawning — killing the late-spawned group");
+                    if let Some(pid) = child.id() {
+                        let _ = crate::process_control::signal_group(
+                            pid as i32,
+                            crate::process_control::SIGTERM,
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        let _ = crate::process_control::signal_group(
+                            pid as i32,
+                            crate::process_control::SIGKILL,
+                        );
+                    }
+                }
                 if let Some(pid) = child.id()
                     && let Err(e) = sqlx::query("UPDATE runs SET pid = ? WHERE id = ?")
                         .bind(pid as i64)
@@ -398,11 +445,6 @@ pub fn spawn_background_run_with_args(
                         .await
                 {
                     warn!("Failed to record PID for run {run_id}: {e}");
-                }
-
-                // Register the process group so cancel/pause/resume can signal it.
-                if let Some(pid) = child.id() {
-                    crate::process_control::register(&run_id, pid as i32);
                 }
 
                 // Real resource telemetry (issue #82 P1-2): sample the
@@ -429,8 +471,16 @@ pub fn spawn_background_run_with_args(
                 }
             }
             Err(e) => {
-                error!("Failed to spawn child process for run {run_id}: {e}");
-                mark_run_failed(&run_id).await;
+                error!(
+                    "Failed to spawn child process for run {run_id} \
+                     after {spawn_attempts} retries: {e}"
+                );
+                // A cancel that landed during the retry window is the
+                // terminal truth — never overwrite 'cancelled' with a
+                // fabricated 'failed' (issue #136 tier-2).
+                if !run_is_cancelled(&run_id).await {
+                    mark_run_failed(&run_id).await;
+                }
             }
         }
     });
@@ -444,6 +494,18 @@ pub fn spawn_background_run_with_args(
 /// attributed as failed. A run already marked 'cancelled' is left untouched:
 /// the terminal write happened at cancel time and the kill fallout must not
 /// overwrite it back to completed/failed.
+/// True when the run row has been cancelled — the terminal state that must
+/// never be overwritten nor executed past (a cancel is the user's last
+/// word; the kill fallout must not rewrite it).
+async fn run_is_cancelled(run_id: &str) -> bool {
+    sqlx::query_scalar("SELECT COUNT(*) FROM runs WHERE id = ? AND status = 'cancelled'")
+        .bind(run_id)
+        .fetch_one(db::pool())
+        .await
+        .map(|n: i64| n > 0)
+        .unwrap_or(false)
+}
+
 pub(crate) async fn finalize_run(run_id: &str, exit_code: Option<i32>, log_path: &std::path::Path) {
     crate::process_control::unregister(run_id);
     let success = exit_code == Some(0);
@@ -456,14 +518,7 @@ pub(crate) async fn finalize_run(run_id: &str, exit_code: Option<i32>, log_path:
         crate::infra::quota::global_quota_tracker().record_complete(&user_id, threads, memory_mb);
     }
 
-    let cancelled: bool =
-        sqlx::query_scalar("SELECT COUNT(*) FROM runs WHERE id = ? AND status = 'cancelled'")
-            .bind(run_id)
-            .fetch_one(db::pool())
-            .await
-            .map(|n: i64| n > 0)
-            .unwrap_or(false);
-    if cancelled {
+    if run_is_cancelled(run_id).await {
         info!("Run {run_id} exited after cancel; keeping 'cancelled'");
         return;
     }

--- a/crates/oxo-flow-web/src/process_control.rs
+++ b/crates/oxo-flow-web/src/process_control.rs
@@ -93,30 +93,105 @@ pub fn probe_alive(pid: i32) -> bool {
 /// Best-effort guard against pid recycling: after a restart, a reused pid
 /// may be alive but belong to an unrelated process. The command line is
 /// inspected for the CLI; a mismatch means the recorded pid is stale.
+///
+/// The match is ANCHORED, not a bare substring: the recorded process must
+/// be the oxo-flow CLI itself (its binary path as the FIRST argv element)
+/// or the executor's `sh -c` wrapper (an `.exit-code` path directly before
+/// the binary token). A process whose command line merely MENTIONS
+/// "oxo-flow" — an editor session, `grep -r oxo-flow`, a shell whose cwd
+/// contains the name — must NOT pass the probe; the guard's only job is to
+/// prove the pid belongs to a run the server itself started.
 pub fn looks_like_oxo_flow(pid: i32) -> bool {
     match std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "args="])
         .output()
     {
-        Ok(out) => {
-            let args = String::from_utf8_lossy(&out.stdout);
-            // Two independent signals: the binary name and the workflow file
-            // argument every run command carries.
-            args.contains("oxo-flow") || args.contains("workflow.oxoflow")
-        }
+        Ok(out) => cmdline_is_oxo_flow(&String::from_utf8_lossy(&out.stdout)),
         Err(_) => false,
+    }
+}
+
+/// Whether one `ps` args= line belongs to the oxo-flow CLI or its wrapper.
+///
+/// Two accepted shapes, both anchored on the command line's structure:
+///   - the CLI itself: the FIRST argv element is the oxo-flow binary (a
+///     path whose file name is `oxo-flow`, or the bare name from a PATH
+///     lookup — the executor's payload);
+///   - the executor's wrapper (see [`crate::executor`]): the line carries
+///     an exit-record path (file name `.exit-code`) followed within a few
+///     argv elements by the oxo-flow binary token — the exact composition
+///     of `spawn_background_run_with_args`, including the `sudo -n -u
+///     <user>` prefix in between.
+fn cmdline_is_oxo_flow(args: &str) -> bool {
+    let tokens: Vec<&str> = args.split_whitespace().collect();
+    if tokens.is_empty() {
+        return false;
+    }
+    if is_oxo_flow_token(tokens[0]) {
+        return true;
+    }
+    for (i, token) in tokens.iter().enumerate() {
+        if std::path::Path::new(token)
+            .file_name()
+            .is_some_and(|f| f == ".exit-code")
+        {
+            let lookahead = &tokens[i + 1..(i + 1 + 5).min(tokens.len())];
+            if lookahead.iter().any(|t| is_oxo_flow_token(t)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn is_oxo_flow_token(token: &str) -> bool {
+    std::path::Path::new(token)
+        .file_name()
+        .is_some_and(|f| f == "oxo-flow")
+}
+
+/// Group-level identity guard for the case where the group LEADER has been
+/// reaped but the group itself survives — the wrapper `sh` died while the
+/// orphaned CLI and rule subprocesses keep running under the same pgid (the
+/// window `cancel_run`'s DB-pid fallback must cover, issue #136 tier-2).
+/// The leader's command line is gone, so every surviving member is scanned:
+/// at least one must look like the CLI or its wrapper.
+///
+/// `ps -g <pgid>` means something different per platform (user group here,
+/// session-or-group on Linux), so all processes are enumerated and filtered
+/// on the `pgid` column instead — identical output on both.
+pub fn group_looks_like_oxo_flow(pgid: i32) -> bool {
+    match std::process::Command::new("ps")
+        .args(["-e", "-o", "pid=,pgid=,args="])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            String::from_utf8_lossy(&out.stdout).lines().any(|line| {
+                // ps pads columns to the widest value, so `pid pgid` can be
+                // separated by several spaces — split on whitespace RUNS and
+                // rejoin the args column (the rejoin is lossless for the
+                // downstream tokenizer, which splits on whitespace anyway).
+                let mut fields = line.split_whitespace();
+                let member_pgid = fields.nth(1).and_then(|g| g.parse::<i32>().ok());
+                member_pgid == Some(pgid) && {
+                    let args = fields.collect::<Vec<_>>().join(" ");
+                    cmdline_is_oxo_flow(&args)
+                }
+            })
+        }
+        _ => false,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
     use std::thread;
     use std::time::Duration;
 
     fn spawn_sleep_child() -> std::process::Child {
         // process_group(0) makes the child a group leader; child.id() == pgid.
-        use std::os::unix::process::CommandExt;
         Command::new("sleep")
             .arg("5")
             .process_group(0)
@@ -153,6 +228,128 @@ mod tests {
         super::signal_group(pgid, super::SIGCONT).expect("sigcont");
         super::signal_group(pgid, super::SIGKILL).expect("sigkill");
         child.wait().expect("wait");
+    }
+
+    /// A process whose command line merely MENTIONS "oxo-flow" (an editor
+    /// session, `grep -r oxo-flow`, a forged argv[0]) must fail the
+    /// identity probe — the guard is anchored, not a bare substring match.
+    #[test]
+    fn looks_like_oxo_flow_rejects_substring_mentions() {
+        let mut child = Command::new("sh")
+            .args(["-c", "exec -a 'grep -r oxo-flow .' sleep 5"])
+            .process_group(0)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn forged-argv child");
+        let pid = child.id() as i32;
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            !super::looks_like_oxo_flow(pid),
+            "a substring mention of oxo-flow must not pass the identity probe"
+        );
+        let _ = super::signal_group(pid, super::SIGKILL);
+        let _ = child.wait();
+    }
+
+    /// The executor's wrapper composition (`sh -c <script> sh <exitfile>
+    /// <binary> run …`) must pass the identity probe even though its first
+    /// argv element is `sh` — the binary token follows the exit record.
+    #[test]
+    fn looks_like_oxo_flow_accepts_executor_wrapper_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let exit_file = dir.path().join(".exit-code");
+        // Stand-in script body that only sleeps — the binary path need not
+        // exist; `ps` sees the command line either way.
+        let mut child = Command::new("sh")
+            .args(["-c", "f=\"$1\"; shift; sleep 5"])
+            .arg("sh")
+            .arg(&exit_file)
+            .arg("/opt/oxo/bin/oxo-flow")
+            .arg("run")
+            .arg("wf.oxoflow")
+            .process_group(0)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn wrapper-shaped child");
+        let pid = child.id() as i32;
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            super::looks_like_oxo_flow(pid),
+            "the executor wrapper shape must pass the identity probe"
+        );
+        let _ = super::signal_group(pid, super::SIGKILL);
+        let _ = child.wait();
+    }
+
+    /// The identity guard is anchored on the command line's STRUCTURE:
+    /// substring presence decides nothing.
+    #[test]
+    fn cmdline_identity_is_anchored_not_substring() {
+        // Mentions without structure must fail.
+        assert!(!super::cmdline_is_oxo_flow("grep -r oxo-flow ."));
+        assert!(!super::cmdline_is_oxo_flow(
+            "vim /tmp/oxo-flow-analysis.txt"
+        ));
+        assert!(!super::cmdline_is_oxo_flow("sh -c oxo-flow"));
+        assert!(!super::cmdline_is_oxo_flow(""));
+        // An exit-record path WITHOUT the binary token must fail.
+        assert!(!super::cmdline_is_oxo_flow(
+            "sh -c 'echo hi' sh /tmp/run/.exit-code echo hi"
+        ));
+        // A binary whose name merely CONTAINS "oxo-flow" must fail.
+        assert!(!super::cmdline_is_oxo_flow(
+            "sh -c x sh /tmp/run/.exit-code /usr/bin/oxo-flow-bench run wf"
+        ));
+        // The CLI itself: binary path or bare name as the FIRST argv element.
+        assert!(super::cmdline_is_oxo_flow(
+            "/usr/local/bin/oxo-flow run wf.oxoflow --workdir /tmp/run"
+        ));
+        assert!(super::cmdline_is_oxo_flow("oxo-flow run wf.oxoflow"));
+        // The executor wrapper: exit record directly before the binary…
+        assert!(super::cmdline_is_oxo_flow(
+            "sh -c f=\"$1\"; shift; \"$@\"; rc=$?; printf '%s' \"$rc\" > \"$f\"; exit \"$rc\" sh /tmp/run/.exit-code /usr/local/bin/oxo-flow run wf.oxoflow --workdir /tmp/run"
+        ));
+        // …including the sudo prefix (`sudo -n -u <user>` between them).
+        assert!(super::cmdline_is_oxo_flow(
+            "sh -c f=\"$1\"; shift; \"$@\"; rc=$?; printf '%s' \"$rc\" > \"$f\"; exit \"$rc\" sh /tmp/run/.exit-code sudo -n -u bioinfo /usr/local/bin/oxo-flow run wf.oxoflow"
+        ));
+    }
+
+    /// A group whose only member is a plain `sleep` must fail the group
+    /// probe; a group with an oxo-flow-shaped member passes (the shape a
+    /// reaped wrapper leader leaves behind: orphaned CLI, no leader). The
+    /// CLI-shaped member is its OWN group leader — joining an existing
+    /// leader's group from the test races `setpgid` on macOS, and the
+    /// reaped-leader scenario is covered end-to-end by the integration test.
+    #[test]
+    fn group_identity_scans_surviving_members() {
+        let mut member = Command::new("sh")
+            .args(["-c", "f=\"$1\"; shift; sleep 5"])
+            .arg("sh")
+            .arg("/tmp/run/.exit-code")
+            .arg("/opt/oxo/bin/oxo-flow")
+            .arg("run")
+            .arg("wf.oxoflow")
+            .process_group(0)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn CLI-shaped group member");
+        let pgid = member.id() as i32;
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            super::group_looks_like_oxo_flow(pgid),
+            "a group with an oxo-flow-shaped member must pass"
+        );
+        // A group of unrelated processes must fail the group probe.
+        let mut plain = spawn_sleep_child();
+        assert!(!super::group_looks_like_oxo_flow(plain.id() as i32));
+        let _ = super::signal_group(pgid, super::SIGKILL);
+        let _ = super::signal_group(plain.id() as i32, super::SIGKILL);
+        let _ = member.wait();
+        let _ = plain.wait();
     }
 
     #[test]

--- a/crates/oxo-flow-web/tests/process_control_integration.rs
+++ b/crates/oxo-flow-web/tests/process_control_integration.rs
@@ -1,12 +1,15 @@
 //! Real process control: cancel/pause/resume must signal the CLI subprocess.
 //!
-//! The executor's CLI lookup honors OXO_FLOW_BIN first, but these tests
-//! bypass spawning entirely: they register a `sleep` child's pgid under a
-//! run id the same way the executor does, then drive the HTTP handlers.
+//! The executor's CLI lookup honors OXO_FLOW_BIN first, but most of these
+//! tests bypass spawning entirely: they register a `sleep` child's pgid
+//! under a run id the same way the executor does, then drive the HTTP
+//! handlers. Two tests exercise the full executor spawn path (the EAGAIN
+//! retry contract) and one runs the real CLI binary (the orphaned-group
+//! cancel window) — those need `cargo build --workspace` first.
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
-use oxo_flow_web::{process_control, server};
+use oxo_flow_web::{executor, process_control, server};
 use serde_json::json;
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
@@ -40,6 +43,85 @@ async fn insert_run_row(run_id: &str, status: &str) {
     .execute(pool)
     .await
     .unwrap();
+}
+
+/// Locate a workspace binary from the target directory. The CLI is not a
+/// dependency of the web crate, so `CARGO_BIN_EXE_oxo-flow` is unset for
+/// these tests; the sibling-path lookup mirrors tests/web_integration.rs.
+/// Requires `cargo build --workspace` first (CI does this).
+fn workspace_bin(name: &str) -> std::path::PathBuf {
+    let mut target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+    let candidate_exe = target_dir.join(format!("{name}.exe"));
+    if candidate_exe.exists() {
+        return candidate_exe;
+    }
+    target_dir = target_dir.join("deps");
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+/// Serializes the `OXO_FLOW_TEST_SPAWN_FAIL`-dependent tests: env-var
+/// mutation is process-global and integration tests run on parallel
+/// threads. No other test reads the variable.
+static SPAWN_FAIL_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard: set the executor's spawn-failure test seam, restore on drop.
+struct SpawnFailEnv {
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl Drop for SpawnFailEnv {
+    fn drop(&mut self) {
+        // Soundness: SPAWN_FAIL_ENV serializes every writer and reader of
+        // this variable inside the test binary.
+        unsafe {
+            std::env::remove_var("OXO_FLOW_TEST_SPAWN_FAIL");
+        }
+    }
+}
+
+fn set_spawn_fail(n: u32) -> SpawnFailEnv {
+    // Poison recovery: a failing test unwinds while holding the guard, and
+    // the next test must still be able to take the lock.
+    let guard = SPAWN_FAIL_ENV
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Soundness: SPAWN_FAIL_ENV serializes every writer and reader of this
+    // variable inside the test binary.
+    unsafe {
+        std::env::set_var("OXO_FLOW_TEST_SPAWN_FAIL", n.to_string());
+    }
+    SpawnFailEnv { _guard: guard }
+}
+
+/// True while any live process command line contains `needle` (used to
+/// prove a late-spawned CLI did not survive a cancel).
+fn process_alive_with(needle: &str) -> bool {
+    std::process::Command::new("ps")
+        .args(["-e", "-o", "args="])
+        .output()
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .any(|line| line.contains(needle))
+        })
+        .unwrap_or(false)
 }
 
 async fn run_status(run_id: &str) -> Option<String> {
@@ -136,6 +218,297 @@ async fn cancel_falls_back_to_db_pid_when_registry_is_empty() {
     );
     process_control::signal_group(child.id() as i32, process_control::SIGKILL).expect("cleanup");
     child.wait().expect("wait after cleanup");
+}
+
+/// Regression (issue #136 tier-2): the DB-pid fallback must signal the
+/// process GROUP, not just probe the recorded wrapper pid.
+///
+/// The window: finalize_run unregisters the moment the CLI wrapper leader
+/// is reaped, while orphaned group members (the CLI itself and the running
+/// rule) keep executing under the same pgid. A cancel landing then finds
+/// no registry entry; the recorded pid probes dead (the leader WAS reaped)
+/// — but `killpg(pgid, 0)` still answers. The fallback must probe group
+/// liveness and, guarded by the identity check against the group's
+/// surviving members, signal the group.
+///
+/// Simulation gap: the real trigger (OOM/load killing the wrapper or the
+/// unregister-before-status-update race) is not reproducible on demand, so
+/// the test kills the wrapper leader directly after the rule starts — the
+/// resulting state (leader reaped, group alive, registry empty) is
+/// byte-for-byte the window the fix targets.
+#[tokio::test]
+async fn cancel_kills_orphaned_group_when_wrapper_leader_is_gone() {
+    common::ensure_db().await;
+    insert_run_row("pc-orphan", "running").await;
+
+    // Real CLI running a long rule, wrapped exactly as the executor wraps
+    // it (`sh -c <exit-record script> sh <exitfile> <binary> run …`).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workdir = dir.path();
+    let workflow = workdir.join("workflow.oxoflow");
+    std::fs::write(
+        &workflow,
+        "[workflow]\nname = \"sleepy\"\nversion = \"1.0\"\n\n[[rules]]\nname = \"sleepy\"\nshell = \"sleep 30\"\n",
+    )
+    .expect("write workflow");
+
+    let bin = workspace_bin("oxo-flow");
+    let exit_file = workdir.join(".exit-code");
+    let log_file = std::fs::File::create(workdir.join("execution.log")).expect("create log");
+    let mut wrapper = Command::new("sh")
+        .arg("-c")
+        .arg(executor::EXIT_CODE_WRAPPER_SCRIPT)
+        .arg("sh")
+        .arg(&exit_file)
+        .arg(&bin)
+        .arg("run")
+        .arg(&workflow)
+        .arg("--workdir")
+        .arg(workdir)
+        .process_group(0)
+        .stdout(Stdio::from(log_file.try_clone().expect("clone log")))
+        .stderr(Stdio::from(log_file))
+        .spawn()
+        .expect("spawn wrapper");
+    let wrapper_pid = wrapper.id() as i32;
+    // Record the wrapper pid like the executor does — but never register
+    // in-memory: the finalize_run window this reproduces has already run
+    // unregister (the wrapper was reaped by the executor).
+    sqlx::query("UPDATE runs SET pid = ? WHERE id = ?")
+        .bind(wrapper_pid as i64)
+        .bind("pc-orphan")
+        .execute(oxo_flow_web::infra::db::sqlite::pool())
+        .await
+        .unwrap();
+    assert!(process_control::pgid("pc-orphan").is_none());
+
+    // Wait for the CLI to start the rule (execution.log gains the
+    // "Running:" progress line).
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut started = false;
+    while std::time::Instant::now() < deadline {
+        if std::fs::read_to_string(workdir.join("execution.log"))
+            .map(|log| log.contains("Running:"))
+            .unwrap_or(false)
+        {
+            started = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(started, "CLI must start the rule before the crash window");
+
+    // Simulate the crash window: the wrapper LEADER dies while its group —
+    // the CLI and the running rule — keeps executing as orphans. kill()
+    // targets a single process; the group survives.
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(wrapper_pid),
+        nix::sys::signal::Signal::SIGKILL,
+    )
+    .expect("kill wrapper leader");
+    wrapper.wait().expect("reap wrapper");
+    assert!(
+        process_control::group_alive(wrapper_pid),
+        "the orphaned group must outlive its wrapper leader"
+    );
+
+    // Cancel: the registry is empty and the recorded pid probes dead —
+    // only the group-liveness + group-identity fallback can find the run.
+    let (status, body) = post_json("/api/runs/pc-orphan/cancel", json!({})).await;
+    assert_eq!(status, StatusCode::OK, "cancel response: {body:?}");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while process_control::group_alive(wrapper_pid) && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        !process_control::group_alive(wrapper_pid),
+        "the orphaned group (CLI + rule) must be dead after cancel"
+    );
+    assert_eq!(run_status("pc-orphan").await.as_deref(), Some("cancelled"));
+}
+
+/// Regression (issue #136 tier-2): the grace→SIGKILL escalation must
+/// actually run. A rule that traps (ignores) SIGTERM cannot be stopped by
+/// the graceful signal; only the SIGKILL escalation kills its group, so the
+/// group's death within the grace+verify window proves the escalation fired.
+#[tokio::test]
+async fn cancel_escalates_to_sigkill_when_sigterm_is_ignored() {
+    common::ensure_db().await;
+    insert_run_row("pc-escalate", "running").await;
+    // `trap '' TERM` makes the shell ignore SIGTERM; `sleep` exec'd from it
+    // inherits the ignored disposition. Neither member can be killed by
+    // SIGTERM — only SIGKILL ends the group.
+    let mut child = Command::new("sh")
+        .args(["-c", "trap '' TERM; sleep 30"])
+        .process_group(0)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn TERM-immune group");
+    let pgid = child.id() as i32;
+    process_control::register("pc-escalate", pgid);
+
+    let (status, body) = post_json("/api/runs/pc-escalate/cancel", json!({})).await;
+    assert_eq!(status, StatusCode::OK, "cancel response: {body:?}");
+
+    // The handler waits out the full 5 s grace window (nothing dies on
+    // SIGTERM), then SIGKILLs. Poll past grace + verify + margin.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut exited = false;
+    while std::time::Instant::now() < deadline {
+        if child.try_wait().expect("try_wait").is_some() {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        exited,
+        "TERM-immune group must be killed by the SIGKILL escalation"
+    );
+    let _ = child.wait();
+    assert!(
+        !process_control::group_alive(pgid),
+        "whole group must be dead after the escalation"
+    );
+    assert_eq!(
+        run_status("pc-escalate").await.as_deref(),
+        Some("cancelled")
+    );
+}
+
+/// Spawn a background run through the real executor with a workdir and CLI
+/// args derived from a tempdir (the EAGAIN retry-contract tests below).
+///
+/// The workflow contains a long rule so a late-spawned CLI stays alive long
+/// enough for the tests to observe it (a fast-exiting CLI would make the
+/// "no survivor" assertion pass vacuously).
+fn spawn_real_run(run_id: &str, workdir: &std::path::Path) {
+    let workflow = workdir.join("workflow.oxoflow");
+    std::fs::write(
+        &workflow,
+        "[workflow]\nname = \"sleepy\"\nversion = \"1.0\"\n\n[[rules]]\nname = \"sleepy\"\nshell = \"sleep 30\"\n",
+    )
+    .expect("write workflow");
+    let args: Vec<std::ffi::OsString> = [
+        "run",
+        workflow.to_str().unwrap(),
+        "--workdir",
+        workdir.to_str().unwrap(),
+    ]
+    .into_iter()
+    .map(std::ffi::OsString::from)
+    .collect();
+    executor::spawn_background_run_with_args(
+        run_id.to_string(),
+        "default".to_string(),
+        "none".to_string(),
+        "local".to_string(),
+        Some(workdir.to_path_buf()),
+        args,
+    );
+}
+
+/// The spawn EAGAIN retry contract (issue #136 tier-2): when every retry is
+/// exhausted the run must fail loudly — never dangle as 'running' with a
+/// NULL pid.
+#[tokio::test]
+async fn eagain_retry_marks_run_failed_when_exhausted() {
+    common::ensure_db().await;
+    let _env = set_spawn_fail(100);
+    let dir = tempfile::tempdir().expect("tempdir");
+    insert_run_row("pc-eagain-fail", "queued").await;
+    spawn_real_run("pc-eagain-fail", dir.path());
+
+    // All 3 retries fail (test seam), the spawn gives up, and the run is
+    // marked failed — loudly, without a lingering 'running' row.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while run_status("pc-eagain-fail").await.as_deref() != Some("failed")
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        run_status("pc-eagain-fail").await.as_deref(),
+        Some("failed"),
+        "retry exhaustion must mark the run failed"
+    );
+}
+
+/// Regression (issue #136 tier-2): a cancel landing while the spawn retry
+/// window is open must stick — the exhaustion path must not overwrite the
+/// 'cancelled' terminal state with 'failed'.
+#[tokio::test]
+async fn eagain_retry_cancel_keeps_cancelled_on_exhaustion() {
+    common::ensure_db().await;
+    let _env = set_spawn_fail(100);
+    let dir = tempfile::tempdir().expect("tempdir");
+    insert_run_row("pc-eagain-cancel", "queued").await;
+    spawn_real_run("pc-eagain-cancel", dir.path());
+
+    // Wait for the executor to pick the run up (queued → running), then
+    // cancel inside the retry window (3 × 250 ms of sleeps).
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while run_status("pc-eagain-cancel").await.as_deref() != Some("running")
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let (status, body) = post_json("/api/runs/pc-eagain-cancel/cancel", json!({})).await;
+    assert_eq!(status, StatusCode::OK, "cancel response: {body:?}");
+
+    // Give the executor time to exhaust all retries; the row must stay
+    // 'cancelled' (marking it failed would lie about the user's intent).
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert_eq!(
+        run_status("pc-eagain-cancel").await.as_deref(),
+        Some("cancelled"),
+        "retry exhaustion must not overwrite a cancelled run"
+    );
+}
+
+/// Regression (issue #136 tier-2): a cancel that lands while the spawn
+/// retry window is open must win — the CLI must not start executing a
+/// workflow the user already stopped.
+#[tokio::test]
+async fn eagain_retry_cancel_aborts_late_spawn() {
+    common::ensure_db().await;
+    let _env = set_spawn_fail(3); // 3 failures, then the 4th attempt is real
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workdir_str = dir.path().to_string_lossy().into_owned();
+    insert_run_row("pc-eagain-abort", "queued").await;
+    spawn_real_run("pc-eagain-abort", dir.path());
+
+    // Wait for the executor to pick the run up, then cancel inside the
+    // retry window.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while run_status("pc-eagain-abort").await.as_deref() != Some("running")
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let (status, body) = post_json("/api/runs/pc-eagain-abort/cancel", json!({})).await;
+    assert_eq!(status, StatusCode::OK, "cancel response: {body:?}");
+
+    // A late-spawned CLI would carry the workdir path on its command line.
+    // First wait PAST the full retry window (3 × 250 ms + margin) so a
+    // late spawn has time to appear, then watch for a survivor — the CLI
+    // must never start executing the cancelled workflow.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        assert!(
+            !process_alive_with(&workdir_str),
+            "a late-spawned CLI must not survive the cancel"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(
+        run_status("pc-eagain-abort").await.as_deref(),
+        Some("cancelled"),
+        "cancelled run must stay cancelled"
+    );
 }
 
 #[tokio::test]

--- a/docs/guide/src/commands/test.md
+++ b/docs/guide/src/commands/test.md
@@ -30,7 +30,7 @@ catch issues early.
 | `--output` | — | — | Output file path to verify after the run (fails with exit code 1 if the file is not found) |
 | `--run` | — | — | Execute the workflow after validation and lint (runs for real) |
 | `--jobs` | `-j` | `1` | Number of parallel jobs (only with `--run`) |
-| `--samples` | — | — | Test only a subset of samples: `first:N` (pilot), explicit names, or `ready` (complete entry inputs; repeatable, comma-separated) |
+| `--samples` | — | — | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--workdir` | `-d` | — | Working directory for the test run (default: the workflow file's directory) |
 | `--profile` | — | — | Execution profile for the `--run` step (same merge semantics as `run`) |
 | `--target` | `-t` | — | Run only specific target rules (repeatable, prefix matching) — applies to the `--run` step |


### PR DESCRIPTION
## Summary

Tier-2 of the #136 unified audit — closes the web cancel family, the wait-loop races, and the LOW tail on top of tier-1 (#138) and the cluster H-items (#139). 15 files, 27 new tests, full gate green.

**Web cancel integrity**
- The DB-pid fallback now probes process-GROUP liveness (`killpg`) with the identity guard applied to surviving members — previously `unregister` ran first and the wrapper pid probed dead, so the fallback never fired and orphaned groups escaped with cancel returning 200. Positive-path regression test drives the real CLI through the fallback; a SIGTERM-immune rule test covers the grace→SIGKILL→verify escalation.
- Spawn EAGAIN retry: cancel re-checked per iteration (cancelled wins on exhaustion), group registered before the DB pid write, late-spawned groups killed after cancel.
- `looks_like_oxo_flow` is now anchored argv matching, not a bare substring. While testing, a real production bug surfaced and was fixed: `ps` column padding made the pgid scan nondeterministic.

**Wait-loop correctness**
- Pre-registered `notified()` future closes the lost-wakeup TOCTOU between resource check and park.
- The 60s diagnostics interval is injectable (`LocalExecutor::set_wait_report_interval`) with a throttling test.
- Fixed the tracing callsite interest-cache flake (global `Interest::never` after a no-subscriber thread) via `rebuild_interest_cache` under the subscriber guard.

**LOW tail**
- `blockage_report`'s "no single constraint" branch is reachable (FIFO senior-waiter blocking) — replaced with an informative queued-behind message; over-capacity declarations now warn loudly.
- `mask_sensitive` masks all non-empty sensitive values (the 4-char threshold leaked short credentials; live-verified with a 2-char secret).
- Output invalidation adds size comparison (same-mtime rewrites) and never clobbers the `.oxo-failed` aside.
- Conda env names from untrusted YAMLs validated (fail fast); singularity https SIF naming fixed; conda verify requires a non-empty bin dir.
- `find_repo_root` handles directory inputs; `cache_dir_name` injective (FNV-1a suffix).
- `{source}` shell-quoted; `test --samples` help mirrors unified semantics; dry-run shares the known-modules hint; `@sheet` resolves against the workdir base; cluster wires `--cache-dir` and warns loudly on unsupported flags; driver propagates `index.json` write errors.

## Tests
- 27 new tests (web 9, core 10, cli 8), all RED-first; web suite 364/0, core 1102/0 stable across repeated runs, cli 126/0.
- Full `make ci` on the exact tree: fmt + clippy `-D warnings` + build + test + audit → exit 0.
- Live-verified: 2-char sensitive secret masked in the run-log header.

## Test plan for reviewers
- [ ] `make ci`
- [ ] `cargo test -p oxo-flow-web` (cancel fallback + SIGKILL escalation integration tests)
- [ ] `oxo-flow run w.oxoflow --arg KEY=ab` with `KEY = { sensitive = true }` → log shows `KEY=***`

Fixes #136 (tier-2; the closing checklist lives on the issue).
