### PR TITLE
fix(cli): template -o treats a trailing slash as a directory intent

### DIFF
--- a/crates/oxo-flow-cli/src/commands/project.rs
+++ b/crates/oxo-flow-cli/src/commands/project.rs
@@ -474,10 +474,13 @@ fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
     // Substitute the `name` field
     let new_content = substitute_workflow_name(content, &new_name);
 
-    // Write to specified output path, or current directory with template name
+    // Write to specified output path, or current directory with template name.
+    // A trailing slash (or backslash) is an explicit directory intent, even
+    // when the directory does not exist yet.
     let output_path = match output {
         Some(p) => {
-            if p.is_dir() {
+            let lossy = p.to_string_lossy();
+            if p.is_dir() || lossy.ends_with('/') || lossy.ends_with('\\') {
                 p.join(format!("{}.oxoflow", new_name))
             } else {
                 p
@@ -494,6 +497,15 @@ fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
              Remove it first or choose a different name.",
             output_path.display()
         );
+    }
+
+    // Create the destination directory when it does not exist yet (covers
+    // both `-o projects/new/` and `-o projects/new.oxoflow`).
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create {}", parent.display()))?;
     }
 
     std::fs::write(&output_path, new_content)
@@ -698,6 +710,27 @@ mod tests {
 
         // Templates without aux files copy nothing extra.
         apply_template("01_hello_world", Some(dir.path().to_path_buf())).unwrap();
+    }
+
+    #[test]
+    fn apply_template_treats_trailing_slash_output_as_directory() {
+        // `-o projects/pipeline/` (nonexistent, trailing slash) must be
+        // treated as a directory intent, not as a literal file path.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("projects").join("new-pipeline");
+        let out = format!("{}/", target.to_string_lossy());
+        apply_template("01_hello_world", Some(PathBuf::from(out))).unwrap();
+        let workflows: Vec<_> = std::fs::read_dir(&target)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "oxoflow"))
+            .collect();
+        assert_eq!(
+            workflows.len(),
+            1,
+            "trailing-slash output must contain exactly one generated workflow"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -359,7 +359,11 @@ pub enum Commands {
             help = "Template name or natural-language description (with --ai)"
         )]
         template: Option<String>,
-        #[arg(short = 'o', long, help = "Output file path")]
+        #[arg(
+            short = 'o',
+            long,
+            help = "Output file or directory (a trailing slash forces a directory)"
+        )]
         output: Option<PathBuf>,
         /// Enable AI-powered workflow generation from natural language.
         #[arg(long)]

--- a/docs/guide/src/commands/template.md
+++ b/docs/guide/src/commands/template.md
@@ -29,7 +29,7 @@ immediately complete and runnable.
 
 | Option | Description |
 |--------|-------------|
-| `-o, --output <OUTPUT>` | Output path (file or directory). Defaults to current directory with template name |
+| `-o, --output <OUTPUT>` | Output file or directory (a trailing slash forces a directory, created if missing). Defaults to current directory with template name |
 | `--ai` | Generate the workflow with AI from a natural language description |
 | `--from-url <URL>` | URL(s) to use as reference material for AI generation (repeatable) |
 | `--from-file <PATH>` | File(s) to use as reference material for AI generation (repeatable) |


### PR DESCRIPTION
## What

`oxo-flow template -o projects/pipeline/` (nonexistent directory + trailing slash) failed with `No such file or directory`, and a plain file path with a missing parent failed the same way. The trailing slash is now an explicit directory intent: the directory is created and the workflow (plus its aux files) land inside it.

Found by the verification lane after #168.

## Changes

- `apply_template`: trailing `/` or `\` on `-o` → directory intent (created if missing); the parent directory is now created for plain file paths too
- New `apply_template_treats_trailing_slash_output_as_directory` test (RED first, then GREEN)
- Help text: `-o` documents the trailing-slash semantics; `commands/template.md` updated

## Verification

- `cargo test -p oxo-flow-cli --bin oxo-flow project::tests` — 5/5 green
- `cargo fmt -- --check` clean