### PR TITLE
fix: persona-testing #142 — silent-failure traps, audit-path bugs, module semantics, docs batch

### DIFF
--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -1047,10 +1047,32 @@ pub fn create_provider(
 /// Create a provider from environment variables or persisted config.
 pub fn create_provider_from_env() -> AiProvider {
     let provider_str = std::env::var("OXO_FLOW_AI_PROVIDER").unwrap_or_default();
+    resolve_provider(
+        &provider_str,
+        load_ai_config()
+            .as_ref()
+            .map(|(a, b, c, d)| (a.as_str(), b.as_str(), c.as_str(), d.as_str())),
+    )
+}
 
-    if !provider_str.is_empty()
-        && !provider_str.eq_ignore_ascii_case("disabled")
-        && let Ok(kind) = provider_str.parse::<ProviderKind>()
+/// Pure provider-resolution core: the env provider string plus an optional
+/// persisted config.
+///
+/// Split from the env/file I/O so the precedence contract is unit-testable
+/// without process-global env mutation (this crate forbids unsafe, and
+/// edition-2024 env mutation requires it). Precedence: env > persisted —
+/// and `OXO_FLOW_AI_PROVIDER=disabled` is an explicit opt-out that must
+/// win over a saved config (issue #142 M10): previously the "disabled"
+/// spelling skipped the env branch and fell through to the persisted
+/// provider, so the override silently did nothing.
+fn resolve_provider(provider_env: &str, saved: Option<(&str, &str, &str, &str)>) -> AiProvider {
+    if provider_env.eq_ignore_ascii_case("disabled") {
+        tracing::info!("AI provider disabled via OXO_FLOW_AI_PROVIDER=disabled");
+        return AiProvider::Noop;
+    }
+
+    if !provider_env.is_empty()
+        && let Ok(kind) = provider_env.parse::<ProviderKind>()
     {
         let provider = create_provider(kind, None, None, None);
         tracing::info!(
@@ -1062,7 +1084,7 @@ pub fn create_provider_from_env() -> AiProvider {
     }
 
     // Fall back to persisted config
-    if let Some((kind_str, api_key, api_url, model)) = load_ai_config()
+    if let Some((kind_str, api_key, api_url, model)) = saved
         && !kind_str.is_empty()
         && kind_str != "disabled"
         && let Ok(kind) = kind_str.parse::<ProviderKind>()
@@ -1070,14 +1092,18 @@ pub fn create_provider_from_env() -> AiProvider {
         let key = if api_key.is_empty() {
             None
         } else {
-            Some(api_key)
+            Some(api_key.to_string())
         };
         let url = if api_url.is_empty() {
             None
         } else {
-            Some(api_url)
+            Some(api_url.to_string())
         };
-        let mdl = if model.is_empty() { None } else { Some(model) };
+        let mdl = if model.is_empty() {
+            None
+        } else {
+            Some(model.to_string())
+        };
         let provider = create_provider(kind, key, url, mdl);
         tracing::info!("AI provider from saved config: {}", provider.name());
         return provider;
@@ -1217,6 +1243,34 @@ mod tests {
     fn noop_provider_returns_error() {
         let provider = AiProvider::Noop;
         assert_eq!(provider.name(), "disabled");
+    }
+
+    #[test]
+    fn env_disabled_wins_over_persisted_config() {
+        // Regression (issue #142 M10): `OXO_FLOW_AI_PROVIDER=disabled`
+        // used to skip the env branch and fall through to the persisted
+        // provider — the explicit opt-out silently did nothing. The env
+        // tier is the highest-precedence tier, so it must be able to turn
+        // AI off even when a saved config exists.
+        let saved = ("deepseek", "sk-test", "", "");
+        assert!(
+            matches!(resolve_provider("disabled", Some(saved)), AiProvider::Noop),
+            "OXO_FLOW_AI_PROVIDER=disabled must win over a saved config"
+        );
+        // Case-insensitive, like the ProviderKind parse.
+        assert!(
+            matches!(resolve_provider("DISABLED", Some(saved)), AiProvider::Noop),
+            "the disabled spelling must be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn env_absent_falls_back_to_saved_config() {
+        let saved = ("deepseek", "sk-test", "", "");
+        let provider = resolve_provider("", Some(saved));
+        assert_eq!(provider.name(), "deepseek");
+        // No env, no config → Noop.
+        assert!(matches!(resolve_provider("", None), AiProvider::Noop));
     }
 
     #[tokio::test]

--- a/crates/oxo-flow-cli/src/commands/ai_explain.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_explain.rs
@@ -325,13 +325,22 @@ pub async fn ai_explain_command(
 
     let provider = oxo_flow_ai::provider::create_provider_from_env();
     if matches!(provider, oxo_flow_ai::provider::AiProvider::Noop) {
-        anyhow::bail!(
-            "AI provider not configured — 'ai explain' needs a provider to write \
-             plain-language prose.\n\
-             Configure one with 'oxo-flow ai setup' (or OXO_FLOW_AI_PROVIDER + *_API_KEY).\n\
-             Offline alternatives: 'oxo-flow graph' (DAG view) and \
-             'oxo-flow dry-run' (what will execute)."
-        );
+        // Degraded mode (issue #142 M10): the model is optional — the
+        // deterministic grounding layers are still useful on their own.
+        // `OXO_FLOW_AI_PROVIDER=disabled` explicitly opts into exactly
+        // this offline path; an unconfigured provider gets the same
+        // skeleton plus configuration guidance.
+        let note = if std::env::var("OXO_FLOW_AI_PROVIDER")
+            .is_ok_and(|v| v.eq_ignore_ascii_case("disabled"))
+        {
+            "AI provider disabled via OXO_FLOW_AI_PROVIDER=disabled — emitting the \
+             deterministic explanation skeleton without model prose."
+        } else {
+            "AI provider not configured — emitting the deterministic explanation \
+             skeleton without model prose. Configure one with 'oxo-flow ai setup' \
+             (or OXO_FLOW_AI_PROVIDER + *_API_KEY) to add prose."
+        };
+        return emit_degraded_explanation(&plan, workflow, level, json, note).await;
     }
 
     // In --json mode stdout carries ONLY the JSON document (machine
@@ -371,9 +380,19 @@ pub async fn ai_explain_command(
     } else {
         println!("  {}", "Explaining...".bold().cyan());
     }
-    let response = provider
-        .chat_with_tools_overflow_safe(&messages, &[])
-        .await?;
+    let response = match provider.chat_with_tools_overflow_safe(&messages, &[]).await {
+        Ok(response) => response,
+        // Provider errors (auth, network) degrade to the deterministic
+        // skeleton instead of hard-failing the command (issue #142 M10).
+        Err(e) => {
+            let note = format!(
+                "AI provider call failed ({e}) — emitting the deterministic explanation \
+                 skeleton without model prose."
+            );
+            session.complete_quiet(0.0);
+            return emit_degraded_explanation(&plan, workflow, level, json, &note).await;
+        }
+    };
     session.record_usage(&response.usage);
     let mut text = response.content.unwrap_or_default();
 
@@ -390,10 +409,16 @@ pub async fn ai_explain_command(
                 "Your response was not valid JSON matching the template. \
                  Reply with ONLY the JSON object, no other text.",
             ));
-            let retry = provider.chat_with_tools(&messages, &[]).await?;
-            session.record_usage(&retry.usage);
-            text = retry.content.unwrap_or_default();
-            explanation = parse_ai_explanation(&text);
+            // A failed retry falls into the same skeleton fallback below —
+            // the command degrades, it does not hard-fail (issue #142 M10).
+            match provider.chat_with_tools(&messages, &[]).await {
+                Ok(retry) => {
+                    session.record_usage(&retry.usage);
+                    text = retry.content.unwrap_or_default();
+                    explanation = parse_ai_explanation(&text);
+                }
+                Err(e) => eprintln!("  {} AI retry failed: {e}", "⚠".yellow()),
+            }
         }
         match explanation {
             Some(ai) => merge_explanation(&mut plan, &ai),
@@ -486,6 +511,109 @@ fn explain_json(
         }),
     );
     output
+}
+
+// ── Degraded mode (no model) ───────────────────────────────────────────────
+
+/// Emit the explanation WITHOUT model prose: the deterministic grounding
+/// layers (plan facts, knowledge-base refs, scientific findings) that the
+/// three-layer explain computes before any provider call.
+///
+/// The degraded path is a first-class output, not an error (issue #142
+/// M10): it is what `OXO_FLOW_AI_PROVIDER=disabled` explicitly requests,
+/// and what a failed provider call (auth/network) falls back to — the
+/// command exits 0 so scripts can rely on the skeleton being present.
+async fn emit_degraded_explanation(
+    plan: &ExplainPlan,
+    workflow: &Path,
+    level: ExplainLevel,
+    json: bool,
+    note: &str,
+) -> Result<()> {
+    use colored::Colorize;
+
+    if json {
+        // stdout carries ONLY the JSON document (machine-output
+        // convention); the note goes to stderr.
+        eprintln!("  {} {note}", "⚠".yellow());
+        let output = explain_json(plan, workflow, level, None);
+        println!("\n{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        eprintln!("\n  {} {note}", "⚠".yellow());
+        print_plan_skeleton(plan);
+    }
+
+    // The deterministic findings are always surfaced — with or without a
+    // model, they cannot be dropped (mirrors the happy path).
+    if !plan.warnings.is_empty() {
+        eprintln!("\n{}", "Scientific findings (verified):".bold().yellow());
+        for warning in &plan.warnings {
+            eprintln!(
+                "  ⚠ [{}] {}: {}",
+                warning.code, warning.rule, warning.message
+            );
+            eprintln!("    {} {}", "→".bold(), warning.suggestion);
+        }
+    }
+
+    if json {
+        eprintln!(
+            "  {} run with a configured provider to add plain-language prose",
+            "Hint:".bold().cyan()
+        );
+    } else {
+        println!(
+            "\n{} Run with a configured provider to add plain-language prose.",
+            "Hint:".bold().cyan()
+        );
+    }
+    Ok(())
+}
+
+/// Human-readable rendering of the deterministic skeleton (no prose) —
+/// the facts the model would have wrapped in prose.
+fn print_plan_skeleton(plan: &ExplainPlan) {
+    use colored::Colorize;
+
+    println!(
+        "\n{} {}",
+        plan.workflow_name.bold(),
+        "(deterministic skeleton)".dimmed()
+    );
+    println!("  version: {}", plan.workflow_version);
+    if let Some(ref desc) = plan.workflow_description {
+        println!("  {desc}");
+    }
+    let domains = if plan.domains.is_empty() {
+        String::new()
+    } else {
+        format!(", domains: {}", plan.domains.join(", "))
+    };
+    println!("  {} rule(s){domains}", plan.rule_count);
+    println!("  entry rules: {}", plan.entry_rules.join(", "));
+    println!("  final rules: {}", plan.final_rules.join(", "));
+    for step in &plan.steps {
+        println!();
+        println!("  {}. {}", step.order, step.name.bold());
+        if let Some(ref desc) = step.description {
+            println!("     {desc}");
+        }
+        if !step.tools.is_empty() {
+            println!("     tools: {}", step.tools.join(", "));
+        }
+        if !step.inputs.is_empty() {
+            println!("     inputs: {}", step.inputs.join(", "));
+        }
+        if !step.outputs.is_empty() {
+            println!("     outputs: {}", step.outputs.join(", "));
+        }
+        if let Some(threads) = step.threads {
+            println!("     threads: {threads}");
+        }
+        if let Some(memory) = &step.memory {
+            println!("     memory: {memory}");
+        }
+    }
 }
 
 // ── AI prose layer ─────────────────────────────────────────────────────────

--- a/crates/oxo-flow-cli/src/commands/provenance.rs
+++ b/crates/oxo-flow-cli/src/commands/provenance.rs
@@ -1,14 +1,72 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+/// One verified file's outcome, machine-readable for `--json`.
+#[derive(Debug, Serialize)]
+struct VerifyEntry {
+    file: String,
+    /// `matched`, `mismatched`, or `missing`.
+    status: &'static str,
+    /// The checksum recorded in the checkpoint at run time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected: Option<String>,
+    /// The checksum recomputed from disk (absent for missing files).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    actual: Option<String>,
+    /// Free-form detail (e.g. a checksum computation error).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+}
+
+impl VerifyEntry {
+    fn matched(file: &str, expected: &str, actual: &str) -> Self {
+        Self {
+            file: file.to_string(),
+            status: "matched",
+            expected: Some(expected.to_string()),
+            actual: Some(actual.to_string()),
+            note: None,
+        }
+    }
+    fn mismatched(file: &str, expected: &str, actual: &str) -> Self {
+        Self {
+            file: file.to_string(),
+            status: "mismatched",
+            expected: Some(expected.to_string()),
+            actual: Some(actual.to_string()),
+            note: None,
+        }
+    }
+    fn error(file: &str, expected: &str, note: &str) -> Self {
+        Self {
+            file: file.to_string(),
+            status: "mismatched",
+            expected: Some(expected.to_string()),
+            actual: None,
+            note: Some(note.to_string()),
+        }
+    }
+    fn missing(file: &str, expected: &str) -> Self {
+        Self {
+            file: file.to_string(),
+            status: "missing",
+            expected: Some(expected.to_string()),
+            actual: None,
+            note: None,
+        }
+    }
+}
 
 /// Verify output file checksums stored in a checkpoint file.
 ///
 /// Reads the checkpoint JSON, looks for stored checksums (either embedded
 /// in the checkpoint under a `"checksums"` key or in a companion file),
-/// re-hashes the referenced output files, and reports match/mismatch per file.
-pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
+/// re-hashes the referenced output files, and reports match/mismatch per
+/// file.
+pub fn provenance_verify_command(checkpoint_path: PathBuf, json: bool) -> Result<()> {
     let checkpoint_path =
         std::path::absolute(&checkpoint_path).context("failed to resolve checkpoint path")?;
 
@@ -66,12 +124,29 @@ pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
         }
     };
 
-    let workdir = checkpoint_path
-        .parent()
-        .unwrap_or(std::path::Path::new("."));
+    // Output paths resolve against the workdir the run recorded in the
+    // checkpoint (issue #68), NOT against the checkpoint's own directory:
+    // `.oxo-flow/` is a sibling of the data files, and resolving against
+    // it reported every intact output as "file missing" while the actual
+    // file sat untouched next to it (issue #142 H7). Legacy checkpoints
+    // without a recorded workdir fall back to the checkpoint's parent.
+    let workdir = checkpoint
+        .get("workdir")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            checkpoint_path
+                .parent()
+                .unwrap_or(std::path::Path::new("."))
+                .to_path_buf()
+        });
+    if json {
+        eprintln!("  {} workdir: {}", "•".dimmed(), workdir.display());
+    }
 
     // Determine which files to verify
-    let files_to_check: Vec<String> = if stored_checksums.is_empty() {
+    if stored_checksums.is_empty() {
         // Fallback: try to discover output files from completed rules
         // Look for files matching rule output patterns in the workdir
         if let Some(completed) = checkpoint.get("completed_rules").and_then(|v| v.as_array()) {
@@ -94,27 +169,61 @@ pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
                 "\n{} To verify integrity, provide a checksums file.",
                 "Hint:".bold().cyan()
             );
+            if json {
+                let output = serde_json::json!({
+                    "command": "provenance",
+                    "verify": {
+                        "checkpoint": checkpoint_path.display().to_string(),
+                        "matched": 0,
+                        "mismatched": 0,
+                        "missing": 0,
+                        "entries": [],
+                        "note": "No stored checksums found. Run workflow with --provenance to enable tracking.",
+                    },
+                });
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            }
             return Ok(());
         }
         eprintln!(
             "  {} No completed rules or checksums found.",
             "✗".red().bold()
         );
+        if json {
+            let output = serde_json::json!({
+                "command": "provenance",
+                "verify": {
+                    "checkpoint": checkpoint_path.display().to_string(),
+                    "matched": 0,
+                    "mismatched": 0,
+                    "missing": 0,
+                    "entries": [],
+                    "note": "No completed rules or checksums found in the checkpoint.",
+                },
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        }
         return Ok(());
-    } else {
-        stored_checksums.keys().cloned().collect()
-    };
+    }
 
     let mut matched = 0usize;
     let mut mismatched = 0usize;
     let mut missing = 0usize;
+    let mut entries: Vec<VerifyEntry> = Vec::new();
 
-    for file in &files_to_check {
+    // Deterministic order: HashMap iteration is arbitrary, and both the
+    // human report and the JSON entries must be byte-stable (the same
+    // convention report sections follow, issue #83 P1-4).
+    let mut files_to_check: Vec<&String> = stored_checksums.keys().collect();
+    files_to_check.sort_unstable();
+
+    for file in files_to_check {
         let expected = &stored_checksums[file];
         let full_path = workdir.join(file);
 
         if !full_path.exists() {
             eprintln!("  {} {} (file missing)", "✗".red().bold(), file);
+            entries.push(VerifyEntry::missing(file, expected));
             missing += 1;
             continue;
         }
@@ -122,6 +231,7 @@ pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
         match oxo_flow_core::executor::checkpoint::compute_file_checksum(&full_path) {
             Ok(actual) if actual == *expected => {
                 eprintln!("  {} {} {}", "✓".green().bold(), file, actual.dimmed());
+                entries.push(VerifyEntry::matched(file, expected, &actual));
                 matched += 1;
             }
             Ok(actual) => {
@@ -132,10 +242,12 @@ pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
                     expected,
                     actual
                 );
+                entries.push(VerifyEntry::mismatched(file, expected, &actual));
                 mismatched += 1;
             }
             Err(e) => {
                 eprintln!("  {} {} (checksum error: {})", "✗".red().bold(), file, e);
+                entries.push(VerifyEntry::error(file, expected, &e.to_string()));
                 mismatched += 1;
             }
         }
@@ -150,6 +262,25 @@ pub fn provenance_verify_command(checkpoint_path: PathBuf) -> Result<()> {
         missing
     );
 
+    // Machine-readable verify result — stdout carries ONLY this document
+    // in --json mode (the human report above stays on stderr).
+    if json {
+        let output = serde_json::json!({
+            "command": "provenance",
+            "verify": {
+                "checkpoint": checkpoint_path.display().to_string(),
+                "matched": matched,
+                "mismatched": mismatched,
+                "missing": missing,
+                "entries": entries,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    }
+
+    // Missing files are a verification failure too: a vanished output is
+    // exactly what integrity verification must catch. Exiting 0 there made
+    // the path-resolution false-negative fully silent (issue #142 H7).
     if mismatched > 0 || missing > 0 {
         std::process::exit(1);
     }

--- a/crates/oxo-flow-cli/src/commands/quality.rs
+++ b/crates/oxo-flow-cli/src/commands/quality.rs
@@ -248,6 +248,12 @@ pub async fn lint_command(workflow: PathBuf, strict: bool, json: bool, ai: bool)
             eprint!(" (rule: {})", rule);
         }
         eprintln!();
+        // The fix hint is part of the human output too, not just --json —
+        // the JSON-only placement silently dropped every suggestion from
+        // the text report (issue #142 M11). Same style as validate.
+        if let Some(ref suggestion) = d.suggestion {
+            eprintln!("    hint: {}", suggestion);
+        }
     }
 
     eprintln!(

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -482,6 +482,27 @@ fn known_modules_hint(module_rules: &std::collections::HashMap<String, Vec<Strin
     }
 }
 
+/// Issue #142 H1 gate: an unknown `{config.*}` placeholder used to expand to
+/// literal text while the run exited 0 — silent wrong outputs. This is the
+/// same E005 detector `validate` uses, applied as a hard gate by both `run`
+/// and `dry-run`, so the three surfaces can never disagree about a typo'd
+/// key. Returns the human-readable findings (rule, key, fix) or empty.
+fn undefined_config_findings(config: &WorkflowConfig) -> Vec<String> {
+    config
+        .rules
+        .iter()
+        .flat_map(|rule| oxo_flow_core::format::undefined_config_refs(rule, config))
+        .map(|d| {
+            format!(
+                "rule '{}': {} ({})",
+                d.rule.as_deref().unwrap_or("<unknown>"),
+                d.message,
+                d.suggestion.unwrap_or_default()
+            )
+        })
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_command(
     workflow: Option<PathBuf>,
@@ -605,6 +626,21 @@ pub async fn run_command(
         .expand_wildcards()
         .context("failed to expand wildcard rules")?;
 
+    // ── Undefined `{config.*}` gate (issue #142 H1) ───────────────────────
+    // Runs AFTER expansion so engine-generated rules are covered too, and
+    // before any file is touched — a typo'd key must fail the run, never
+    // produce literal-placeholder outputs with exit 0.
+    let e005 = undefined_config_findings(&config);
+    if !e005.is_empty() {
+        if json {
+            emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0);
+        }
+        return Err(anyhow::anyhow!(
+            "workflow references undefined config variable(s) — fix before running:\n  {}",
+            e005.join("\n  ")
+        ));
+    }
+
     let mut dag = WorkflowDag::from_rules_with_config(
         &config.rules,
         &config_placeholder_values(&config.config),
@@ -620,6 +656,9 @@ pub async fn run_command(
         match config.module_closure(m) {
             Some(names) => target.extend(names),
             None => {
+                // Pre-execution abort: nothing ran, but the summary
+                // contract still holds for --json (issue #142 H6).
+                emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0);
                 return Err(anyhow::anyhow!(
                     "unknown module '{m}' — known modules: {}",
                     known_modules_hint(&config.module_rules)
@@ -781,6 +820,20 @@ pub async fn run_command(
         rerun,
     );
 
+    // Issue #142 M1: rules whose fingerprint differed only in the
+    // sample-derived input list are NOT invalidated — toggling --samples
+    // must not re-run (and overwrite) cohort-level gather outputs. The
+    // input-manifest check re-verifies set + content below, so a genuine
+    // input edit still invalidates there.
+    if !change_report.sample_selection_exempt.is_empty() {
+        eprintln!(
+            "  {} skipped {} rule(s) whose definition only changed with the --samples selection: {} — outputs still cover the previous run's full sample set; use --rerun to regenerate with the new selection",
+            "⚠".yellow(),
+            change_report.sample_selection_exempt.len(),
+            change_report.sample_selection_exempt.join(", ")
+        );
+    }
+
     // All config values (including CLI --arg overrides) become {config.key} in templates.
     let wildcard_values: Arc<HashMap<String, String>> =
         Arc::new(config_placeholder_values(&config.config));
@@ -798,7 +851,7 @@ pub async fn run_command(
         let mut ck = checkpoint.lock().await;
         // Shared with dry-run's read-only preview (issue #66) — keep the
         // detection semantics in ONE place.
-        let (mismatched, missing_inputs, baselined) =
+        let (mismatched, missing_inputs, baselined, sample_selection_driven) =
             crate::commands::run_preview::detect_input_manifest_invalidations(
                 &mut ck,
                 &config,
@@ -807,6 +860,21 @@ pub async fn run_command(
                 workdir_actual.as_ref(),
                 &wildcard_values,
             );
+        // Issue #142 M1: a rule whose only input-manifest change is the
+        // engine-injected sample list is NOT invalidated — toggling
+        // --samples must not overwrite cohort-level gather outputs with a
+        // subset table. Emit the documented warning; the detection function
+        // already proved (re-expansion + content-identity) the change is
+        // sample-selection-only.
+        if !sample_selection_driven.is_empty() {
+            let names: Vec<&str> = sample_selection_driven.iter().map(String::as_str).collect();
+            eprintln!(
+                "  {} skipped {} rule(s) whose inputs only changed with the --samples selection: {} — outputs still cover the previous run's full sample set; use --rerun to regenerate with the new selection",
+                "⚠".yellow(),
+                names.len(),
+                names.join(", ")
+            );
+        }
         // Cascade-up: missing inputs (tombstoned temporaries) re-run their
         // completed producers first — the same semantics the preview shows.
         if !missing_inputs.is_empty() {
@@ -971,6 +1039,23 @@ pub async fn run_command(
             },
         )
         .await?;
+        // The cluster path returns before the common summary emission, so
+        // it routes through the same `--json` contract itself (issue #142
+        // H6): the document must appear on both outcomes.
+        emit_run_json_summary(
+            json,
+            if summary.is_success() {
+                "completed"
+            } else {
+                "failed"
+            },
+            &workflow,
+            summary.succeeded,
+            summary.skipped,
+            summary.failed,
+            summary.non_required_failed,
+            0,
+        );
         if !summary.is_success() {
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
@@ -1047,6 +1132,9 @@ pub async fn run_command(
             .map(|b| format!("  - {b}"))
             .collect::<Vec<_>>()
             .join("\n");
+        // Pre-execution abort: nothing ran — the summary still reports
+        // the failed run for --json consumers (issue #142 H6).
+        emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0);
         return Err(anyhow::anyhow!(
             "resource budget too small for {} rule(s); no rules were run:\n{}",
             breaches.len(),
@@ -1270,6 +1358,9 @@ pub async fn run_command(
                             }
                             Ok(o) => {
                                 let stderr = String::from_utf8_lossy(&o.stderr).into_owned();
+                                // Pre-execution abort — the summary still
+                                // reports the failed run (issue #142 H6).
+                                emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0);
                                 return Err(anyhow::anyhow!(
                                     "failed to set up the environment for reference '{}': {}",
                                     ref_def.name,
@@ -1277,6 +1368,7 @@ pub async fn run_command(
                                 ));
                             }
                             Err(e) => {
+                                emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0);
                                 return Err(anyhow::anyhow!(
                                     "failed to run the environment setup for reference '{}': {e}",
                                     ref_def.name
@@ -1895,6 +1987,18 @@ pub async fn run_command(
                 let Some(rule_name) = task_rule.remove(&e.id()) else {
                     // Internal invariant: every spawned task registers its
                     // name at spawn. Fail the run rather than leak the cap.
+                    // The engine fault counts as a failure in the summary
+                    // (issue #142 H6).
+                    emit_run_json_summary(
+                        json,
+                        "failed",
+                        &workflow,
+                        success_count.load(std::sync::atomic::Ordering::Relaxed),
+                        skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+                        fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                        non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                        blocked.lock().await.len(),
+                    );
                     return Err(anyhow::anyhow!(
                         "internal error: task {} has no recorded rule",
                         e.id()
@@ -2068,6 +2172,18 @@ pub async fn run_command(
                 }
             }
 
+            // The plain-failure abort: emit the summary BEFORE returning,
+            // mirroring the keep-going path's document (issue #142 H6).
+            emit_run_json_summary(
+                json,
+                "failed",
+                &workflow,
+                success_count.load(std::sync::atomic::Ordering::Relaxed),
+                skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+                fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                blocked.lock().await.len(),
+            );
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
 
@@ -2452,23 +2568,23 @@ pub async fn run_command(
         }
     }
 
-    // JSON output mode
-    if json {
-        let wf_path = Some(workflow.to_string_lossy().to_string());
-        let output = serde_json::json!({
-            "command": "run",
-            "status": if fail_count > 0 { "failed" } else { "completed" },
-            "workflow": wf_path,
-            "results": serde_json::json!({
-                "succeeded": success_count,
-                "skipped": skipped_count,
-                "failed": fail_count,
-                "non_required_failed": non_required_fail_count,
-                "blocked": blocked.len(),
-            }),
-        });
-        println!("{}", serde_json::to_string_pretty(&output).unwrap());
-    }
+    // JSON output mode (issue #142 H6): the summary is emitted on EVERY
+    // path — completed, failed, and aborted — so `--json` consumers can
+    // rely on the document regardless of how the run ended.
+    emit_run_json_summary(
+        json,
+        if fail_count > 0 {
+            "failed"
+        } else {
+            "completed"
+        },
+        &workflow,
+        success_count,
+        skipped_count,
+        fail_count,
+        non_required_fail_count,
+        blocked.len(),
+    );
 
     // The verdict is independent of --keep-going (issue #133): keep-going
     // changes SCHEDULING (failures don't stop the run), never the verdict —
@@ -2480,6 +2596,43 @@ pub async fn run_command(
     }
 
     Ok(())
+}
+
+/// Emit the machine-readable run summary (`--json`) in the canonical
+/// `{"command":"run",...}` shape.
+///
+/// Shared by the happy path AND every abort path (preflight failures,
+/// budget breaches, cluster runs, the plain-failure abort) so a failed run
+/// never leaves stdout at zero bytes while the keep-going path emits the
+/// document (issue #142 H6). Only emits when `--json` was requested;
+/// stdout carries nothing else, so the document is always the sole output.
+#[allow(clippy::too_many_arguments)] // matching the crate's established convention
+fn emit_run_json_summary(
+    json: bool,
+    status: &str,
+    workflow: &Path,
+    succeeded: usize,
+    skipped: usize,
+    failed: usize,
+    non_required_failed: usize,
+    blocked: usize,
+) {
+    if !json {
+        return;
+    }
+    let output = serde_json::json!({
+        "command": "run",
+        "status": status,
+        "workflow": workflow.to_string_lossy(),
+        "results": serde_json::json!({
+            "succeeded": succeeded,
+            "skipped": skipped,
+            "failed": failed,
+            "non_required_failed": non_required_failed,
+            "blocked": blocked,
+        }),
+    });
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
 }
 
 /// Sorts the scheduler's ready list by effective priority: declared priority
@@ -2597,6 +2750,16 @@ pub async fn dry_run_command(
     config
         .expand_wildcards()
         .context("failed to expand wildcard rules")?;
+
+    // ── Undefined `{config.*}` gate (issue #142 H1) — the same gate run
+    // applies: preview must refuse a typo'd key exactly like execution.
+    let e005 = undefined_config_findings(&config);
+    if !e005.is_empty() {
+        return Err(anyhow::anyhow!(
+            "workflow references undefined config variable(s) — fix before running:\n  {}",
+            e005.join("\n  ")
+        ));
+    }
 
     let mut dag = WorkflowDag::from_rules_with_config(
         &config.rules,

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -10,9 +10,10 @@
 //! read-only and never mutates the on-disk state.
 
 use anyhow::{Context, Result};
+use colored::Colorize;
 use oxo_flow_core::config::WorkflowConfig;
 use oxo_flow_core::dag::WorkflowDag;
-use oxo_flow_core::executor::checkpoint::{CheckpointState, expand_config_in_path};
+use oxo_flow_core::executor::checkpoint::CheckpointState;
 use oxo_flow_core::rule::Rule;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -92,39 +93,20 @@ pub struct RunPreview {
 /// all outputs exist and (when inputs exist) every output is newer than
 /// every input. `run` skips such rules as "outputs up-to-date" even
 /// without a completion record; the preview mirrors it.
+///
+/// Delegates to the executor's own gate (`checkpoint::should_skip_rule`,
+/// the same function process.rs evaluates) so the two cannot drift: a path
+/// that still contains `{` — an undeclared wildcard like `{sample}` or an
+/// unexpanded config ref — is NOT fresh on the run side (the executor
+/// executes the rule), so the preview must not classify it as "will skip:
+/// outputs up-to-date" (issue #142 H3: dry-run said skip while `run`
+/// actually wrote a literal `out_{sample}.txt`).
 fn rule_outputs_exist_fresh(
     rule: &oxo_flow_core::rule::Rule,
     workdir: &Path,
     wildcard_values: &HashMap<String, String>,
 ) -> bool {
-    !rule.output.is_empty()
-        && rule.output.iter().all(|o| {
-            let expanded = expand_config_in_path(o, wildcard_values);
-            expanded.contains('{') || workdir.join(expanded).exists()
-        })
-        && (rule.input.is_empty()
-            || rule.input.iter().all(|i| {
-                let expanded = expand_config_in_path(i, wildcard_values);
-                if expanded.contains('{') {
-                    return true;
-                }
-                let input_mtime = std::fs::metadata(workdir.join(&expanded))
-                    .and_then(|m| m.modified())
-                    .ok();
-                let Some(input_mtime) = input_mtime else {
-                    return false;
-                };
-                rule.output.iter().all(|o| {
-                    let expanded_o = expand_config_in_path(o, wildcard_values);
-                    if expanded_o.contains('{') {
-                        return true;
-                    }
-                    std::fs::metadata(workdir.join(&expanded_o))
-                        .and_then(|m| m.modified())
-                        .ok()
-                        .is_some_and(|om| om >= input_mtime)
-                })
-            }))
+    oxo_flow_core::executor::checkpoint::should_skip_rule(rule, workdir, wildcard_values)
 }
 
 /// Storage resolver for manifest snapshots and remote staging: local by
@@ -226,18 +208,39 @@ pub fn preview_run_plan(
         config.defaults.shell_prelude.as_deref(),
     );
     let config_invalidated: HashSet<String> = config_report.invalidated.iter().cloned().collect();
+    // Issue #142 M1: rules whose fingerprint differed only in the
+    // sample-derived input list stay completed — warn (mirrors run), and
+    // the input-manifest check below re-verifies set + content, so a
+    // genuine input edit still invalidates.
+    for name in &config_report.sample_selection_exempt {
+        eprintln!(
+            "  {} rule '{}' skipped: its definition only changed with the --samples selection, not a real edit — its outputs still cover the previous run's full sample set",
+            "⚠".yellow(),
+            name
+        );
+    }
 
     // 2. Input-manifest invalidation (issue #72) — on the clone only.
     //    Missing inputs (typically tombstoned temporaries) cascade UP: the
     //    completed producers re-execute first, exactly like run.
-    let (manifest_invalidated, missing_inputs, _baselined) = detect_input_manifest_invalidations(
-        &mut clone,
-        config,
-        dag,
-        order,
-        workdir,
-        wildcard_values,
-    );
+    let (manifest_invalidated, missing_inputs, _baselined, sample_selection_driven) =
+        detect_input_manifest_invalidations(
+            &mut clone,
+            config,
+            dag,
+            order,
+            workdir,
+            wildcard_values,
+        );
+    // Issue #142 M1: rules whose ONLY input change is the engine-injected
+    // sample-list stay skipped — warn (mirrors run), never invalidate.
+    for name in sample_selection_driven.iter() {
+        eprintln!(
+            "  {} rule '{}' skipped: its inputs only reflect the --samples selection, not a real change — its outputs still cover the previous run's full sample set",
+            "⚠".yellow(),
+            name
+        );
+    }
     // Genuinely missing inputs cascade UP: every completed producer of the
     // missing files re-executes first (exactly like run).
     let mut upstream_set: HashSet<String> = cascade_up(&mut clone, dag, &missing_inputs)
@@ -478,8 +481,12 @@ pub fn rule_outputs_exist(
 /// Compare completed rules' input manifests against the current file set.
 ///
 /// Returns (content-mismatched rule names, rules whose inputs are MISSING,
-/// number of legacy-baseline adoptions). The missing set drives cascade-up:
-/// the completed producers of those inputs must re-execute first.
+/// number of legacy-baseline adoptions, rules whose only mismatch is the
+/// engine-injected sample-selection change). The missing set drives
+/// cascade-up: the completed producers of those inputs must re-execute
+/// first. The sample-selection set stays completed — its mismatch does not
+/// invalidate (issue #142 M1, documented run.md contract) and is surfaced
+/// as a warning by the caller.
 ///
 /// Mutates `ck` by recording baselines for legacy checkpoints — exactly
 /// like `run` does; pass a clone for a read-only preview.
@@ -490,10 +497,11 @@ pub fn detect_input_manifest_invalidations(
     order: &[String],
     workdir: &Path,
     wildcard_values: &HashMap<String, String>,
-) -> (HashSet<String>, HashSet<String>, usize) {
+) -> (HashSet<String>, HashSet<String>, usize, HashSet<String>) {
     let mut mismatched: HashSet<String> = HashSet::new();
     let mut missing_inputs: HashSet<String> = HashSet::new();
     let mut baselined = 0usize;
+    let mut sample_selection_driven: HashSet<String> = HashSet::new();
     for name in order {
         if !ck.completed_rules.contains(name) {
             continue;
@@ -511,8 +519,20 @@ pub fn detect_input_manifest_invalidations(
                 Some(recorded)
                     if oxo_flow_core::executor::checkpoint::manifests_match(recorded, &current) => {
                 }
-                Some(_) => {
-                    mismatched.insert(name.clone());
+                Some(recorded) => {
+                    // The file set changed — but if the change is exactly
+                    // the engine's injected sample list (expand_inputs over
+                    // config.samples_list / samples_<group> / pairs_list),
+                    // toggling --samples must stay cheap (run.md contract):
+                    // the rule stays completed, its outputs keep reflecting
+                    // the previous run's sample set. Anything else — a
+                    // genuine file edit, a user-touched set — invalidates
+                    // as before (issue #142 M1).
+                    if manifest_mismatch_is_sample_selection(rule, recorded, &current, config) {
+                        sample_selection_driven.insert(name.clone());
+                    } else {
+                        mismatched.insert(name.clone());
+                    }
                 }
                 None => {
                     // Legacy baseline: adopt the current set.
@@ -547,7 +567,105 @@ pub fn detect_input_manifest_invalidations(
             }
         }
     }
-    (mismatched, missing_inputs, baselined)
+    (
+        mismatched,
+        missing_inputs,
+        baselined,
+        sample_selection_driven,
+    )
+}
+
+/// Whether a recorded-vs-current input-manifest mismatch is caused solely by
+/// the engine's injected sample-list values changing between runs (issue
+/// #142 M1).
+///
+/// The documented contract (run.md): `samples_list` / `samples_<group>` /
+/// `pairs_list` are engine-injected and never trigger invalidation, so
+/// toggling `--samples` stays cheap. Config-impact detection already
+/// excludes those keys; the input-manifest path must too — a gather rule
+/// whose input list is baked from `expand_inputs` over `config.samples_list`
+/// would otherwise re-run on every subset run and overwrite cohort outputs
+/// with a subset table.
+///
+/// Three conditions, ALL verified — the exclusion is never broad:
+/// 1. Some `expand_inputs` pattern of the rule resolves against an
+///    engine-injected config key; any other input source keeps normal
+///    (invalidate) behavior.
+/// 2. Re-expanding under the CURRENT config reproduces the CURRENT manifest
+///    path set exactly — the file set is fully determined by the injected
+///    value; a user-added/removed/touched file set would not reproduce.
+/// 3. Every path present in BOTH manifests is content-identical — a real
+///    edit to a file the rule consumes still invalidates.
+fn manifest_mismatch_is_sample_selection(
+    rule: &Rule,
+    recorded: &[oxo_flow_core::executor::checkpoint::InputManifestEntry],
+    current: &[oxo_flow_core::executor::checkpoint::InputManifestEntry],
+    config: &WorkflowConfig,
+) -> bool {
+    let Some(expected) = engine_expanded_inputs_from_injected(rule, config) else {
+        return false;
+    };
+    // (2) The current manifest must be exactly the engine-derived set.
+    let expected_paths: HashSet<&str> = expected.iter().map(String::as_str).collect();
+    let current_paths: HashSet<&str> = current.iter().map(|e| e.path.as_str()).collect();
+    if current_paths != expected_paths {
+        return false;
+    }
+    // (3) Overlapping entries must be identical (size/hash-aware — the
+    // `PartialEq` on entries covers remote etags too).
+    let current_by_path: HashMap<&str, &oxo_flow_core::executor::checkpoint::InputManifestEntry> =
+        current.iter().map(|e| (e.path.as_str(), e)).collect();
+    recorded
+        .iter()
+        .filter(|r| current_by_path.contains_key(r.path.as_str()))
+        .all(|r| current_by_path[r.path.as_str()] == r)
+}
+
+/// The input paths a rule's `expand_inputs` patterns bake to under the
+/// CURRENT config — the same resolution `expand_wildcards` applies at run
+/// start (config.rs: `resolve_config_list` + `cartesian_expand`, literal
+/// lists, and per-instance `[[values]]` bindings).
+///
+/// Returns None when no `expand_inputs` pattern resolves against an
+/// engine-injected config key (`samples_list` / `samples_<group>` /
+/// `pairs_list`) — the only rules whose manifest mismatch can be a pure
+/// sample-selection change. `[[values]]` per-instance bindings are not
+/// re-applied here: a pattern depending on them fails the path-set
+/// reproduction check (condition 2) and falls back to normal invalidation —
+/// conservative by construction.
+fn engine_expanded_inputs_from_injected(
+    rule: &Rule,
+    config: &WorkflowConfig,
+) -> Option<Vec<String>> {
+    let mut touched_injected = false;
+    let mut expanded: Vec<String> = Vec::new();
+    for exp in &rule.expand_inputs {
+        let mut variables: HashMap<String, Vec<String>> = HashMap::new();
+        for (var_name, var_ref) in &exp.variables {
+            let referenced = var_ref.strip_prefix("config.").unwrap_or(var_ref);
+            if oxo_flow_core::config_impact::is_engine_injected_key(referenced) {
+                touched_injected = true;
+            }
+            if let Some(vals) = config.resolve_config_list(var_ref) {
+                variables.insert(var_name.clone(), vals);
+            } else if var_ref.starts_with('[') && var_ref.ends_with(']') {
+                let inner = &var_ref[1..var_ref.len() - 1];
+                let vals = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                variables.insert(var_name.clone(), vals);
+            } else {
+                variables.insert(var_name.clone(), vec![var_ref.clone()]);
+            }
+        }
+        expanded.extend(oxo_flow_core::wildcard::cartesian_expand(
+            &exp.pattern,
+            &variables,
+        ));
+    }
+    touched_injected.then_some(expanded)
 }
 
 /// Remove the completed UPSTREAM dependencies of `seeds` from the completed
@@ -658,11 +776,36 @@ pub(crate) fn when_condition_false(
     !oxo_flow_core::executor::process::evaluate_condition(condition, &config_values)
 }
 
+/// The profile names available in `<workflow-dir>/profiles/` — `<NAME>`
+/// from every `<NAME>.toml` / `<NAME>.oxoflow` file, sorted and deduped.
+fn available_profiles(workflow_dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(workflow_dir.join("profiles")) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            for ext in [".toml", ".oxoflow"] {
+                if let Some(stripped) = name.strip_suffix(ext) {
+                    return Some(stripped.to_string());
+                }
+            }
+            None
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
 /// Merge a profile's `[config]` table into the workflow config — the same
 /// semantics `run` applies. Profile values only FILL IN keys the workflow
 /// does not set (`or_insert`); profile lookup is workflow-dir-only:
 /// `<workflow-dir>/profiles/<NAME>.toml`, then `.oxoflow`; a missing
-/// profile warns and continues (matching run, issue #76 audit).
+/// profile is a HARD error naming every available profile (issue #142 H4 —
+/// a typo'd `--profile` previously warned and ran with the wrong config).
 pub(crate) fn merge_profile(
     config: &mut WorkflowConfig,
     profile_name: &str,
@@ -680,12 +823,17 @@ pub(crate) fn merge_profile(
     ];
     let profile_path = profile_paths.iter().find(|p| p.exists());
     let Some(path) = profile_path else {
-        eprintln!(
-            "{} Profile '{}' not found in profiles/ directory",
-            "Warning:".bold().yellow(),
+        let available = available_profiles(workflow_dir);
+        let hint = if available.is_empty() {
+            "the profiles/ directory does not exist or contains no .toml/.oxoflow profile files"
+                .to_string()
+        } else {
+            format!("available profiles: {}", available.join(", "))
+        };
+        return Err(anyhow::anyhow!(
+            "profile '{}' not found in profiles/ directory ({hint})",
             profile_name
-        );
-        return Ok(());
+        ));
     };
     let profile_content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read profile {}", path.display()))?;
@@ -1029,8 +1177,15 @@ threshold = 5
     }
 
     #[test]
-    fn merge_profile_missing_profile_warns_and_continues() {
+    fn merge_profile_missing_profile_is_hard_error_with_available_list() {
         let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("profiles")).unwrap();
+        std::fs::write(
+            dir.path().join("profiles/batch.toml"),
+            "[config]\nthreads = 4\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("profiles/dev.oxoflow"), "[config]\n").unwrap();
         let mut config = WorkflowConfig::parse(
             r#"
 [workflow]
@@ -1039,7 +1194,25 @@ version = "1.0"
 "#,
         )
         .unwrap();
-        assert!(merge_profile(&mut config, "nope", dir.path()).is_ok());
+        let err = merge_profile(&mut config, "nope", dir.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("nope"), "error should name the profile: {msg}");
+        assert!(
+            msg.contains("batch") && msg.contains("dev"),
+            "error should list available profiles: {msg}"
+        );
+        // No profile dir at all still errors (with a different hint).
+        let bare = tempfile::tempdir().unwrap();
+        let mut config2 = WorkflowConfig::parse(
+            r#"
+[workflow]
+name = "t"
+version = "1.0"
+"#,
+        )
+        .unwrap();
+        let err2 = merge_profile(&mut config2, "nope", bare.path()).unwrap_err();
+        assert!(format!("{err2:#}").contains("no .toml/.oxoflow profile files"));
     }
 
     #[test]
@@ -1236,5 +1409,205 @@ version = "1.0"
 
         let preview = run_preview(&ck, &config, &dag, &order, dir.path(), &wildcard_values);
         assert!(preview.plan.iter().all(|r| r.status == RuleStatus::Skipped));
+    }
+
+    // ─── Issue #142 H3a: undeclared wildcard parity ────────────────────
+
+    /// A rule whose output contains an undeclared `{sample}` is NEVER fresh:
+    /// the brace path cannot exist as itself (the executor runs the rule and
+    /// writes the literal name), so the preview must say `NeverCompleted` —
+    /// never `SkippedFresh` — matching `should_skip_rule` exactly.
+    #[test]
+    fn undeclared_wildcard_output_is_never_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = WorkflowConfig::parse(
+            r#"
+[workflow]
+name = "t"
+version = "1.0"
+
+[[rules]]
+name = "gen"
+output = ["out_{sample}.txt"]
+shell = "echo hi > {output}"
+"#,
+        )
+        .unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let dag = WorkflowDag::from_rules(&config.rules).unwrap();
+        let order = dag.execution_order().unwrap();
+        let wildcard_values = HashMap::new();
+        let ck = CheckpointState::new();
+
+        // Pre-create the LITERAL brace-named file — even then the rule must
+        // not classify as fresh, exactly like the executor treats it.
+        std::fs::write(dir.path().join("out_{sample}.txt"), "hi").unwrap();
+
+        let preview = run_preview(&ck, &config, &dag, &order, dir.path(), &wildcard_values);
+        assert_eq!(
+            status_of(&preview, "gen"),
+            &RuleStatus::NeverCompleted,
+            "an undeclared-wildcard output must never count as up-to-date"
+        );
+        assert!(
+            !preview
+                .plan
+                .iter()
+                .any(|r| r.status == RuleStatus::SkippedFresh)
+        );
+    }
+
+    // ─── Issue #142 M1: sample-selection manifest exclusion ────────────
+
+    fn manifest_entry(
+        path: &str,
+        size: u64,
+    ) -> oxo_flow_core::executor::checkpoint::InputManifestEntry {
+        oxo_flow_core::executor::checkpoint::InputManifestEntry {
+            path: path.to_string(),
+            size,
+            mtime_nanos: 1000,
+            hash: Some("sha256:abc".to_string()),
+            remote: None,
+        }
+    }
+
+    fn gather_config(samples_list: &str) -> WorkflowConfig {
+        let toml = format!(
+            r#"
+[workflow]
+name = "t"
+version = "1.0"
+
+[config]
+samples_list = "{samples_list}"
+
+[[rules]]
+name = "gather"
+output = ["counts.txt"]
+expand_inputs = [{{ pattern = "per/{{sample}}.txt", variables = {{ sample = "config.samples_list" }} }}]
+shell = "cat {{input}} > {{output}}"
+"#
+        );
+        let mut config = WorkflowConfig::parse(&toml).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        config
+    }
+
+    #[test]
+    fn engine_expanded_inputs_from_injected_lists_injected_rules() {
+        let config = gather_config("S1,S2,S3");
+        let gather = config.get_rule("gather").unwrap();
+        let expanded =
+            engine_expanded_inputs_from_injected(gather, &config).expect("injected expansion");
+        assert_eq!(expanded, vec!["per/S1.txt", "per/S2.txt", "per/S3.txt"]);
+    }
+
+    #[test]
+    fn engine_expanded_inputs_from_injected_is_none_without_injected_keys() {
+        let mut config = WorkflowConfig::parse(
+            r#"
+[workflow]
+name = "t"
+version = "1.0"
+
+[config]
+ref = "ref.fa"
+
+[[rules]]
+name = "gather"
+output = ["counts.txt"]
+expand_inputs = [{ pattern = "raw/{sample}.txt", variables = { sample = "config.ref" } }]
+shell = "cat {input} > {output}"
+"#,
+        )
+        .unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+        let gather = config.get_rule("gather").unwrap();
+        assert!(
+            engine_expanded_inputs_from_injected(gather, &config).is_none(),
+            "a config.key that is NOT engine-injected must not qualify"
+        );
+        // No expand_inputs at all — also none.
+        let mut plain = WorkflowConfig::parse(
+            r#"
+[workflow]
+name = "t"
+version = "1.0"
+
+[[rules]]
+name = "gen"
+output = ["out.txt"]
+shell = "echo hi > {output}"
+"#,
+        )
+        .unwrap();
+        plain.apply_defaults();
+        plain.expand_wildcards().unwrap();
+        assert!(
+            engine_expanded_inputs_from_injected(plain.get_rule("gen").unwrap(), &plain).is_none()
+        );
+    }
+
+    /// The true case: the recorded full-cohort manifest vs the subset
+    /// manifest, under the subset config — identical overlap, set
+    /// reproduced by re-expansion → sample-selection-driven.
+    #[test]
+    fn manifest_mismatch_is_sample_selection_on_pure_subset_change() {
+        let config = gather_config("S2");
+        let gather = config.get_rule("gather").unwrap();
+        let recorded = vec![
+            manifest_entry("per/S1.txt", 10),
+            manifest_entry("per/S2.txt", 20),
+            manifest_entry("per/S3.txt", 30),
+        ];
+        let current = vec![manifest_entry("per/S2.txt", 20)];
+        assert!(
+            manifest_mismatch_is_sample_selection(gather, &recorded, &current, &config),
+            "a pure samples_list subset change must classify as selection-driven"
+        );
+    }
+
+    /// A content edit to a file the rule consumes still invalidates: the
+    /// overlapping entry differs (condition 3).
+    #[test]
+    fn manifest_mismatch_with_edited_file_is_not_sample_selection() {
+        let config = gather_config("S2");
+        let gather = config.get_rule("gather").unwrap();
+        let recorded = vec![
+            manifest_entry("per/S1.txt", 10),
+            manifest_entry("per/S2.txt", 20),
+            manifest_entry("per/S3.txt", 30),
+        ];
+        let mut current = vec![manifest_entry("per/S2.txt", 20)];
+        current[0].size = 99; // the file the rule consumes was edited
+        assert!(
+            !manifest_mismatch_is_sample_selection(gather, &recorded, &current, &config),
+            "an edited consumed file must invalidate, never exempt"
+        );
+    }
+
+    /// A file set the injected value does not reproduce is not exempt: a
+    /// user-added input file means a real (non-selection) change.
+    #[test]
+    fn manifest_mismatch_with_foreign_file_is_not_sample_selection() {
+        let config = gather_config("S2");
+        let gather = config.get_rule("gather").unwrap();
+        let recorded = vec![
+            manifest_entry("per/S1.txt", 10),
+            manifest_entry("per/S2.txt", 20),
+            manifest_entry("per/S3.txt", 30),
+        ];
+        let current = vec![
+            manifest_entry("per/S2.txt", 20),
+            manifest_entry("per/S4.txt", 40), // S4 not in samples_list
+        ];
+        assert!(
+            !manifest_mismatch_is_sample_selection(gather, &recorded, &current, &config),
+            "a set the injected value cannot produce must invalidate"
+        );
     }
 }

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -942,8 +942,66 @@ pub enum ProvenanceAction {
     },
 }
 
+/// Migration hint for commands removed in v0.13 (issue #76).
+///
+/// clap would otherwise answer `oxo-flow history` with a bare
+/// "unrecognized subcommand" (and `watch` even suggested unrelated
+/// commands); scripts and muscle memory deserve the actual migration
+/// path (issue #142 H2). Returns the hint when the first positional
+/// argument names a removed command.
+fn legacy_command_hint() -> Option<String> {
+    let mut args = std::env::args_os().skip(1);
+    // Global flags are all boolean and take no values, so skipping them
+    // by name finds the subcommand position deterministically.
+    for arg in args.by_ref() {
+        let s = arg.to_string_lossy();
+        match s.as_ref() {
+            "-v" | "--verbose" | "-q" | "--quiet" | "--json" | "--no-color" | "-h" | "--help"
+            | "-V" | "--version" => continue,
+            "history" => {
+                return Some(
+                    "'history' was removed in v0.13 — 'oxo-flow status --timing' shows run \
+                     history with wall times."
+                        .into(),
+                );
+            }
+            "package" => {
+                return Some(
+                    "'package' was removed in v0.13 — use 'oxo-flow export' (compose support \
+                     included)."
+                        .into(),
+                );
+            }
+            "profile" => {
+                return Some(
+                    "'profile' was removed in v0.13 — use 'run --profile <NAME>' (or dry-run) \
+                     instead."
+                        .into(),
+                );
+            }
+            "watch" => {
+                return Some(
+                    "'watch' was removed in v0.13 with no replacement — poll 'oxo-flow status' \
+                     (or 'status --timing') instead."
+                        .into(),
+                );
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Removed commands (issue #76) get a migration hint instead of clap's
+    // bare "unrecognized subcommand" (issue #142 H2).
+    if let Some(hint) = legacy_command_hint() {
+        eprintln!("{hint}");
+        eprintln!("Run 'oxo-flow --help' to see the current command set.");
+        std::process::exit(1);
+    }
+
     // clap prints -h/--help during parsing, so pick the banner variant up
     // front: colors only on an interactive terminal, and never when
     // NO_COLOR is set or --no-color was passed.
@@ -1439,7 +1497,9 @@ async fn main() -> Result<()> {
             .await?
         }
         Commands::Provenance { action } => match action {
-            ProvenanceAction::Verify { checkpoint } => provenance_verify_command(checkpoint)?,
+            ProvenanceAction::Verify { checkpoint } => {
+                provenance_verify_command(checkpoint, cli.json)?
+            }
         },
         Commands::Schema => {
             let schema = include_str!("../schema/oxoflow-v1.schema.json");

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -2489,6 +2489,11 @@ impl WorkflowConfig {
                     message: e.to_string(),
                 })?;
 
+            // Declarative `[config]` entries (`key = { default, ... }`)
+            // are extracted exactly as they would be standalone, so their
+            // defaults merge below as plain values (issue #142 M3).
+            inc_config.extract_declarative_config()?;
+
             // Recursively resolve nested includes
             inc_config.resolve_includes_with_depth(&inc_base_dir, depth + 1)?;
             // Nested contracts merge first (their provenance indices shift
@@ -2545,11 +2550,26 @@ impl WorkflowConfig {
                 .or_default()
                 .extend(module_members);
             // Contract params fill config keys in profile-style — host
-            // values win (or_insert).
+            // values win (or_insert). The module's own `[config]`
+            // defaults are merged after, so they fill only the gaps
+            // params left open (issue #142 M3): a module declaring
+            // `[config] trim_quality = "20"` keeps that default when
+            // included without host params, while any host value — its
+            // own `[config]` table or `[[include]] params` — wins.
             for (key, value) in &inc.params {
                 self.config
                     .entry(key.clone())
                     .or_insert_with(|| value.clone());
+            }
+            for (key, value) in &inc_config.config {
+                self.config
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
+            }
+            for (key, def) in &inc_config.config_meta {
+                self.config_meta
+                    .entry(key.clone())
+                    .or_insert_with(|| def.clone());
             }
         }
         self.includes = includes;
@@ -2598,8 +2618,13 @@ impl WorkflowConfig {
     /// a declared concrete input nobody produces, and a declared output no
     /// module rule produces (or produced outside the module). Warnings
     /// cover encapsulation: a host rule reading a module-internal file the
-    /// contract does not declare. Wildcarded patterns are skipped here —
-    /// their wiring is verified by DAG edge inference at run time.
+    /// contract does not declare. Wildcarded patterns are checked
+    /// structurally — an engine-wildcarded input (`{sample}`, `{config.x}`)
+    /// forms no DAG edge (placeholder values only exist at run time), so a
+    /// wildcarded host input that could address a module-internal output
+    /// pattern (identical literal prefix and suffix) warns when the
+    /// contract declares no overlapping pattern; patterns that resolve to
+    /// different literals are not statically checkable.
     pub fn check_include_contracts(&self) -> (Vec<String>, Vec<String>) {
         let mut errors = Vec::new();
         let mut warnings = Vec::new();
@@ -2653,6 +2678,28 @@ impl WorkflowConfig {
                 }
                 for inp in rule.input.to_vec() {
                     if inp.contains('{') {
+                        // Wildcarded inputs cannot be resolved through the
+                        // exact-string producer map, and they form no DAG
+                        // edge (placeholder values only exist at run time),
+                        // so fall back to a structural pattern match: warn
+                        // when the pattern could address a module-internal
+                        // output and the contract declares no overlapping
+                        // pattern.
+                        let internal = self.rules.iter().any(|r| {
+                            self.module_of.get(&r.name).is_some_and(|p| *p == idx)
+                                && r.output
+                                    .iter()
+                                    .any(|o| Self::wildcarded_patterns_overlap(&inp, o))
+                        });
+                        let declared_overlap = declared
+                            .iter()
+                            .any(|d| Self::wildcarded_patterns_overlap(&inp, d));
+                        if internal && !declared_overlap {
+                            warnings.push(format!(
+                                "rule '{}' reads module-internal file pattern '{inp}' which the include contract does not declare — add it to `outputs` to keep the coupling explicit",
+                                rule.name
+                            ));
+                        }
                         continue;
                     }
                     let internal = producers
@@ -2668,6 +2715,35 @@ impl WorkflowConfig {
             }
         }
         (errors, warnings)
+    }
+
+    /// Split a wildcarded path into its literal prefix (up to the first
+    /// `{`) and literal suffix (after the last `}`). A path without
+    /// wildcards yields `(path, "")`.
+    fn wildcard_literals(pattern: &str) -> (&str, &str) {
+        match (pattern.find('{'), pattern.rfind('}')) {
+            (Some(open), Some(close)) if close > open => (&pattern[..open], &pattern[close + 1..]),
+            _ => (pattern, ""),
+        }
+    }
+
+    /// Structural overlap of a wildcarded `pattern` with another path.
+    ///
+    /// The other side may itself be wildcarded (then both literal prefixes
+    /// and both literal suffixes must match) or concrete (then the pattern
+    /// must bound it on both sides). `qc/{sample}.html` overlaps
+    /// `qc/{sample}.html` but not `qc/{sample}.bcf`; `qc/{sample}.html`
+    /// overlaps the concrete `qc/sample1.html`. Deliberately conservative:
+    /// patterns whose wildcard sits in different places never overlap.
+    fn wildcarded_patterns_overlap(pattern: &str, other: &str) -> bool {
+        debug_assert!(pattern.contains('{'));
+        let (pre, suf) = Self::wildcard_literals(pattern);
+        if other.contains('{') {
+            let (o_pre, o_suf) = Self::wildcard_literals(other);
+            pre == o_pre && suf == o_suf
+        } else {
+            other.starts_with(pre) && other.ends_with(suf) && other.len() >= pre.len() + suf.len()
+        }
     }
 
     /// Validate that all execution group references point to existing rules.
@@ -6478,6 +6554,116 @@ shell = "true"
     }
 
     #[test]
+    fn include_contract_warns_on_wildcarded_internal_reads() {
+        // Wildcarded host inputs cannot be resolved through the
+        // exact-string producer map, and they form no DAG edge (placeholder
+        // values only exist at run time), so the encapsulation check falls
+        // back to a structural pattern match: identical literal prefix and
+        // suffix against a module-internal output.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("qc.oxoflow"),
+            r#"[workflow]
+name = "qc"
+version = "1.0.0"
+
+[[rules]]
+name = "fastqc"
+input = ["raw/{sample}.fq"]
+output = ["qc/{sample}.html"]
+shell = "true"
+
+[[rules]]
+name = "internal"
+input = ["qc/{sample}.html"]
+output = ["qc/{sample}.tmp"]
+shell = "true"
+"#,
+        )
+        .unwrap();
+
+        // (a) host reads a wildcarded pattern that structurally matches a
+        // module-internal output, undeclared → warning
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/{sample}.fq"]
+outputs = ["qc/{sample}.html"]
+
+[[rules]]
+name = "peeker"
+input = ["qc/{sample}.tmp"]
+output = ["peek.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        let (errors, warnings) = config.check_include_contracts();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert!(
+            warnings.iter().any(|w| w.contains("qc/{sample}.tmp")),
+            "wildcarded encapsulation warning must fire: {warnings:?}"
+        );
+
+        // (b) the same pattern declared in the contract → no warning
+        let host2 = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/{sample}.fq"]
+outputs = ["qc/{sample}.html", "qc/{sample}.tmp"]
+
+[[rules]]
+name = "peeker"
+input = ["qc/{sample}.tmp"]
+output = ["peek.txt"]
+shell = "true"
+"#;
+        let wf2 = dir.path().join("host2.oxoflow");
+        std::fs::write(&wf2, host2).unwrap();
+        let config2 = WorkflowConfig::from_file(&wf2).unwrap();
+        let (errors2, warnings2) = config2.check_include_contracts();
+        assert!(errors2.is_empty(), "unexpected errors: {errors2:?}");
+        assert!(
+            !warnings2.iter().any(|w| w.contains("qc/{sample}.tmp")),
+            "declared wildcarded outputs must not warn: {warnings2:?}"
+        );
+
+        // (c) a pattern that cannot address the module's files (different
+        // literal suffix) → no warning
+        let host3 = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "qc.oxoflow"
+inputs = ["raw/{sample}.fq"]
+outputs = ["qc/{sample}.html"]
+
+[[rules]]
+name = "peeker"
+input = ["qc/{sample}.bcf"]
+output = ["peek.txt"]
+shell = "true"
+"#;
+        let wf3 = dir.path().join("host3.oxoflow");
+        std::fs::write(&wf3, host3).unwrap();
+        let config3 = WorkflowConfig::from_file(&wf3).unwrap();
+        let (errors3, warnings3) = config3.check_include_contracts();
+        assert!(errors3.is_empty(), "unexpected errors: {errors3:?}");
+        assert!(
+            !warnings3.iter().any(|w| w.contains("qc/{sample}.bcf")),
+            "patterns with different literals must not warn: {warnings3:?}"
+        );
+    }
+
+    #[test]
     fn include_contract_params_fill_in_config_defaults() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -6515,6 +6701,188 @@ shell = "true"
             config.config.get("threads").and_then(toml::Value::as_str),
             Some("8"),
             "params defaults must fill in config keys"
+        );
+    }
+
+    #[test]
+    fn include_module_config_defaults_fill_gaps() {
+        // Issue #142 M3: a module declaring `[config]` defaults keeps them
+        // when included without host params — previously the run failed
+        // E005 (undefined config variable) because only `[[include]]
+        // params` were merged into the host config.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mod.oxoflow"),
+            r#"[workflow]
+name = "mod"
+version = "1.0.0"
+
+[config]
+trim_quality = "20"
+
+[[rules]]
+name = "step"
+output = ["o.txt"]
+shell = "echo {config.trim_quality} > o.txt"
+"#,
+        )
+        .unwrap();
+
+        // (a) module default fills the gap when no params are supplied
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "mod.oxoflow"
+outputs = ["o.txt"]
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        assert_eq!(
+            config
+                .config
+                .get("trim_quality")
+                .and_then(toml::Value::as_str),
+            Some("20"),
+            "module [config] defaults must fill gaps left by missing params"
+        );
+
+        // (b) host params win over the module default
+        let host2 = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "mod.oxoflow"
+outputs = ["o.txt"]
+params = { trim_quality = "30" }
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf2 = dir.path().join("host2.oxoflow");
+        std::fs::write(&wf2, host2).unwrap();
+        let config2 = WorkflowConfig::from_file(&wf2).unwrap();
+        assert_eq!(
+            config2
+                .config
+                .get("trim_quality")
+                .and_then(toml::Value::as_str),
+            Some("30"),
+            "host params must override the module default"
+        );
+
+        // (c) declarative `{ default = ... }` entries follow the same
+        // extraction semantics as standalone validation
+        std::fs::write(
+            dir.path().join("dec.oxoflow"),
+            r#"[workflow]
+name = "dec"
+version = "1.0.0"
+
+[config]
+trim_quality = { default = "25" }
+
+[[rules]]
+name = "step"
+output = ["o.txt"]
+shell = "echo {config.trim_quality} > o.txt"
+"#,
+        )
+        .unwrap();
+        let host3 = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "dec.oxoflow"
+outputs = ["o.txt"]
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf3 = dir.path().join("host3.oxoflow");
+        std::fs::write(&wf3, host3).unwrap();
+        let config3 = WorkflowConfig::from_file(&wf3).unwrap();
+        assert_eq!(
+            config3
+                .config
+                .get("trim_quality")
+                .and_then(toml::Value::as_str),
+            Some("25"),
+            "declarative module defaults must be extracted and merged"
+        );
+    }
+
+    #[test]
+    fn include_module_undefined_config_key_still_errors() {
+        // Issue #142 M3 regression guard: when neither the host config,
+        // `[[include]] params`, nor the module's own `[config]` define a
+        // referenced key, the reference stays undefined — lint still
+        // reports E005.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mod.oxoflow"),
+            r#"[workflow]
+name = "mod"
+version = "1.0.0"
+
+[[rules]]
+name = "step"
+output = ["o.txt"]
+shell = "echo {config.trim_quality} > o.txt"
+"#,
+        )
+        .unwrap();
+        let host = r#"[workflow]
+name = "host"
+version = "1.0.0"
+
+[[include]]
+path = "mod.oxoflow"
+outputs = ["o.txt"]
+
+[[rules]]
+name = "use"
+input = ["o.txt"]
+output = ["u.txt"]
+shell = "true"
+"#;
+        let wf = dir.path().join("host.oxoflow");
+        std::fs::write(&wf, host).unwrap();
+        let config = WorkflowConfig::from_file(&wf).unwrap();
+        assert!(
+            !config.config.contains_key("trim_quality"),
+            "a key defined nowhere must stay undefined"
+        );
+        let result = crate::format::validate_format(&config);
+        assert!(
+            !result.valid
+                && result
+                    .errors()
+                    .iter()
+                    .any(|d| d.code == "E005" && d.message.contains("trim_quality")),
+            "validation must still flag the undefined config reference, got: {:?}",
+            result
+                .errors()
+                .iter()
+                .filter(|d| d.code == "E005")
+                .map(|d| d.message.as_str())
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/oxo-flow-core/src/config_impact.rs
+++ b/crates/oxo-flow-core/src/config_impact.rs
@@ -202,6 +202,28 @@ pub fn rule_fingerprint(
     interpreter_map: &HashMap<String, String>,
     shell_prelude: Option<&str>,
 ) -> String {
+    rule_fingerprint_impl(rule, interpreter_map, shell_prelude, true)
+}
+
+/// Same fingerprint with the `input` field EXCLUDED (issue #142 M1): for an
+/// expand_inputs-over-injected-key rule the baked input list IS the
+/// `--samples` selection, so the full fingerprint differs on every subset
+/// run while this one stays identical. A match proves the rule definition —
+/// shell, outputs, env, conditions, everything else — is unchanged.
+pub fn rule_fingerprint_without_input(
+    rule: &Rule,
+    interpreter_map: &HashMap<String, String>,
+    shell_prelude: Option<&str>,
+) -> String {
+    rule_fingerprint_impl(rule, interpreter_map, shell_prelude, false)
+}
+
+fn rule_fingerprint_impl(
+    rule: &Rule,
+    interpreter_map: &HashMap<String, String>,
+    shell_prelude: Option<&str>,
+    include_input: bool,
+) -> String {
     let mut hasher = Sha256::new();
     // Field name + value pairs separated by NUL bytes: unambiguous framing,
     // deterministic ordering (maps sorted by key, lists in semantic order).
@@ -219,7 +241,9 @@ pub fn rule_fingerprint(
     add("shell_prelude", shell_prelude.unwrap_or(""));
     add("shell", rule.shell.as_deref().unwrap_or(""));
     add("script", rule.script.as_deref().unwrap_or(""));
-    add("input", &canonical_file_patterns(&rule.input));
+    if include_input {
+        add("input", &canonical_file_patterns(&rule.input));
+    }
     add("output", &canonical_file_patterns(&rule.output));
     add("envvars", &canonical_string_map(&rule.envvars));
     add("params", &canonical_toml_map(&rule.params));
@@ -345,6 +369,12 @@ pub struct ConfigChangeReport {
     pub removed_keys: Vec<String>,
     /// Rules whose stored structural fingerprint differs from the current one.
     pub fingerprint_mismatches: Vec<String>,
+    /// Completed rules whose fingerprint differed ONLY in the sample-derived
+    /// input list (`expand_inputs` over an engine-injected key, issue #142
+    /// M1): NOT invalidated — toggling `--samples` must not re-run gather
+    /// rules. The input-manifest check still re-verifies set + content, so a
+    /// genuine input edit invalidates there.
+    pub sample_selection_exempt: Vec<String>,
     /// Rules directly affected (reference a changed key or mismatch).
     pub directly_affected: Vec<String>,
     /// Full invalidation set: directly affected rules plus their transitive
@@ -412,23 +442,52 @@ pub fn detect_config_changes(
     // ── 2. Rule fingerprints (all rules in this run) ─────────────────────
     let graph = ConfigReferenceGraph::from_rules(rules);
     let mut current_fingerprints: HashMap<String, String> = HashMap::new();
+    let mut current_no_input_fingerprints: HashMap<String, String> = HashMap::new();
     let mut fingerprint_mismatches: Vec<String> = Vec::new();
+    let mut sample_selection_exempt: Vec<String> = Vec::new();
     for rule in rules {
         let fingerprint = rule_fingerprint(rule, interpreter_map, shell_prelude);
         if let Some(stored) = checkpoint.rule_fingerprints.get(&rule.name)
             && *stored != fingerprint
             && checkpoint.is_completed(&rule.name)
         {
-            fingerprint_mismatches.push(rule.name.clone());
+            // Issue #142 M1: an expand_inputs-over-injected-key rule bakes
+            // the --samples selection into its input list, so the full
+            // fingerprint differs on every subset run. When the
+            // input-excluded fingerprint still matches, the ONLY change is
+            // the selection — not an invalidation (the input-manifest check
+            // re-verifies set + content later, so a genuine input edit still
+            // invalidates there). Checkpoints from older binaries carry no
+            // input-excluded fingerprints — those keep invalidating.
+            let selection_only = expand_inputs_refs_engine_injected(rule)
+                && checkpoint.rule_fingerprints_no_input.get(&rule.name)
+                    == Some(&rule_fingerprint_without_input(
+                        rule,
+                        interpreter_map,
+                        shell_prelude,
+                    ));
+            if selection_only {
+                sample_selection_exempt.push(rule.name.clone());
+            } else {
+                fingerprint_mismatches.push(rule.name.clone());
+            }
         }
         current_fingerprints.insert(rule.name.clone(), fingerprint);
+        current_no_input_fingerprints.insert(
+            rule.name.clone(),
+            rule_fingerprint_without_input(rule, interpreter_map, shell_prelude),
+        );
     }
     fingerprint_mismatches.sort();
+    sample_selection_exempt.sort();
 
     // ── 3. Bootstrap path: record provenance, keep everything completed ──
     if is_legacy {
         checkpoint.config_snapshot = build_config_snapshot(current, sensitive_keys);
         checkpoint.rule_fingerprints.extend(current_fingerprints);
+        checkpoint
+            .rule_fingerprints_no_input
+            .extend(current_no_input_fingerprints);
         return ConfigChangeReport {
             is_legacy: true,
             ..Default::default()
@@ -460,6 +519,9 @@ pub fn detect_config_changes(
     }
     checkpoint.config_snapshot = build_config_snapshot(current, sensitive_keys);
     checkpoint.rule_fingerprints.extend(current_fingerprints);
+    checkpoint
+        .rule_fingerprints_no_input
+        .extend(current_no_input_fingerprints);
 
     let mut directly_affected: Vec<String> = directly_affected.into_iter().collect();
     directly_affected.sort();
@@ -472,9 +534,23 @@ pub fn detect_config_changes(
         added_keys,
         removed_keys,
         fingerprint_mismatches,
+        sample_selection_exempt,
         directly_affected,
         invalidated,
     }
+}
+
+/// Whether any `expand_inputs` pattern of the rule resolves against an
+/// engine-injected config key (`samples_list` / `samples_<group>` /
+/// `pairs_list`). Only such rules can have a fingerprint mismatch that is
+/// purely the `--samples` selection (issue #142 M1).
+fn expand_inputs_refs_engine_injected(rule: &Rule) -> bool {
+    rule.expand_inputs.iter().any(|exp| {
+        exp.variables.values().any(|var_ref| {
+            let key = var_ref.strip_prefix("config.").unwrap_or(var_ref);
+            is_engine_injected_key(key)
+        })
+    })
 }
 
 /// Build the snapshot map: engine-injected keys excluded, sensitive values

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -184,6 +184,15 @@ pub struct CheckpointState {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub rule_fingerprints: HashMap<String, String>,
+    /// Per-rule fingerprints with the input field EXCLUDED (issue #142 M1).
+    /// Distinguishes a genuine rule edit from a pure `--samples` selection
+    /// change: expand_inputs-over-injected-key rules bake the selection into
+    /// their input list, so the full fingerprint differs on every subset
+    /// run while this one stays identical. Absent for checkpoints written by
+    /// older binaries — those keep invalidating (safe default).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub rule_fingerprints_no_input: HashMap<String, String>,
     /// Per-rule input manifests at completion time (issue #72).
     /// Maps rule name → sorted list of (relative path, size, mtime) for every
     /// file the rule's inputs resolved to. A mismatch with the current file
@@ -244,6 +253,7 @@ impl CheckpointState {
             checksums: HashMap::new(),
             config_snapshot: HashMap::new(),
             rule_fingerprints: HashMap::new(),
+            rule_fingerprints_no_input: HashMap::new(),
             input_manifests: HashMap::new(),
             tombstones: HashMap::new(),
             reentries: Vec::new(),

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -9,6 +9,7 @@
 
 use crate::config::WorkflowConfig;
 use crate::dag::WorkflowDag;
+use crate::rule::Rule;
 use serde::{Deserialize, Serialize};
 
 /// Current .oxoflow format specification version.
@@ -110,6 +111,64 @@ impl ValidationResult {
 /// - Resource constraint consistency
 /// - Environment specification validity
 /// - Wildcard consistency between inputs and outputs
+///
+/// E005: references to undefined config variables across a rule's shell,
+/// script, input/output paths, and `when` condition.
+///
+/// The single source of truth shared by `validate` (E005 diagnostics) and
+/// `run`/`dry-run` (hard gate before execution, issue #142 H1): a typo'd
+/// config key must never silently expand to the literal placeholder text
+/// and exit 0 with wrong data. `when` conditions reference keys bare
+/// (`config.enabled`), the other surfaces use the `{config.key}` brace form.
+pub fn undefined_config_refs(rule: &Rule, config: &WorkflowConfig) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let config_ref_re = regex::Regex::new(r"\{config\.(\w+)\}").expect("valid regex");
+    let when_ref_re = regex::Regex::new(r"config\.(\w+)").expect("valid regex");
+
+    let check = |field: &str, text: &str, diagnostics: &mut Vec<Diagnostic>| {
+        for cap in config_ref_re.captures_iter(text) {
+            let key = &cap[1];
+            if config.get_config_value(key).is_none() {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    message: format!("{field} references undefined config variable '{key}'"),
+                    rule: Some(rule.name.clone()),
+                    code: "E005".to_string(),
+                    suggestion: Some(format!("define '{key}' in the [config] section")),
+                });
+            }
+        }
+    };
+
+    if let Some(ref shell) = rule.shell {
+        check("shell command", shell, &mut diagnostics);
+    }
+    if let Some(ref script) = rule.script {
+        check("script path", script, &mut diagnostics);
+    }
+    for output in &rule.output {
+        check("output path", output, &mut diagnostics);
+    }
+    for input in &rule.input {
+        check("input path", input, &mut diagnostics);
+    }
+    if let Some(ref when) = rule.when {
+        for cap in when_ref_re.captures_iter(when) {
+            let key = &cap[1];
+            if config.get_config_value(key).is_none() {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    message: format!("when condition references undefined config variable '{key}'"),
+                    rule: Some(rule.name.clone()),
+                    code: "E005".to_string(),
+                    suggestion: Some(format!("define '{key}' in the [config] section")),
+                });
+            }
+        }
+    }
+    diagnostics
+}
+
 pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
     let mut diagnostics = Vec::new();
 
@@ -123,8 +182,6 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
             suggestion: Some("add a non-empty name to the [workflow] section".to_string()),
         });
     }
-
-    let config_ref_re = regex::Regex::new(r"\{config\.(\w+)\}").expect("valid regex");
 
     // Validate each rule
     for rule in &config.rules {
@@ -240,62 +297,10 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
             });
         }
 
-        // E005: Shell command references existing config variables
-        if let Some(ref shell) = rule.shell {
-            for cap in config_ref_re.captures_iter(shell) {
-                let key = &cap[1];
-                if config.get_config_value(key).is_none() {
-                    diagnostics.push(Diagnostic {
-                        severity: Severity::Error,
-                        message: format!(
-                            "shell command references undefined config variable '{}'",
-                            key
-                        ),
-                        rule: Some(rule.name.clone()),
-                        code: "E005".to_string(),
-                        suggestion: Some(format!("define '{}' in the [config] section", key)),
-                    });
-                }
-            }
-        }
-
-        // E005: Check output paths for undefined config variables
-        for output in &rule.output {
-            for cap in config_ref_re.captures_iter(output) {
-                let key = &cap[1];
-                if config.get_config_value(key).is_none() {
-                    diagnostics.push(Diagnostic {
-                        severity: Severity::Error,
-                        message: format!(
-                            "output path references undefined config variable '{}'",
-                            key
-                        ),
-                        rule: Some(rule.name.clone()),
-                        code: "E005".to_string(),
-                        suggestion: Some(format!("define '{}' in the [config] section", key)),
-                    });
-                }
-            }
-        }
-
-        // E005: Check input paths for undefined config variables
-        for input in &rule.input {
-            for cap in config_ref_re.captures_iter(input) {
-                let key = &cap[1];
-                if config.get_config_value(key).is_none() {
-                    diagnostics.push(Diagnostic {
-                        severity: Severity::Error,
-                        message: format!(
-                            "input path references undefined config variable '{}'",
-                            key
-                        ),
-                        rule: Some(rule.name.clone()),
-                        code: "E005".to_string(),
-                        suggestion: Some(format!("define '{}' in the [config] section", key)),
-                    });
-                }
-            }
-        }
+        // E005: Undefined config variable references — shared with the
+        // run/dry-run pre-execution gate (issue #142 H1), so validate and
+        // run cannot drift on what counts as defined.
+        diagnostics.extend(undefined_config_refs(rule, config));
     }
 
     // E013: checkpoint rule without a re-entry manifest (issue #78 P3).
@@ -747,6 +752,59 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
     // Build DAG for dependency analysis
     let dag = WorkflowDag::from_rules(&config.rules).ok();
 
+    // Wildcard sources the engine can actually expand (W024): the same
+    // trigger sets expand_wildcards fans out on (config.rs) plus group/pair
+    // metadata keys and [[values]] tables — anything else referenced as
+    // `{name}` stays LITERAL at run time.
+    let mut declared_wildcards: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    if config.workflow.sample_pattern.is_some()
+        || !config.sample_groups.is_empty()
+        || !config.pairs.is_empty()
+    {
+        declared_wildcards.insert("sample".to_string());
+    }
+    if !config.sample_groups.is_empty() {
+        declared_wildcards.insert("group".to_string());
+        for group in &config.sample_groups {
+            for key in group.metadata.keys() {
+                declared_wildcards.insert(key.clone());
+            }
+        }
+    }
+    if !config.pairs.is_empty() {
+        for wc in [
+            "pair_id",
+            "experiment",
+            "control",
+            "tumor",
+            "normal",
+            "experiment_type",
+            "tumor_type",
+        ] {
+            declared_wildcards.insert(wc.to_string());
+        }
+        for pair in &config.pairs {
+            for key in pair.metadata.keys() {
+                declared_wildcards.insert(key.clone());
+            }
+        }
+    }
+    for table in &config.values {
+        declared_wildcards.insert(table.name.clone());
+    }
+    // Engine placeholders substituted at execution time (process.rs) —
+    // always available, never literal.
+    const ENGINE_PLACEHOLDERS: [&str; 7] = [
+        "input",
+        "output",
+        "log",
+        "threads",
+        "memory",
+        "effective_threads",
+        "effective_memory_mb",
+    ];
+
     for rule in &config.rules {
         // W003: Missing rule description
         if rule.description.is_none() {
@@ -782,6 +840,27 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
                 code: "W005".to_string(),
                 suggestion: Some(
                     "add memory = \"32G\" or appropriate memory specification".to_string(),
+                ),
+            });
+        }
+
+        // W025: Deprecated rule-level threads/memory keys (issue #142 M12).
+        // `threads`/`memory` at rule level were superseded by
+        // `resources.threads`/`resources.memory` in v0.4 and are never
+        // flagged — a deprecated key that silently passes lint invites
+        // new workflows to keep using it.
+        if rule.threads.is_some() || rule.memory.is_some() {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Info,
+                message: "rule uses deprecated rule-level threads/memory — move them under \
+                          [rules.resources]"
+                    .to_string(),
+                rule: Some(rule.name.clone()),
+                code: "W025".to_string(),
+                suggestion: Some(
+                    "replace `threads = N` / `memory = \"8G\"` with \
+                     `resources.threads = N` / `resources.memory = \"8G\"` under this rule"
+                        .to_string(),
                 ),
             });
         }
@@ -1047,6 +1126,46 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
                     });
                     break;
                 }
+            }
+        }
+
+        // W024: expandable wildcard with no declared source (issue #142 H3).
+        // A `{sample}`/`{group}`/pair wildcard the engine can never expand —
+        // no sample_pattern, [[sample_groups]], [[pairs]], [[values]], or
+        // metadata declares it — stays LITERAL at run time: the shell
+        // receives the raw text and may write a file literally named
+        // `out_{sample}.txt`, silently producing wrong data with exit 0.
+        // MEDIUM severity: a warning, not an error — `--samples <name>`
+        // can declare samples at run time, and transform split variables
+        // (`_`-prefixed) are engine-managed.
+        if !can_never_run {
+            let text = format!(
+                "{} {} {} {}",
+                rule.shell.as_deref().unwrap_or(""),
+                rule.script.as_deref().unwrap_or(""),
+                rule.input.to_vec().join(" "),
+                rule.output.to_vec().join(" ")
+            );
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for wc in crate::wildcard::extract_wildcards(&text) {
+                let declared_here = rule.scatter.as_ref().is_some_and(|s| s.variable == wc)
+                    || ENGINE_PLACEHOLDERS.contains(&wc.as_str())
+                    || declared_wildcards.contains(&wc)
+                    || wc.starts_with('_');
+                if declared_here || !seen.insert(wc.clone()) {
+                    continue;
+                }
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    message: format!(
+                        "wildcard '{{{wc}}}' has no declared source — it will stay literal at run time and files may be written literally named after the placeholder"
+                    ),
+                    rule: Some(rule.name.clone()),
+                    code: "W024".to_string(),
+                    suggestion: Some(
+                        "declare a source for the wildcard (sample_pattern in [config], [[sample_groups]], [[pairs]], or a [[values]] table), or remove the placeholder".to_string(),
+                    ),
+                });
             }
         }
     }
@@ -1852,6 +1971,161 @@ mod tests {
     }
 
     #[test]
+    fn lint_undeclared_sample_wildcard_fires_w024() {
+        // Issue #142 H3: `{sample}` with no sample_pattern / [[pairs]] /
+        // [[sample_groups]] stays literal at run time — the lint must say
+        // so instead of passing silently.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "gen"
+            input = ["in_{sample}.txt"]
+            output = ["out_{sample}.txt"]
+            shell = "cp {input[0]} {output[0]}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        let w024: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.code == "W024").collect();
+        assert_eq!(
+            w024.len(),
+            1,
+            "one W024 for {{sample}}, got: {diagnostics:?}"
+        );
+        assert!(w024[0].message.contains("sample"));
+        assert_eq!(w024[0].severity, Severity::Warning);
+        assert_eq!(w024[0].rule.as_deref(), Some("gen"));
+        assert!(w024[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn lint_declared_sample_sources_are_silent() {
+        // sample_pattern, sample groups, pairs, values tables, and engine
+        // placeholders all keep the wildcard expandable — no W024.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [config]
+            sample_pattern = "data/{sample}.txt"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+            metadata = { batch = "A" }
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "T1"
+            control = "N1"
+            metadata = { lane = "L1" }
+
+            [[values]]
+            name = "assembler"
+            values = ["spades", "megahit"]
+
+            [[rules]]
+            name = "gen"
+            input = ["data/{sample}_{batch}.txt"]
+            output = ["out_{sample}.txt"]
+            shell = "echo {threads} {input} {output} {assembler} {experiment} {pair_id} {lane} > {log}"
+
+            [[rules]]
+            name = "split_gen"
+            input = ["x_{assembler}.txt"]
+            output = ["y_{assembler}.txt"]
+            scatter = { variable = "assembler", values = ["spades", "megahit"] }
+            shell = "echo {assembler}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W024"),
+            "no W024 expected, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_underscore_split_variable_is_not_literal() {
+        // Transform split variables (`_`-prefixed) are engine-managed —
+        // never flagged as undeclared.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "map"
+            output = ["chunk_{_part}.txt"]
+            shell = "echo {_part}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(!diagnostics.iter().any(|d| d.code == "W024"));
+    }
+
+    #[test]
+    fn undefined_config_refs_covers_all_surfaces() {
+        // The shared E005 gate (issue #142 H1): shell, script, input,
+        // output, and when must all flag an unknown `{config.*}` key.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [config]
+            good = "yes"
+
+            [[rules]]
+            name = "gen"
+            input = ["{config.ineed_input}.txt"]
+            output = ["{config.ineed_output}.txt"]
+            script = "scripts/{config.ineed_script}.sh"
+            shell = "echo {config.ineed_shell}"
+            when = "config.ineed_when"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let rule = config.rules[0].clone();
+        let diags = undefined_config_refs(&rule, &config);
+        let codes: Vec<&str> = diags.iter().map(|d| d.code.as_str()).collect();
+        assert_eq!(codes, vec!["E005"; 5], "one E005 per surface: {diags:?}");
+        let joined = diags
+            .iter()
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        for key in [
+            "ineed_shell",
+            "ineed_script",
+            "ineed_input",
+            "ineed_output",
+            "ineed_when",
+        ] {
+            assert!(joined.contains(key), "missing {key}: {joined}");
+        }
+        for d in &diags {
+            assert_eq!(d.rule.as_deref(), Some("gen"));
+            assert!(d.suggestion.is_some());
+        }
+        // Defined keys never flag.
+        let defined_toml = r#"
+            [workflow]
+            name = "test"
+
+            [config]
+            good = "yes"
+
+            [[rules]]
+            name = "gen"
+            input = ["{config.good}.txt"]
+            output = ["{config.good}_out.txt"]
+            shell = "echo {config.good}"
+            when = "config.good"
+        "#;
+        let defined = WorkflowConfig::parse(defined_toml).unwrap();
+        assert!(undefined_config_refs(&defined.rules[0], &defined).is_empty());
+    }
+
+    #[test]
     fn lint_missing_log() {
         let toml = r#"
             [workflow]
@@ -2241,11 +2515,17 @@ mod tests {
 
     #[test]
     fn lint_when_conditional_rule() {
+        // The `when` key must be defined: an undefined one silently
+        // disables the rule (evaluate_condition → false) — E005, the same
+        // gate the run pre-execution check enforces (issue #142 H1).
         let toml = r#"
             [workflow]
             name = "test"
             description = "desc"
             author = "me"
+
+            [config]
+            enabled = "true"
 
             [[rules]]
             name = "step1"
@@ -3434,6 +3714,58 @@ mod tests {
             !suggestion.contains("every consumer"),
             "the old suggestion ('add depends_on to every consumer') could not silence \
              the warning once dependents skip it: {suggestion}"
+        );
+    }
+
+    // ---- W025: Deprecated rule-level threads/memory (issue #142 M12) ----
+
+    #[test]
+    fn lint_w025_flags_deprecated_rule_level_threads_memory() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+            threads = 4
+            memory = "8G"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        let w025 = diagnostics
+            .iter()
+            .find(|d| d.code == "W025")
+            .expect("rule-level threads/memory must be flagged (issue #142 M12)");
+        assert_eq!(w025.rule.as_deref(), Some("step1"));
+        let suggestion = w025.suggestion.as_deref().unwrap_or_default();
+        assert!(
+            suggestion.contains("resources"),
+            "the suggestion must point at [rules.resources], got: {suggestion}"
+        );
+    }
+
+    #[test]
+    fn lint_w025_silent_for_resources_block() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+
+            [rules.resources]
+            threads = 4
+            memory = "8G"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W025"),
+            "resources-block keys must not be flagged"
         );
     }
 }

--- a/crates/oxo-flow-core/src/report.rs
+++ b/crates/oxo-flow-core/src/report.rs
@@ -2159,17 +2159,43 @@ impl ReportSectionGenerator for CommandManifestGenerator {
             .config
             .rules
             .iter()
-            .map(|r| {
+            .flat_map(|r| {
                 let declared = r.shell.clone().unwrap_or_else(|| "(none)".into());
-                match ctx.checkpoint.and_then(|c| c.rule_runs.get(&r.name)) {
+                // Wildcard rules execute once per sample, and the checkpoint
+                // records each instance under `{rule}_{sample}` (the same
+                // convention config expansion uses). An exact-name lookup
+                // alone therefore reported "no execution record" for every
+                // expanded rule (issue #142 M9): match the rule name itself
+                // OR every expanded instance keyed `{rule}_...`.
+                let mut runs: Vec<(&String, &crate::executor::checkpoint::RuleRunRecord)> = ctx
+                    .checkpoint
+                    .map(|c| {
+                        c.rule_runs
+                            .iter()
+                            .filter(|(name, _)| {
+                                *name == &r.name || name.starts_with(&format!("{}_", r.name))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if runs.is_empty() {
                     // The command that actually ran, with wildcards and
                     // {config.x} resolved (issue #83 P0-6).
-                    Some(run) => vec![r.name.clone(), run.command.clone().unwrap_or(declared)],
-                    None => vec![
+                    return vec![vec![
                         r.name.clone(),
                         format!("{declared} (declared template — no execution record)"),
-                    ],
+                    ]];
                 }
+                // Deterministic order — one row per executed instance.
+                runs.sort_by(|a, b| a.0.cmp(b.0));
+                runs.into_iter()
+                    .map(|(name, run)| {
+                        vec![
+                            name.clone(),
+                            run.command.clone().unwrap_or_else(|| declared.clone()),
+                        ]
+                    })
+                    .collect()
             })
             .collect();
         vec![ReportSection {
@@ -4096,6 +4122,76 @@ shell = "echo hi"
         assert!(html.contains("<main id=\"main\">"));
         assert!(html.contains("scope=\"col\""));
         assert!(html.contains("@media print"));
+    }
+
+    #[test]
+    fn commands_section_renders_expanded_instance_runs() {
+        // A wildcard rule executes once per sample, and the checkpoint
+        // records each instance under `{rule}_{sample}`. The Commands
+        // section must render every executed command instead of reporting
+        // "no execution record" for the whole rule (issue #142 M9).
+        let config = workflow_config(
+            r#"[[rules]]
+name = "summarize_cohort"
+shell = "summarize.sh"
+[[rules]]
+name = "align"
+shell = "bwa mem"
+"#,
+        );
+        let mut ck = fixture_checkpoint();
+        ck.rule_runs.insert(
+            "summarize_cohort_S1".to_string(),
+            crate::executor::checkpoint::RuleRunRecord {
+                exit_code: Some(0),
+                command: Some("summarize.sh cohort_S1".to_string()),
+                stderr_tail: None,
+            },
+        );
+        ck.rule_runs.insert(
+            "summarize_cohort_S2".to_string(),
+            crate::executor::checkpoint::RuleRunRecord {
+                exit_code: Some(0),
+                command: Some("summarize.sh cohort_S2".to_string()),
+                stderr_tail: None,
+            },
+        );
+        let ctx = ctx_for(&config, Some(&ck), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let commands = sections.iter().find(|s| s.id == "commands").unwrap();
+        let ReportContent::Table { headers, rows } = &commands.content else {
+            panic!("commands section must be a table");
+        };
+        assert_eq!(headers, &vec!["Task".to_string(), "Command".to_string()]);
+        // Declaration order for the rule, then each expanded instance in
+        // deterministic (sorted) order — never "no execution record" for
+        // a rule that actually ran.
+        let tasks: Vec<&String> = rows.iter().map(|r| &r[0]).collect();
+        assert_eq!(
+            tasks,
+            vec!["summarize_cohort_S1", "summarize_cohort_S2", "align"]
+        );
+        assert!(
+            rows.iter().any(|r| r[1] == "summarize.sh cohort_S1"),
+            "expanded command for S1 must be rendered: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|r| r[1] == "summarize.sh cohort_S2"),
+            "expanded command for S2 must be rendered: {rows:?}"
+        );
+        // The unexpanded template must not be reported for executed rules;
+        // the never-run rule keeps the honest declared-template note.
+        assert!(
+            !rows
+                .iter()
+                .any(|r| r[0] != "align" && r[1].contains("no execution record")),
+            "executed instances must not carry the no-record marker: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r[0] == "align" && r[1].contains("no execution record")),
+            "the never-run rule keeps the declared-template marker: {rows:?}"
+        );
     }
 }
 

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -26,6 +26,22 @@ oxo-flow ai explain wf.oxoflow
    model-written prose. The grounding is deterministic — the model only
    writes prose around machine-derived facts.
 
+## Degraded mode
+
+`ai explain` never hard-fails on the model: when the provider is
+unreachable, errors, or is explicitly disabled, it emits the
+**deterministic grounding skeleton** (workflow identity, per-step
+order/description/tools/inputs/outputs/resources, and the knowledge-base
+grounding) with a note on stderr, and **exits 0**. The skeleton is the
+same data the model would have received — verification data, not
+hallucination — so scripts can rely on the JSON contract in every state.
+
+- `OXO_FLOW_AI_PROVIDER=disabled` explicitly disables the model and
+  overrides any saved provider configuration: the skeleton is emitted
+  with a "disabled" note and exit 0.
+- A failed provider call (dead endpoint, quota, timeout) degrades the
+  same way, with the error explained in the note.
+
 ## The `--ai` flag on other commands
 
 One flag, a different action per command — the context is the command

--- a/docs/guide/src/commands/cluster.md
+++ b/docs/guide/src/commands/cluster.md
@@ -50,6 +50,7 @@ oxo-flow cluster <ACTION> [OPTIONS]
 | `--extra-arg` | — | — | Extra scheduler argument, passed through verbatim (repeatable) |
 | `--output` | `-o` | `cluster_scripts` | Directory for generated scripts |
 | `--target` | `-t` | — | Target rule(s) to execute |
+| `--module` | — | — | Run one include module plus the producers of its declared inputs (repeatable; unions with `--target`). Module names are the include's `name` field or its file stem |
 | `--with-dependencies` | — | — | Generate dependency-aware submit script with job chains |
 | `--dry-run` | — | — | Preview scripts without generating files |
 
@@ -171,12 +172,12 @@ scheduler's client commands on `PATH`.
 
 ```
 oxo-flow 0.14.1 — Bioinformatics Pipeline Engine
-Cluster: Generating slurm job scripts for 5 rules
+Cluster: Generating slurm job scripts for 5 rule instances
   ✓ cluster_scripts/fastqc.sh
   ✓ cluster_scripts/trim_reads.sh
-  ✓ cluster_scripts/bwa_align.sh
-  ✓ cluster_scripts/sort_bam.sh
-  ✓ cluster_scripts/call_variants.sh
+  ✓ cluster_scripts/bwa_align_S1.sh
+  ✓ cluster_scripts/bwa_align_S2.sh
+  ✓ cluster_scripts/bwa_align_S3.sh
 
 Done: 5 scripts written to cluster_scripts
   Submit with: sbatch cluster_scripts/*.sh
@@ -186,12 +187,12 @@ Done: 5 scripts written to cluster_scripts
 
 ```
 oxo-flow 0.14.1 — Bioinformatics Pipeline Engine
-Cluster: Generating slurm job scripts for 5 rules
+Cluster: Generating slurm job scripts for 5 rule instances
   ✓ cluster_scripts/fastqc.sh
   ✓ cluster_scripts/trim_reads.sh
-  ✓ cluster_scripts/bwa_align.sh
-  ✓ cluster_scripts/sort_bam.sh
-  ✓ cluster_scripts/call_variants.sh
+  ✓ cluster_scripts/bwa_align_S1.sh
+  ✓ cluster_scripts/bwa_align_S2.sh
+  ✓ cluster_scripts/bwa_align_S3.sh
   ✓ cluster_scripts/submit.sh (dependency-aware submit script)
 
 Done: 6 scripts written to cluster_scripts
@@ -204,7 +205,8 @@ Done: 6 scripts written to cluster_scripts
 
 For a workflow rule with conda environment, different backends produce different scripts
 (threads/memory come from the rule's resources; the `-q`/`-a` flags add queue/account
-directives; there is no walltime option):
+directives; `--walltime` — or a rule's `time_limit`, which wins — adds a time directive,
+`#SBATCH --time=` on SLURM and `walltime=` on PBS):
 
 ### SLURM Script
 

--- a/docs/guide/src/commands/diff.md
+++ b/docs/guide/src/commands/diff.md
@@ -47,3 +47,5 @@ Diff: 2 difference(s) between v1.oxoflow and v2.oxoflow:
 - Performs a semantic comparison of workflow structures, not just a line-by-line diff
 - Detects changes in rules, configuration variables, and metadata
 - Useful for tracking changes during pipeline development
+- All output goes to **stderr** and the exit code is always 0 — CI jobs
+  must capture stderr (not the exit code) to detect differences

--- a/docs/guide/src/commands/lint.md
+++ b/docs/guide/src/commands/lint.md
@@ -54,11 +54,26 @@ oxo-flow lint pipeline.oxoflow --strict
 ```
 oxo-flow 0.14.1 — Bioinformatics Pipeline Engine
   warning [W003]: rule has no description (rule: bwa_align)
+    hint: add a `description` field to the rule
   warning [W004]: rule has a shell command but no log file specified (rule: bwa_align)
+    hint: add `log = "logs/bwa_align.log"` to the rule
   info [W007]: leaf rule (no dependents) could be marked as target = true (rule: fastqc)
+  info [W025]: rule uses deprecated rule-level threads/memory (rule: bwa_align)
+    hint: move `threads`/`memory` under `[rules.resources]`
 
-Summary: 0 error(s), 2 warning(s), 1 info
+Summary: 0 error(s), 2 warning(s), 2 info
 ```
+
+Each diagnostic prints a `hint:` line (when a suggestion exists) showing
+the fix, matching the style of `validate` and `run` output. W007
+suggests `target = true`: a rule marked as a target is built by default
+when `oxo-flow run` is invoked without an explicit `-t`, so marking the
+final leaf rules (like `fastqc` above) makes them part of the default
+run — see [Workflow Format: Priority and Targeting](workflow-format.md#priority-and-targeting).
+W025 flags the deprecated rule-level `threads = N` / `memory = "8G"`
+fields (removed in v0.4.0 in favor of `[rules.resources]`) so old
+workflows surface the migration instead of silently keeping their old
+settings — see [Workflow Format: Rule resources](workflow-format.md#rule-resources).
 
 ---
 

--- a/docs/guide/src/commands/provenance.md
+++ b/docs/guide/src/commands/provenance.md
@@ -65,7 +65,14 @@ Summary: 2 matched, 1 mismatched, 0 missing
 - Checksums are stored only when `--provenance` is passed to `oxo-flow run`.
 - File checksums use streaming I/O (64KB buffer) to handle large files
   (BAM, FASTQ >100GB) without excessive memory usage.
-- Mismatches exit with code 1 (useful for CI/CD pipelines).
+- Mismatches and missing files exit with code 1 (useful for CI/CD
+  pipelines).
+- Output paths are resolved against the checkpoint's recorded `workdir`
+  (the directory the run executed in), not the checkpoint's own
+  directory — so the checkpoint can live anywhere (e.g. `.oxo-flow/` on
+  the run host while outputs are read from the recorded run directory).
+  For legacy checkpoints without a `workdir` field, the checkpoint's
+  parent directory is used.
 
 ### Verify without stored checksums
 
@@ -89,6 +96,31 @@ Provenance Verify .oxo-flow/checkpoint.json
 ```
 
 To get real integrity verification, re-run with `--provenance`.
+
+## JSON output
+
+With `--json`, the verification document is written to stdout (stdout
+carries nothing else):
+
+```
+{
+  "command": "provenance",
+  "verify": {
+    "checkpoint": "/path/to/.oxo-flow/checkpoint.json",
+    "matched": 2,
+    "mismatched": 1,
+    "missing": 0,
+    "entries": [
+      {"file": "output/sample1.vcf", "status": "matched", "expected": "sha256:abc123...", "actual": "sha256:abc123..."},
+      {"file": "output/report.html", "status": "mismatched", "expected": "sha256:xxx", "actual": "sha256:yyy"}
+    ]
+  }
+}
+```
+
+`entries` is sorted by file path for byte-stable output. When the
+checkpoint has no stored checksums, the document is still emitted with a
+`note` field describing the degradation.
 
 ## See Also
 

--- a/docs/guide/src/commands/pull.md
+++ b/docs/guide/src/commands/pull.md
@@ -2,8 +2,8 @@
 
 Fetch an oxo-flow workflow from a remote source. Two modes:
 
-- **Bundle mode** — download a published bundle, verify every file's SHA-256
-  checksum against its `manifest.json`, ready for `oxo-flow run --bundle`.
+- **Bundle mode** — download a published bundle, verify every
+  manifest-listed file's SHA-256 checksum, ready for `oxo-flow run --bundle`.
 - **Repository mode** — `git clone` a workflow repository directly. No
   packaging step is needed on the publishing side: anything that is a git
   repo with an `.oxoflow` file at its root works.

--- a/docs/guide/src/commands/report.md
+++ b/docs/guide/src/commands/report.md
@@ -292,10 +292,13 @@ declares when it applies (e.g. `failure-diagnosis` only when rules failed,
 sections = ["universal", "workflow-info", "commands"]
 ```
 
-- Available built-in section IDs: `universal`, `execution-status`,
-  `failure-diagnosis`, `clinical-compliance`, `workflow-info`, `commands`,
-  `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`,
-  `task-summary`
+- Available built-in section IDs (generator names used by the filter):
+  `universal`, `execution-status`, `failure-diagnosis`,
+  `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`,
+  `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary` —
+  the rendered HTML id can differ from the generator name: `universal`
+  renders the `dashboard` section, and `execution-status` renders both
+  `execution-status` and `benchmarks`
 - The filter applies to **all** sections, including `task-summary`
 - Explicitly listing `clinical-compliance` includes it regardless of the
   detected workflow domain

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -27,6 +27,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 |---|---|---|---|
 | `--jobs` | `-j` | `1` | Maximum number of concurrent jobs |
 | `--keep-going` | `-k` | — | Continue execution when a job fails |
+| `--json` | — | — | Emit a machine-readable JSON summary on stdout after the run (`command`, `status`, `results` counts). The document is emitted on **every** exit path — completed, failed, and aborted (preflight failures, budget breaches, cluster runs, plain-failure aborts) — so `--json` consumers never get zero bytes. `status` is `"completed"` only when the run finished with zero required failures; every other exit is `"failed"`. Human progress and result output on stderr is **not** suppressed — this flag appends the summary, it does not switch the run to machine-only mode |
 | `--workdir` | `-d` | Workflow file's directory | Working directory for execution |
 | `--log-file` | — | `.oxo-flow/logs/oxo-flow.log` in the workdir | Write the run log to a custom path instead (relative paths resolve against the workdir; previous logs rotate to `PATH.1` … `PATH.9`) |
 | `--target` | `-t` | All rules | Run only specific target rules |
@@ -258,8 +259,11 @@ name = "rnaseq"
 profile_mode = "override"   # fill | override (default: fill)
 ```
 
-If the named profile file does not exist, `run` prints a
-warning and proceeds with the workflow's own config.
+If the named profile file does not exist, `run` (and `dry-run`) **fail
+loudly** with a nonzero exit and an error listing every available profile
+in the `profiles/` directory — a typo'd `--profile` must never silently
+run with the workflow's own config. The same hard error applies when the
+profile file exists but its TOML fails to parse or merge.
 
 #### Cluster submission
 
@@ -552,7 +556,20 @@ compares them against the current workflow:
 - **Edited rule definitions** (shell, inputs, outputs, environment, …) are
   caught by the per-rule fingerprint and invalidate the same way.
 - `samples_list` / `samples_<group>` are engine-injected and never trigger
-  invalidation, so toggling `--samples` between runs stays cheap.
+  invalidation, so toggling `--samples` between runs stays cheap. This
+  covers rules whose input list is baked from an injected key
+  (`expand_inputs` over `config.samples_list`, a gather-rule pattern):
+  their rule fingerprint and input manifest change with the selection, and
+  oxo-flow treats that change as non-invalidating. When such a rule is
+  skipped because of a selection change, `run` prints a warning naming the
+  rule — **its outputs still reflect the previous run's full sample set**,
+  and `--rerun` is the documented way to regenerate them under the new
+  selection. The exclusion is narrow and verified: the rule's other
+  definition fields must be byte-identical, and the current input file set
+  must be exactly reproducible from the injected value with unchanged
+  content — any genuine edit still invalidates. Checkpoints written by
+  older binaries lack the input-excluded fingerprint, so the first subset
+  run after an upgrade may re-run such a rule once (safe default).
 
 ```bash
 # min_quality is referenced by fastp_trim; only it and its downstream re-run

--- a/docs/guide/src/commands/serve.md
+++ b/docs/guide/src/commands/serve.md
@@ -155,7 +155,23 @@ curl http://127.0.0.1:8080/api/health
 ```json
 {
   "status": "ok",
-  "version": "0.14.1"
+  "version": "0.14.1",
+  "mode": "personal",
+  "uptime_secs": 12,
+  "components": {
+    "database": { "status": "ok", "latency_ms": null },
+    "filesystem": { "status": "ok", "latency_ms": null },
+    "scheduler": null,
+    "ai_provider": null
+  },
+  "resources": { "cpu_pct": 0.0, "memory_used_pct": 0.0, "disk_used_pct": 0.0 },
+  "license": {
+    "license_type": "academic",
+    "valid": true,
+    "commercial_use": "requires_authorization",
+    "contact": "w_shixiang@163.com",
+    "message": "Free for academic use. Commercial use requires authorization."
+  }
 }
 ```
 

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -175,6 +175,19 @@ matched knowledge, findings) with model-written prose in dedicated fields —
 safe for documentation generators. `--level` defaults to `beginner` because
 the audience cannot be inferred from the workflow itself; experts opt in.
 
+### Degraded mode (no model)
+
+`ai explain` exits 0 with the deterministic skeleton whenever the model
+layer is unavailable — provider errors, quota limits, dead endpoints, or
+explicit disable:
+
+- `OXO_FLOW_AI_PROVIDER=disabled` overrides any saved provider
+  configuration and produces the skeleton with a "disabled" note on stderr.
+- A failed provider call degrades the same way, with the error summarized
+  in the note; the skeleton and its knowledge-base grounding (bioSkills,
+  tool table, pipeline graph) are still emitted in full, and `--json`
+  consumers still get the JSON contract (prose fields empty).
+
 ```json
 {
   "workflow_name": "wgs-germline-calling",

--- a/docs/guide/src/reference/reporting-system.md
+++ b/docs/guide/src/reference/reporting-system.md
@@ -201,8 +201,14 @@ sections = ["universal", "workflow-info", "commands", "failure-diagnosis"]
 `[report].sections` filters which sections are included, by generator
 name. Available names: `universal`, `execution-status`,
 `failure-diagnosis`, `clinical-compliance`, `workflow-info`, `commands`,
-`file-manifest`, `environment`, `provenance`, `task-summary` — enumerable
-at runtime with `oxo-flow report WF --list-sections`.
+`file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`,
+`task-summary` — enumerable at runtime with
+`oxo-flow report WF --list-sections`.
+
+The filter name is the generator name; the rendered HTML id can differ —
+the `universal` generator renders the `dashboard` section, and
+`execution-status` renders both `execution-status` and `benchmarks`.
+Filters and rendered ids are distinct namespaces.
 
 ### Templates
 

--- a/docs/guide/src/reference/security.md
+++ b/docs/guide/src/reference/security.md
@@ -46,7 +46,9 @@ Output paths are validated to prevent file system escape:
 |-------|----------|------------|
 | `..` in path | Blocked — prevents directory traversal | E009 |
 | Absolute paths outside workdir | Lint warning (W017); blocked at runtime when they escape the workdir | W017 |
-| Interpreter paths | Only simple names or paths under `/usr/bin`, `/usr/local/bin`, `/opt`, `/home`, `/Users` | Validation |
+| Interpreter paths | Only simple names or paths under `/usr/bin`, `/usr/local/bin`, `/opt`, `/home`, `/Users` | Run time (script execution) |
+
+Interpreter paths are enforced at **run time**, when a script rule's `interpreter` override is resolved (`validate_interpreter_path`): a rejected path is logged as a warning and the override is ignored, so the script runs without its declared interpreter. `validate` does not check interpreter paths.
 
 ---
 
@@ -69,7 +71,7 @@ Hardcoded credentials in workflow TOML content are detected by the `oxo-flow lin
 
 Secret values are **redacted** in findings — only the first and last 4 characters are shown.
 
-Additionally, workflow config values declared with `sensitive = true` in a `[config]` definition are masked as `****` in logs, `--help`, and error output.
+Additionally, workflow config values declared with `sensitive = true` in a `[config]` definition are masked as `***` in logs, `--help`, and error output.
 
 ---
 

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -126,7 +126,7 @@ Upload a commercial license file for validation and activation.
 ### Users (admin)
 ```
 GET    /api/runs/{id}/preview   # Instance-level dry-run plan (will_run/will_skip + expanded rule instances)
-GET    /api/users          # List users (requires a valid session)
+GET    /api/users          # List users (admin only)
 POST   /api/users          # Create user
 DELETE /api/users/{id}     # Delete user
 ```

--- a/docs/guide/src/reference/wildcards.md
+++ b/docs/guide/src/reference/wildcards.md
@@ -213,6 +213,7 @@ If a value discovered from the filesystem does not match its constraint, it is i
 When a rule is expanded from wildcards, its unique name in the DAG is modified to include the wildcard values to avoid collisions:
 
 - **Sample/group wildcards**: `align` → `align_control_S1` — one expanded rule per (group, sample) combination
+- **Group-less declared samples**: a flat sample list with no `[[sample_groups]]` collapses into a single implicit group named `samples`, so `align` → `align_samples_S1`. The same applies to `--samples` overrides of a workflow that declares no groups
 - **Pairs**: `mutect2` → `mutect2_CASE_001`
 
 ---

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -154,9 +154,9 @@ shell = "true"
 
 | Field | Type | Description |
 |---|---|---|
-| `inputs` | Array of String | File patterns the host must wire into the module. A concrete declared input (no `{`-wildcard) that no rule produces fails validation with the gap named; wildcarded patterns are verified by DAG edge inference at run time |
-| `outputs` | Array of String | Files the module exposes to the host. A declared output not produced by a module rule fails validation; a host rule reading a module-internal file that is **not** declared here produces an encapsulation warning |
-| `params` | Table | Defaults for config keys the module reads, filled in profile-style (`or_insert` — explicit host values win) |
+| `inputs` | Array of String | File patterns the host must wire into the module. A concrete declared input (no `{`-wildcard) that no rule produces fails validation with the gap named; wildcarded declared inputs are not statically checkable (a `{sample}` input forms no DAG edge — the placeholder only resolves at run time) — the host is responsible for wiring them |
+| `outputs` | Array of String | Files the module exposes to the host. A declared output not produced by a module rule fails validation; a host rule reading a module-internal file that is **not** declared here produces an encapsulation warning. Wildcarded host inputs are matched structurally (identical literal prefix and suffix, e.g. `qc/{sample}.tmp`), so patterns that could address the same files warn too; patterns that resolve to different literals are not statically checkable |
+| `params` | Table | Defaults for config keys the module reads, filled in profile-style (`or_insert` — explicit host values win). The module's own `[config]` entries fill any remaining gaps: a module declaring `[config] trim_quality = "20"` keeps that default when included without `params`, while any host value (its own `[config]` table or `[[include]]` `params`) still wins. A key referenced but defined nowhere remains an E005 error |
 | `name` | String | Module identity for partial runs (`run --module <name>`). Defaults to the included file's stem (`rules/20_germline.oxoflow` → `20_germline`), so existing composed workflows are addressable without changes |
 | `repo` + `ref` | String pair | Pin the included path to a git repository at a tag/branch/commit: `repo = "https://github.com/org/oxo-flow-modules"`, `ref = "v0.14.1"`, `path = "rules/qc.oxoflow"`. Any git URL works (https/ssh/file://); github.com clones fall back to China mirrors. Checkouts are cached under `~/.cache/oxo-flow/modules/<repo>@<ref>` (`OXO_FLOW_MODULE_CACHE` overrides) — versioned modules, reproducible composition |
 
@@ -508,8 +508,8 @@ memory = "32G"
 | `shell` | String | No | Shell command to execute |
 | `script` | String | No | Script file path (auto-detects interpreter) |
 | `description` | String | No | Human-readable description of what this rule does |
-| `threads` | Integer | No | *(Deprecated)* CPU threads — use `resources.threads` instead |
-| `memory` | String | No | *(Deprecated)* Memory allocation — use `resources.memory` instead |
+| `threads` | Integer | No | *(Deprecated)* CPU threads — use `resources.threads` instead. Still honored, but `oxo-flow lint` flags it with a W025 suggestion to move it under `[rules.resources]` |
+| `memory` | String | No | *(Deprecated)* Memory allocation — use `resources.memory` instead. Still honored, but `oxo-flow lint` flags it with a W025 suggestion to move it under `[rules.resources]` |
 | `resources` | Table | No | Full resource specification (threads, memory, gpu, disk, time_limit, partition, groups) |
 | `environment` | Table | No | Environment specification |
 | `transform` | Table | No | Unified scatter-gather operator (split → map → combine) |
@@ -1047,7 +1047,7 @@ target = true   # Included when running without -t
 | Field | Type | Description |
 |-------|------|-------------|
 | `optional` | Boolean | If `true`, missing inputs become warnings instead of errors |
-| `required` | Boolean | If `false`, a failure of this rule does not fail the run: the failure is recorded and listed, its dependents are blocked, and the run exits 0 (best-effort / continue-on-error, e.g. QC steps). Defaults to `true` — required failures fail the run (or, with `--keep-going`, keep it running but exit 0 with failures listed) |
+| `required` | Boolean | If `false`, a failure of this rule does not fail the run: the failure is recorded and listed, its dependents are blocked, and the run exits 0 (best-effort / continue-on-error, e.g. QC steps). Defaults to `true` — required failures fail the run (or, with `--keep-going`, keep it running but still exit non-zero with the failures listed: keep-going changes scheduling, never the verdict) |
 
 ```toml
 [[rules]]

--- a/docs/guide/src/tutorials/installation.md
+++ b/docs/guide/src/tutorials/installation.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 oxo-flow --version
-# oxo-flow 0.10.2
+# oxo-flow 0.14.1
 ```
 
 !!! tip "Updating"

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -429,7 +429,7 @@ fn cli_ai_explain_unknown_step_fails_fast_without_provider() {
 }
 
 #[test]
-fn cli_ai_explain_without_provider_fails_cleanly() {
+fn cli_ai_explain_without_provider_degrades_to_skeleton() {
     let dir = tempfile::tempdir().unwrap();
     oxo_flow_cmd()
         .env("HOME", dir.path())
@@ -439,7 +439,9 @@ fn cli_ai_explain_without_provider_fails_cleanly() {
             "examples/gallery/13_simple_variant_calling.oxoflow",
         ])
         .assert()
-        .failure()
+        // M10 degraded mode: no provider → deterministic skeleton, exit 0.
+        .success()
+        .stdout(predicate::str::contains("(deterministic skeleton)"))
         .stderr(predicate::str::contains("AI provider not configured"))
         .stderr(predicate::str::contains("ai setup"));
 }
@@ -812,18 +814,32 @@ shell = "echo {config.mode} {config.extra} > out.txt"
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("[skip: up to date]"), "{stderr}");
 
-    // dry-run WITHOUT the profile: `extra` is missing — the preview flags
-    // exactly what run would invalidate.
+    // dry-run WITHOUT the profile: `{config.extra}` is undefined — the H1
+    // gate (issue #142) refuses the run instead of executing with the
+    // literal placeholder. The merged config difference is no longer
+    // previewed as "config changed": it is a hard error.
     let out = oxo_flow_cmd()
         .args(["dry-run", wf.to_str().unwrap()])
         .current_dir(dir.path())
         .output()
         .unwrap();
-    assert!(out.status.success());
+    assert!(
+        !out.status.success(),
+        "a workflow referencing {{config.extra}} without the defining profile must be refused"
+    );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("[run: config changed]"),
-        "preview must flag the profile-driven config difference: {stderr}"
+        stderr.contains("extra"),
+        "the refusal must name the undefined key: {stderr}"
+    );
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "run must apply the same gate: no profile, undefined key, no execution"
     );
 }
 

--- a/tests/dispatch_fairness.rs
+++ b/tests/dispatch_fairness.rs
@@ -123,6 +123,352 @@ fn cli_job1_keep_going_continues_after_rule_failure() {
     );
 }
 
+// ─── run --json on abort paths (issue #142 H6) ─────────────────────────
+
+/// `run --json` must emit the summary document even when the run aborts on
+/// the first failure: the plain-failure path returned early (before the
+/// summary emission) and left stdout at zero bytes, so scripts keying on
+/// the JSON document got nothing while the keep-going path emitted it.
+#[test]
+fn cli_run_json_emits_failed_summary_on_abort() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("failjson.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"failjson\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"boom\"\noutput = [\"boom.txt\"]\nshell = \"exit 3\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "failed run must exit nonzero");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("abort path stdout must be JSON, got: {stdout}");
+    assert_eq!(doc["command"], "run");
+    assert_eq!(doc["status"], "failed");
+    assert_eq!(doc["results"]["failed"], 1);
+}
+
+/// Pre-execution aborts (unknown --module) also emit the failed summary
+/// instead of zero bytes.
+#[test]
+fn cli_run_json_emits_failed_summary_on_preflight_abort() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("modjson.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"modjson\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--module", "nope", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "unknown module must exit nonzero");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("preflight abort stdout must be JSON, got: {stdout}");
+    assert_eq!(doc["command"], "run");
+    assert_eq!(doc["status"], "failed");
+    assert_eq!(doc["results"]["succeeded"], 0);
+}
+
+// ─── provenance verify path resolution + exit codes (issue #142 H7) ──
+
+/// The documented invocation — `run --provenance`, then
+/// `provenance verify .oxo-flow/checkpoint.json` — must verify the intact
+/// outputs and exit 0. Regression: output paths resolved against
+/// `.oxo-flow/` (the checkpoint's parent) instead of the recorded
+/// workdir, so every intact output was reported "file missing".
+#[test]
+fn cli_provenance_verify_documented_invocation_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("prov.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"prov\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--provenance"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let checkpoint = dir.path().join(".oxo-flow/checkpoint.json");
+    assert!(
+        checkpoint.exists(),
+        "run --provenance must write the checkpoint"
+    );
+
+    // Invoke from OUTSIDE the workdir so CWD-relative resolution cannot
+    // accidentally mask the bug: the checkpoint's recorded workdir is the
+    // only correct base.
+    let verify_dir = tempfile::tempdir().unwrap();
+    oxo_flow_cmd()
+        .args(["provenance", "verify", checkpoint.to_str().unwrap()])
+        .current_dir(verify_dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "1 matched, 0 mismatched, 0 missing",
+        ));
+
+    assert!(dir.path().join("out.txt").exists());
+}
+
+/// `provenance verify --json` must emit the verify document on stdout
+/// (issue #142 M8) — previously --json produced nothing at all.
+#[test]
+fn cli_provenance_verify_json_emits_document() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("provjson.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"provjson\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--provenance"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let output = oxo_flow_cmd()
+        .args([
+            "provenance",
+            "verify",
+            dir.path()
+                .join(".oxo-flow/checkpoint.json")
+                .to_str()
+                .unwrap(),
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("verify --json stdout must be JSON, got: {stdout}");
+    assert_eq!(doc["command"], "provenance");
+    assert_eq!(doc["verify"]["matched"], 1);
+    assert_eq!(doc["verify"]["mismatched"], 0);
+    assert_eq!(doc["verify"]["missing"], 0);
+    assert_eq!(doc["verify"]["entries"][0]["status"], "matched");
+}
+
+/// A deleted output file is a verification failure: missing files exit 1
+/// (previously they exited 0, which made the false-negative silent).
+#[test]
+fn cli_provenance_verify_missing_file_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("provmiss.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"provmiss\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--provenance"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Simulate a vanished (or tampered-away) output.
+    fs::remove_file(dir.path().join("out.txt")).unwrap();
+
+    oxo_flow_cmd()
+        .args([
+            "provenance",
+            "verify",
+            dir.path()
+                .join(".oxo-flow/checkpoint.json")
+                .to_str()
+                .unwrap(),
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "0 matched, 0 mismatched, 1 missing",
+        ));
+}
+
+// ─── Deleted-command migration hints (issue #142 H2) ──────────────────
+
+/// Removed commands (issue #76) must name their replacement instead of
+/// clap's bare "unrecognized subcommand" — scripts and muscle memory get
+/// the migration path. Each legacy name exits nonzero with a hint naming
+/// the successor command.
+#[test]
+fn cli_legacy_commands_print_migration_hints() {
+    let expectations: &[(&str, &str)] = &[
+        ("history", "status --timing"),
+        ("package", "export"),
+        ("profile", "run --profile"),
+        ("watch", "status"),
+    ];
+    for (legacy, successor) in expectations {
+        let dir = tempfile::tempdir().unwrap();
+        let output = oxo_flow_cmd()
+            .arg(legacy)
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "'{legacy}' must exit nonzero, not silently succeed"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(successor),
+            "'{legacy}' hint must name the successor '{successor}', got: {stderr}"
+        );
+        assert!(
+            stderr.contains("removed"),
+            "'{legacy}' hint must say the command was removed, got: {stderr}"
+        );
+    }
+}
+
+/// The migration hint fires in the subcommand position even when global
+/// flags precede it.
+#[test]
+fn cli_legacy_command_hint_survives_global_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = oxo_flow_cmd()
+        .args(["--json", "history"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("status"));
+}
+
+// ─── ai explain degraded mode (issue #142 M10) ────────────────────────
+
+/// A dead provider endpoint must degrade to the deterministic skeleton
+/// and exit 0, not hard-fail: `OPENAI_BASE_URL` pointing at a dead local
+/// port makes the provider call fail, and the explain output must still
+/// carry the verified grounding (--json, no prose fields).
+#[test]
+fn cli_ai_explain_degrades_when_provider_unreachable() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("explain.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"explain\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["ai", "explain", wf.to_str().unwrap(), "--json"])
+        .env("OXO_FLOW_AI_PROVIDER", "openai")
+        .env("OPENAI_BASE_URL", "http://127.0.0.1:1")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "a failed provider call must degrade, not hard-fail: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("explain --json stdout must be JSON, got: {stdout}");
+    // The deterministic skeleton is present without model prose.
+    assert_eq!(doc["workflow_name"], "explain");
+    assert_eq!(doc["steps"][0]["name"], "gen");
+    assert_eq!(doc["overview_summary"], "");
+    assert!(
+        doc["provenance"]["bio_skills"].as_u64().unwrap() >= 500,
+        "the knowledge-base grounding must survive a provider failure"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skeleton"),
+        "the degraded note must be visible on stderr: {stderr}"
+    );
+}
+
+/// `OXO_FLOW_AI_PROVIDER=disabled` is an explicit opt-out: it must
+/// override any saved config and still produce the skeleton with exit 0.
+#[test]
+fn cli_ai_explain_disabled_emits_skeleton_and_exits_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("explain2.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"explain2\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["ai", "explain", wf.to_str().unwrap(), "--json"])
+        .env("OXO_FLOW_AI_PROVIDER", "disabled")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "explicit disable must exit 0 with the skeleton: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("explain --json stdout must be JSON, got: {stdout}");
+    assert_eq!(doc["workflow_name"], "explain2");
+    assert_eq!(doc["overview_summary"], "");
+}
+
+// ─── lint text output carries hints (issue #142 M11) ──────────────────
+
+/// The human lint report must include the fix suggestion, matching
+/// validate's `hint:` line — previously only --json carried it.
+#[test]
+fn cli_lint_text_output_prints_hints() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("lintsugg.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"lintsugg\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["lint", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // W001 (no workflow description) and W003 (no rule description) both
+    // carry suggestions; the text renderer must print them.
+    assert!(
+        stderr.contains("hint:"),
+        "lint text output must print suggestion hints, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("description"),
+        "a W00x hint must be present, got: {stderr}"
+    );
+}
+
 // ─── Run-log header masking (issue #136 fix 3) ───────────────────────
 
 /// The run-log header embeds the raw command line; sensitive values passed
@@ -186,5 +532,315 @@ fn cli_log_file_relative_path_resolves_against_workdir() {
     assert!(
         !dir.path().join("logs/custom.log").exists(),
         "relative --log-file must NOT resolve against the current directory"
+    );
+}
+
+// ─── Undefined {config.*} gate (issue #142 H1) ─────────────────────────
+
+/// A typo'd `{config.*}` key must fail `run` loudly — naming the key and
+/// the rule — and must not write the literal-placeholder output file.
+/// Previously the placeholder expanded to literal text, the run exited 0,
+/// and the wrong data shipped silently.
+#[test]
+fn cli_run_undefined_config_key_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("typo.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"typo\"\nversion = \"1.0.0\"\n\n[config]\nFOO = \"bar\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo {config.FOO} {config.FO} > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "an undefined config key must fail the run, not exit 0"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("FO") && stderr.contains("gen"),
+        "error must name the undefined key and the rule, got: {stderr}"
+    );
+    assert!(
+        !dir.path().join("out.txt").exists(),
+        "no output file may be produced when the run fails the gate"
+    );
+}
+
+/// `dry-run` applies the same gate: a typo'd key must be refused in the
+/// preview too, so the user cannot get a "will run" plan for a workflow
+/// that `run` rejects.
+#[test]
+fn cli_dry_run_undefined_config_key_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("typo2.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"typo2\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo {config.NOPE} > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("NOPE") && stderr.contains("gen"),
+        "dry-run must refuse the same typo, got: {stderr}"
+    );
+}
+
+/// `run --json` on the H1 gate abort must still emit the failed summary
+/// document (issue #142 H6 contract — every terminal path emits it).
+#[test]
+fn cli_run_json_emits_failed_summary_on_undefined_config_abort() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("typo3.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"typo3\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo {config.NOPE} > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout).expect("gate abort stdout must be JSON, got: {stdout}");
+    assert_eq!(doc["status"], "failed");
+    assert_eq!(doc["results"]["succeeded"], 0);
+}
+
+// ─── Undeclared wildcard: preview/run parity (issue #142 H3a) ──────────
+
+/// A workflow whose output contains an UNDECLARED `{sample}` wildcard must
+/// be reported as WILL RUN by dry-run on a fresh dir — the brace path is
+/// not an existing output, so the executor runs the rule (writing the
+/// literal file name). Previously the preview counted the brace-containing
+/// path as "outputs up-to-date" and said skip while `run` executed —
+/// preview and run disagreed (issue #142 H3).
+#[test]
+fn cli_dry_run_reports_undeclared_wildcard_as_will_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("h3a.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"h3a\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out_{sample}.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "dry-run itself must succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[run: never completed]"),
+        "fresh undeclared-wildcard rule must be reported as will run, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("[skip: outputs up-to-date]"),
+        "the brace path must not count as an existing fresh output, got: {stderr}"
+    );
+}
+
+/// Parity on the run side: the executor executes the rule and writes the
+/// LITERAL file `out_{sample}.txt` (the placeholder never expands).
+#[test]
+fn cli_run_undeclared_wildcard_writes_literal_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("h3b.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"h3b\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out_{sample}.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        dir.path().join("out_{sample}.txt").exists(),
+        "run must write the literal placeholder-named file (the wildcard has no source)"
+    );
+    // Dry-run AFTER the run agrees the rule is now up-to-date — the two
+    // surfaces stay in lockstep on the second round too.
+    let output = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[skip: up to date]"),
+        "after a real run the literal file exists, so dry-run must agree the rule is fresh, got: {stderr}"
+    );
+}
+
+// ─── Undeclared wildcard lint (issue #142 H3b) ─────────────────────────
+
+/// `lint` must flag an expandable-looking wildcard with no declared source
+/// (W024) and name the placeholder — the fix suggestion points at the
+/// declaration surfaces.
+#[test]
+fn cli_lint_warns_undeclared_wildcard() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("h3c.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"h3c\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out_{sample}.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["lint", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("W024") && stderr.contains("sample"),
+        "lint must flag the undeclared wildcard with its code and name, got: {stderr}"
+    );
+}
+
+// ─── Missing --profile is a hard error (issue #142 H4) ─────────────────
+
+/// `run --profile <typo>` must exit nonzero and name the typo plus every
+/// available profile. Previously it warned and ran with the workflow's own
+/// config — the wrong environment for a silent production run.
+#[test]
+fn cli_run_missing_profile_exits_nonzero_and_lists_profiles() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("prof.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"prof\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {output}\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(dir.path().join("profiles")).unwrap();
+    fs::write(
+        dir.path().join("profiles/batch.toml"),
+        "[config]\nthreads = 4\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("profiles/dev.oxoflow"),
+        "[config]\nthreads = 2\n",
+    )
+    .unwrap();
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--profile", "nope"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "a missing profile must fail the run, not warn-and-continue"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nope"),
+        "error must name the typo'd profile, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("batch") && stderr.contains("dev"),
+        "error must list the available profiles, got: {stderr}"
+    );
+    assert!(
+        !dir.path().join("out.txt").exists(),
+        "a gate-aborted run must not execute rules"
+    );
+}
+
+// ─── --samples subset must not overwrite gather outputs (issue #142 M1) ─
+
+/// A cohort gather rule whose inputs are baked from `config.samples_list`
+/// must NOT re-run (and overwrite the cohort table) when a later
+/// `--samples S2` run changes the selection: the engine-injected list is
+/// documented as non-invalidating. The run skips gather with a WARNING and
+/// the counts file keeps the full-cohort content.
+#[test]
+fn cli_samples_subset_does_not_overwrite_gather_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("m1.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"m1\"\nversion = \"1.0.0\"\n\n[[sample_groups]]\nname = \"batch\"\nsamples = [\"S1\", \"S2\", \"S3\"]\n\n[[rules]]\nname = \"per_sample\"\noutput = [\"per/{sample}.txt\"]\nshell = \"echo {sample} > {output}\"\n\n[[rules]]\nname = \"gather\"\noutput = [\"counts.txt\"]\nexpand_inputs = [{ pattern = \"per/{sample}.txt\", variables = { sample = \"config.samples_list\" } }]\nshell = \"cat {input} > {output}\"\ndepends_on = [\"per_sample\"]\n",
+    )
+    .unwrap();
+
+    // Full cohort run.
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let full_counts = fs::read_to_string(dir.path().join("counts.txt")).unwrap();
+    assert_eq!(
+        full_counts.lines().count(),
+        3,
+        "full run must gather all three per-sample files: {full_counts}"
+    );
+
+    // Subset run: gather must be skipped with a warning, not re-run.
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--samples", "S2"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "subset run itself must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("gather") && stderr.contains("--samples"),
+        "subset run must warn that gather was skipped due to the sample selection, got: {stderr}"
+    );
+    let subset_counts = fs::read_to_string(dir.path().join("counts.txt")).unwrap();
+    assert_eq!(
+        subset_counts, full_counts,
+        "gather must NOT overwrite the cohort table with the 1-sample subset: {subset_counts}"
+    );
+    // The dry-run preview agrees: gather shows as skipped, not re-run.
+    let preview = oxo_flow_cmd()
+        .args(["dry-run", wf.to_str().unwrap(), "--samples", "S2"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let preview_err = String::from_utf8_lossy(&preview.stderr);
+    assert!(
+        preview_err.contains("[skip: up to date]"),
+        "preview must agree gather stays skipped, got: {preview_err}"
+    );
+    assert!(
+        !preview_err.contains("[run: input changed]"),
+        "preview must not report gather as input-invalidated, got: {preview_err}"
     );
 }

--- a/tests/preview_parity.rs
+++ b/tests/preview_parity.rs
@@ -366,8 +366,10 @@ shell = "echo step2 >> exec_log.txt; cp out1.txt out2.txt"
 }
 
 /// 5. Profile fill difference: the baseline ran WITH a profile that filled a
-///    config key; predicting and executing WITHOUT it must agree on the
-///    resulting config-change invalidation.
+///    config key. Dropping the profile leaves `{config.extra}` undefined —
+///    under the H1 gate (issue #142) BOTH dry-run and run must refuse the
+///    run with the same hard error instead of executing with the literal
+///    placeholder. Parity now means: identical refusal.
 #[test]
 fn parity_profile_fill_difference() {
     let dir = tempfile::tempdir().unwrap();
@@ -394,19 +396,25 @@ shell = "echo step1 >> exec_log.txt; cp in.txt out1.txt; echo {config.mode}-{con
     fs::write(dir.path().join("in.txt"), "alpha").unwrap();
     baseline_run(dir.path(), &wf, &["--profile", "batch"]);
 
-    // No profile on either side: `extra` is missing from the merged config,
-    // so both the preview and the run must flag step1 as config-changed.
-    let (predicted_run, _) = assert_parity(
-        dir.path(),
-        &[wf.to_str().unwrap()],
-        &[wf.to_str().unwrap()],
-        "profile fill difference",
-    );
-    assert_eq!(
-        predicted_run,
-        HashSet::from(["step1".to_string()]),
-        "dropping the profile must invalidate exactly the rule referencing the filled key"
-    );
+    // No profile on either side: `{config.extra}` is undefined — the H1
+    // gate refuses the run on BOTH surfaces (parity of the hard error).
+    for surface in ["dry-run", "run"] {
+        let out = oxo_flow()
+            .arg(surface)
+            .arg(wf.to_str().unwrap())
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            !out.status.success(),
+            "[{surface}] without the defining profile the run must be refused"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("extra"),
+            "[{surface}] the refusal must name the undefined key: {stderr}"
+        );
+    }
 }
 
 /// 6. `when` condition flip: the gate rule toggles between executed and


### PR DESCRIPTION
## Summary

Persona-lane fixes from issue #142 (the 12-role simulation of v0.14.1 — every HIGH was reproduced by the main session before implementation). 31 files, ~40 new/updated tests, three parallel implementation agents with RED→GREEN evidence.

**Silent-failure traps closed**
- `run`/`dry-run` hard-fail on undefined `{config.*}` references (shared E005 detector) — no more literal-placeholder output with exit 0.
- `run --profile <typo>` is a hard error listing available profiles.
- `--samples` subset runs no longer overwrite cohort-level gather outputs: two-layer narrow exemption (checkpoint `rule_fingerprints_no_input` + config-impact exemption for engine-injected sample keys; manifest re-expansion + content-identity recheck) → skip with a loud warning + `--rerun` pointer; genuine edits still invalidate; old checkpoints degrade to one-time invalidation.
- Transform-preview parity by construction: the preview delegates to the executor's `should_skip_rule`; W024 lints undeclared wildcards.

**Audit/CI path repaired**
- `run --json` emits the failed summary on all 8 exit paths.
- `provenance verify` resolves against the checkpoint's recorded workdir; missing files exit 1; `--json` emits a machine-readable document.
- Report Commands section renders wildcard-expanded instance commands.
- `ai explain` degrades to the deterministic skeleton (provider broken / `OXO_FLOW_AI_PROVIDER=disabled` overrides persisted config).
- Deleted commands print migration hints (history→status --timing, package→export, profile→run --profile, watch→status).
- lint prints fix hints; W025 flags deprecated rule-level threads/memory.

**Module semantics + docs**
- Include modules' `[config]` defaults merge or_insert (host > params > module defaults); undefined keys still E005.
- Encapsulation warnings cover structurally-matching wildcarded host inputs.
- 13-doc batch (version strings, mask literal, web-api admin-only, serve health shape, pull.md, cluster.md, lint.md, wildcards.md, report section IDs, diff.md, run.md --json, workflow-format.md `-k` contradiction, ai.md).

## Tests

- ~40 new/updated; full `make ci` on the exact tree green (~2170 tests, fmt + clippy `-D warnings` + build + test + audit).
- Live-verified: H1/H4 exit 1 with actionable errors; H6 emits `status: failed` JSON; H7 documented verify invocation reports `1 matched, 0 mismatched, 0 missing`; M1 subset run keeps `counts.txt` byte-identical with both layer warnings.

## Test plan for reviewers

- [ ] `make ci`
- [ ] `run` a workflow with a config-key typo → nonzero, names the key
- [ ] `run --profile nope` → nonzero, lists profiles
- [ ] `run --provenance` then `provenance verify .oxo-flow/checkpoint.json` → all ✓
- [ ] Full cohort run, then `--samples S2` → warnings, gather output unchanged

Fixes #142 (persona lane; H5/M4/M5 land via the driver lane's PR).
