### PR TITLE
feat: background runs + verified concurrent reuse of shared workflows (#158)

### DIFF
--- a/crates/oxo-flow-cli/src/background.rs
+++ b/crates/oxo-flow-cli/src/background.rs
@@ -1,0 +1,374 @@
+//! Background execution (`run --background` / `resume --background`,
+//! issue #158 idea 1).
+//!
+//! The foreground invocation never executes the workflow: it spawns a
+//! DETACHED child that re-runs the same binary with the same argv minus
+//! `--background` (every other flag passes through verbatim), writes the
+//! child's pid to `<workdir>/.oxo-flow/background.pid`, redirects the
+//! child's stdout+stderr to the run log (the tracing tee already writes
+//! there; the redirect captures anything non-tracing), prints a one-line
+//! summary on stderr, and exits 0. The child then runs the normal flow —
+//! checkpoint, workdir lock, and resume semantics are unchanged, so
+//! monitoring works through `oxo-flow status`, the run log, and report
+//! snapshots exactly as for a foreground run.
+
+use anyhow::{Context as _, Result};
+use oxo_flow_core::executor::{CheckpointState, WorkdirLock};
+use std::ffi::{OsStr, OsString};
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+/// Build the detached child's argv from the foreground process's full
+/// argument list (`std::env::args_os()`, argv[0] included): drop argv[0]
+/// (the spawn replaces it with [`std::env::current_exe`]) and every exact
+/// `--background` token. Exact-token removal is safe because this helper
+/// only runs after clap parsed `background = true` — the flag was consumed
+/// as a flag, never as another option's value — so the remainder re-parses
+/// to the identical command line minus the flag.
+pub fn strip_background_flag(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
+    args.into_iter()
+        .skip(1) // argv[0]: replaced by current_exe() in spawn_detached
+        .filter(|arg| arg.as_os_str() != OsStr::new("--background"))
+        .collect()
+}
+
+/// Resolve the run-log path exactly like `run_command` (issue #136 fix 4):
+/// an absolute `--log-file` passes through, a relative one resolves against
+/// the workdir, and the default is `<workdir>/.oxo-flow/logs/oxo-flow.log`.
+pub fn resolve_log_path(workdir: &Path, log_file: Option<&Path>) -> PathBuf {
+    match log_file {
+        Some(p) if p.is_absolute() => p.to_path_buf(),
+        Some(p) => workdir.join(p),
+        None => workdir.join(".oxo-flow/logs/oxo-flow.log"),
+    }
+}
+
+/// Effective workdir for a background `run`, mirroring `run_command`'s
+/// resolution (issue #68): explicit `--workdir` wins; repository runs
+/// (nextflow-style URLs) execute from the current directory; otherwise the
+/// workflow's own directory. `--bundle` without `--workdir` is refused: the
+/// bundle's extracted directory is created per-process, so the foreground
+/// invocation cannot predict where the child will run.
+pub fn background_workdir_for_run(
+    workflow: Option<&Path>,
+    workdir: Option<&Path>,
+    bundle: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(wd) = workdir {
+        return Ok(wd.to_path_buf());
+    }
+    if bundle.is_some() {
+        anyhow::bail!(
+            "run --background with --bundle requires an explicit --workdir: the bundle's \
+             extracted directory is created per-process and cannot be predicted from the \
+             foreground invocation.\n\
+             Use: oxo-flow run --bundle <bundle> --workdir <dir> --yes --background"
+        );
+    }
+    let wf = match workflow {
+        Some(w) => w.to_path_buf(),
+        None => crate::commands::resolve_workflow(None)?,
+    };
+    if crate::commands::pull::classify_run_source(&wf.to_string_lossy()).is_some() {
+        Ok(std::env::current_dir()?)
+    } else {
+        Ok(oxo_flow_core::parent_dir(&wf).to_path_buf())
+    }
+}
+
+/// Effective workdir for a background `resume`, mirroring `resume_command`:
+/// explicit `--workdir` > the workdir the checkpoint records > the recorded
+/// workflow's directory.
+pub fn background_workdir_for_resume(checkpoint: &Path, workdir: Option<&Path>) -> Result<PathBuf> {
+    if let Some(wd) = workdir {
+        return Ok(wd.to_path_buf());
+    }
+    let state = CheckpointState::load_from_file(checkpoint)?;
+    if let Some(wd) = state.workdir {
+        return Ok(PathBuf::from(wd));
+    }
+    if let Some(wf) = state.workflow_path {
+        return Ok(oxo_flow_core::parent_dir(Path::new(&wf)).to_path_buf());
+    }
+    anyhow::bail!(
+        "cannot resolve a working directory for the background resume: the checkpoint \
+         records neither a workdir nor a workflow path"
+    )
+}
+
+/// Spawn the detached child: same binary, `args`, stdout+stderr redirected
+/// to the run log. Unix: the child gets its own process group, so it
+/// survives the terminal's SIGHUP (and Ctrl-C's SIGINT targets the
+/// foreground group, not this child). Windows: CREATE_NEW_PROCESS_GROUP |
+/// DETACHED_PROCESS. The log is opened in append mode — the child's
+/// `activate_run_log` truncates it and the tracing tee writes the header;
+/// the inherited descriptors capture anything the tee does not.
+fn spawn_detached(args: &[OsString], log_path: &Path) -> io::Result<Child> {
+    // The child's `activate_run_log` creates parent directories for the log;
+    // the parent must do the same before it can open the redirect target.
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .args(args)
+        .stdout(Stdio::from(log.try_clone()?))
+        .stderr(Stdio::from(log));
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        command.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+    }
+    command.spawn()
+}
+
+/// Write the child's pid to `<workdir>/.oxo-flow/background.pid`. The
+/// `.oxo-flow` directory is created here so the pid file's placement never
+/// depends on the child acquiring the workdir lock first.
+fn write_pid_file(workdir: &Path, pid: u32) -> io::Result<PathBuf> {
+    let dir = workdir.join(".oxo-flow");
+    fs::create_dir_all(&dir)?;
+    let path = dir.join("background.pid");
+    fs::write(&path, format!("{pid}\n"))?;
+    Ok(path)
+}
+
+/// Spawn the detached child, record its pid, print the one-line summary on
+/// stderr, and return. The caller exits 0; the child runs the normal flow.
+pub fn launch_in_background(args: &[OsString], workdir: &Path, log_path: &Path) -> Result<()> {
+    // Fail fast instead of reporting "started" for a child that would
+    // immediately die on the workdir lock (issue #70). Advisory: the child
+    // still enforces the lock itself.
+    if WorkdirLock::is_locked(workdir) {
+        anyhow::bail!(
+            "another run is already active in {} — the background run would fail on the \
+             workdir lock ({}); wait for it to finish or stop it first",
+            workdir.display(),
+            workdir.join(".oxo-flow/lock").display()
+        );
+    }
+    let child = spawn_detached(args, log_path).with_context(|| {
+        format!(
+            "failed to spawn the background process (log: {})",
+            log_path.display()
+        )
+    })?;
+    let pid = child.id();
+    let pid_file = write_pid_file(workdir, pid)?;
+    let checkpoint = workdir.join(".oxo-flow/checkpoint.json");
+    eprintln!(
+        "started in background (pid {pid}) · log: {} · monitor: oxo-flow status {} · stop: kill {pid}",
+        log_path.display(),
+        checkpoint.display()
+    );
+    tracing::info!(
+        pid,
+        pid_file = %pid_file.display(),
+        log = %log_path.display(),
+        "run detached into background"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn strip_background_flag_drops_argv0_and_flag_keeps_rest() {
+        // Full args_os() shape: argv[0] first, the flag anywhere after.
+        let args = os(&[
+            "/usr/bin/oxo-flow",
+            "run",
+            "--background",
+            "wf.oxoflow",
+            "-j",
+            "4",
+        ]);
+        assert_eq!(
+            strip_background_flag(args),
+            os(&["run", "wf.oxoflow", "-j", "4"])
+        );
+    }
+
+    #[test]
+    fn strip_background_flag_handles_leading_global_flags() {
+        let args = os(&[
+            "/usr/bin/oxo-flow",
+            "--json",
+            "run",
+            "wf.oxoflow",
+            "--background",
+        ]);
+        assert_eq!(
+            strip_background_flag(args),
+            os(&["--json", "run", "wf.oxoflow"])
+        );
+    }
+
+    #[test]
+    fn strip_background_flag_keeps_values_that_merely_contain_the_token() {
+        // A config override value that contains "--background" is NOT the
+        // flag and must survive (the flag itself was already consumed by
+        // clap as a flag for the helper to be called at all).
+        let args = os(&[
+            "/usr/bin/oxo-flow",
+            "run",
+            "wf.oxoflow",
+            "TAG=--background",
+            "--background",
+            "NAME=x",
+        ]);
+        assert_eq!(
+            strip_background_flag(args),
+            os(&["run", "wf.oxoflow", "TAG=--background", "NAME=x"])
+        );
+    }
+
+    #[test]
+    fn resolve_log_path_defaults_under_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_log_path(dir.path(), None),
+            dir.path().join(".oxo-flow/logs/oxo-flow.log")
+        );
+    }
+
+    #[test]
+    fn resolve_log_path_joins_relative_log_file_against_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_log_path(dir.path(), Some(Path::new("logs/custom.log"))),
+            dir.path().join("logs/custom.log")
+        );
+    }
+
+    #[test]
+    fn resolve_log_path_passes_absolute_log_file_through() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_log_path(dir.path(), Some(Path::new("/tmp/abs.log"))),
+            PathBuf::from("/tmp/abs.log")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_run_prefers_explicit_workdir() {
+        let wf = Path::new("/data/wf.oxoflow");
+        let wd = Path::new("/analysis");
+        assert_eq!(
+            background_workdir_for_run(Some(wf), Some(wd), None).unwrap(),
+            PathBuf::from("/analysis")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_run_defaults_to_workflow_parent() {
+        let wf = Path::new("/data/nested/wf.oxoflow");
+        assert_eq!(
+            background_workdir_for_run(Some(wf), None, None).unwrap(),
+            PathBuf::from("/data/nested")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_run_uses_cwd_for_repository_runs() {
+        let wf = Path::new("gh:owner/pipeline@v1.2.3");
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            background_workdir_for_run(Some(wf), None, None).unwrap(),
+            cwd
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_run_refuses_bundle_without_workdir() {
+        let err = background_workdir_for_run(None, None, Some(Path::new("b.tgz")))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("--workdir"),
+            "bundle+background without --workdir must name the fix: {err}"
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_run_accepts_bundle_with_workdir() {
+        let wd = Path::new("/analysis");
+        assert_eq!(
+            background_workdir_for_run(None, Some(wd), Some(Path::new("b.tgz"))).unwrap(),
+            PathBuf::from("/analysis")
+        );
+    }
+
+    /// `completed_rules`/`failed_rules`/`benchmarks` are required checkpoint
+    /// fields (no serde defaults), so every fixture carries them.
+    fn checkpoint_with(dir: &Path, extra: &str) -> PathBuf {
+        let path = dir.join("checkpoint.json");
+        fs::write(
+            &path,
+            format!(
+                r#"{{"completed_rules": [], "failed_rules": [], "benchmarks": {{}}, {extra}}}"#
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn background_workdir_for_resume_prefers_explicit_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let ck = checkpoint_with(dir.path(), r#""workdir": "/wrong""#);
+        assert_eq!(
+            background_workdir_for_resume(&ck, Some(Path::new("/right"))).unwrap(),
+            PathBuf::from("/right")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_resume_uses_checkpoint_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let ck = checkpoint_with(dir.path(), r#""workdir": "/recorded/wd""#);
+        assert_eq!(
+            background_workdir_for_resume(&ck, None).unwrap(),
+            PathBuf::from("/recorded/wd")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_resume_falls_back_to_workflow_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let ck = checkpoint_with(dir.path(), r#""workflow_path": "/repo/nested/wf.oxoflow""#);
+        assert_eq!(
+            background_workdir_for_resume(&ck, None).unwrap(),
+            PathBuf::from("/repo/nested")
+        );
+    }
+
+    #[test]
+    fn background_workdir_for_resume_errors_without_recorded_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let ck = checkpoint_with(dir.path(), r#""workflow_name": "x""#);
+        assert!(
+            background_workdir_for_resume(&ck, None).is_err(),
+            "a checkpoint with no workdir and no workflow path cannot resolve a workdir"
+        );
+    }
+}

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -582,7 +582,14 @@ pub async fn run_command(
     // releases it automatically if this process exits or crashes, so there
     // are no stale locks.
     let workdir_effective = workdir.as_ref().unwrap_or(&workdir_default);
-    let _workdir_lock = WorkdirLock::acquire(workdir_effective)?;
+    // Surface the lock error's suggestion (issue #158): without it a user
+    // hitting a busy workdir learns WHAT is wrong but not that the lock
+    // auto-releases when the other process exits.
+    let _workdir_lock =
+        WorkdirLock::acquire(workdir_effective).map_err(|e| match e.suggestion() {
+            Some(s) => anyhow::anyhow!("{e}\n  hint: {s}"),
+            None => anyhow::anyhow!("{e}"),
+        })?;
 
     let mut config = WorkflowConfig::from_file(&workflow)
         .with_context(|| format!("failed to parse {}", workflow.display()))?;

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -3,6 +3,7 @@
 //!
 //! Provides subcommands for running, validating, and managing workflows.
 
+mod background;
 pub mod banner;
 pub mod commands;
 mod logging;
@@ -188,6 +189,14 @@ pub enum Commands {
             help = "Cluster jobs in flight at once (overrides the profile's max_submitted)"
         )]
         max_submitted: Option<usize>,
+        /// Detach execution into a background process: the foreground
+        /// invocation spawns a detached child that re-runs this command
+        /// without the flag, writes its pid to .oxo-flow/background.pid,
+        /// prints a summary on stderr, and exits 0 immediately. Monitor
+        /// with `oxo-flow status`, the run log, or report snapshots; stop
+        /// with `kill <pid>` (the pid is in the summary and the pid file).
+        #[arg(long)]
+        background: bool,
     },
     /// Resume an interrupted workflow from a checkpoint.
     Resume {
@@ -233,6 +242,13 @@ pub enum Commands {
             help = "Skip the automatic report snapshot after the resumed run"
         )]
         no_report_snapshot: bool,
+        /// Detach the resumed run into a background process: the foreground
+        /// invocation spawns a detached child that re-runs `resume` without
+        /// the flag, writes its pid to .oxo-flow/background.pid, prints a
+        /// summary on stderr, and exits 0 immediately (see `run
+        /// --background`).
+        #[arg(long)]
+        background: bool,
     },
     /// Preview execution without running any commands.
     DryRun {
@@ -1106,7 +1122,30 @@ async fn main() -> Result<()> {
             rerun,
             no_report_snapshot,
             max_submitted,
+            background,
         } => {
+            // ── Background runs (issue #158) ─────────────────────────────
+            // The foreground process never executes the workflow: it spawns
+            // a DETACHED child that re-runs the same command without
+            // --background (same argv, so --bundle/--profile/--samples/…
+            // pass through verbatim), writes the child's pid, prints a
+            // one-line summary on stderr, and exits 0. The child then runs
+            // the normal flow — checkpoint, workdir lock, and resume
+            // semantics are unchanged. Bundle confirmation still applies in
+            // the child; a detached child cannot prompt, so bundle runs
+            // need --yes (fail-closed, same as any non-interactive session).
+            if background {
+                let bg_workdir = crate::background::background_workdir_for_run(
+                    workflow.as_deref(),
+                    workdir.as_deref(),
+                    bundle.as_deref(),
+                )?;
+                let log_path =
+                    crate::background::resolve_log_path(&bg_workdir, log_file.as_deref());
+                let args = crate::background::strip_background_flag(std::env::args_os());
+                crate::background::launch_in_background(&args, &bg_workdir, &log_path)?;
+                std::process::exit(0);
+            }
             use anyhow::Context as _;
             use colored::Colorize as _;
             #[allow(unused_imports)]
@@ -1243,7 +1282,22 @@ async fn main() -> Result<()> {
             timeout,
             workdir,
             no_report_snapshot,
+            background,
         } => {
+            // ── Background resume (issue #158) ───────────────────────────
+            // Same detach contract as `run --background`; the workdir comes
+            // from the checkpoint when --workdir is not given, exactly as
+            // `resume_command` resolves it.
+            if background {
+                let bg_workdir = crate::background::background_workdir_for_resume(
+                    &checkpoint,
+                    workdir.as_deref(),
+                )?;
+                let log_path = crate::background::resolve_log_path(&bg_workdir, None);
+                let args = crate::background::strip_background_flag(std::env::args_os());
+                crate::background::launch_in_background(&args, &bg_workdir, &log_path)?;
+                std::process::exit(0);
+            }
             resume_command(
                 checkpoint,
                 jobs,

--- a/docs/guide/mkdocs.yml
+++ b/docs/guide/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
       - Generate Reports: how-to/generate-reports.md
       - Experiment-Control Pairing: how-to/experiment-control-pairing.md
       - Cohort Sample Groups: how-to/cohort-sample-groups.md
+      - Concurrent Runs: how-to/concurrent-runs.md
       - Conditional Rules: how-to/conditional-rules.md
       - China Mirrors: how-to/china-mirrors.md
       - Editor Setup: how-to/editor-setup.md

--- a/docs/guide/src/commands/resume.md
+++ b/docs/guide/src/commands/resume.md
@@ -46,6 +46,7 @@ re-execute the affected rules (see
 | `--keep-going` | `-k` | Continue execution when a job fails (same semantics as `run`) |
 | `--timeout <SECS>` | — | Timeout per job in seconds (0 = disabled), or a duration like `1h`/`30m` |
 | `--no-report-snapshot` | — | Skip the automatic report snapshot after the resumed run (same flag as `run`) |
+| `--background` | — | Detach the resumed run into a background process and exit 0 immediately (see [Background runs (--background)](run.md#background-runs---background)) |
 
 ## Examples
 
@@ -67,6 +68,8 @@ oxo-flow resume .oxo-flow/checkpoint.json -j 4
   The standalone `resume` command is useful for explicitly re-running after
   inspecting the checkpoint state.
 - Use `oxo-flow status` to inspect the checkpoint before resuming.
+- `--background` detaches the resumed run (see
+  [run's Background runs section](run.md#background-runs---background)).
 
 ## See Also
 

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -51,6 +51,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--samples` | — | `LIST` | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--rerun` | — | — | Force re-execution of this run's rules (ignore up-to-date checks). Checkpoint records for rules outside this run are kept |
 | `--no-report-snapshot` | — | — | Skip the automatic report snapshot written after the run (see [Report snapshots](#report-snapshots)); `resume` has the same flag |
+| `--background` | — | — | Detach the run into a background process and exit 0 immediately (see [Background runs (--background)](#background-runs---background)) |
 | `--verbose` | `-v` | — | Enable debug-level logging |
 
 ---
@@ -480,6 +481,60 @@ Semantics:
   reported as workflow-level inputs.
 - The report is also available as JSON via `dry-run --json` (the `samples`
   block), and `--samples ready` works in `test --run` as well.
+
+---
+
+## Background runs (`--background`)
+
+`run --background` (and `resume --background`) detaches execution into a
+background process and returns to the shell immediately:
+
+```bash
+# Foreground prints one line and exits 0; the run continues in the background
+oxo-flow run pipeline.oxoflow --background
+#   started in background (pid 48291) · log: .oxo-flow/logs/oxo-flow.log ·
+#   monitor: oxo-flow status .oxo-flow/checkpoint.json · stop: kill 48291
+
+# Detach a resumed run the same way
+oxo-flow resume .oxo-flow/checkpoint.json --background
+```
+
+Mechanics:
+
+- The foreground process spawns a **detached child** that re-runs the same
+  command with `--background` removed — every other flag (`-j`, `--profile`,
+  `--samples`, `--rerun`, `--log-file`, …) passes through verbatim, so a
+  background run behaves exactly like a foreground one: checkpoint, workdir
+  lock, report snapshots, and resume semantics are unchanged.
+- The child's stdout and stderr are redirected to the run log
+  (`--log-file` if given, otherwise `.oxo-flow/logs/oxo-flow.log` in the
+  workdir) — the tracing stream lands there too, so the log records the
+  whole run.
+- The child's pid is written to `.oxo-flow/background.pid` in the workdir
+  (also shown in the summary).
+- The child gets its own process group, so it survives terminal close and
+  Ctrl-C at the shell — it keeps running until it finishes or is killed.
+- The foreground exits **0** once the child is spawned; it does not wait.
+  If the spawn fails (for example because another run already holds the
+  workdir lock), the foreground exits nonzero with the reason.
+
+Monitoring a background run works exactly like a foreground one: poll
+`oxo-flow status .oxo-flow/checkpoint.json` (or `status --timing`), read
+the run log, and check the report snapshots in `.oxo-flow/reports/`. Stop
+a background run with `kill <pid>` (Unix) or `taskkill /PID <pid>` —
+the pid is in the summary line and in `.oxo-flow/background.pid`.
+
+Notes:
+
+- Combined with the global `--json`, the foreground still prints its
+  one-line summary to **stderr** and exits 0; stdout stays empty (the JSON
+  run summary belongs to the actual run, which happens in the child).
+- Bundle runs need an explicit `--workdir` (the bundle's extracted
+  directory is created per-process, so it cannot be predicted from the
+  foreground invocation) and `--yes` — a detached child cannot prompt.
+- `--background` is a launcher flag, not a workflow setting: the child
+  re-parses the remaining argv, so flag ordering rules (run flags before
+  `KEY=VALUE` overrides) apply to the whole command line as usual.
 
 ---
 

--- a/docs/guide/src/how-to/concurrent-runs.md
+++ b/docs/guide/src/how-to/concurrent-runs.md
@@ -1,0 +1,79 @@
+# Concurrent Runs
+
+This guide explains how oxo-flow behaves when the same workflow is run more
+than once — at the same time, or one after another — and the pattern for
+sharing one workflow across many analyses.
+
+---
+
+## The guarantee
+
+A single workflow file is safe to reuse in three ways at once:
+
+- **Many workdirs, concurrently** — any number of `oxo-flow run` invocations
+  can execute the same workflow file at the same time, each in its own
+  workdir (`-d`). Every run gets its own checkpoint, logs, chunks, and
+  outputs; the workflow file itself is only ever read.
+- **Many users, concurrently** — runs under different `HOME`s are fully
+  isolated (config, per-user state), and the one shared piece of state
+  outside the workdir — the module cache used by git-pinned
+  `[[include]]`s — is clone-locked, so two processes fetching the same
+  module at the same time are serialized instead of racing (one clones,
+  the other waits and reuses).
+- **One workdir, exclusively** — two runs pointed at the *same* workdir
+  are refused: the second fails fast with
+  `Error: workdir is locked by another oxo-flow process`, and the lock
+  releases automatically when the first run exits (even if it crashes).
+
+Re-running the same workflow later from a new workdir starts from a fresh
+checkpoint; nothing written by an earlier run leaks into the new one.
+
+---
+
+## What is shared vs per-workdir
+
+| | Shared across concurrent runs | Per workdir (`-d` / workdir) |
+|---|---|---|
+| Workflow file (`.oxoflow`) | Read-only — never written | — |
+| Git-pinned `[[include]]` module cache (`~/.cache/oxo-flow/modules`, or `$OXO_FLOW_MODULE_CACHE`) | Clone-locked, safe to share | — |
+| Profiles (`profiles/*.toml` next to the workflow) | Read-only, shared | — |
+| Checkpoint (`.oxo-flow/checkpoint.json`) | — | Own checkpoint per workdir |
+| Logs (`.oxo-flow/logs/`) | — | Own logs per workdir |
+| Transform chunks (`.oxo-flow/chunks/`) | — | Own chunks per workdir |
+| Outputs / intermediate files | — | Written in the workdir |
+| Environment setups (`envs_dir`) | — | Resolved per run |
+
+The workdir lock lives at `.oxo-flow/lock` inside each workdir — that is
+why different workdirs never contend, and why the same workdir refuses a
+second concurrent run before any rule starts.
+
+---
+
+## The recommended pattern
+
+Keep the workflow in one read-only location and run each analysis in its
+own workdir:
+
+```bash
+# One shared workflow file, e.g. in a central repo directory
+ls /share/pipelines/rnaseq.oxoflow
+
+# Each analysis gets its own workdir — these run concurrently and safely
+oxo-flow run /share/pipelines/rnaseq.oxoflow -d analyses/sample-A
+oxo-flow run /share/pipelines/rnaseq.oxoflow -d analyses/sample-B
+```
+
+The workflow directory only needs to be readable — a `chmod 555` central
+directory (or a read-only mount) works fine; the engine never writes next
+to the workflow file. Per-analysis `-d` directories hold everything that
+varies: checkpoints, logs, chunks, and outputs.
+
+---
+
+## Troubleshooting
+
+**`Error: workdir is locked by another oxo-flow process: <path>`**
+
+Another run is active in that workdir (or a previous one crashed mid-run —
+the lock releases automatically, so this is transient). Wait for it to
+finish, or point the new run at a fresh workdir with `-d`.

--- a/tests/background_run.rs
+++ b/tests/background_run.rs
@@ -1,0 +1,365 @@
+//! Background-run integration tests (issue #158 idea 1).
+//!
+//! `run --background` / `resume --background` must return immediately with
+//! exit 0 while a DETACHED child runs the workflow to completion: the pid
+//! file lands in the workdir, the run log carries the version header (the
+//! child's tracing tee works), the checkpoint reflects the completed rules,
+//! and the child process is gone once the run finishes.
+//!
+//! Kept in a dedicated crate so parallel sessions can own the other
+//! integration-test files independently (each integration-test crate
+//! compiles and links on its own).
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// Locate a workspace binary by name from the target directory.
+///
+/// This handles the case where binaries are defined in workspace sub-crates
+/// rather than the root package, which means `CARGO_BIN_EXE_*` env vars
+/// are not automatically set.
+fn workspace_bin(name: &str) -> PathBuf {
+    // Cargo sets OUT_DIR for build scripts and CARGO_MANIFEST_DIR for the package.
+    // For integration tests, we can derive the target dir from the test binary location.
+    let mut target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+
+    // Try the binary directly in the target/debug (or target/release) directory.
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    // On Windows, binaries have a .exe extension.
+    let candidate_exe = target_dir.join(format!("{name}.exe"));
+    if candidate_exe.exists() {
+        return candidate_exe;
+    }
+
+    // Fall back to the deps subdirectory.
+    target_dir = target_dir.join("deps");
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+fn oxo_flow_cmd() -> Command {
+    Command::new(workspace_bin("oxo-flow"))
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+/// Poll `cond` every 500ms until it returns true or `timeout` elapses.
+fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    cond()
+}
+
+/// Whether a process with the given pid currently exists (and is not a
+/// zombie). `ps -p` on Unix; `tasklist` on Windows.
+#[cfg(unix)]
+fn process_alive(pid: u32) -> bool {
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn process_alive(pid: u32) -> bool {
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}")])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Read and parse the background pid file.
+fn read_pid_file(dir: &std::path::Path) -> u32 {
+    let text = fs::read_to_string(dir.join(".oxo-flow/background.pid"))
+        .expect("background.pid must be written by the foreground process");
+    text.trim()
+        .parse()
+        .expect("background.pid must contain a numeric pid")
+}
+
+/// Whether the checkpoint records `rule` as completed.
+fn checkpoint_completed(dir: &std::path::Path, rule: &str) -> bool {
+    let Ok(text) = fs::read_to_string(dir.join(".oxo-flow/checkpoint.json")) else {
+        return false;
+    };
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return false;
+    };
+    doc["completed_rules"]
+        .as_array()
+        .map(|rules| rules.iter().any(|r| r == rule))
+        .unwrap_or(false)
+}
+
+/// A workflow whose single rule sleeps briefly so the detached child is
+/// provably alive right after the foreground returns, then writes out.txt.
+fn trivial_workflow(dir: &std::path::Path, name: &str) -> PathBuf {
+    let wf = dir.join(format!("{name}.oxoflow"));
+    fs::write(
+        &wf,
+        format!(
+            "[workflow]\nname = \"{name}\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"sleep 1 && echo hi > {{output}}\"\n"
+        ),
+    )
+    .unwrap();
+    wf
+}
+
+// ─── run --background (issue #158 idea 1) ──────────────────────────────
+
+/// The foreground invocation must exit 0 almost immediately (it only spawns
+/// the detached child), the pid file must name a process that is alive right
+/// after the spawn, and the workflow must complete in the background — the
+/// checkpoint records the rule and out.txt exists. Once complete, the child
+/// process is gone.
+#[test]
+fn cli_run_background_returns_immediately_and_completes() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = trivial_workflow(dir.path(), "bg");
+
+    let started = Instant::now();
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--background"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        output.status.success(),
+        "foreground run --background must exit 0: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "foreground must return immediately (took {elapsed:?}), not run the workflow"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a background run must not emit the run's stdout from the foreground"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("started in background (pid"),
+        "summary must announce the background pid, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("oxo-flow status"),
+        "summary must name the monitoring command, got: {stderr}"
+    );
+
+    // The pid file names a live process right after the spawn (the rule
+    // sleeps 1s, so the child cannot have finished yet).
+    let pid = read_pid_file(dir.path());
+    assert!(
+        process_alive(pid),
+        "child pid {pid} must be alive right after the foreground returns"
+    );
+
+    // … and the workflow completes in the background.
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            dir.path().join("out.txt").exists() && checkpoint_completed(dir.path(), "gen")
+        }),
+        "workflow must complete in the background within 60s (child {pid} alive: {})",
+        process_alive(pid)
+    );
+
+    // Once complete, the child process is gone.
+    assert!(
+        !process_alive(pid),
+        "child pid {pid} must be gone after the background run completes"
+    );
+}
+
+// ─── resume --background (issue #158 idea 1) ───────────────────────────
+
+/// A failed run leaves the checkpoint; after the failure cause is fixed,
+/// `resume <checkpoint> --background` must complete the remaining rules in
+/// the background: foreground exits 0 immediately, both rules complete, and
+/// the child process is gone afterwards.
+#[test]
+fn cli_resume_background_completes_remaining_rule() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("bgres.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"bgres\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"step1\"\noutput = [\"out1.txt\"]\nshell = \"test -f go.txt && echo ok > {output} || { echo 'step1 needs go.txt'; exit 1; }\"\n\n[[rules]]\nname = \"step2\"\noutput = [\"out2.txt\"]\nshell = \"echo done > {output}\"\ndepends_on = [\"step1\"]\n",
+    )
+    .unwrap();
+
+    // First run fails at step1 (go.txt absent); step2 never runs.
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+    assert!(
+        !dir.path().join("out2.txt").exists(),
+        "step2 must not run while step1 failed"
+    );
+
+    // Fix the condition, then resume in the background.
+    fs::write(dir.path().join("go.txt"), "go\n").unwrap();
+    let checkpoint = dir.path().join(".oxo-flow/checkpoint.json");
+    let started = Instant::now();
+    let output = oxo_flow_cmd()
+        .args(["resume", checkpoint.to_str().unwrap(), "--background"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        output.status.success(),
+        "foreground resume --background must exit 0: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "foreground resume must return immediately (took {elapsed:?})"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("started in background (pid"),
+        "resume summary must announce the background pid"
+    );
+
+    let pid = read_pid_file(dir.path());
+    assert!(
+        process_alive(pid),
+        "child pid {pid} must be alive right after the foreground returns"
+    );
+
+    assert!(
+        wait_until(Duration::from_secs(60), || {
+            dir.path().join("out2.txt").exists()
+                && checkpoint_completed(dir.path(), "step1")
+                && checkpoint_completed(dir.path(), "step2")
+        }),
+        "resume must complete both rules in the background within 60s (child {pid} alive: {})",
+        process_alive(pid)
+    );
+    assert!(
+        !process_alive(pid),
+        "child pid {pid} must be gone after the resumed background run completes"
+    );
+}
+
+// ─── pid file + run log (child tee) ────────────────────────────────────
+
+/// The pid file lives at `<workdir>/.oxo-flow/background.pid` and the run
+/// log — written by the CHILD's tracing tee, not the foreground — carries
+/// the version header naming the workflow.
+#[test]
+fn cli_run_background_pid_file_and_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = trivial_workflow(dir.path(), "bgl");
+
+    oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--background"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        wait_until(Duration::from_secs(60), || checkpoint_completed(
+            dir.path(),
+            "gen"
+        )),
+        "workflow must complete in the background within 60s"
+    );
+
+    // Pid file: exists with a numeric pid naming a now-gone process.
+    let pid_text = fs::read_to_string(dir.path().join(".oxo-flow/background.pid"))
+        .expect("background.pid must exist");
+    let pid: u32 = pid_text
+        .trim()
+        .parse()
+        .expect("background.pid must contain a numeric pid");
+    assert!(
+        !process_alive(pid),
+        "child pid {pid} must be gone after the background run completes"
+    );
+
+    // Run log: the child's tracing tee wrote the version header.
+    let log = fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log"))
+        .expect("the child's run log must exist");
+    assert!(
+        log.contains("oxo-flow run log"),
+        "run log must carry the header, got: {log}"
+    );
+    assert!(
+        log.contains("oxo-flow: v"),
+        "run log must carry the version header, got: {log}"
+    );
+    assert!(
+        log.contains("workflow_name: bgl"),
+        "run log must name the workflow, got: {log}"
+    );
+}
+
+// ─── --background combined with --json ─────────────────────────────────
+
+/// `--background` + `--json`: the foreground prints its summary to stderr
+/// and exits 0 — stdout stays empty (the JSON run summary belongs to the
+/// actual run, which happens in the child; documented in run.md).
+#[test]
+fn cli_run_background_with_json_exits_zero_and_keeps_stdout_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = trivial_workflow(dir.path(), "bgj");
+
+    let output = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--background", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "run --background --json must exit 0: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "--background must not emit the run's JSON summary from the foreground"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("started in background (pid"),
+        "the background summary must be on stderr"
+    );
+
+    // The workflow still completes in the background.
+    assert!(
+        wait_until(Duration::from_secs(60), || checkpoint_completed(
+            dir.path(),
+            "gen"
+        )),
+        "workflow must complete in the background within 60s"
+    );
+}

--- a/tests/concurrency_reuse.rs
+++ b/tests/concurrency_reuse.rs
@@ -1,0 +1,566 @@
+//! Concurrency and reuse guarantees for shared workflows (issue #158, idea 2).
+//!
+//! One workflow file must be safely runnable by many users and many workdirs
+//! at the same time, while a single workdir stays exclusive. These tests pin
+//! that contract end-to-end through the compiled `oxo-flow` binary:
+//!
+//! 1. same workflow, different workdirs, truly concurrent — both succeed,
+//!    each workdir carries its own outputs + checkpoint, no cross-talk;
+//! 2. different HOME users sharing one module cache with a git-pinned
+//!    `[[include]]` from a local file:// repo — both succeed concurrently
+//!    (the cache clone is CloneLock-serialized, issue #136);
+//! 3. same workdir, concurrent — the second run fails fast with the
+//!    workdir-lock message instead of racing the checkpoint (issue #70);
+//! 4. workflow in a read-only directory — concurrent runs with per-analysis
+//!    `-d` workdirs both succeed (nothing writes next to the workflow file);
+//! 5. sequential reuse — a second run from a fresh workdir is unaffected by
+//!    the first (independent checkpoint, rules execute fresh).
+//!
+//! Kept in a dedicated crate so parallel sessions can own other integration
+//! tests independently (each integration-test crate compiles and links on
+//! its own).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+/// Locate a workspace binary by name from the target directory.
+///
+/// This handles the case where binaries are defined in workspace sub-crates
+/// rather than the root package, which means `CARGO_BIN_EXE_*` env vars
+/// are not automatically set.
+fn workspace_bin(name: &str) -> PathBuf {
+    // Cargo sets OUT_DIR for build scripts and CARGO_MANIFEST_DIR for the package.
+    // For integration tests, we can derive the target dir from the test binary location.
+    let mut target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+
+    // Try the binary directly in the target/debug (or target/release) directory.
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    // On Windows, binaries have a .exe extension.
+    let candidate_exe = target_dir.join(format!("{name}.exe"));
+    if candidate_exe.exists() {
+        return candidate_exe;
+    }
+
+    // Fall back to the deps subdirectory.
+    target_dir = target_dir.join("deps");
+    let candidate = target_dir.join(name);
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+fn oxo_flow_bin() -> &'static str {
+    "oxo-flow"
+}
+
+/// Write a minimal workflow whose single rule records its working directory
+/// (after an optional sleep) into `out.txt` — the workdir-relative shell
+/// path makes each run's output prove which workdir it executed in.
+fn write_pwd_workflow(dir: &Path, name: &str, sleep_secs: u64) -> PathBuf {
+    let wf = dir.join(format!("{name}.oxoflow"));
+    let sleep = if sleep_secs > 0 {
+        format!("sleep {sleep_secs} && ")
+    } else {
+        String::new()
+    };
+    fs::write(
+        &wf,
+        format!(
+            "[workflow]\nname = \"{name}\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"gen\"\noutput = [\"out.txt\"]\nshell = \"{sleep}pwd > {{output}}\"\n"
+        ),
+    )
+    .unwrap();
+    wf
+}
+
+/// Spawn a run of `wf` in `workdir` with extra env vars, capturing output.
+fn spawn_run(wf: &Path, workdir: &Path, envs: &[(&str, &str)]) -> Child {
+    let mut cmd = Command::new(workspace_bin(oxo_flow_bin()));
+    cmd.args(["run", wf.to_str().unwrap(), "-d", workdir.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.spawn().expect("failed to spawn oxo-flow run")
+}
+
+/// Wait for a child up to `deadline`; on expiry kill it and return `None`.
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Option<Output> {
+    let start = Instant::now();
+    loop {
+        match child.try_wait().expect("failed to poll child") {
+            Some(status) => {
+                // Read the remaining piped output.
+                let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+                let mut stderr = std::io::BufReader::new(child.stderr.take().unwrap());
+                use std::io::Read;
+                let mut out_buf = Vec::new();
+                let mut err_buf = Vec::new();
+                stdout.read_to_end(&mut out_buf).unwrap();
+                stderr.read_to_end(&mut err_buf).unwrap();
+                return Some(Output {
+                    status,
+                    stdout: out_buf,
+                    stderr: err_buf,
+                });
+            }
+            None => {
+                if start.elapsed() > deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// Poll until a path exists or the deadline passes.
+fn wait_until_exists(path: &Path, deadline: Duration) -> bool {
+    let start = Instant::now();
+    while !path.exists() {
+        if start.elapsed() > deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    true
+}
+
+fn canonical(s: &Path) -> String {
+    fs::canonicalize(s)
+        .unwrap_or_else(|e| panic!("cannot canonicalize {}: {e}", s.display()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+// ─── Scenario 1: same workflow, different workdirs, concurrent ──────────
+
+/// One workflow file, two simultaneous runs in two workdirs: both must
+/// succeed, each workdir must get its own checkpoint and its own outputs,
+/// and the outputs must not be cross-contaminated — each out.txt must
+/// contain exactly its own workdir's path (the shell `pwd` runs in the
+/// workdir).
+#[test]
+fn cli_same_workflow_different_workdirs_concurrent() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_pwd_workflow(dir.path(), "shared", 1);
+    let wd_a = dir.path().join("wdA");
+    let wd_b = dir.path().join("wdB");
+    fs::create_dir_all(&wd_a).unwrap();
+    fs::create_dir_all(&wd_b).unwrap();
+
+    // Spawn both ~simultaneously, then wait for both.
+    let mut child_a = spawn_run(&wf, &wd_a, &[]);
+    let mut child_b = spawn_run(&wf, &wd_b, &[]);
+    let out_a = wait_with_deadline(&mut child_a, Duration::from_secs(30))
+        .expect("run A must finish within 30s");
+    let out_b = wait_with_deadline(&mut child_b, Duration::from_secs(30))
+        .expect("run B must finish within 30s");
+
+    assert!(
+        out_a.status.success(),
+        "run A must succeed: {}",
+        stderr_of(&out_a)
+    );
+    assert!(
+        out_b.status.success(),
+        "run B must succeed: {}",
+        stderr_of(&out_b)
+    );
+
+    // Each workdir has its own checkpoint and output.
+    for wd in [&wd_a, &wd_b] {
+        assert!(
+            wd.join(".oxo-flow/checkpoint.json").exists(),
+            "{} must have its own checkpoint",
+            wd.display()
+        );
+        assert!(
+            wd.join("out.txt").exists(),
+            "{} must have its output",
+            wd.display()
+        );
+    }
+
+    // No cross-contamination: each out.txt names exactly its own workdir.
+    let out_a_text = fs::read_to_string(wd_a.join("out.txt")).unwrap();
+    let out_b_text = fs::read_to_string(wd_b.join("out.txt")).unwrap();
+    let want_a = canonical(&wd_a);
+    let want_b = canonical(&wd_b);
+    assert_eq!(
+        out_a_text.trim(),
+        want_a,
+        "run A output must contain workdir A's path"
+    );
+    assert_eq!(
+        out_b_text.trim(),
+        want_b,
+        "run B output must contain workdir B's path"
+    );
+    assert!(
+        !out_a_text.contains(&want_b),
+        "run A output must not mention workdir B: {out_a_text}"
+    );
+    assert!(
+        !out_b_text.contains(&want_a),
+        "run B output must not mention workdir A: {out_b_text}"
+    );
+}
+
+// ─── Scenario 2: different HOME, shared module cache, git-pinned include ─
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("git must be available to build the include repo");
+    assert!(
+        out.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Two runs with distinct HOME env vars (different users) share one module
+/// cache via `OXO_FLOW_MODULE_CACHE`; the workflow carries a git-pinned
+/// `[[include]]` from a LOCAL file:// repo, so both processes clone into the
+/// same cache dir concurrently — the CloneLock (issue #136) must serialize
+/// them and both must succeed.
+#[test]
+fn cli_different_home_shared_module_cache_git_pinned_include() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A local git repo holding the included module. Filler files widen the
+    // clone window so both runs genuinely contend on the cache entry.
+    let repo_dir = dir.path().join("module-repo");
+    fs::create_dir_all(repo_dir.join("data")).unwrap();
+    fs::write(
+        repo_dir.join("module.toml"),
+        "[workflow]\nname = \"module\"\nversion = \"1.0\"\n\n[[rules]]\nname = \"mod_gen\"\noutput = [\"mod_out.txt\"]\nshell = \"echo module > {output}\"\n",
+    )
+    .unwrap();
+    for i in 0..200 {
+        fs::write(repo_dir.join(format!("data/f{i:04}.txt")), "filler\n").unwrap();
+    }
+    run_git(&repo_dir, &["init", "-q"]);
+    run_git(&repo_dir, &["config", "user.email", "test@example.com"]);
+    run_git(&repo_dir, &["config", "user.name", "test"]);
+    run_git(&repo_dir, &["add", "-A"]);
+    run_git(&repo_dir, &["commit", "-qm", "init"]);
+    run_git(&repo_dir, &["branch", "-M", "main"]);
+
+    // Shared workflow (outside both HOMEs) with the pinned include.
+    let wf = dir.path().join("homeiso.oxoflow");
+    let repo_url = format!("file://{}", repo_dir.display());
+    fs::write(
+        &wf,
+        format!(
+            "[workflow]\nname = \"homeiso\"\nversion = \"1.0.0\"\n\n[[include]]\npath = \"module.toml\"\nrepo = \"{repo_url}\"\nref = \"main\"\n\n[[rules]]\nname = \"main_gen\"\noutput = [\"out.txt\"]\nshell = \"echo hi > {{output}}\"\ndepends_on = [\"mod_gen\"]\n"
+        ),
+    )
+    .unwrap();
+
+    // Two users with distinct HOMEs, sharing ONE module cache.
+    let home_a = dir.path().join("homeA");
+    let home_b = dir.path().join("homeB");
+    fs::create_dir_all(&home_a).unwrap();
+    fs::create_dir_all(&home_b).unwrap();
+    let cache = dir.path().join("module-cache");
+    fs::create_dir_all(&cache).unwrap();
+    let wd_a = dir.path().join("wdA");
+    let wd_b = dir.path().join("wdB");
+    fs::create_dir_all(&wd_a).unwrap();
+    fs::create_dir_all(&wd_b).unwrap();
+
+    let mut child_a = spawn_run(
+        &wf,
+        &wd_a,
+        &[
+            ("HOME", home_a.to_str().unwrap()),
+            ("OXO_FLOW_MODULE_CACHE", cache.to_str().unwrap()),
+        ],
+    );
+    let mut child_b = spawn_run(
+        &wf,
+        &wd_b,
+        &[
+            ("HOME", home_b.to_str().unwrap()),
+            ("OXO_FLOW_MODULE_CACHE", cache.to_str().unwrap()),
+        ],
+    );
+    let out_a = wait_with_deadline(&mut child_a, Duration::from_secs(120))
+        .expect("run A must finish within 120s");
+    let out_b = wait_with_deadline(&mut child_b, Duration::from_secs(120))
+        .expect("run B must finish within 120s");
+
+    assert!(
+        out_a.status.success(),
+        "run A (user A) must succeed: {}",
+        stderr_of(&out_a)
+    );
+    assert!(
+        out_b.status.success(),
+        "run B (user B) must succeed: {}",
+        stderr_of(&out_b)
+    );
+
+    // The included module's rule executed in BOTH workdirs, alongside the
+    // host rule — no cache corruption, no cross-user bleed.
+    for wd in [&wd_a, &wd_b] {
+        assert!(
+            wd.join("out.txt").exists(),
+            "{} must have the host rule output",
+            wd.display()
+        );
+        assert!(
+            wd.join("mod_out.txt").exists(),
+            "{} must have the included module's output (git-pinned include)",
+            wd.display()
+        );
+        assert!(
+            wd.join(".oxo-flow/checkpoint.json").exists(),
+            "{} must have its own checkpoint",
+            wd.display()
+        );
+    }
+}
+
+// ─── Scenario 3: same workdir, concurrent — second fails fast ───────────
+
+/// Two runs on the SAME workdir: the first holds the exclusive workdir lock
+/// (issue #70) for the whole run; the second must fail fast — nonzero exit,
+/// within a bounded time, naming the lock — instead of racing the same
+/// checkpoint. The first run must be unaffected and complete normally.
+#[test]
+fn cli_same_workdir_second_run_fails_fast_with_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    // Long enough that the second run's fast-fail demonstrably happens
+    // while the first is still executing.
+    let wf = write_pwd_workflow(dir.path(), "exclusive", 6);
+
+    let mut run1 = Command::new(workspace_bin(oxo_flow_bin()))
+        .args(["run", wf.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn first run");
+
+    // Wait until run1 actually holds the workdir lock (the lock file is
+    // created on acquisition), then launch the contender.
+    assert!(
+        wait_until_exists(&dir.path().join(".oxo-flow/lock"), Duration::from_secs(10)),
+        "run1 must acquire the workdir lock within 10s"
+    );
+
+    let mut run2 = Command::new(workspace_bin(oxo_flow_bin()))
+        .args(["run", wf.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn second run");
+
+    let start = Instant::now();
+    let out2 = wait_with_deadline(&mut run2, Duration::from_secs(20))
+        .expect("the second run must exit within 20s — the lock fails fast");
+    let elapsed = start.elapsed();
+
+    assert!(
+        !out2.status.success(),
+        "the second run on the same workdir must exit nonzero, got: {}",
+        stderr_of(&out2)
+    );
+    let err2 = stderr_of(&out2);
+    assert!(
+        err2.contains("workdir is locked by another oxo-flow process"),
+        "the second run must name the workdir lock, got: {err2}"
+    );
+    assert!(
+        err2.contains("wait for it to finish"),
+        "the lock error must advise waiting, got: {err2}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "the second run must fail within seconds, took {elapsed:?}"
+    );
+
+    // The first run is still executing (holds the lock) when the second
+    // fails — this is a real fast-fail, not a post-hoc collision.
+    assert!(
+        run1.try_wait().unwrap().is_none(),
+        "run1 must still be running while run2 fails fast"
+    );
+
+    let out1 = wait_with_deadline(&mut run1, Duration::from_secs(30))
+        .expect("run1 must finish within 30s");
+    assert!(
+        out1.status.success(),
+        "run1 (the lock holder) must complete normally: {}",
+        stderr_of(&out1)
+    );
+    assert!(
+        dir.path().join(".oxo-flow/checkpoint.json").exists(),
+        "the lock holder must write its checkpoint"
+    );
+    assert!(
+        dir.path().join("out.txt").exists(),
+        "the lock holder must write its output"
+    );
+}
+
+// ─── Scenario 4: read-only shared workflow location ─────────────────────
+
+fn running_as_root() -> bool {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
+        .unwrap_or(false)
+}
+
+/// A workflow in a read-only (chmod 555) directory is the recommended
+/// central-repo pattern: two concurrent runs pointing at the same file with
+/// per-analysis `-d` workdirs must both succeed — the engine never writes
+/// next to the workflow file.
+#[test]
+fn cli_readonly_workflow_dir_concurrent_runs() {
+    if running_as_root() {
+        eprintln!("skipping: running as root, chmod 555 does not restrict root");
+        return;
+    }
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let wf_dir = dir.path().join("central");
+    fs::create_dir(&wf_dir).unwrap();
+    let wf = write_pwd_workflow(&wf_dir, "central", 1);
+    fs::set_permissions(&wf_dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let wd_a = dir.path().join("wdA");
+    let wd_b = dir.path().join("wdB");
+    fs::create_dir_all(&wd_a).unwrap();
+    fs::create_dir_all(&wd_b).unwrap();
+
+    let mut child_a = spawn_run(&wf, &wd_a, &[]);
+    let mut child_b = spawn_run(&wf, &wd_b, &[]);
+    let out_a = wait_with_deadline(&mut child_a, Duration::from_secs(30))
+        .expect("run A must finish within 30s");
+    let out_b = wait_with_deadline(&mut child_b, Duration::from_secs(30))
+        .expect("run B must finish within 30s");
+
+    // Restore permissions so the tempdir can be cleaned up.
+    fs::set_permissions(&wf_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(
+        out_a.status.success(),
+        "run A from the read-only workflow dir must succeed: {}",
+        stderr_of(&out_a)
+    );
+    assert!(
+        out_b.status.success(),
+        "run B from the read-only workflow dir must succeed: {}",
+        stderr_of(&out_b)
+    );
+    for wd in [&wd_a, &wd_b] {
+        assert!(
+            wd.join("out.txt").exists(),
+            "{} must have its output",
+            wd.display()
+        );
+        assert!(
+            wd.join(".oxo-flow/checkpoint.json").exists(),
+            "{} must have its own checkpoint",
+            wd.display()
+        );
+    }
+    // The read-only dir must be untouched: no .oxo-flow appeared next to
+    // the shared workflow file.
+    assert!(
+        !wf_dir.join(".oxo-flow").exists(),
+        "nothing may be written next to the shared workflow file"
+    );
+}
+
+// ─── Scenario 5: sequential reuse from a fresh workdir ──────────────────
+
+/// Running the same workflow again from a DIFFERENT workdir must be
+/// unaffected by the first run: the second checkpoint is fresh, the rule
+/// executes again (not skipped), and each workdir keeps its own outputs.
+#[test]
+fn cli_sequential_reuse_from_fresh_workdir() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_pwd_workflow(dir.path(), "reuse", 0);
+
+    let wd_a = dir.path().join("wdA");
+    let wd_b = dir.path().join("wdB");
+    fs::create_dir_all(&wd_a).unwrap();
+    fs::create_dir_all(&wd_b).unwrap();
+
+    let mut run1 = spawn_run(&wf, &wd_a, &[]);
+    let out1 = wait_with_deadline(&mut run1, Duration::from_secs(30))
+        .expect("first run must finish within 30s");
+    assert!(
+        out1.status.success(),
+        "first run must succeed: {}",
+        stderr_of(&out1)
+    );
+    assert!(
+        wd_a.join(".oxo-flow/checkpoint.json").exists(),
+        "first run must leave its checkpoint in wdA"
+    );
+    assert_eq!(
+        fs::read_to_string(wd_a.join("out.txt")).unwrap().trim(),
+        canonical(&wd_a),
+        "first run's output must name wdA"
+    );
+
+    // Second run from a fresh workdir: fresh checkpoint, rule executes.
+    let mut run2 = spawn_run(&wf, &wd_b, &[]);
+    let out2 = wait_with_deadline(&mut run2, Duration::from_secs(30))
+        .expect("second run must finish within 30s");
+    assert!(
+        out2.status.success(),
+        "second run must succeed: {}",
+        stderr_of(&out2)
+    );
+    assert!(
+        stderr_of(&out2).contains("1 succeeded"),
+        "second run must execute the rule fresh (new workdir = fresh checkpoint): {}",
+        stderr_of(&out2)
+    );
+    assert!(
+        wd_b.join(".oxo-flow/checkpoint.json").exists(),
+        "second run must leave its own checkpoint in wdB"
+    );
+    assert_eq!(
+        fs::read_to_string(wd_b.join("out.txt")).unwrap().trim(),
+        canonical(&wd_b),
+        "second run's output must name wdB — unaffected by the first run"
+    );
+}


### PR DESCRIPTION
## Summary

Implements both ideas from #158 after scientific/engineering evaluation — both are genuinely valuable (SSH disconnect kills long bioinformatics runs; shared workflows are the documented central-workflow pattern):

**1. `--background` for `run` and `resume`**
- Foreground spawns a detached child (same argv minus the flag) and exits 0 immediately; the child runs the normal flow with full checkpoint/lock/resume semantics.
- Unix: `process_group(0)` (survives terminal SIGHUP); Windows: `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS` — no new dependencies, no unsafe.
- Child stdio → run log; `.oxo-flow/background.pid` written; summary prints monitor/stop commands; advisory workdir-lock pre-check fails fast.
- 15 unit + 4 integration tests RED-first (incl. resume completing the remaining rule after a failure; --json stdout stays clean).

**2. Concurrent reuse of a shared workflow — verified, one real fix**
- 5 simulation scenarios in tests/concurrency_reuse.rs: two workdirs concurrently; two users (distinct HOME) + shared module cache with a git-pinned file:// include; same-workdir fast-fail; read-only central workflow dir; sequential reuse. Four scenarios already held and are now pinned by tests.
- Fix: the workdir-lock error now surfaces the core `suggestion()` hint ("wait for it to finish; the lock releases automatically") — users previously saw WHAT was wrong but not that it self-heals.
- Docs: how-to/concurrent-runs.md (guarantee, shared-vs-per-workdir table, central workflow + `-d` pattern), run.md Background runs section, resume.md row.

## Tests

- 19 new (background: 15 unit + 4 integration) + 5 concurrency scenarios; full `make ci` green.
- Live-verified: foreground returns ~2s while the run completes in the background; two workdirs complete concurrently with isolated outputs; same-workdir second run fails fast with the hint.

## Test plan for reviewers

- [ ] `make ci`
- [ ] `run wf.oxoflow --background` → immediate exit 0, pid file, run completes, `status <checkpoint>` shows completion
- [ ] Two `run wf -d A` / `-d B` concurrently → both succeed
- [ ] Second run in the same workdir → `Error: workdir is locked… hint: …wait for it to finish`

Fixes #158.
