### PR TITLE
fix(gallery): container image references must exist and be registry-qualified

### DIFF
--- a/crates/oxo-flow-cli/templates/05_conda_environments.oxoflow
+++ b/crates/oxo-flow-cli/templates/05_conda_environments.oxoflow
@@ -55,7 +55,7 @@ threads = 8
 memory = "16G"
 
 [rules.environment]
-docker = "biocontainers/bwa-mem2:2.2.1"
+docker = "quay.io/biocontainers/bwa-mem2:2.2.1--he70b90d_8"
 
 [[rules]]
 name = "analyze_results"

--- a/crates/oxo-flow-cli/templates/09_single_cell_rnaseq.oxoflow
+++ b/crates/oxo-flow-cli/templates/09_single_cell_rnaseq.oxoflow
@@ -41,7 +41,7 @@ threads = 16
 memory = "64G"
 
 [rules.environment]
-docker = "10xgenomics/cellranger:7.1.0"
+docker = "quay.io/nf-core/cellranger:7.1.0"
 
 [[rules]]
 name = "clustering_analysis"

--- a/docs/guide/src/how-to/troubleshooting.md
+++ b/docs/guide/src/how-to/troubleshooting.md
@@ -155,7 +155,7 @@ convention.
 **Solution**:
 
 1. Check that Docker is installed and running: `docker info`
-2. Verify the image reference: `docker pull biocontainers/bwa:0.7.17`
+2. Verify the image reference: `docker pull quay.io/biocontainers/bwa:0.7.19--h577a1d6_1`
 3. Check for authentication if using private registries
 
 ### HPC modules not available

--- a/docs/guide/src/how-to/use-environments.md
+++ b/docs/guide/src/how-to/use-environments.md
@@ -53,7 +53,7 @@ shell = "bwa mem ref.fa reads.fastq.gz | samtools sort -o aligned.bam"
 ```toml
 [[rules]]
 name = "align"
-environment = { docker = "biocontainers/bwa:0.7.17--h7132678_3" }
+environment = { docker = "quay.io/biocontainers/bwa:0.7.19--h577a1d6_1" }
 shell = "bwa mem ref.fa reads.fastq.gz | samtools sort -o aligned.bam"
 ```
 
@@ -72,7 +72,7 @@ oxo-flow automatically mounts the working directory into the container. Input an
 Images are pulled on first use. If you need offline operation, pre-pull images:
 
 ```bash
-docker pull biocontainers/bwa:0.7.17--h7132678_3
+docker pull quay.io/biocontainers/bwa:0.7.19--h577a1d6_1
 ```
 
 ---
@@ -84,7 +84,7 @@ docker pull biocontainers/bwa:0.7.17--h7132678_3
 ```toml
 [[rules]]
 name = "align"
-environment = { singularity = "docker://biocontainers/bwa:0.7.17--h7132678_3" }
+environment = { singularity = "docker://quay.io/biocontainers/bwa:0.7.19--h577a1d6_1" }
 shell = "bwa mem ref.fa reads.fastq.gz > aligned.sam"
 ```
 

--- a/docs/guide/src/index.md
+++ b/docs/guide/src/index.md
@@ -135,7 +135,7 @@ memory = "8G"
 name = "bwa_align"
 input = ["{sample}_R1.fastq.gz", "{sample}_R2.fastq.gz"]
 output = ["aligned/{sample}.bam"]
-environment = { docker = "biocontainers/bwa:0.7.17" }
+environment = { docker = "quay.io/biocontainers/bwa:0.7.19--h577a1d6_1" }
 shell = "bwa mem -t {threads} {config.reference} {input} | samtools sort -o {output}"
 
 [rules.resources]

--- a/examples/gallery/05_conda_environments.oxoflow
+++ b/examples/gallery/05_conda_environments.oxoflow
@@ -55,7 +55,7 @@ threads = 8
 memory = "16G"
 
 [rules.environment]
-docker = "biocontainers/bwa-mem2:2.2.1"
+docker = "quay.io/biocontainers/bwa-mem2:2.2.1--he70b90d_8"
 
 [[rules]]
 name = "analyze_results"

--- a/examples/gallery/09_single_cell_rnaseq.oxoflow
+++ b/examples/gallery/09_single_cell_rnaseq.oxoflow
@@ -41,7 +41,7 @@ threads = 16
 memory = "64G"
 
 [rules.environment]
-docker = "10xgenomics/cellranger:7.1.0"
+docker = "quay.io/nf-core/cellranger:7.1.0"
 
 [[rules]]
 name = "clustering_analysis"


### PR DESCRIPTION
## What

tx-ubuntu live testing of the gallery (the 实测 pass requested for the examples) found two container references that do not resolve anywhere:

- `05_conda_environments`: `biocontainers/bwa-mem2:2.2.1` — Docker Hub API: not found; quay.io has no bare tag. Correct, pull-verified: `quay.io/biocontainers/bwa-mem2:2.2.1--he70b90d_8`
- `09_single_cell_rnaseq`: `10xgenomics/cellranger:7.1.0` — the repo does not exist on Docker Hub (10x publishes no official images). Correct: `quay.io/nf-core/cellranger:7.1.0` (verified via quay API)
- `07/08/13` `broadinstitute/gatk:4.5.0.0` — verified real via the Docker Hub API, left unchanged

The same broken pattern appeared in the docs examples (bare `biocontainers/bwa` with a nonexistent tag) — index.md, troubleshooting.md, use-environments.md now use the quay-verified `quay.io/biocontainers/bwa:0.7.19--h577a1d6_1`.

Root cause note: the engine passes the image spec verbatim to `docker pull` (no implicit quay.io fallback), so references must be fully qualified — worth a future UX improvement (auto-try quay.io/biocontainers for bare biocontainers names).

## Verification

- quay.io API: bwa-mem2 tag exists; nf-core/cellranger:7.1.0 exists; bwa tag exists
- Docker Hub API: broadinstitute/gatk:4.5.0.0 exists (kept); biocontainers/bwa-mem2:2.2.1 and 10xgenomics/cellranger do not (fixed)
- tx-ubuntu: `docker pull quay.io/biocontainers/bwa-mem2:2.2.1--he70b90d_8` succeeded
- drift-guard test green after mirror sync