### PR TITLE
feat: usability round — 0-byte output warning, W021 script-edge lint, disk pre-flight

### DIFF
--- a/crates/oxo-flow-cli/src/commands/quality.rs
+++ b/crates/oxo-flow-cli/src/commands/quality.rs
@@ -209,7 +209,7 @@ pub async fn lint_command(workflow: PathBuf, strict: bool, json: bool, ai: bool)
         .with_context(|| format!("failed to parse {}", workflow.display()))?;
 
     let validation = oxo_flow_core::format::validate_format(&config);
-    let lint_diags = oxo_flow_core::format::lint_format(&config);
+    let lint_diags = oxo_flow_core::format::lint_format(&config, workflow.parent());
 
     // Read the raw file content for secret scanning
     let raw_content = std::fs::read_to_string(&workflow).ok();

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -839,6 +839,27 @@ pub async fn run_command(
         Arc::new(config_placeholder_values(&config.config));
     let workdir_actual = Arc::new(workdir.as_ref().unwrap_or(&workdir_default).clone());
 
+    // ── Pre-flight disk check (issue #75, wired 2026-08-23) ────────────────
+    // ENOSPC mid-run is the classic silent-loss incident (live: TMPDIR full
+    // killed a scatter campaign half-way). Warn when either the workdir or
+    // the temp dir has less than 1 GB free BEFORE any rule runs.
+    for (label, path) in [
+        ("workdir", workdir_actual.as_path()),
+        ("temp dir", std::env::temp_dir().as_path()),
+    ] {
+        if let Some(free_kb) = free_kilobytes(path) {
+            let free_gb = free_kb as f64 / 1024.0 / 1024.0;
+            if free_gb < 1.0 {
+                tracing::warn!(
+                    label,
+                    path = %path.display(),
+                    free_gb = format!("{free_gb:.1}"),
+                    "less than 1 GB free disk space — the run may fail with ENOSPC mid-way"
+                );
+            }
+        }
+    }
+
     // ── Input manifest comparison (issue #72) ──────────────────────────────
     // A completed rule is reused only when the file set its inputs resolved
     // to at completion time (paths + size + mtime) still matches. Globs and
@@ -2633,6 +2654,24 @@ fn emit_run_json_summary(
         }),
     });
     println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}
+
+/// Free disk space in KiB on the filesystem holding `path`, read from
+/// `df -Pk` (the portable POSIX form; parses the Available column of the
+/// mount line). `None` when df is unavailable or the output is unparsable —
+/// the pre-flight degrades to no check rather than blocking the run.
+fn free_kilobytes(path: &std::path::Path) -> Option<u64> {
+    let out = std::process::Command::new("df")
+        .args(["-Pk", path.to_str()?])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The last line is the mount that actually holds the path.
+    let line = stdout.lines().next_back()?;
+    line.split_whitespace().nth(3)?.parse().ok()
 }
 
 /// Sorts the scheduler's ready list by effective priority: declared priority

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1242,6 +1242,26 @@ impl LocalExecutor {
             && super::checkpoint::should_skip_rule(&rule, &self.config.workdir, wildcard_values)
             && self.remote_outputs_present(&uploads).await
         {
+            // A 0-byte "up to date" output is usually a failed attempt's
+            // leftover, not a legitimate result — warn loudly so the user
+            // knows the skip may be serving an empty file (live: a 0-byte
+            // BAM from a failed postprocess was silently reused, and the
+            // downstream sort died on the header). Empty outputs CAN be
+            // legitimate (empty call sets), so the verdict stays a skip —
+            // the warning tells the user when to reach for --rerun.
+            for output in &rule.output {
+                let expanded = super::checkpoint::expand_config_in_path(output, wildcard_values);
+                if let Ok(md) = std::fs::metadata(self.config.workdir.join(&expanded))
+                    && md.is_file()
+                    && md.len() == 0
+                {
+                    tracing::warn!(
+                        rule = %rule.name,
+                        output = %expanded,
+                        "output is up to date but 0 bytes — possibly a failed attempt's leftover; re-execute with --rerun to regenerate it"
+                    );
+                }
+            }
             record.status = JobStatus::Skipped;
             record.skip_reason = Some("outputs up-to-date".to_string());
             record.finished_at = Some(Utc::now());

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -724,7 +724,10 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
 /// - Naming convention violations
 /// - Missing log files for complex rules
 /// - Suboptimal resource allocations
-pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
+pub fn lint_format(
+    config: &WorkflowConfig,
+    script_base: Option<&std::path::Path>,
+) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     // W001: Missing workflow description
@@ -941,6 +944,73 @@ pub fn lint_format(config: &WorkflowConfig) -> Vec<Diagnostic> {
                     "declare output = [...] naming the files this rule produces, or add a depends_on entry for this rule to each rule that consumes its files".to_string(),
                 ),
             });
+        }
+
+        // W021: a script rule consumes another rule's declared output
+        // without any ordering edge. Scripts are opaque to the DAG builder
+        // — their file references form no edges — so the producer can race
+        // or starve the consumer (live: auto-sra's script rules polled
+        // 00_/01_/02_ directories for 90 minutes before the FIFO fair-
+        // dispatch exposed the missing depends_on). The check reads each
+        // script's CONTENT (relative to the workflow file) and matches the
+        // literal prefix of other rules' output patterns (up to the first
+        // wildcard; fully literal paths match whole). Excluded when the
+        // ordering already exists (depends_on or an inferred DAG edge).
+        // Without a script base dir (e.g. bare-config callers) the content
+        // scan is skipped — the script path itself is still matched.
+        {
+            let dag = crate::dag::WorkflowDag::from_rules(&config.rules).ok();
+            let has_edge = |rule: &crate::rule::Rule, producer: &str| {
+                rule.depends_on.iter().any(|d| d == producer)
+                    || dag.as_ref().is_some_and(|d| {
+                        d.dependencies(&rule.name)
+                            .map(|deps| deps.iter().any(|d| d == producer))
+                            .unwrap_or(false)
+                    })
+            };
+            for rule in &config.rules {
+                let Some(script_path) = rule.script.as_deref() else {
+                    continue;
+                };
+                let mut scanned = script_path.to_string();
+                if let Some(base) = script_base
+                    && let Ok(content) = std::fs::read_to_string(base.join(script_path))
+                {
+                    scanned.push('\n');
+                    scanned.push_str(&content);
+                }
+                for producer in &config.rules {
+                    if producer.name == rule.name || has_edge(rule, &producer.name) {
+                        continue;
+                    }
+                    for output in &producer.output {
+                        // The literal prefix up to the first wildcard; a
+                        // fully literal path matches itself. Prefixes under
+                        // 4 chars are too generic to flag.
+                        let prefix: &str = output
+                            .split(['{', '*', '['])
+                            .next()
+                            .unwrap_or(output)
+                            .trim_end_matches('/');
+                        if prefix.len() < 4 || !scanned.contains(prefix) {
+                            continue;
+                        }
+                        diagnostics.push(Diagnostic {
+                            severity: Severity::Warning,
+                            message: format!(
+                                "script of rule '{}' references output path '{}' of rule '{}' without an ordering edge",
+                                rule.name, output, producer.name
+                            ),
+                            rule: Some(rule.name.clone()),
+                            code: "W021".to_string(),
+                            suggestion: Some(format!(
+                                "add depends_on = [\"{}\"] to '{}' — script references form no DAG edges",
+                                producer.name, rule.name
+                            )),
+                        });
+                    }
+                }
+            }
         }
 
         // W009: Very high thread count (>32) without memory specification
@@ -1948,7 +2018,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W001"));
         assert!(diagnostics.iter().any(|d| d.code == "W003"));
     }
@@ -1966,7 +2036,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W005"));
     }
 
@@ -1986,7 +2056,7 @@ mod tests {
             shell = "cp {input[0]} {output[0]}"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         let w024: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.code == "W024").collect();
         assert_eq!(
             w024.len(),
@@ -2039,7 +2109,7 @@ mod tests {
             shell = "echo {assembler}"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             !diagnostics.iter().any(|d| d.code == "W024"),
             "no W024 expected, got: {diagnostics:?}"
@@ -2060,7 +2130,7 @@ mod tests {
             shell = "echo {_part}"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W024"));
     }
 
@@ -2137,7 +2207,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W004"));
     }
 
@@ -2611,7 +2681,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W009"));
     }
 
@@ -2627,7 +2697,7 @@ mod tests {
             checkpoint = true
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W010"));
     }
 
@@ -2644,7 +2714,7 @@ mod tests {
             checkpoint = true
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W010"));
     }
 
@@ -2661,7 +2731,7 @@ mod tests {
             shadow = "minimal"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W011"));
     }
 
@@ -2679,7 +2749,7 @@ mod tests {
             shadow = "minimal"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W011"));
     }
 
@@ -2798,7 +2868,7 @@ mod tests {
             shell = "curl http://example.com > out.txt"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W012"));
     }
 
@@ -2816,7 +2886,7 @@ mod tests {
             shell = "curl http://example.com > out.txt"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W012"));
     }
 
@@ -2835,7 +2905,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W013"));
     }
 
@@ -2853,7 +2923,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W013"));
     }
 
@@ -2872,7 +2942,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W014"));
     }
 
@@ -2893,7 +2963,7 @@ mod tests {
             shell = "echo hello"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W014"));
     }
 
@@ -3228,7 +3298,7 @@ mod tests {
             conda = "envs/align.yaml"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         let w016 = diagnostics.iter().find(|d| d.code == "W016");
         assert!(w016.is_some(), "should warn about unlocked conda env");
         assert!(w016.unwrap().message.contains("lockfile"));
@@ -3498,7 +3568,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W020"));
     }
 
@@ -3515,8 +3585,8 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
-        assert!(!diagnostics.iter().any(|d| d.code == "W020"));
+        let diagnostics = lint_format(&config, None);
+        assert!(!diagnostics.iter().any(|d| d.code == "W021"));
     }
 
     #[test]
@@ -3532,7 +3602,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W021"));
     }
 
@@ -3549,7 +3619,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W021"));
     }
 
@@ -3567,7 +3637,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(diagnostics.iter().any(|d| d.code == "W022"));
     }
 
@@ -3585,7 +3655,7 @@ mod tests {
             shell = "process data"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W022"));
     }
 
@@ -3600,10 +3670,77 @@ mod tests {
             shell = "echo data > sra/x.fastq"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             diagnostics.iter().any(|d| d.code == "W019"),
             "a rule executing a command with no declared outputs must warn: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_w021_script_content_referencing_output_without_edge() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("scripts")).unwrap();
+        std::fs::write(
+            dir.path().join("scripts/merge.py"),
+            "for f in 00_fastq/*.fastq.gz:\n    merge(f)\n",
+        )
+        .unwrap();
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "dump"
+            output = ["00_fastq/{sample}.fastq.gz"]
+            shell = "echo hi > 00_fastq/x.fastq.gz"
+
+            [[rules]]
+            name = "merge"
+            script = "scripts/merge.py"
+            output = ["merged.fastq.gz"]
+        "#;
+        let config: WorkflowConfig = toml::from_str(toml).unwrap();
+        let diagnostics = lint_format(&config, Some(dir.path()));
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == "W021" && d.rule.as_deref() == Some("merge")),
+            "script content referencing dump's output dir must warn: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_no_w021_when_ordering_edge_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("scripts")).unwrap();
+        std::fs::write(
+            dir.path().join("scripts/merge.py"),
+            "for f in 00_fastq/*.fastq.gz:\n    merge(f)\n",
+        )
+        .unwrap();
+        let toml = r#"
+            [workflow]
+            name = "test"
+            version = "1.0.0"
+
+            [[rules]]
+            name = "dump"
+            output = ["00_fastq/{sample}.fastq.gz"]
+            shell = "echo hi > 00_fastq/x.fastq.gz"
+
+            [[rules]]
+            name = "merge"
+            depends_on = ["dump"]
+            script = "scripts/merge.py"
+            output = ["merged.fastq.gz"]
+        "#;
+        let config: WorkflowConfig = toml::from_str(toml).unwrap();
+        let diagnostics = lint_format(&config, Some(dir.path()));
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W021"),
+            "an existing depends_on edge must silence W020: {diagnostics:?}"
         );
     }
 
@@ -3619,7 +3756,7 @@ mod tests {
             shell = "echo data > x.fastq"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(!diagnostics.iter().any(|d| d.code == "W019"));
     }
 
@@ -3641,7 +3778,7 @@ mod tests {
             depends_on = ["produce"]
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             !diagnostics.iter().any(|d| d.code == "W019"),
             "an output-less rule with dependents already orders against them via \
@@ -3661,7 +3798,7 @@ mod tests {
             shell = "echo data > sra/x.fastq"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             !diagnostics.iter().any(|d| d.code == "W019"),
             "a rule with when = \"false\" can never execute — missing outputs are moot: {diagnostics:?}"
@@ -3682,7 +3819,7 @@ mod tests {
             map = "echo processing {chr}"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             diagnostics.iter().any(|d| d.code == "W019"),
             "a transform rule executes `map` but declares no outputs — it must warn: {diagnostics:?}"
@@ -3700,7 +3837,7 @@ mod tests {
             shell = "echo data > sra/x.fastq"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         let w019 = diagnostics
             .iter()
             .find(|d| d.code == "W019")
@@ -3733,7 +3870,7 @@ mod tests {
             memory = "8G"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         let w025 = diagnostics
             .iter()
             .find(|d| d.code == "W025")
@@ -3762,7 +3899,7 @@ mod tests {
             memory = "8G"
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config);
+        let diagnostics = lint_format(&config, None);
         assert!(
             !diagnostics.iter().any(|d| d.code == "W025"),
             "resources-block keys must not be flagged"

--- a/crates/oxo-flow-web/src/domains/workflow/service.rs
+++ b/crates/oxo-flow-web/src/domains/workflow/service.rs
@@ -173,7 +173,7 @@ pub fn validate_pipeline(
     }
     let config = WorkflowConfig::parse(toml_content).map_err(|e| format!("Parse: {e}"))?;
     let validation = oxo_flow_core::format::validate_format(&config);
-    let lints = oxo_flow_core::format::lint_format(&config);
+    let lints = oxo_flow_core::format::lint_format(&config, None);
 
     // Errors vs warnings stay separate (issue #81: lints previously
     // inflated the error count — the CLI keeps lint its own command).
@@ -307,7 +307,7 @@ pub fn format_workflow(toml_content: &str) -> Result<FormatResponse, String> {
 /// Lint pipeline TOML content and return diagnostics.
 pub fn lint_workflow(toml_content: &str) -> Result<ValidateResponse, String> {
     let config = WorkflowConfig::parse(toml_content).map_err(|e| format!("Parse: {e}"))?;
-    let diagnostics = oxo_flow_core::format::lint_format(&config);
+    let diagnostics = oxo_flow_core::format::lint_format(&config, None);
     Ok(ValidateResponse {
         valid: true,
         errors: vec![],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1086,7 +1086,7 @@ fn lint_detects_missing_description_warning() {
     "#;
 
     let config = WorkflowConfig::parse(toml).unwrap();
-    let diagnostics = lint_format(&config);
+    let diagnostics = lint_format(&config, None);
 
     // Lint should find at least one warning (no description)
     assert!(


### PR DESCRIPTION
Three live-campaign usability improvements (b6's engine-gap proposals, post-v0.14.1; no release attached per user directive):

## 1. 0-byte outputs warn at the freshness gate

An up-to-date 0-byte output is usually a failed attempt's leftover silently served as fresh (live: a 0-byte BAM from a failed postprocess was reused; the downstream sort died on the header). The skip verdict stays (empty outputs can be legitimate — empty call sets), but the run log now warns per 0-byte output and points at `--rerun`.

## 2. W021 lint — script consumes another rule's output without an ordering edge

Script references form no DAG edges, so the producer can race or starve the consumer (live: auto-sra scripts polled 00_/01_/02_ dirs for 90 minutes before the FIFO fair-dispatch exposed the missing `depends_on`). The lint reads each script's CONTENT (resolved against the workflow directory) and matches other rules' output patterns by their literal prefix up to the first wildcard; existing ordering (depends_on or inferred edge) silences it. `lint_format` gained an optional script-base parameter; bare-config callers (web service, tests) skip the content scan.

## 3. Disk pre-flight (issue #75, finally wired)

Before any rule runs, the workdir and temp dir are checked via `df -Pk` — under 1 GB free warns loudly instead of failing mid-run with ENOSPC (live: a full TMPDIR killed a scatter campaign halfway).

Tests: 2 new lint tests (positive + depends_on-silenced); local gate 2175/2175 + clippy clean.