### PR TITLE
fix(gallery): complete the gallery — aux files for 09/11/14/15, real BWA-MEM2 in 05, template copies aux files

### DIFF
--- a/crates/oxo-flow-cli/src/commands/project.rs
+++ b/crates/oxo-flow-cli/src/commands/project.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::commands::print_banner;
 
@@ -261,6 +261,47 @@ const EMBEDDED_GALLERY: &[(&str, &str)] = &[
     ),
 ];
 
+/// Auxiliary files (scripts, report templates) referenced by gallery
+/// workflows, embedded with the same include_str! mirroring so `template`
+/// copies them next to the generated workflow. Keys are gallery-relative
+/// paths — the canonical sources in `examples/gallery/` (the drift-guard
+/// test compares both lists and contents against that directory).
+const EMBEDDED_GALLERY_AUX: &[(&str, &str)] = &[
+    (
+        "scripts/report.py",
+        include_str!("../../templates/aux/scripts/report.py"),
+    ),
+    (
+        "scripts/generate_report.py",
+        include_str!("../../templates/aux/scripts/generate_report.py"),
+    ),
+    (
+        "scripts/seurat_analysis.R",
+        include_str!("../../templates/aux/scripts/seurat_analysis.R"),
+    ),
+    (
+        "templates/sc_report.Rmd",
+        include_str!("../../templates/aux/templates/sc_report.Rmd"),
+    ),
+];
+
+/// Which templates reference which auxiliary files (by template stem).
+const TEMPLATE_AUX_FILES: &[(&str, &[&str])] = &[
+    (
+        "09_single_cell_rnaseq",
+        &["scripts/seurat_analysis.R", "templates/sc_report.Rmd"],
+    ),
+    ("11_conditional_workflow", &["scripts/report.py"]),
+    (
+        "14_paired_experiment_control",
+        &["scripts/generate_report.py"],
+    ),
+    (
+        "15_paired_experiment_control_pairs",
+        &["scripts/generate_report.py"],
+    ),
+];
+
 /// Match an embedded template by exact stem or `_<name>` suffix (the same
 /// rules the filesystem scan used); exact matches win.
 fn find_embedded_template<'a>(
@@ -374,6 +415,49 @@ fn list_templates() -> Result<()> {
 // Apply a single template (copy + name substitution)
 // ---------------------------------------------------------------------------
 
+/// Copy the auxiliary files (scripts/report templates) a template
+/// references next to the generated workflow. Returns the copied
+/// gallery-relative paths. An existing file is only left untouched when
+/// its content matches the embedded copy, so generating two templates that
+/// share a script into the same directory stays safe.
+fn copy_template_aux(template_stem: &str, dest_dir: &Path) -> Result<Vec<String>> {
+    let Some((_, aux_files)) = TEMPLATE_AUX_FILES
+        .iter()
+        .find(|(stem, _)| *stem == template_stem)
+    else {
+        return Ok(Vec::new());
+    };
+    let mut copied = Vec::new();
+    for rel_path in *aux_files {
+        let (_, content) = EMBEDDED_GALLERY_AUX
+            .iter()
+            .find(|(path, _)| path == rel_path)
+            .ok_or_else(|| anyhow::anyhow!("embedded aux file {rel_path} not found"))?;
+        let dest = dest_dir.join(rel_path);
+        if dest.exists() {
+            let existing = std::fs::read_to_string(&dest)
+                .with_context(|| format!("cannot read {}", dest.display()))?;
+            if existing != *content {
+                anyhow::bail!(
+                    "{} already exists and differs from the template's copy — \
+                     remove it or choose a different output location",
+                    dest.display()
+                );
+            }
+            copied.push(rel_path.to_string());
+            continue;
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("cannot create {}", parent.display()))?;
+        }
+        std::fs::write(&dest, content)
+            .with_context(|| format!("cannot write {}", dest.display()))?;
+        copied.push(rel_path.to_string());
+    }
+    Ok(copied)
+}
+
 fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
     let (template_stem, content) = match find_embedded_template(EMBEDDED_GALLERY, template_name) {
         Some(found) => found,
@@ -415,6 +499,10 @@ fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
     std::fs::write(&output_path, new_content)
         .with_context(|| format!("cannot write {}", output_path.display()))?;
 
+    let copied_aux =
+        copy_template_aux(template_stem, output_path.parent().unwrap_or(Path::new("")))
+            .with_context(|| format!("cannot copy auxiliary files for template {template_stem}"))?;
+
     eprintln!();
     eprintln!(
         "{} Created workflow from template: {}",
@@ -422,6 +510,9 @@ fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
         template_stem
     );
     eprintln!("  {}", output_path.display());
+    for rel in copied_aux {
+        eprintln!("  {}", rel.dimmed());
+    }
     eprintln!();
     eprintln!("{}  To run this workflow:", "Next steps:".bold().cyan());
     eprintln!("    oxo-flow run {}", output_path.display());
@@ -549,6 +640,64 @@ mod tests {
             let disk = std::fs::read_to_string(disk_dir.join(format!("{stem}.oxoflow"))).unwrap();
             assert_eq!(content, disk, "embedded content for {stem} diverged");
         }
+
+        // Auxiliary files (scripts/, templates/) must stay in sync too —
+        // comparing the full sorted (path, content) lists covers both
+        // additions/removals and content drift.
+        let mut disk_aux: Vec<(String, String)> = Vec::new();
+        for sub in ["scripts", "templates"] {
+            let sub_dir = disk_dir.join(sub);
+            if !sub_dir.is_dir() {
+                continue;
+            }
+            for entry in std::fs::read_dir(&sub_dir).unwrap().filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if !path.is_file() {
+                    continue;
+                }
+                let rel = format!("{sub}/{}", path.file_name().unwrap().to_string_lossy());
+                disk_aux.push((rel, std::fs::read_to_string(&path).unwrap()));
+            }
+        }
+        disk_aux.sort();
+        let mut embedded_aux: Vec<(String, String)> = EMBEDDED_GALLERY_AUX
+            .iter()
+            .map(|(path, content)| (path.to_string(), content.to_string()))
+            .collect();
+        embedded_aux.sort();
+        assert_eq!(
+            embedded_aux, disk_aux,
+            "embedded aux files diverged from examples/gallery/scripts and \
+             examples/gallery/templates — update EMBEDDED_GALLERY_AUX and \
+             crates/oxo-flow-cli/templates/aux/"
+        );
+    }
+
+    #[test]
+    fn apply_template_copies_aux_files() {
+        let dir = tempfile::tempdir().unwrap();
+
+        apply_template("09_single_cell_rnaseq", Some(dir.path().to_path_buf())).unwrap();
+        assert!(dir.path().join("scripts/seurat_analysis.R").exists());
+        assert!(dir.path().join("templates/sc_report.Rmd").exists());
+
+        apply_template(
+            "14_paired_experiment_control",
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        assert!(dir.path().join("scripts/generate_report.py").exists());
+
+        // 15 shares scripts/generate_report.py with 14: re-writing the same
+        // content must succeed, not bail.
+        apply_template(
+            "15_paired_experiment_control_pairs",
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+        // Templates without aux files copy nothing extra.
+        apply_template("01_hello_world", Some(dir.path().to_path_buf())).unwrap();
     }
 
     #[test]

--- a/crates/oxo-flow-cli/templates/05_conda_environments.oxoflow
+++ b/crates/oxo-flow-cli/templates/05_conda_environments.oxoflow
@@ -40,8 +40,15 @@ conda = "envs/qc.yaml"
 [[rules]]
 name = "align_sequences"
 input = ["data/sequences.fasta"]
-output = ["aligned/alignment.bam"]
-shell = "echo 'Alignment placeholder' > {output[0]}"
+output = ["aligned/alignment.sam"]
+# Self-alignment demo: the demo sequences serve as both reference and
+# reads, so the rule runs end-to-end with only the pinned docker image.
+description = "Self-alignment with BWA-MEM2 (reference = demo sequences)"
+shell = """
+mkdir -p aligned
+bwa-mem2 index {input[0]}
+bwa-mem2 mem -t {threads} {input[0]} {input[0]} > {output[0]}
+"""
 
 [rules.resources]
 threads = 8
@@ -52,7 +59,7 @@ docker = "biocontainers/bwa-mem2:2.2.1"
 
 [[rules]]
 name = "analyze_results"
-input = ["aligned/alignment.bam", "qc/report.txt"]
+input = ["aligned/alignment.sam", "qc/report.txt"]
 output = ["results/analysis.json"]
 shell = """
 mkdir -p results

--- a/crates/oxo-flow-cli/templates/09_single_cell_rnaseq.oxoflow
+++ b/crates/oxo-flow-cli/templates/09_single_cell_rnaseq.oxoflow
@@ -67,7 +67,7 @@ output = ["results/{sample}.sc_report.html"]
 description = "Generate single-cell analysis report"
 shell = """
 mkdir -p results
-Rscript -e "rmarkdown::render('templates/sc_report.Rmd', output_file='{output[0]}')"
+Rscript -e "rmarkdown::render('templates/sc_report.Rmd', output_file='{output[0]}', params=list(sample='{sample}', analysis_dir='analysis/{sample}/'))"
 """
 
 [rules.environment]

--- a/crates/oxo-flow-cli/templates/README.md
+++ b/crates/oxo-flow-cli/templates/README.md
@@ -1,18 +1,23 @@
 # Embedded template gallery
 
-Publish-time copies of `examples/gallery/*.oxoflow` for the `template`
-command. `cargo package`/`cargo publish` can only bundle files inside the
-crate root, so the canonical sources at the workspace root must be mirrored
-here.
+Publish-time copies of `examples/gallery/` for the `template` command.
+`cargo package`/`cargo publish` can only bundle files inside the crate
+root, so the canonical sources at the workspace root must be mirrored
+here — both the `*.oxoflow` workflows and the auxiliary files
+(`scripts/`, report `templates/`) they reference.
 
 **Do not edit these files by hand.** The canonical source of truth is
 `examples/gallery/`. Sync by copying:
 
 ```bash
 cp examples/gallery/*.oxoflow crates/oxo-flow-cli/templates/
+rm -rf crates/oxo-flow-cli/templates/aux
+cp -r examples/gallery/scripts examples/gallery/templates crates/oxo-flow-cli/templates/aux/
 ```
 
 The drift-guard test `embedded_gallery_matches_disk_gallery`
 (`src/commands/project.rs`) compares stems and content against
-`examples/gallery/` and fails CI on any divergence, so an out-of-sync copy
-cannot ship.
+`examples/gallery/` — workflows and aux files alike — and fails CI on
+any divergence, so an out-of-sync copy cannot ship. `TEMPLATE_AUX_FILES`
+maps template stems to the aux files `template` copies next to a
+generated workflow.

--- a/crates/oxo-flow-cli/templates/aux/scripts/generate_report.py
+++ b/crates/oxo-flow-cli/templates/aux/scripts/generate_report.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generate a clinical-style variant report for galleries 14 and 15.
+
+Reads a VEP-annotated VCF (plain or gzip-compressed) and writes an HTML
+report summarizing variant counts, PASS rate, and consequence classes,
+with the top high/moderate-impact variants listed. Stdlib only — runs
+inside gallery envs/report.yaml.
+"""
+
+import argparse
+import gzip
+import html
+import os
+from collections import Counter
+
+# IMPACT ordering used to keep the most severe transcript per variant.
+IMPACT_RANK = {"HIGH": 0, "MODERATE": 1, "LOW": 2, "MODIFIER": 3}
+
+
+def open_maybe_gzip(path):
+    """Open a file that may be gzip-compressed (VEP output is .vcf.gz)."""
+    with open(path, "rb") as fh:
+        magic = fh.read(2)
+    if magic == b"\x1f\x8b":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "rt", encoding="utf-8", errors="replace")
+
+
+def csq_columns(header_lines):
+    """Find the Consequence/IMPACT/SYMBOL positions in the CSQ format.
+
+    VEP defines the CSQ layout inside the ##INFO Description string
+    ("... Format: Allele|Consequence|IMPACT|SYMBOL|..."); parsing it
+    (instead of assuming Consequence is first) keeps the report correct
+    across VEP versions and `--fields` overrides.
+    """
+    consequence = impact = symbol = None
+    for line in header_lines:
+        if line.startswith("##INFO=<ID=CSQ,"):
+            marker = "Format:"
+            idx = line.find(marker)
+            if idx == -1:
+                continue
+            rest = line[idx + len(marker):].split('"', 1)[0].strip()
+            fields = rest.split("|")
+            consequence = fields.index("Consequence") if "Consequence" in fields else 0
+            impact = fields.index("IMPACT") if "IMPACT" in fields else None
+            symbol = fields.index("SYMBOL") if "SYMBOL" in fields else None
+    return consequence, impact, symbol
+
+
+def worst_csq(csq_value, consequence_col, impact_col, symbol_col):
+    """Pick the most severe transcript's annotations from a CSQ= value."""
+    consequence_col = consequence_col or 0
+    impact_col = impact_col or 2
+    symbol_col = symbol_col or 1
+    best = None
+    for record in csq_value.split(","):
+        fields = record.split("|")
+        impact = fields[impact_col] if impact_col is not None else "MODIFIER"
+        if best is None or IMPACT_RANK.get(impact, 3) < IMPACT_RANK[best[1]]:
+            best = (
+                fields[consequence_col] if consequence_col < len(fields) else "unknown",
+                impact,
+                fields[symbol_col] if symbol_col is not None and symbol_col < len(fields) else "",
+            )
+    return best or ("unknown", "MODIFIER", "")
+
+
+def parse_vcf(path):
+    """Return (variants, passing, impact counter, top variants)."""
+    variants = 0
+    passing = 0
+    impacts = Counter()
+    top = []
+
+    header_lines = []
+    with open_maybe_gzip(path) as fh:
+        lines = fh
+        for line in lines:
+            if line.startswith("##"):
+                header_lines.append(line.rstrip("\n"))
+                continue
+            if line.startswith("#CHROM"):
+                break
+        consequence_col, impact_col, symbol_col = csq_columns(header_lines)
+
+        for line in lines:
+            variants += 1
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 8:
+                continue
+            chrom, pos, _, ref, alt, _, filt, info = fields[:8]
+            if filt == "PASS":
+                passing += 1
+
+            consequence = impact = "MODIFIER"
+            symbol = ""
+            for entry in info.split(";"):
+                if entry.startswith("CSQ="):
+                    consequence, impact, symbol = worst_csq(
+                        entry[len("CSQ="):], consequence_col, impact_col, symbol_col
+                    )
+                    break
+            impacts[impact] += 1
+            if impact in ("HIGH", "MODERATE") and len(top) < 20:
+                top.append(
+                    {
+                        "chrom": chrom,
+                        "pos": pos,
+                        "ref": ref,
+                        "alt": alt,
+                        "gene": symbol,
+                        "consequence": consequence,
+                        "impact": impact,
+                    }
+                )
+    return variants, passing, impacts, top
+
+
+def render_html(sample_label, stats, output_path):
+    variants, passing, impacts, top = stats
+    rows = []
+    for v in top:
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(v['chrom'])}:{html.escape(v['pos'])}</td>"
+            f"<td>{html.escape(v['ref'])} &rarr; {html.escape(v['alt'])}</td>"
+            f"<td>{html.escape(v['gene'] or '-')}</td>"
+            f"<td>{html.escape(v['consequence'])}</td>"
+            f"<td>{html.escape(v['impact'])}</td>"
+            "</tr>"
+        )
+
+    impact_rows = "".join(
+        f"<tr><td>{impact}</td><td>{count}</td></tr>"
+        for impact, count in sorted(impacts.items(), key=lambda kv: IMPACT_RANK.get(kv[0], 9))
+    )
+
+    doc = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>{html.escape(sample_label)} — Variant Report</title>
+<style>
+body {{ font-family: sans-serif; margin: 2em; }}
+table {{ border-collapse: collapse; }}
+td, th {{ border: 1px solid #ccc; padding: 0.4em 0.8em; text-align: left; }}
+</style>
+</head>
+<body>
+<h1>{html.escape(sample_label)} — Variant Report</h1>
+<h2>Summary</h2>
+<p>Total variants: {variants}</p>
+<p>PASS filter: {passing}</p>
+<h2>Impact classes</h2>
+<table>
+<tr><th>IMPACT</th><th>Variants</th></tr>
+{impact_rows}
+</table>
+<h2>Top high/moderate-impact variants</h2>
+<table>
+<tr><th>Locus</th><th>Change</th><th>Gene</th><th>Consequence</th><th>IMPACT</th></tr>
+{''.join(rows) or '<tr><td colspan="5">none</td></tr>'}
+</table>
+</body>
+</html>
+"""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(doc)
+    print(f"Wrote {output_path} ({variants} variants, {passing} PASS)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--input", required=True, help="VEP-annotated VCF (may be .vcf.gz)")
+    ap.add_argument("--output", required=True, help="output HTML path")
+    label = ap.add_mutually_exclusive_group()
+    label.add_argument("--sample", help="sample name (gallery 14)")
+    label.add_argument("--pair", help="experiment-control pair id (gallery 15)")
+    args = ap.parse_args()
+
+    sample_label = args.sample or args.pair or os.path.basename(args.input)
+    render_html(sample_label, parse_vcf(args.input), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/oxo-flow-cli/templates/aux/scripts/report.py
+++ b/crates/oxo-flow-cli/templates/aux/scripts/report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Generate an HTML report for gallery 11 (conditional execution).
+
+Reads a VEP-annotated VCF (plain or gzip-compressed) and a qc/ directory
+of FastQC/mosdepth outputs, and writes a small self-contained HTML report.
+Stdlib only — runs inside gallery envs/report.yaml.
+"""
+
+import argparse
+import gzip
+import html
+import os
+
+
+def open_maybe_gzip(path):
+    """Open a file that may be gzip-compressed (VEP output is .vcf.gz)."""
+    with open(path, "rb") as fh:
+        magic = fh.read(2)
+    if magic == b"\x1f\x8b":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "rt", encoding="utf-8", errors="replace")
+
+
+def vcf_stats(path):
+    """Count variants and PASS calls in a VCF."""
+    variants = 0
+    passing = 0
+    with open_maybe_gzip(path) as fh:
+        for line in fh:
+            if line.startswith("#"):
+                continue
+            variants += 1
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) > 6 and fields[6] == "PASS":
+                passing += 1
+    return variants, passing
+
+
+def qc_summary(qc_dir):
+    """List the QC artifacts (name + size) for the report."""
+    rows = []
+    if os.path.isdir(qc_dir):
+        for name in sorted(os.listdir(qc_dir)):
+            path = os.path.join(qc_dir, name)
+            if os.path.isfile(path):
+                rows.append((name, os.path.getsize(path)))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--vcf", required=True, help="VEP-annotated VCF (may be .vcf.gz)")
+    ap.add_argument("--qc", required=True, help="directory with QC artifacts")
+    ap.add_argument("--out", required=True, help="output HTML path")
+    args = ap.parse_args()
+
+    variants, passing = vcf_stats(args.vcf)
+    qc_rows = qc_summary(args.qc)
+
+    body = [
+        "<h1>Conditional Workflow Report</h1>",
+        "<h2>Variants</h2>",
+        f"<p>Total variants: {variants}</p>",
+        f"<p>PASS filter: {passing}</p>",
+        "<h2>QC artifacts</h2>",
+        "<ul>",
+    ]
+    for name, size in qc_rows:
+        body.append(f"<li>{html.escape(name)} ({size} bytes)</li>")
+    body.append("</ul>")
+
+    doc = (
+        "<!DOCTYPE html>\n<html>\n<head>\n<meta charset='utf-8'>\n"
+        "<title>Conditional Workflow Report</title>\n"
+        "</head>\n<body>\n"
+        + "\n".join(body)
+        + "\n</body>\n</html>\n"
+    )
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(doc)
+    print(f"Wrote {args.out} ({variants} variants, {passing} PASS)")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/oxo-flow-cli/templates/aux/scripts/seurat_analysis.R
+++ b/crates/oxo-flow-cli/templates/aux/scripts/seurat_analysis.R
@@ -1,0 +1,45 @@
+#!/usr/bin/env Rscript
+# Seurat clustering + UMAP for gallery 09 (single-cell RNA-seq).
+#
+# Reads a CellRanger filtered feature-barcode matrix (HDF5), runs the
+# standard QC -> normalize -> PCA -> UMAP -> clustering pipeline, and
+# writes a Seurat object (RDS) plus a UMAP plot into --output-dir.
+#
+# Requirements: r-seurat >= 5 (see gallery envs/seurat.yaml).
+
+args <- commandArgs(trailingOnly = TRUE)
+
+parse_arg <- function(name) {
+  idx <- match(name, args)
+  if (is.na(idx)) {
+    stop("missing required argument: ", name)
+  }
+  if (idx == length(args) || startsWith(args[idx + 1], "--")) {
+    stop("argument ", name, " is missing its value")
+  }
+  args[idx + 1]
+}
+
+input <- parse_arg("--input")
+output_dir <- parse_arg("--output-dir")
+
+suppressPackageStartupMessages(library(Seurat))
+
+counts <- Read10X_h5(input)
+seu <- CreateSeuratObject(counts = counts, min.cells = 3, min.features = 200)
+seu[["percent.mt"]] <- PercentageFeatureSet(seu, pattern = "^MT-")
+seu <- subset(seu, subset = nFeature_RNA > 200 & percent.mt < 5)
+
+seu <- NormalizeData(seu)
+seu <- FindVariableFeatures(seu, selection.method = "vst", nfeatures = 2000)
+seu <- ScaleData(seu)
+seu <- RunPCA(seu, npcs = 30)
+seu <- RunUMAP(seu, dims = 1:30)
+seu <- FindNeighbors(seu, dims = 1:30)
+seu <- FindClusters(seu, resolution = 0.5)
+
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+saveRDS(seu, file = file.path(output_dir, "seurat_object.rds"))
+png(file.path(output_dir, "umap_plot.png"), width = 800, height = 600)
+print(DimPlot(seu, reduction = "umap", label = TRUE))
+invisible(dev.off())

--- a/crates/oxo-flow-cli/templates/aux/templates/sc_report.Rmd
+++ b/crates/oxo-flow-cli/templates/aux/templates/sc_report.Rmd
@@ -1,0 +1,37 @@
+---
+title: "`r params$sample` — Single-Cell Report"
+output: html_document
+params:
+  sample: "sample1"
+  analysis_dir: "analysis/sample1"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
+suppressPackageStartupMessages(library(Seurat))
+seu <- readRDS(file.path(params$analysis_dir, "seurat_object.rds"))
+```
+
+# Sample summary
+
+- Sample: `r params$sample`
+- Cells: `r ncol(seu)`
+- Genes detected: `r nrow(seu)`
+
+# UMAP
+
+```{r, out.width="90%"}
+DimPlot(seu, reduction = "umap", label = TRUE)
+```
+
+# Cluster composition
+
+```{r}
+knitr::kable(table(Idents(seu)), col.names = c("Cluster", "Cells"))
+```
+
+# QC overview
+
+```{r, out.width="90%"}
+VlnPlot(seu, features = c("nFeature_RNA", "nCount_RNA", "percent.mt"), ncol = 3)
+```

--- a/docs/guide/src/commands/template.md
+++ b/docs/guide/src/commands/template.md
@@ -19,6 +19,12 @@ from a one-rule hello-world to production-grade multi-omics pipelines. The
 gallery is embedded in the binary at build time, so it works identically
 whether oxo-flow is installed from a release or run from a source checkout.
 
+Templates that reference auxiliary files (scripts and report templates —
+`09_single_cell_rnaseq`, `11_conditional_workflow`,
+`14_paired_experiment_control`, `15_paired_experiment_control_pairs`) copy
+them next to the generated workflow, so the generated pipeline is
+immediately complete and runnable.
+
 ## Options
 
 | Option | Description |
@@ -59,6 +65,12 @@ oxo-flow template 07_wgs_germline -o projects/wgs/
 | `08_multiomics_integration` | Multi-omics integration |
 | `09_single_cell_rnaseq` | Single-cell RNA-seq processing |
 | `10_transform_operator` | Transform operator demo |
+| `11_conditional_workflow` | Conditional execution |
+| `12_cohort_analysis` | Cohort-level QC aggregation |
+| `13_simple_variant_calling` | Simple germline variant calling |
+| `14_paired_experiment_control` | Somatic variant calling (single pair) |
+| `15_paired_experiment_control_pairs` | Somatic variant calling (multiple pairs) |
+| `16_16s_qiime2_amplicon` | 16S amplicon analysis with QIIME2 |
 
 ## See Also
 

--- a/examples/gallery/05_conda_environments.oxoflow
+++ b/examples/gallery/05_conda_environments.oxoflow
@@ -40,8 +40,15 @@ conda = "envs/qc.yaml"
 [[rules]]
 name = "align_sequences"
 input = ["data/sequences.fasta"]
-output = ["aligned/alignment.bam"]
-shell = "echo 'Alignment placeholder' > {output[0]}"
+output = ["aligned/alignment.sam"]
+# Self-alignment demo: the demo sequences serve as both reference and
+# reads, so the rule runs end-to-end with only the pinned docker image.
+description = "Self-alignment with BWA-MEM2 (reference = demo sequences)"
+shell = """
+mkdir -p aligned
+bwa-mem2 index {input[0]}
+bwa-mem2 mem -t {threads} {input[0]} {input[0]} > {output[0]}
+"""
 
 [rules.resources]
 threads = 8
@@ -52,7 +59,7 @@ docker = "biocontainers/bwa-mem2:2.2.1"
 
 [[rules]]
 name = "analyze_results"
-input = ["aligned/alignment.bam", "qc/report.txt"]
+input = ["aligned/alignment.sam", "qc/report.txt"]
 output = ["results/analysis.json"]
 shell = """
 mkdir -p results

--- a/examples/gallery/09_single_cell_rnaseq.oxoflow
+++ b/examples/gallery/09_single_cell_rnaseq.oxoflow
@@ -67,7 +67,7 @@ output = ["results/{sample}.sc_report.html"]
 description = "Generate single-cell analysis report"
 shell = """
 mkdir -p results
-Rscript -e "rmarkdown::render('templates/sc_report.Rmd', output_file='{output[0]}')"
+Rscript -e "rmarkdown::render('templates/sc_report.Rmd', output_file='{output[0]}', params=list(sample='{sample}', analysis_dir='analysis/{sample}/'))"
 """
 
 [rules.environment]

--- a/examples/gallery/scripts/generate_report.py
+++ b/examples/gallery/scripts/generate_report.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generate a clinical-style variant report for galleries 14 and 15.
+
+Reads a VEP-annotated VCF (plain or gzip-compressed) and writes an HTML
+report summarizing variant counts, PASS rate, and consequence classes,
+with the top high/moderate-impact variants listed. Stdlib only — runs
+inside gallery envs/report.yaml.
+"""
+
+import argparse
+import gzip
+import html
+import os
+from collections import Counter
+
+# IMPACT ordering used to keep the most severe transcript per variant.
+IMPACT_RANK = {"HIGH": 0, "MODERATE": 1, "LOW": 2, "MODIFIER": 3}
+
+
+def open_maybe_gzip(path):
+    """Open a file that may be gzip-compressed (VEP output is .vcf.gz)."""
+    with open(path, "rb") as fh:
+        magic = fh.read(2)
+    if magic == b"\x1f\x8b":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "rt", encoding="utf-8", errors="replace")
+
+
+def csq_columns(header_lines):
+    """Find the Consequence/IMPACT/SYMBOL positions in the CSQ format.
+
+    VEP defines the CSQ layout inside the ##INFO Description string
+    ("... Format: Allele|Consequence|IMPACT|SYMBOL|..."); parsing it
+    (instead of assuming Consequence is first) keeps the report correct
+    across VEP versions and `--fields` overrides.
+    """
+    consequence = impact = symbol = None
+    for line in header_lines:
+        if line.startswith("##INFO=<ID=CSQ,"):
+            marker = "Format:"
+            idx = line.find(marker)
+            if idx == -1:
+                continue
+            rest = line[idx + len(marker):].split('"', 1)[0].strip()
+            fields = rest.split("|")
+            consequence = fields.index("Consequence") if "Consequence" in fields else 0
+            impact = fields.index("IMPACT") if "IMPACT" in fields else None
+            symbol = fields.index("SYMBOL") if "SYMBOL" in fields else None
+    return consequence, impact, symbol
+
+
+def worst_csq(csq_value, consequence_col, impact_col, symbol_col):
+    """Pick the most severe transcript's annotations from a CSQ= value."""
+    consequence_col = consequence_col or 0
+    impact_col = impact_col or 2
+    symbol_col = symbol_col or 1
+    best = None
+    for record in csq_value.split(","):
+        fields = record.split("|")
+        impact = fields[impact_col] if impact_col is not None else "MODIFIER"
+        if best is None or IMPACT_RANK.get(impact, 3) < IMPACT_RANK[best[1]]:
+            best = (
+                fields[consequence_col] if consequence_col < len(fields) else "unknown",
+                impact,
+                fields[symbol_col] if symbol_col is not None and symbol_col < len(fields) else "",
+            )
+    return best or ("unknown", "MODIFIER", "")
+
+
+def parse_vcf(path):
+    """Return (variants, passing, impact counter, top variants)."""
+    variants = 0
+    passing = 0
+    impacts = Counter()
+    top = []
+
+    header_lines = []
+    with open_maybe_gzip(path) as fh:
+        lines = fh
+        for line in lines:
+            if line.startswith("##"):
+                header_lines.append(line.rstrip("\n"))
+                continue
+            if line.startswith("#CHROM"):
+                break
+        consequence_col, impact_col, symbol_col = csq_columns(header_lines)
+
+        for line in lines:
+            variants += 1
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 8:
+                continue
+            chrom, pos, _, ref, alt, _, filt, info = fields[:8]
+            if filt == "PASS":
+                passing += 1
+
+            consequence = impact = "MODIFIER"
+            symbol = ""
+            for entry in info.split(";"):
+                if entry.startswith("CSQ="):
+                    consequence, impact, symbol = worst_csq(
+                        entry[len("CSQ="):], consequence_col, impact_col, symbol_col
+                    )
+                    break
+            impacts[impact] += 1
+            if impact in ("HIGH", "MODERATE") and len(top) < 20:
+                top.append(
+                    {
+                        "chrom": chrom,
+                        "pos": pos,
+                        "ref": ref,
+                        "alt": alt,
+                        "gene": symbol,
+                        "consequence": consequence,
+                        "impact": impact,
+                    }
+                )
+    return variants, passing, impacts, top
+
+
+def render_html(sample_label, stats, output_path):
+    variants, passing, impacts, top = stats
+    rows = []
+    for v in top:
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(v['chrom'])}:{html.escape(v['pos'])}</td>"
+            f"<td>{html.escape(v['ref'])} &rarr; {html.escape(v['alt'])}</td>"
+            f"<td>{html.escape(v['gene'] or '-')}</td>"
+            f"<td>{html.escape(v['consequence'])}</td>"
+            f"<td>{html.escape(v['impact'])}</td>"
+            "</tr>"
+        )
+
+    impact_rows = "".join(
+        f"<tr><td>{impact}</td><td>{count}</td></tr>"
+        for impact, count in sorted(impacts.items(), key=lambda kv: IMPACT_RANK.get(kv[0], 9))
+    )
+
+    doc = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>{html.escape(sample_label)} — Variant Report</title>
+<style>
+body {{ font-family: sans-serif; margin: 2em; }}
+table {{ border-collapse: collapse; }}
+td, th {{ border: 1px solid #ccc; padding: 0.4em 0.8em; text-align: left; }}
+</style>
+</head>
+<body>
+<h1>{html.escape(sample_label)} — Variant Report</h1>
+<h2>Summary</h2>
+<p>Total variants: {variants}</p>
+<p>PASS filter: {passing}</p>
+<h2>Impact classes</h2>
+<table>
+<tr><th>IMPACT</th><th>Variants</th></tr>
+{impact_rows}
+</table>
+<h2>Top high/moderate-impact variants</h2>
+<table>
+<tr><th>Locus</th><th>Change</th><th>Gene</th><th>Consequence</th><th>IMPACT</th></tr>
+{''.join(rows) or '<tr><td colspan="5">none</td></tr>'}
+</table>
+</body>
+</html>
+"""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(doc)
+    print(f"Wrote {output_path} ({variants} variants, {passing} PASS)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--input", required=True, help="VEP-annotated VCF (may be .vcf.gz)")
+    ap.add_argument("--output", required=True, help="output HTML path")
+    label = ap.add_mutually_exclusive_group()
+    label.add_argument("--sample", help="sample name (gallery 14)")
+    label.add_argument("--pair", help="experiment-control pair id (gallery 15)")
+    args = ap.parse_args()
+
+    sample_label = args.sample or args.pair or os.path.basename(args.input)
+    render_html(sample_label, parse_vcf(args.input), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gallery/scripts/report.py
+++ b/examples/gallery/scripts/report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Generate an HTML report for gallery 11 (conditional execution).
+
+Reads a VEP-annotated VCF (plain or gzip-compressed) and a qc/ directory
+of FastQC/mosdepth outputs, and writes a small self-contained HTML report.
+Stdlib only — runs inside gallery envs/report.yaml.
+"""
+
+import argparse
+import gzip
+import html
+import os
+
+
+def open_maybe_gzip(path):
+    """Open a file that may be gzip-compressed (VEP output is .vcf.gz)."""
+    with open(path, "rb") as fh:
+        magic = fh.read(2)
+    if magic == b"\x1f\x8b":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "rt", encoding="utf-8", errors="replace")
+
+
+def vcf_stats(path):
+    """Count variants and PASS calls in a VCF."""
+    variants = 0
+    passing = 0
+    with open_maybe_gzip(path) as fh:
+        for line in fh:
+            if line.startswith("#"):
+                continue
+            variants += 1
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) > 6 and fields[6] == "PASS":
+                passing += 1
+    return variants, passing
+
+
+def qc_summary(qc_dir):
+    """List the QC artifacts (name + size) for the report."""
+    rows = []
+    if os.path.isdir(qc_dir):
+        for name in sorted(os.listdir(qc_dir)):
+            path = os.path.join(qc_dir, name)
+            if os.path.isfile(path):
+                rows.append((name, os.path.getsize(path)))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--vcf", required=True, help="VEP-annotated VCF (may be .vcf.gz)")
+    ap.add_argument("--qc", required=True, help="directory with QC artifacts")
+    ap.add_argument("--out", required=True, help="output HTML path")
+    args = ap.parse_args()
+
+    variants, passing = vcf_stats(args.vcf)
+    qc_rows = qc_summary(args.qc)
+
+    body = [
+        "<h1>Conditional Workflow Report</h1>",
+        "<h2>Variants</h2>",
+        f"<p>Total variants: {variants}</p>",
+        f"<p>PASS filter: {passing}</p>",
+        "<h2>QC artifacts</h2>",
+        "<ul>",
+    ]
+    for name, size in qc_rows:
+        body.append(f"<li>{html.escape(name)} ({size} bytes)</li>")
+    body.append("</ul>")
+
+    doc = (
+        "<!DOCTYPE html>\n<html>\n<head>\n<meta charset='utf-8'>\n"
+        "<title>Conditional Workflow Report</title>\n"
+        "</head>\n<body>\n"
+        + "\n".join(body)
+        + "\n</body>\n</html>\n"
+    )
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(doc)
+    print(f"Wrote {args.out} ({variants} variants, {passing} PASS)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gallery/scripts/seurat_analysis.R
+++ b/examples/gallery/scripts/seurat_analysis.R
@@ -1,0 +1,45 @@
+#!/usr/bin/env Rscript
+# Seurat clustering + UMAP for gallery 09 (single-cell RNA-seq).
+#
+# Reads a CellRanger filtered feature-barcode matrix (HDF5), runs the
+# standard QC -> normalize -> PCA -> UMAP -> clustering pipeline, and
+# writes a Seurat object (RDS) plus a UMAP plot into --output-dir.
+#
+# Requirements: r-seurat >= 5 (see gallery envs/seurat.yaml).
+
+args <- commandArgs(trailingOnly = TRUE)
+
+parse_arg <- function(name) {
+  idx <- match(name, args)
+  if (is.na(idx)) {
+    stop("missing required argument: ", name)
+  }
+  if (idx == length(args) || startsWith(args[idx + 1], "--")) {
+    stop("argument ", name, " is missing its value")
+  }
+  args[idx + 1]
+}
+
+input <- parse_arg("--input")
+output_dir <- parse_arg("--output-dir")
+
+suppressPackageStartupMessages(library(Seurat))
+
+counts <- Read10X_h5(input)
+seu <- CreateSeuratObject(counts = counts, min.cells = 3, min.features = 200)
+seu[["percent.mt"]] <- PercentageFeatureSet(seu, pattern = "^MT-")
+seu <- subset(seu, subset = nFeature_RNA > 200 & percent.mt < 5)
+
+seu <- NormalizeData(seu)
+seu <- FindVariableFeatures(seu, selection.method = "vst", nfeatures = 2000)
+seu <- ScaleData(seu)
+seu <- RunPCA(seu, npcs = 30)
+seu <- RunUMAP(seu, dims = 1:30)
+seu <- FindNeighbors(seu, dims = 1:30)
+seu <- FindClusters(seu, resolution = 0.5)
+
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+saveRDS(seu, file = file.path(output_dir, "seurat_object.rds"))
+png(file.path(output_dir, "umap_plot.png"), width = 800, height = 600)
+print(DimPlot(seu, reduction = "umap", label = TRUE))
+invisible(dev.off())

--- a/examples/gallery/templates/sc_report.Rmd
+++ b/examples/gallery/templates/sc_report.Rmd
@@ -1,0 +1,37 @@
+---
+title: "`r params$sample` — Single-Cell Report"
+output: html_document
+params:
+  sample: "sample1"
+  analysis_dir: "analysis/sample1"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
+suppressPackageStartupMessages(library(Seurat))
+seu <- readRDS(file.path(params$analysis_dir, "seurat_object.rds"))
+```
+
+# Sample summary
+
+- Sample: `r params$sample`
+- Cells: `r ncol(seu)`
+- Genes detected: `r nrow(seu)`
+
+# UMAP
+
+```{r, out.width="90%"}
+DimPlot(seu, reduction = "umap", label = TRUE)
+```
+
+# Cluster composition
+
+```{r}
+knitr::kable(table(Idents(seu)), col.names = c("Cluster", "Cells"))
+```
+
+# QC overview
+
+```{r, out.width="90%"}
+VlnPlot(seu, features = c("nFeature_RNA", "nCount_RNA", "percent.mt"), ncol = 3)
+```


### PR DESCRIPTION
## What

Audit of `examples/gallery` (16 workflows) found one literal placeholder and five references to auxiliary files that do not exist — rules that can never run as-is. This PR completes the gallery and makes `template` copy the aux files so generated workflows are runnable.

## Changes

**New auxiliary files** (canonical in `examples/gallery/`, mirrored in the crate for `cargo package`):
- `scripts/seurat_analysis.R` + `templates/sc_report.Rmd` — gallery 09's clustering + report rules now resolve; report rule passes `sample`/`analysis_dir` as rmarkdown params
- `scripts/report.py` — gallery 11's conditional report
- `scripts/generate_report.py` — galleries 14/15 clinical report: parses the VEP CSQ `Format:` from the `##INFO` header (no assumption on field order), reads plain and gzip VCFs, keeps the most severe transcript per variant

**05 placeholder removed**: the align rule now runs a real `bwa-mem2 index` + `mem` self-alignment with only the already-pinned `biocontainers/bwa-mem2:2.2.1` image (output .sam, downstream rule updated).

**`template` copies aux files**: `EMBEDDED_GALLERY_AUX` + `TEMPLATE_AUX_FILES` embed and copy the aux files next to generated workflows (09/11/14/15), with overwrite protection (bail on differing content, idempotent for shared scripts). Drift-guard test extended to aux files; new `apply_template_copies_aux_files` test.

## Verification

- `make ci` full gate green (fmt/clippy/build/test/schema-drift/audit)
- Live: `template 09_single_cell_rnaseq -o dir/` copies both aux files; `template 14` copies the report script; `template 05` copies nothing extra
- Live: both Python report scripts run against a synthetic VEP-annotated VCF, plain and gzipped (3 variants / 2 PASS / CSQ parsing incl. multi-transcript worst-impact selection)
- `Rscript -e parse(...)` syntax-check green on seurat_analysis.R; validate passes on all five touched workflows

## Notes

- The R script was not executed end-to-end (requires a CellRanger matrix + r-seurat 5); it follows the standard Seurat 5 pipeline.
- Docs: `commands/template.md` now documents aux copying and lists all 16 templates; gallery pages embed the .oxoflow files so the 05 fix propagates automatically.