### PR TITLE
fix(core): cache-hit envs re-verify on disk — vanished envs invalidate and rebuild

### DIFF
--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -910,6 +910,18 @@ impl EnvironmentCache {
         }
     }
 
+    /// Remove the entry for `key` — the cached environment no longer exists
+    /// on disk (migrated, deleted, or failed mid-setup). The next readiness
+    /// check misses and the setup path rebuilds it.
+    pub fn invalidate(&mut self, key: &str) {
+        if self.ready.remove(key) {
+            // Persist to file if configured
+            if let Err(e) = self.save() {
+                tracing::warn!("could not save environment cache: {}", e);
+            }
+        }
+    }
+
     /// Load cache from file.
     fn load(&mut self) -> Result<()> {
         if let Some(ref path) = self.cache_file
@@ -1035,6 +1047,12 @@ impl EnvironmentResolver {
     pub async fn cache_mark_ready(&self, key: &str) {
         let mut cache = self.cache.lock().await;
         cache.mark_ready(key);
+    }
+
+    /// Invalidate a cache entry (the cached environment vanished on disk).
+    pub async fn cache_invalidate(&self, key: &str) {
+        let mut cache = self.cache.lock().await;
+        cache.invalidate(key);
     }
 
     /// Wrap a command using the appropriate environment backend.
@@ -1759,6 +1777,18 @@ mod tests {
         cache.mark_ready("system");
         cache.mark_ready("system");
         assert!(cache.is_ready("system"));
+    }
+
+    #[test]
+    fn cache_invalidate_removes_entry() {
+        let mut cache = EnvironmentCache::new();
+        cache.mark_ready("conda:envs/qc.yaml");
+        cache.mark_ready("docker:ubuntu:22.04");
+        cache.invalidate("conda:envs/qc.yaml");
+        assert!(!cache.is_ready("conda:envs/qc.yaml"));
+        assert!(cache.is_ready("docker:ubuntu:22.04"));
+        // Invalidating an unknown key is a no-op, not an error.
+        cache.invalidate("pixi:default");
     }
 
     // ── EnvironmentResolver ────────────────────────────────────────

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -615,7 +615,33 @@ impl LocalExecutor {
         }
         let key = self.env_resolver.cache_key(env_spec);
         if self.env_resolver.cache_is_ready(&key).await {
-            return Ok(());
+            // A cache HIT is a promise, not a proof: the env may have
+            // vanished since it was recorded (box migration, manual rm,
+            // disk cleanup — live: tx-ubuntu's ENOSPC env migration left
+            // stale entries that surfaced as EnvironmentLocationNotFound
+            // at rule time). Re-verify in place; a failed check
+            // invalidates the entry and falls through to the setup path
+            // below instead of failing the rule later.
+            match self.env_resolver.verify_command(env_spec) {
+                Ok(Some(verify)) => {
+                    if self.env_verify(&verify).await {
+                        return Ok(());
+                    }
+                    tracing::warn!(
+                        rule = %rule.name,
+                        env = %key,
+                        "cached environment no longer exists; invalidating the cache entry and rebuilding"
+                    );
+                    self.env_resolver.cache_invalidate(&key).await;
+                }
+                // Backends without a filesystem env (system) or unverifiable
+                // specs: nothing to check — keep the cache hit.
+                Ok(None) => return Ok(()),
+                Err(_) => {
+                    // Unparseable spec: let the setup path produce the
+                    // proper error instead of failing here.
+                }
+            }
         }
         // Cold cache but the env may already exist (checkpoint wipe, a
         // previous run, an external `conda create`): verify it in place


### PR DESCRIPTION
## Problem

Stale `environment_cache.json` entries (env moved/deleted after being recorded) surfaced as `EnvironmentLocationNotFound` at rule execution time. Hit twice in one campaign: batch 1 (unsupervised, stale entry after env rebuild) and the heavy group (tx-ubuntu ENOSPC env migration leftovers). A cache hit previously skipped ALL verification.

## Fix

`ensure_environment_ready` cache-hit branch now re-verifies the env in place with the backend's existing verify command (conda: CONDA_PREFIX/bin existence — the issue #136 check). A failed verify invalidates the cache entry and falls through to the existing cold-cache verify → setup path, so the env rebuilds automatically.

- `EnvironmentCache::invalidate` + `EnvironmentResolver::cache_invalidate` (async wrapper)
- Backends without a filesystem env (system) or unverifiable specs keep the cache hit
- Unit test: `cache_invalidate_removes_entry`

## Verification

Local `make ci` green (exit 0): fmt + clippy -D warnings + workspace tests + audit.