### PR TITLE
fix(info-test): drop env-coupled git_remote assertion (#136 item 29)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -586,9 +586,21 @@ mod tests {
         let fixture = "../../examples/gallery/05_conda_environments.oxoflow";
         let meta = meta(fixture, fixture);
         assert_eq!(meta["git_sha"].as_str().map(|s| !s.is_empty()), Some(true));
+        // git_remote is only derivable when the repository has an origin
+        // remote — the key is omitted otherwise (the catalog contract).
+        // Assert presence ONLY when this checkout actually has an origin,
+        // so tarball / --no-remote / mirror checkouts don't fail the test
+        // (issue #136 finding 29: the old unconditional assertion was
+        // environment-coupled).
+        let has_origin = std::process::Command::new("git")
+            .args(["remote", "get-url", "origin"])
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
         assert_eq!(
             meta["git_remote"].as_str().map(|s| !s.is_empty()),
-            Some(true)
+            has_origin.then_some(true)
         );
         assert_eq!(
             meta["git_describe"].as_str().map(|s| !s.is_empty()),


### PR DESCRIPTION
## Summary

Closes the last open item of the #136 closing checklist: the `info` unit test asserted `git_remote` is always present in the derived metadata, failing in checkouts without an `origin` remote (tarball, `--no-remote` clone, mirrors) — an environment-coupled assertion unrelated to the code under test.

The assertion now runs only when the checkout actually has an origin (`git remote get-url origin` succeeds); the key-omission contract remains covered by the integration test (`tests/workflow_versioning.rs`, fresh repo with origin) and the absent-outside-repo test.

## Tests

- `cargo test -p oxo-flow-cli info::tests::git_provenance` → 2/2
- `cargo clippy -p oxo-flow-cli --all-targets -- -D warnings` → clean
- fmt clean

Fixes #136 (item 29).
