### PR TITLE
fix(web): dev-mode login role matches account; drop nonexistent serve --json doc row

### DIFF
--- a/crates/oxo-flow-web/src/domains/auth/service.rs
+++ b/crates/oxo-flow-web/src/domains/auth/service.rs
@@ -53,10 +53,20 @@ pub fn authenticate(username: &str, password: &str) -> Result<LoginResponse, Str
             "DEV MODE: accepted password==username login for '{}'",
             username
         );
+        // The role must reflect the account, not a hardcoded "user" —
+        // /api/auth/me derives admin for the admin username, and the login
+        // response must agree (issue #142 persona testing, M6).
+        let role = if username == "admin" {
+            "admin"
+        } else if username == "viewer" {
+            "viewer"
+        } else {
+            "user"
+        };
         return Ok(LoginResponse {
             token: generate_token(),
             username: username.into(),
-            role: "user".into(),
+            role: role.into(),
         });
     }
 
@@ -278,6 +288,20 @@ pub async fn handle_oauth_callback(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_dev_mode_login_role_matches_account() {
+        // M6 regression: the dev-mode password==username fallback must not
+        // hardcode "user" — admin must come back as admin (agrees with
+        // /api/auth/me's derivation).
+        if std::env::var("OXO_FLOW_DEV_MODE").as_deref() != Ok("1") {
+            return; // dev-mode branch not active in this environment
+        }
+        let resp = authenticate("admin", "admin").unwrap();
+        assert_eq!(resp.role, "admin");
+        let resp = authenticate("alice", "alice").unwrap();
+        assert_eq!(resp.role, "user");
+    }
 
     #[test]
     fn test_authenticate_password_equals_username_rejected_in_production() {

--- a/docs/guide/src/commands/serve.md
+++ b/docs/guide/src/commands/serve.md
@@ -24,7 +24,6 @@ oxo-flow serve [OPTIONS]
 | `--verbose` | `-v` | — | Enable debug-level logging |
 | `--quiet` | — | — | Suppress non-essential output (errors only) |
 | `--no-color` | — | — | Disable colored output |
-| `--json` | — | — | Output machine-readable JSON to stdout (suppresses human-readable stderr output) |
 
 ---
 


### PR DESCRIPTION
Closes the two remaining web items from the persona-testing audits (#142): the dev-mode password==username login fallback hardcoded role 'user' even for admin (now derived from the username, agreeing with /api/auth/me; regression test under DEV_MODE=1), and serve.md's --json row documenting a flag that never existed (removed — the server's machine surface is the HTTP API + OpenAPI). Web lane for the 24h campaign; the deployment + 3-role simulation test plan is coordinated with the verification lane.