### PR TITLE
fix(ci): re-point the tag to the synced commit on tag-push releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,21 @@ jobs:
           git push origin "$TAG_NAME"
           echo "Tag $TAG_NAME created at $TARGET_SHA"
 
+      # Tag-push releases (a tag pushed directly, no dispatch): the tag must
+      # reference the synced tree the steps above commit (version bump +
+      # CHANGELOG), because publish-crates checks out by tag name and fails
+      # its version-match check against pre-bump versions. The tag is moved
+      # to HEAD exactly once per release; a re-fire with an already-synced
+      # tag exits early above ("Version already synced") and never reaches
+      # this step, so the tag stays put.
+      - name: Re-point tag to the synced commit (tag-push releases)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push --force origin "HEAD:refs/tags/${RELEASE_TAG}"
+          echo "Tag ${RELEASE_TAG} re-pointed to $(git rev-parse HEAD)"
+
   # ─── Quality gate: fmt + clippy + tests ────────────────────────────────────
   test:
     name: Test (fmt, clippy, test)


### PR DESCRIPTION
## What

The v0.15.0 tag-push release failed at `Publish to crates.io` — `Confirm version matches tag`: tag=0.15.0 vs oxo-flow-core=0.14.1.

**Root cause**: the tag-push release path never moved the tag to the version-bump commit. `sync-version` bumps the workspace and commits to main (it did — 357c886 + the CHANGELOG commit), but only the dispatch path creates the tag against the synced tree (`Create and push release tag` is `workflow_dispatch`-only). `publish-crates` checks out by tag name (`github.ref`), so it saw the pre-bump tree.

**Side discovery**: oxo-flow-core on crates.io tops out at 0.9.4 — the tag-push path has never published 0.10+ successfully; this fix (plus the v0.15.0 re-fire) closes that gap.

## Change

New `sync-version` step `Re-point tag to the synced commit`, gated to `startsWith(github.ref, 'refs/tags/v')`: force-pushes HEAD to the tag ref after the bump/changelog commits. Runs once per release; a re-fire with an already-synced tag exits early in the bump step and never reaches it, so the tag stays put.

## Verification

- YAML valid (pyyaml parse)
- The v0.15.0 release will be repaired by this exact mechanism (manual tag re-point to the already-pushed bump commit 357c886 + re-fire) and watched end-to-end