### PR TITLE
docs(lint): fix broken relative links (mkdocs strict)

### DIFF
--- a/docs/guide/src/commands/lint.md
+++ b/docs/guide/src/commands/lint.md
@@ -69,11 +69,11 @@ the fix, matching the style of `validate` and `run` output. W007
 suggests `target = true`: a rule marked as a target is built by default
 when `oxo-flow run` is invoked without an explicit `-t`, so marking the
 final leaf rules (like `fastqc` above) makes them part of the default
-run — see [Workflow Format: Priority and Targeting](workflow-format.md#priority-and-targeting).
+run — see [Workflow Format: Priority and Targeting](../reference/workflow-format.md#priority-and-targeting).
 W025 flags the deprecated rule-level `threads = N` / `memory = "8G"`
 fields (removed in v0.4.0 in favor of `[rules.resources]`) so old
 workflows surface the migration instead of silently keeping their old
-settings — see [Workflow Format: Rule resources](workflow-format.md#rule-resources).
+settings — see [Workflow Format: Rule resources](../reference/workflow-format.md#rule-resources).
 
 ---
 


### PR DESCRIPTION
Fixes two broken relative links in lint.md introduced by #144 (W007/W025 docs): `workflow-format.md` → `../reference/workflow-format.md`. `mkdocs build --strict` now passes with zero warnings.