### PR TITLE
fix(core): #142 H5/M4/M5 — transform required inheritance, profile max_array_size, per-element array logs

### DIFF
--- a/crates/oxo-flow-core/src/cluster.rs
+++ b/crates/oxo-flow-core/src/cluster.rs
@@ -207,6 +207,33 @@ pub fn generate_array_submit_script(
     // contains shell metacharacters.
     lines.push(format!("sh \"{cmd_dir}/cmd.${{INDEX}}.sh\""));
 
+    // Per-element logs (issue #142 M5): a shared output/error path would
+    // interleave every element's output into one file. SLURM interpolates
+    // %A (job id) + %a (array index) in the directive; LSF uses %I. PBS and
+    // SGE append per-subjob suffixes themselves, so their directives stay
+    // unchanged.
+    match backend {
+        ClusterBackend::Slurm => {
+            for line in lines.iter_mut() {
+                if line.starts_with("#SBATCH --output=") {
+                    *line = format!("#SBATCH --output=logs/{}.%A_%a.out", rule.name);
+                } else if line.starts_with("#SBATCH --error=") {
+                    *line = format!("#SBATCH --error=logs/{}.%A_%a.err", rule.name);
+                }
+            }
+        }
+        ClusterBackend::Lsf => {
+            for line in lines.iter_mut() {
+                if line.starts_with("#BSUB -o ") {
+                    *line = format!("#BSUB -o logs/{}.%I.out", rule.name);
+                } else if line.starts_with("#BSUB -e ") {
+                    *line = format!("#BSUB -e logs/{}.%I.err", rule.name);
+                }
+            }
+        }
+        _ => {}
+    }
+
     lines.join("\n")
 }
 
@@ -614,6 +641,27 @@ mod tests {
         );
         assert!(script.contains("SLURM_ARRAY_TASK_ID"), "{script}");
         assert!(script.contains("/run/jobs/align/cmd."), "{script}");
+        // Per-element logs (issue #142 M5): shared output paths would
+        // interleave every element's output into one file.
+        assert!(
+            script.contains("#SBATCH --output=logs/align.%A_%a.out"),
+            "{script}"
+        );
+        assert!(
+            script.contains("#SBATCH --error=logs/align.%A_%a.err"),
+            "{script}"
+        );
+
+        // LSF interpolates %I for per-element logs (issue #142 M5).
+        let lsf = generate_array_submit_script(
+            &ClusterBackend::Lsf,
+            &rule,
+            "/run/jobs/align",
+            3,
+            &config,
+        );
+        assert!(lsf.contains("#BSUB -o logs/align.%I.out"), "{lsf}");
+        assert!(lsf.contains("#BSUB -e logs/align.%I.err"), "{lsf}");
 
         // Other backends use their own range syntax + task variable.
         for (backend, range, var) in [

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -504,6 +504,7 @@ impl ClusterProfile {
             account,
             walltime,
             max_submitted,
+            max_array_size,
             poll_interval
         );
         // Arrays replace wholesale in override mode, matching how
@@ -3519,6 +3520,12 @@ impl WorkflowConfig {
                         input: rule.input.clone(),
                         output: vec![chunk_output].into(),
                         shell: Some(map_shell),
+                        // Inherit the parent's required semantics (issue
+                        // #142 H5): Rule's plain Default makes bools false
+                        // while serde defaults `required` to true — an
+                        // engine-generated chunk must not silently become
+                        // best-effort.
+                        required: rule.required,
 
                         threads: rule.threads,
                         memory: rule.memory.clone(),
@@ -3589,6 +3596,7 @@ impl WorkflowConfig {
                         input: FilePatterns::List(all_chunk_outputs.clone()),
                         output: rule.output.clone(),
                         shell: Some(combine_shell),
+                        required: rule.required,
                         cleanup_chunks: transform.cleanup,
                         threads: rule.threads,
                         memory: rule.memory.clone(),
@@ -7393,6 +7401,131 @@ shell = "true"
         assert_eq!(config.config["threads"].as_str(), Some("32"));
         assert_eq!(config.config["scheduler"].as_str(), Some("slurm"));
         assert_eq!(config.config["genome"].as_str(), Some("hg38"));
+    }
+
+    #[test]
+    fn cluster_profile_merge_carries_max_array_size() {
+        // M4 (#142): profile-level max_array_size was silently dropped by
+        // merge_from — the driver always fell back to its default chunking.
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+            profile_mode = "override"
+
+            [cluster]
+            backend = "slurm"
+            max_array_size = 25
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let profile: toml::Value = toml::from_str(
+            r#"
+            [cluster]
+            max_array_size = 50
+            poll_interval = "10s"
+            "#,
+        )
+        .unwrap();
+        config.merge_profile(&profile).unwrap();
+        let cluster = config.cluster.as_ref().expect("cluster block present");
+        assert_eq!(
+            cluster.max_array_size,
+            Some(50),
+            "override mode must replace"
+        );
+        assert_eq!(cluster.poll_interval.as_deref(), Some("10s"));
+        assert_eq!(
+            cluster.backend.as_deref(),
+            Some("slurm"),
+            "other keys intact"
+        );
+    }
+
+    #[test]
+    fn cluster_profile_merge_fill_mode_keeps_own_max_array_size() {
+        // Fill mode (default): a profile value must not clobber a value the
+        // workflow already declares.
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [cluster]
+            backend = "slurm"
+            max_array_size = 25
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        let profile: toml::Value = toml::from_str(
+            r#"
+            [cluster]
+            max_array_size = 50
+            "#,
+        )
+        .unwrap();
+        config.merge_profile(&profile).unwrap();
+        let cluster = config.cluster.as_ref().expect("cluster block present");
+        assert_eq!(
+            cluster.max_array_size,
+            Some(25),
+            "fill mode keeps the workflow's own value"
+        );
+    }
+
+    #[test]
+    #[test]
+    fn transform_chunks_inherit_required_from_the_parent_rule() {
+        // H5 (#142): engine-generated map/combine chunk rules were built
+        // with Rule::default() — bools false — so a required=true transform
+        // produced best-effort chunks whose failure exited 0. The serde
+        // default for `required` is true; the plain Default is false.
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "t"
+            required = false
+            output = ["combined.txt"]
+            transform = { split = { by = "part", values = ["a", "b"] },
+                          map = "echo {part} > chunk",
+                          combine = { shell = "cat {chunks} > {output}" } }
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        for name in ["t_a", "t_b", "t_combine"] {
+            let r = config
+                .get_rule(name)
+                .unwrap_or_else(|| panic!("{name} generated"));
+            assert!(!r.required, "{name} must inherit required=false");
+        }
+    }
+
+    #[test]
+    fn transform_chunks_default_to_required_like_the_parent() {
+        // Default parent (serde: required=true) → chunks must be required.
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "t"
+            output = ["combined.txt"]
+            transform = { split = { by = "part", values = ["a", "b"] },
+                          map = "echo {part} > chunk",
+                          combine = { shell = "cat {chunks} > {output}" } }
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        for name in ["t_a", "t_b", "t_combine"] {
+            let r = config
+                .get_rule(name)
+                .unwrap_or_else(|| panic!("{name} generated"));
+            assert!(r.required, "{name} must inherit required=true");
+        }
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -7472,7 +7472,6 @@ shell = "true"
     }
 
     #[test]
-    #[test]
     fn transform_chunks_inherit_required_from_the_parent_rule() {
         // H5 (#142): engine-generated map/combine chunk rules were built
         // with Rule::default() — bools false — so a required=true transform


### PR DESCRIPTION
Three of issue #142's findings (the core/driver lane):

## H5 — transform chunk failures exited 0 despite required=true

Engine-generated map/combine chunk rules were built with `Rule::default()` (bools false) while serde defaults `required` to true — a `required=true` transform silently produced best-effort chunks, so a single chunk failure printed `(non-required)` and exited 0 (CI/web judged broken scatter-gather green). Chunks now inherit the parent's `required` flag.

## M4 — profile max_array_size silently ignored

`ClusterProfile::merge_from` never merged the `max_array_size` key, so a profile-level value was dropped and the driver fell back to default chunking. Added to the merge set (both fill and override modes).

## M5 — array elements shared one output file

Array submit scripts inherited the single-job `--output=logs/<rule>.out` — real SLURM elements interleaved into one file. SLURM directives now carry `%A_%a`, LSF carries `%I`; PBS/SGE append per-subjob suffixes themselves and keep plain directives.

## Tests

2 profile-merge tests (override + fill), 2 transform-inheritance tests (required=false parent, default parent), array-script assertions for SLURM %A_%a + LSF %I.