### PR TITLE
ci(docs): versioned documentation with mike (issue #176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,3 +1044,23 @@ jobs:
             echo "Deploying dev version"
             mike deploy --push dev
           fi
+
+      - name: Preserve landing page + static assets at the Pages root
+        run: |
+          # mike's tree replaces the branch root; the hand-authored landing
+          # page and the static docs/ assets must be re-laid after every
+          # deploy (issue #176: keep /oxo-flow/ the landing, versions live
+          # under /latest/, /dev/, /<tag>/).
+          mkdir -p /tmp/pages-extra
+          cp -r docs/index.html docs/CHANGE_CONTROL.md docs/VALIDATION_PROTOCOL.md \
+            docs/schema docs/superpowers /tmp/pages-extra/
+          git fetch origin gh-pages
+          git checkout gh-pages
+          cp /tmp/pages-extra/index.html index.html
+          cp /tmp/pages-extra/CHANGE_CONTROL.md CHANGE_CONTROL.md
+          cp /tmp/pages-extra/VALIDATION_PROTOCOL.md VALIDATION_PROTOCOL.md
+          cp -r /tmp/pages-extra/schema schema
+          cp -r /tmp/pages-extra/superpowers superpowers
+          git add -A
+          git commit -m "chore: preserve landing page + static assets (${GITHUB_SHA:0:7})" \
+            && git push origin gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,42 +1007,40 @@ jobs:
 
   # ─── Deploy GitHub Pages (landing page + MkDocs documentation) ─────────────
   deploy-pages:
-    name: Deploy GitHub Pages
+    name: Deploy versioned documentation (mike)
     runs-on: ubuntu-latest
     needs: [test]
     if: >-
       always() &&
       needs.test.result == 'success' &&
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Install MkDocs Material
-        run: pip install mkdocs-material
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-      - name: Build documentation
+      - name: Install MkDocs Material + mike
+        run: pip install mkdocs-material mike
+
+      - name: Configure git identity (mike pushes the gh-pages branch)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy with mike
         run: |
           cd docs/guide
-          mkdocs build
-
-      - name: Prepare Pages artifact
-        run: |
-          cp -r docs/guide/site docs/documentation
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "Deploying release version ${VERSION} (+ latest alias)"
+            mike deploy --push --update-aliases "${VERSION}" latest
+          else
+            echo "Deploying dev version"
+            mike deploy --push dev
+          fi

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Crates.io](https://img.shields.io/crates/v/oxo-flow-core?label=crates.io&style=flat-square)](https://crates.io/crates/oxo-flow-core)
 [![bioconda](https://anaconda.org/bioconda/oxo-flow-cli/badges/version.svg)](https://bioconda.github.io/recipes/oxo-flow-cli/README.html)
 [![MSRV](https://img.shields.io/badge/MSRV-1.97.1-orange?style=flat-square)](rust-toolchain.toml)
-[![Docs](https://img.shields.io/badge/docs-guide-blue?style=flat-square)](https://traitome.github.io/oxo-flow/documentation/)
+[![Docs](https://img.shields.io/badge/docs-guide-blue?style=flat-square)](https://traitome.github.io/oxo-flow/latest/)
 [![License](https://img.shields.io/badge/license-Apache%202.0%20%7C%20Dual-blue?style=flat-square)](#license)
 [![Rust](https://img.shields.io/badge/rust-2024_edition-orange?style=flat-square)](https://doc.rust-lang.org/edition-guide/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey?style=flat-square)](#quick-start)
@@ -21,7 +21,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/Traitome/oxo-flow?style=flat-square)](https://github.com/Traitome/oxo-flow/stargazers)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Traitome/oxo-flow)
 
-[Documentation](https://traitome.github.io/oxo-flow/documentation/) · [Workflow Gallery](https://traitome.github.io/oxo-flow/documentation/gallery/) · [Community](https://oxo-flow-community.github.io/) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
+[Documentation](https://traitome.github.io/oxo-flow/latest/) · [Workflow Gallery](https://traitome.github.io/oxo-flow/latest/gallery/) · [Community](https://oxo-flow-community.github.io/) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
 
 </div>
 
@@ -70,7 +70,7 @@ oxo-flow is built on five principles:
 
 ## Workflow Gallery
 
-Learn oxo-flow incrementally with curated, validated example workflows — from a one-rule hello-world to production-grade pipelines. Every workflow passes `oxo-flow validate` and is tested in CI. See the [Workflow Gallery](https://traitome.github.io/oxo-flow/documentation/gallery/) for the full catalog with detailed explanations, DAG visualizations, and CLI output.
+Learn oxo-flow incrementally with curated, validated example workflows — from a one-rule hello-world to production-grade pipelines. Every workflow passes `oxo-flow validate` and is tested in CI. See the [Workflow Gallery](https://traitome.github.io/oxo-flow/latest/gallery/) for the full catalog with detailed explanations, DAG visualizations, and CLI output.
 
 ## Quick Start
 
@@ -200,11 +200,11 @@ shell = "bwa-mem2 mem -t {threads} {config.reference} {input[0]} {input[1]} | sa
 docker = "biocontainers/bwa-mem2:2.2.1"
 ```
 
-Wildcards like `{sample}` expand automatically via input file discovery. Features include reference directory conventions, environment groups, optional rules, and directory inputs. See the full [Workflow Format Specification](https://traitome.github.io/oxo-flow/documentation/reference/workflow-format/) for details.
+Wildcards like `{sample}` expand automatically via input file discovery. Features include reference directory conventions, environment groups, optional rules, and directory inputs. See the full [Workflow Format Specification](https://traitome.github.io/oxo-flow/latest/reference/workflow-format/) for details.
 
 ## CLI Commands
 
-The `oxo-flow` binary provides **29 subcommands** covering the complete workflow lifecycle. See the full [CLI Reference](https://traitome.github.io/oxo-flow/documentation/commands/run/) for details.
+The `oxo-flow` binary provides **29 subcommands** covering the complete workflow lifecycle. See the full [CLI Reference](https://traitome.github.io/oxo-flow/latest/commands/run/) for details.
 
 | Category | Commands |
 |----------|----------|
@@ -215,11 +215,11 @@ The `oxo-flow` binary provides **29 subcommands** covering the complete workflow
 | **Deployment** | `serve`, `cluster`, `publish`, `pull` |
 | **AI & System** | `ai`, `completions`, `license` |
 
-See the full [CLI Reference](https://traitome.github.io/oxo-flow/documentation/commands/run/) for detailed usage of each subcommand.
+See the full [CLI Reference](https://traitome.github.io/oxo-flow/latest/commands/run/) for detailed usage of each subcommand.
 
 ## Web API
 
-The `oxo-flow serve` command starts an [axum](https://github.com/tokio-rs/axum)-powered REST server with **50+ endpoints** across 7 domains (observability, pipeline, execution, AI, auth, data, ops). Full API reference at the [OpenAPI 3.1 spec](https://traitome.github.io/oxo-flow/documentation/reference/api/).
+The `oxo-flow serve` command starts an [axum](https://github.com/tokio-rs/axum)-powered REST server with **50+ endpoints** across 7 domains (observability, pipeline, execution, AI, auth, data, ops). Full API reference at the [OpenAPI 3.1 spec](https://traitome.github.io/oxo-flow/latest/reference/api/).
 
 
 oxo-flow is organized as a Cargo workspace with four crates:
@@ -285,17 +285,17 @@ oxo-flow serve --mode hpc --scheduler slurm
 
 ## Documentation
 
-Comprehensive documentation is available at **[traitome.github.io/oxo-flow/documentation/](https://traitome.github.io/oxo-flow/documentation/)**.
+Comprehensive documentation is available at **[traitome.github.io/oxo-flow/latest/](https://traitome.github.io/oxo-flow/latest/)**.
 
 ### 📖 Documentation Quick Links
 
 | If you are... | Recommended Start |
 |---|---|
-| **New to oxo-flow** | [Quick Start](https://traitome.github.io/oxo-flow/documentation/tutorials/quickstart/) · [First Workflow](https://traitome.github.io/oxo-flow/documentation/tutorials/first-workflow/) |
-| **A Bioinformatician** | [Workflow Gallery](https://traitome.github.io/oxo-flow/documentation/gallery/) |
-| **A Pipeline Engineer** | [Workflow Format Specification](https://traitome.github.io/oxo-flow/documentation/reference/workflow-format/) · [CLI Reference](https://traitome.github.io/oxo-flow/documentation/commands/run/) |
-| **A DevOps/Cloud Admin** | [Environment Management](https://traitome.github.io/oxo-flow/documentation/tutorials/environment-management/) · [Running on Cluster](https://traitome.github.io/oxo-flow/documentation/how-to/run-on-cluster/) |
-| **A Bioinformatics Core** | [Workflow Gallery](https://traitome.github.io/oxo-flow/documentation/gallery/) · [Environment Management](https://traitome.github.io/oxo-flow/documentation/tutorials/environment-management/) |
+| **New to oxo-flow** | [Quick Start](https://traitome.github.io/oxo-flow/latest/tutorials/quickstart/) · [First Workflow](https://traitome.github.io/oxo-flow/latest/tutorials/first-workflow/) |
+| **A Bioinformatician** | [Workflow Gallery](https://traitome.github.io/oxo-flow/latest/gallery/) |
+| **A Pipeline Engineer** | [Workflow Format Specification](https://traitome.github.io/oxo-flow/latest/reference/workflow-format/) · [CLI Reference](https://traitome.github.io/oxo-flow/latest/commands/run/) |
+| **A DevOps/Cloud Admin** | [Environment Management](https://traitome.github.io/oxo-flow/latest/tutorials/environment-management/) · [Running on Cluster](https://traitome.github.io/oxo-flow/latest/how-to/run-on-cluster/) |
+| **A Bioinformatics Core** | [Workflow Gallery](https://traitome.github.io/oxo-flow/latest/gallery/) · [Environment Management](https://traitome.github.io/oxo-flow/latest/tutorials/environment-management/) |
 
 MkDocs source lives under [`docs/guide/src/`](docs/guide/src/).
 
@@ -378,7 +378,7 @@ If you use oxo-flow in academic research, please cite:
 
 - 🐛 **Bug reports** — [GitHub Issues](https://github.com/Traitome/oxo-flow/issues) (use [bug report template](.github/ISSUE_TEMPLATE/bug_report.md))
 - 💡 **Feature requests** — [GitHub Issues](https://github.com/Traitome/oxo-flow/issues) (use [feature request template](.github/ISSUE_TEMPLATE/feature_request.md))
-- 📖 **Documentation** — [traitome.github.io/oxo-flow/documentation/](https://traitome.github.io/oxo-flow/documentation/)
+- 📖 **Documentation** — [traitome.github.io/oxo-flow/latest/](https://traitome.github.io/oxo-flow/latest/)
 - ❓ **Questions** — [Ask DeepWiki](https://deepwiki.com/Traitome/oxo-flow)
 
 ### 🧪 Real-World Feedback

--- a/crates/oxo-flow-cli/src/commands/ai_status.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_status.rs
@@ -231,7 +231,7 @@ pub async fn ai_setup_command() -> Result<()> {
         println!("  Or edit the config file directly:");
         println!("    {}", "~/.oxo-flow/ai_config.json".dimmed());
         println!();
-        println!("  See docs: https://traitome.github.io/oxo-flow/documentation/reference/ai-cli/");
+        println!("  See docs: https://traitome.github.io/oxo-flow/latest/reference/ai-cli/");
         return Ok(());
     }
 

--- a/docs/guide/mkdocs.yml
+++ b/docs/guide/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: "oxo-flow"
-site_url: https://traitome.github.io/oxo-flow/documentation/
+site_url: https://traitome.github.io/oxo-flow/
 site_description: "oxo-flow Documentation — Rust-native bioinformatics pipeline engine"
 repo_url: https://github.com/Traitome/oxo-flow
 repo_name: Traitome/oxo-flow
@@ -95,6 +95,11 @@ markdown_extensions:
   - tables
 
 extra:
+  version:
+    # mike-based doc versioning (issue #176): every release tag gets a
+    # frozen version, `latest` aliases the newest release, main pushes
+    # update `dev`. The Material theme renders the version selector.
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/Traitome/oxo-flow

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -63,7 +63,7 @@ Knowledge freshness:
 - `lookup_tool` responses carry the same data date and record count as a
   freshness note, so agents can weigh how current the embedded database is.
 - See "Embedded Knowledge Freshness" in the
-  [AI CLI reference](https://traitome.github.io/oxo-flow/documentation/reference/ai-cli/)
+  [AI CLI reference](https://traitome.github.io/oxo-flow/latest/reference/ai-cli/)
   for the update cadence, the update GitHub Action, and the gate details.
 
 ## The `--ai` flag on other commands

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,7 +268,7 @@
         <a href="#gallery">Gallery</a>
         <a href="#install">Install</a>
         <a href="#quickstart">Quick Start</a>
-        <a href="documentation/">Docs</a>
+        <a href="latest/">Docs</a>
         <a href="https://github.com/Traitome/oxo-flow">GitHub</a>
       </nav>
     </div>
@@ -296,7 +296,7 @@
         </a>
       </div>
       <div class="cta-group">
-        <a class="btn btn-primary" href="documentation/">Read the Docs</a>
+        <a class="btn btn-primary" href="latest/">Read the Docs</a>
         <a class="btn btn-secondary" href="#gallery">Workflow Gallery</a>
         <a class="btn btn-secondary" href="https://github.com/Traitome/oxo-flow">View on GitHub</a>
       </div>
@@ -417,7 +417,7 @@
         </div>
       </div>
       <p style="margin-top:1.5rem;">
-        <a href="documentation/gallery/">Browse the full Gallery documentation →</a>
+        <a href="latest/gallery/">Browse the full Gallery documentation →</a>
       </p>
     </div>
   </section>
@@ -514,7 +514,7 @@ docker = <span class="str">"biocontainers/bwa-mem2:2.2.1"</span>
         <code>cluster</code>, <code>serve</code>, and more.
       </p>
       <p style="margin-top:1rem">
-        <a class="btn btn-primary" href="documentation/commands/run/">CLI Reference →</a>
+        <a class="btn btn-primary" href="latest/commands/run/">CLI Reference →</a>
       </p>
     </div>
   </section>
@@ -530,7 +530,7 @@ docker = <span class="str">"biocontainers/bwa-mem2:2.2.1"</span>
         OpenAPI 3.1 spec at <code>/api/openapi.json</code>.
       </p>
       <p style="margin-top:1rem">
-        <a class="btn btn-primary" href="documentation/reference/api/">API Reference →</a>
+        <a class="btn btn-primary" href="latest/reference/api/">API Reference →</a>
       </p>
     </div>
   </section>
@@ -682,8 +682,8 @@ cargo build --release
           <div class="icon">📖</div>
           <h3>Documentation</h3>
           <p>
-            <a href="documentation/">Full guide</a> ·
-            <a href="documentation/gallery/">Workflow Gallery</a> ·
+            <a href="latest/">Full guide</a> ·
+            <a href="latest/gallery/">Workflow Gallery</a> ·
             <a href="https://deepwiki.com/Traitome/oxo-flow">Ask DeepWiki</a>
           </p>
         </div>
@@ -755,8 +755,8 @@ cargo build --release
         Read the documentation, explore the gallery, or dive straight into the source.
       </p>
       <div class="cta-group" style="justify-content:center;">
-        <a class="btn btn-primary" href="documentation/">Documentation</a>
-        <a class="btn btn-secondary" style="border-color:#0e7c86;color:#0e7c86;" href="documentation/gallery/">Workflow Gallery</a>
+        <a class="btn btn-primary" href="latest/">Documentation</a>
+        <a class="btn btn-secondary" style="border-color:#0e7c86;color:#0e7c86;" href="latest/gallery/">Workflow Gallery</a>
         <a class="btn btn-secondary" style="border-color:#0e7c86;color:#0e7c86;" href="https://github.com/Traitome/oxo-flow">GitHub</a>
         <a class="btn btn-secondary" style="border-color:#0e7c86;color:#0e7c86;" href="https://github.com/Traitome/oxo-flow/blob/main/ROADMAP.md">Roadmap</a>
       </div>
@@ -769,7 +769,7 @@ cargo build --release
       <span>&copy; 2026 Traitome. oxo-flow is open-source software.</span>
       <span>
         <a href="https://github.com/Traitome/oxo-flow">GitHub</a> &middot;
-        <a href="documentation/">Docs</a> &middot;
+        <a href="latest/">Docs</a> &middot;
         <a href="https://github.com/Traitome/oxo-flow/blob/main/ROADMAP.md">Roadmap</a> &middot;
         <a href="https://github.com/Traitome/oxo-flow/blob/main/LICENSE">License</a> &middot;
         <a href="https://deepwiki.com/Traitome/oxo-flow">DeepWiki</a>


### PR DESCRIPTION
## What

Docs site becomes versioned (issue #176): release tags get frozen versions, `latest` aliases the newest release, main pushes update `dev`; the Material theme shows a version selector.

- `mkdocs.yml`: mike version provider; site_url now the Pages root
- `deploy-pages`: tag push → `mike deploy --push --update-aliases <tag> latest`; main push → `mike deploy --push dev`; then the hand-authored **landing page + static assets (index.html, CHANGE_CONTROL, VALIDATION_PROTOCOL, schema/, superpowers/) are re-laid at the Pages root** so /oxo-flow/ keeps serving the landing (versions live under /latest/, /dev/, /<tag>/)
- Landing page links repointed from /documentation/ to /latest/
- ai.md cross-link updated

## Infra (out-of-band, done)

- gh-pages branch pre-seeded: 0.14.1 + latest (mike 2.2.0) + landing/assets (252cf2e)
- Pages source switched from the Actions artifact to the gh-pages branch

## Verification

- mkdocs build clean; mike list shows 0.14.1 [latest]
- Live checks post-merge: /oxo-flow/ (landing), /oxo-flow/latest/ (docs + selector), /oxo-flow/0.14.1/