### PR TITLE
fix(cli): help-text drift + license --json machine output + 4 doc table rows

### DIFF
--- a/crates/oxo-flow-cli/src/commands/infra.rs
+++ b/crates/oxo-flow-cli/src/commands/infra.rs
@@ -319,7 +319,10 @@ pub fn handle_license(path: Option<std::path::PathBuf>, json: bool) -> Result<()
             }
             Err(e) => {
                 if json {
-                    println!("{}", serde_json::json!({ "verified": false, "error": e.to_string() }));
+                    println!(
+                        "{}",
+                        serde_json::json!({ "verified": false, "error": e.to_string() })
+                    );
                 }
                 anyhow::bail!("License verification failed: {e}");
             }

--- a/crates/oxo-flow-cli/src/commands/infra.rs
+++ b/crates/oxo-flow-cli/src/commands/infra.rs
@@ -290,19 +290,50 @@ pub fn handle_config(action: ConfigAction) -> Result<()> {
 }
 
 /// Verify a license file, or display the current license status without one.
-pub fn handle_license(path: Option<std::path::PathBuf>) -> Result<()> {
+/// With `json` set, both branches emit a machine-readable object on stdout
+/// instead of the human summary (the global `--json` flag was previously a
+/// silent no-op for this command).
+pub fn handle_license(path: Option<std::path::PathBuf>, json: bool) -> Result<()> {
     let status = oxo_flow_web::check_license();
     if let Some(p) = path {
         match oxo_license::load_and_verify(Some(&p), &oxo_flow_web::OXO_FLOW_CONFIG) {
             Ok(license) => {
-                println!("{} License verified successfully", "✓".green().bold());
-                println!("  Type:    {}", license.payload.license_type);
-                println!("  Issued:  {}", license.payload.issued_to_org);
-                println!("  Schema:  {}", license.payload.schema);
-                println!("  ID:      {}", license.payload.license_id);
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "verified": true,
+                            "type": license.payload.license_type,
+                            "issued_to": license.payload.issued_to_org,
+                            "schema": license.payload.schema,
+                            "id": license.payload.license_id,
+                        })
+                    );
+                } else {
+                    println!("{} License verified successfully", "✓".green().bold());
+                    println!("  Type:    {}", license.payload.license_type);
+                    println!("  Issued:  {}", license.payload.issued_to_org);
+                    println!("  Schema:  {}", license.payload.schema);
+                    println!("  ID:      {}", license.payload.license_id);
+                }
             }
-            Err(e) => anyhow::bail!("License verification failed: {e}"),
+            Err(e) => {
+                if json {
+                    println!("{}", serde_json::json!({ "verified": false, "error": e.to_string() }));
+                }
+                anyhow::bail!("License verification failed: {e}");
+            }
         }
+    } else if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "valid": status.valid,
+                "license_type": status.license_type,
+                "issued_to": status.issued_to,
+                "message": status.message,
+            })
+        );
     } else {
         println!("License status:");
         if status.valid {

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -57,7 +57,7 @@ pub struct Cli {
     #[arg(global = true, long)]
     no_color: bool,
 
-    /// Output machine-readable JSON to stdout (suppresses human-readable stderr output).
+    /// Output machine-readable JSON to stdout (human-readable logs stay on stderr).
     #[arg(global = true, long)]
     json: bool,
 }
@@ -296,7 +296,6 @@ pub enum Commands {
             help = "Direct config overrides: KEY=VALUE or --KEY=VALUE; --KEY VALUE (space form) is accepted for declared [config] keys — unknown --flags are rejected"
         )]
         config_overrides: Vec<String>,
-        /// Add a sample to the preview (repeatable, merges with all
         /// Force re-execution of this run's rules (ignore up-to-date
         /// checks) — previews exactly what `run --rerun` would execute.
         #[arg(long)]
@@ -1612,7 +1611,7 @@ async fn main() -> Result<()> {
             with_lockfiles,
             format,
         } => publish_command(workflow, output, with_lockfiles, format)?,
-        Commands::License { path } => handle_license(path)?,
+        Commands::License { path } => handle_license(path, cli.json)?,
     }
 
     Ok(())

--- a/docs/guide/src/commands/dry-run.md
+++ b/docs/guide/src/commands/dry-run.md
@@ -33,6 +33,7 @@ are up to date is predicted as skipped, exactly as `run` would skip it.
 | Option | Short | Description |
 |---|---|---|
 | `--target` | `-t` | Run only specific target rules and their dependencies (repeatable, prefix matching) |
+| `--module` | — | Run one include module and the producers of its declared inputs (repeatable; unions with `--target`). Module names are the include's `name` field or its file stem |
 | `--samples <LIST>` | — | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--workdir <DIR>` | `-d` | Resolve relative paths against this directory (default: the workflow file's directory) |
 | `--profile <NAME>` | — | Execution profile loaded from `profiles/<NAME>.toml` — the SAME merge semantics as `run` |

--- a/docs/guide/src/commands/resume.md
+++ b/docs/guide/src/commands/resume.md
@@ -45,6 +45,7 @@ re-execute the affected rules (see
 | `--workdir <DIR>` | `-d` | Working directory to resume in (default: the one recorded in the checkpoint) |
 | `--keep-going` | `-k` | Continue execution when a job fails (same semantics as `run`) |
 | `--timeout <SECS>` | — | Timeout per job in seconds (0 = disabled), or a duration like `1h`/`30m` |
+| `--no-report-snapshot` | — | Skip the automatic report snapshot after the resumed run (same flag as `run`) |
 
 ## Examples
 

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -31,6 +31,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--workdir` | `-d` | Workflow file's directory | Working directory for execution |
 | `--log-file` | — | `.oxo-flow/logs/oxo-flow.log` in the workdir | Write the run log to a custom path instead (relative paths resolve against the workdir; previous logs rotate to `PATH.1` … `PATH.9`) |
 | `--target` | `-t` | All rules | Run only specific target rules |
+| `--module` | — | — | Run one include module and the producers of its declared inputs (repeatable; unions with `--target`). Module names are the include's `name` field or its file stem (see [Partial module runs](#partial-module-runs---module)) |
 | `--retry` | `-r` | `0` | Number of times to retry failed jobs |
 | `--timeout` | — | `0` (disabled) | Timeout per job in seconds |
 | `--max-threads` | — | `0` (auto-detect) | Maximum CPU threads available for execution |
@@ -40,6 +41,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--cache-dir` | — | — | Directory for caching environment setup state (entries untouched for 90 days are cleaned up after each run; override with the `cache_max_age_days` config key, `0` disables aging) |
 | `--resume-failed` | — | — | Resume only failed rules from a previous run |
 | `--profile` | — | — | Execution profile name, loaded from `profiles/<NAME>.toml` or `profiles/<NAME>.oxoflow` (see [Execution profiles](#execution-profiles)) |
+| `--max-submitted` | — | `N` | Cluster jobs in flight at once (overrides the profile's `max_submitted`) |
 | `--provenance` | — | — | Track output file checksums for later verification |
 | `--arg` | — | — | Legacy form: set a workflow config value (`KEY=VALUE`). Repeatable. See `[config]` in workflow-format |
 | `--bundle` | — | — | Execute from a published bundle (`.tar.zst` or `.tar.gz`). Extracts, verifies checksums, shows resource requirements, and prompts for confirmation |

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2964,6 +2964,22 @@ fn cli_license_invalid_path_fails() {
         .stderr(predicate::str::contains("License verification failed"));
 }
 
+#[test]
+fn cli_license_status_json_emits_machine_readable_object() {
+    // `license --json` must not be a silent no-op: status mode emits a
+    // single JSON object with a `valid` boolean on stdout.
+    let output = oxo_flow_cmd()
+        .args(["license", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let parsed: serde_json::Value = serde_json::from_slice(&output)
+        .expect("license --json stdout must be a single JSON document");
+    assert!(parsed.get("valid").and_then(|v| v.as_bool()).is_some());
+}
+
 // ─── Config subcommand ───────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## What

From 9c's CLI↔docs consistency audit (30 commands × 30 pages):

- `dry-run --rerun` help no longer carries `--samples` residue (broken doc comment)
- global `--json` help matches actual behavior: JSON on stdout, human logs stay on stderr (previous text claimed stderr suppression that does not happen — live-verified)
- `license --json` was a silent no-op → now emits a real machine-readable object in both status and verify modes
- run.md: `--module` + `--max-submitted` rows; dry-run.md: `--module` row; resume.md: `--no-report-snapshot` row (the 4 command-level missing rows)
- test: `cli_license_status_json_emits_machine_readable_object`

## Verification

- Local `make ci` green (fmt + clippy -D warnings + workspace tests + audit), exit 0
- New test passes as part of the gate