### PR TITLE
feat: issue #67 follow-ups — SSE broadcast verification + env-ai matching tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "toml",
  "uuid",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ tempfile = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 reqwest = { workspace = true }
 uuid = { workspace = true }
 zstd = { version = "0.13", default-features = false }

--- a/crates/oxo-flow-cli/src/commands/infra.rs
+++ b/crates/oxo-flow-cli/src/commands/infra.rs
@@ -360,6 +360,45 @@ pub fn handle_license(path: Option<std::path::PathBuf>, json: bool) -> Result<()
 
 /// Generate an environment spec (conda YAML or pixi TOML) from a
 /// natural-language description using the AI provider + built-in tool table.
+/// Pre-resolve tools mentioned in a natural-language description against
+/// the embedded Bioconda database (`env create --ai`).
+///
+/// Generic stop words and short fragments are filtered before matching,
+/// and only NAME-level matches (the tool name contains the word) are
+/// injected — summary-only matches are too loose. Returns (name, version,
+/// summary) triples, deduplicated.
+fn match_description_tools(description: &str) -> Vec<(String, String, String)> {
+    const STOP_WORDS: &[&str] = &[
+        "and", "the", "for", "with", "using", "into", "from", "your", "pipeline", "workflow",
+        "analysis", "data", "files", "output", "input", "all", "new", "this", "that", "via",
+        "then", "also", "based", "need", "want", "please",
+    ];
+    let mut matched = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for word in description
+        .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
+        .filter(|w| w.len() >= 3 && !STOP_WORDS.contains(&w.to_ascii_lowercase().as_str()))
+    {
+        let word_lower = word.to_ascii_lowercase();
+        for tool in oxo_flow_ai::knowledge::bioconda::search_tools(word, 3) {
+            // Keep only matches where the tool name actually contains the
+            // word — summary-only matches are too loose to inject.
+            if !tool.name.to_ascii_lowercase().contains(&word_lower) {
+                continue;
+            }
+            if seen.insert(tool.name.clone()) {
+                let summary = if tool.summary.is_empty() {
+                    "(no description)".to_string()
+                } else {
+                    tool.summary.clone()
+                };
+                matched.push((tool.name.clone(), tool.version.clone(), summary));
+            }
+        }
+    }
+    matched
+}
+
 async fn create_env_from_ai(
     description: &std::path::Path,
     name: Option<String>,
@@ -381,46 +420,11 @@ async fn create_env_from_ai(
     println!("  Backend: {}", if is_pixi { "pixi" } else { "conda" });
     println!("  Description: {description}\n");
 
-    // Pre-resolve tools mentioned in the description against the embedded
-    // Bioconda database — inject real names + current versions so the model
-    // pins accurately instead of guessing. Generic words and loose summary
-    // matches are filtered out so unrelated tools don't pollute the prompt.
-    const STOP_WORDS: &[&str] = &[
-        "and", "the", "for", "with", "using", "into", "from", "your", "pipeline", "workflow",
-        "analysis", "data", "files", "output", "input", "all", "new", "this", "that", "via",
-        "then", "also", "based", "need", "want", "please",
-    ];
-    let mut matched = String::new();
-    let mut seen = std::collections::HashSet::new();
-    for word in description
-        .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
-        .filter(|w| w.len() >= 3 && !STOP_WORDS.contains(&w.to_ascii_lowercase().as_str()))
-    {
-        let word_lower = word.to_ascii_lowercase();
-        for tool in oxo_flow_ai::knowledge::bioconda::search_tools(word, 3) {
-            // Keep only matches where the tool name actually contains the
-            // word — summary-only matches are too loose to inject.
-            if !tool.name.to_ascii_lowercase().contains(&word_lower) {
-                continue;
-            }
-            if seen.insert(tool.name.clone()) {
-                matched.push_str(&format!(
-                    "- {} {} — {}\n",
-                    tool.name,
-                    tool.version,
-                    if tool.summary.is_empty() {
-                        "(no description)"
-                    } else {
-                        &tool.summary
-                    }
-                ));
-            }
-        }
-    }
+    let matched = match_description_tools(&description);
     if !matched.is_empty() {
         eprintln!("{}", "  Matched Bioconda tools:".bold().cyan());
-        for line in matched.lines() {
-            eprintln!("    {line}");
+        for (name, version, summary) in &matched {
+            eprintln!("    - {name} {version} — {summary}");
         }
     }
 
@@ -457,9 +461,13 @@ Rules:
 "#,
             oxo_flow_ai::knowledge::builtin::format_tool_table(),
             if matched.is_empty() {
-                "(none matched)"
+                "(none matched)".to_string()
             } else {
-                &matched
+                matched
+                    .iter()
+                    .map(|(n, v, s)| format!("- {n} {v} — {s}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             }
         )
     } else {
@@ -495,9 +503,13 @@ Rules:
 "#,
             oxo_flow_ai::knowledge::builtin::format_tool_table(),
             if matched.is_empty() {
-                "(none matched)"
+                "(none matched)".to_string()
             } else {
-                &matched
+                matched
+                    .iter()
+                    .map(|(n, v, s)| format!("- {n} {v} — {s}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             }
         )
     };
@@ -591,4 +603,65 @@ fn extract_toml(response: &str) -> Option<String> {
         return Some(response[pos..].trim().to_string());
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stop words and short fragments must not match anything.
+    #[test]
+    fn description_matching_filters_stop_words_and_short_words() {
+        let matched = match_description_tools("please align with using fastp for the data");
+        assert!(
+            matched.iter().any(|(name, _, _)| name == "fastp"),
+            "fastp must be matched: {matched:?}"
+        );
+        for (name, _, _) in &matched {
+            assert_ne!(name, "and");
+            assert_ne!(name, "using");
+            assert_ne!(name, "the");
+        }
+    }
+
+    /// Only NAME-level matches are injected: a query word that only
+    /// appears in a summary must not pull the tool in.
+    #[test]
+    fn description_matching_requires_name_level_hit() {
+        let matched = match_description_tools("trimming");
+        for (name, _, _) in &matched {
+            assert!(
+                name.to_ascii_lowercase().contains("trim"),
+                "name-level match required, got {name}"
+            );
+        }
+    }
+
+    /// The same tool mentioned twice contributes once.
+    #[test]
+    fn description_matching_deduplicates_tools() {
+        let matched = match_description_tools("fastp fastp fastp");
+        let fastp_hits: Vec<_> = matched.iter().filter(|(n, _, _)| n == "fastp").collect();
+        assert_eq!(fastp_hits.len(), 1, "fastp must appear once: {matched:?}");
+    }
+
+    /// A known tool mentioned in the description resolves to a pinned
+    /// version from the embedded database.
+    #[test]
+    fn description_matching_pins_versions_from_knowledge_base() {
+        let matched = match_description_tools("trim adapters with fastp and index with samtools");
+        let fastp = matched.iter().find(|(n, _, _)| n == "fastp").unwrap();
+        assert!(
+            !fastp.1.is_empty(),
+            "fastp must carry a version: {matched:?}"
+        );
+        assert!(
+            !fastp.2.is_empty(),
+            "fastp must carry a summary: {matched:?}"
+        );
+        assert!(
+            matched.iter().any(|(n, _, _)| n == "samtools"),
+            "samtools must be matched: {matched:?}"
+        );
+    }
 }

--- a/tests/web_sse_load.rs
+++ b/tests/web_sse_load.rs
@@ -1,0 +1,286 @@
+//! SSE terminal-broadcast verification under load + crash recovery
+//! (issue #67 §4).
+//!
+//! Drives the REAL `oxo-flow-web` binary:
+//!  - load: 8 concurrent runs (success + failure mix) must each deliver
+//!    their terminal SSE event exactly once to a connected /api/events
+//!    stream, with the correct type per outcome;
+//!  - crash: a server killed mid-run must not lose the terminal
+//!    broadcast — after restart, the startup re-attach path
+//!    (resume_monitoring) finalizes the orphaned run and broadcasts.
+//!
+//! Single sequential test to avoid parallel-server flakiness.
+
+use reqwest::Client;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+fn workspace_bin(name: &str) -> PathBuf {
+    let target_dir = std::env::current_exe()
+        .expect("cannot find current test executable path")
+        .parent()
+        .expect("no parent dir for test exe")
+        .parent()
+        .expect("no grandparent dir for test exe")
+        .to_path_buf();
+    for candidate in [
+        target_dir.join(name),
+        target_dir.join("deps").join(name),
+        target_dir.join(format!("{name}.exe")),
+    ] {
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!(
+        "could not find binary '{name}' in target directory; \
+         run `cargo build --workspace` first"
+    );
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+struct Server {
+    child: Child,
+    base: String,
+    log_path: PathBuf,
+}
+
+fn spawn_server(dir: &std::path::Path, port: u16, extra_envs: &[(&str, &str)]) -> Server {
+    let log_path = dir.join("web-server.log");
+    let log_file = std::fs::File::create(&log_path).expect("create server log");
+    let mut cmd = Command::new(workspace_bin("oxo-flow-web"));
+    cmd.current_dir(dir)
+        .env("OXO_FLOW_BIN", workspace_bin("oxo-flow"))
+        .env("OXO_FLOW_HOST", "127.0.0.1")
+        .env("OXO_FLOW_PORT", port.to_string())
+        .env(
+            "OXO_FLOW_FRONTEND_DIR",
+            dir.join("missing-frontend").to_str().unwrap(),
+        );
+    for (k, v) in extra_envs {
+        cmd.env(k, v);
+    }
+    let child = cmd
+        .stdout(Stdio::from(log_file.try_clone().unwrap()))
+        .stderr(Stdio::from(log_file))
+        .spawn()
+        .expect("web server must start");
+    Server {
+        child,
+        base: format!("http://127.0.0.1:{port}"),
+        log_path,
+    }
+}
+
+fn log_tail(s: &Server) -> String {
+    match std::fs::read(&s.log_path) {
+        Ok(bytes) => {
+            let tail = if bytes.len() > 4096 {
+                &bytes[bytes.len() - 4096..]
+            } else {
+                &bytes[..]
+            };
+            String::from_utf8_lossy(tail).into_owned()
+        }
+        Err(_) => "(no server log)".to_string(),
+    }
+}
+
+async fn wait_ready(base: &str) {
+    let client = Client::new();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "server did not become ready at {base}"
+        );
+        if client
+            .get(format!("{base}/api/health"))
+            .send()
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn post_run(base: &str, toml: &str) -> String {
+    let client = Client::new();
+    let resp = client
+        .post(format!("{base}/api/runs"))
+        .json(&json!({"toml_content": toml}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "run create failed");
+    resp.json::<Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Parse SSE frames ("data: {json}\n\n") into (type, run_id) pairs.
+fn parse_sse_frame(frame: &str) -> Option<(String, String)> {
+    let line = frame.lines().find(|l| l.starts_with("data:"))?;
+    let json: Value = serde_json::from_str(line.trim_start_matches("data:").trim()).ok()?;
+    let event_type = json.get("type")?.as_str()?.to_string();
+    let run_id = json
+        .get("data")?
+        .get("run_id")?
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    Some((event_type, run_id))
+}
+
+/// Open the SSE stream and pipe terminal events into the channel.
+fn spawn_sse_reader(
+    base: String,
+    tx: mpsc::Sender<(String, String)>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let client = Client::new();
+        let resp = client
+            .get(format!("{base}/api/events"))
+            .send()
+            .await
+            .expect("SSE stream must connect");
+        let mut stream = resp.bytes_stream();
+        let mut buf = String::new();
+        use tokio_stream::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let Ok(bytes) = chunk else { break };
+            buf.push_str(&String::from_utf8_lossy(&bytes));
+            while let Some(pos) = buf.find("\n\n") {
+                let frame: String = buf.drain(..pos + 2).collect();
+                if let Some((event_type, run_id)) = parse_sse_frame(&frame)
+                    && (event_type == "run_completed" || event_type == "run_failed")
+                    && tx.send((event_type, run_id)).await.is_err()
+                {
+                    return; // test side dropped the receiver
+                }
+            }
+        }
+    })
+}
+
+const OK_RUN: &str = "[workflow]\nname = \"ok\"\n\n[[rules]]\nname = \"do\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output}\"\n";
+const BAD_RUN: &str = "[workflow]\nname = \"bad\"\n\n[[rules]]\nname = \"fail\"\noutput = [\"out2.txt\"]\nshell = \"exit 1\"\n";
+
+/// 8 concurrent runs (6 success + 2 failure): every run's terminal event
+/// must arrive exactly once with the correct type.
+#[tokio::test]
+async fn sse_terminal_events_under_load() {
+    let dir = tempfile::tempdir().unwrap();
+    let port = free_port();
+    let mut server = spawn_server(dir.path(), port, &[("OXO_FLOW_MODE", "personal")]);
+    wait_ready(&server.base).await;
+
+    let (tx, mut rx) = mpsc::channel::<(String, String)>(64);
+    let reader = spawn_sse_reader(server.base.clone(), tx);
+
+    // Let the stream connect before the runs fire.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut expected = std::collections::HashMap::new();
+    for i in 0..8 {
+        let toml = if i < 6 { OK_RUN } else { BAD_RUN };
+        let run_id = post_run(&server.base, toml).await;
+        expected.insert(run_id, if i < 6 { "run_completed" } else { "run_failed" });
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    let mut seen = std::collections::HashMap::new();
+    while seen.len() < expected.len() {
+        assert!(
+            Instant::now() < deadline,
+            "only {}/{} terminal events arrived: {seen:?}\n{}",
+            seen.len(),
+            expected.len(),
+            log_tail(&server)
+        );
+        let Ok(Some((event_type, run_id))) =
+            tokio::time::timeout(Duration::from_secs(30), rx.recv()).await
+        else {
+            continue;
+        };
+        let Some(want) = expected.get(&run_id) else {
+            continue; // foreign event (startup scans etc.) — ignore
+        };
+        assert_eq!(
+            &event_type, want,
+            "run {run_id} broadcast {event_type}, expected {want}"
+        );
+        // Exactly-once: duplicates would panic on re-insert.
+        assert!(
+            seen.insert(run_id.clone(), event_type).is_none(),
+            "run {run_id} broadcast twice"
+        );
+    }
+    reader.abort();
+    server.child.kill().unwrap();
+    let _ = server.child.wait();
+}
+
+/// A server killed mid-run must not lose the terminal broadcast: after
+/// restart the orphaned run is re-attached and finalizes with a broadcast.
+#[tokio::test]
+async fn sse_terminal_event_survives_server_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let port = free_port();
+    let mut server = spawn_server(dir.path(), port, &[("OXO_FLOW_MODE", "personal")]);
+    wait_ready(&server.base).await;
+
+    let slow_toml = "[workflow]\nname = \"slow\"\n\n[[rules]]\nname = \"wait\"\noutput = [\"later.txt\"]\nshell = \"sleep 25; echo ok > {output}\"\n";
+    let run_id = post_run(&server.base, slow_toml).await;
+    tokio::time::sleep(Duration::from_secs(3)).await; // let the CLI child start
+
+    // Crash the server while the run executes (the CLI survives in its
+    // own process group).
+    server.child.kill().unwrap();
+    let _ = server.child.wait();
+
+    // Restart on the same working dir: startup re-attach (db.rs) must
+    // resume monitoring the executing run.
+    let port2 = free_port();
+    let mut server2 = spawn_server(dir.path(), port2, &[("OXO_FLOW_MODE", "personal")]);
+    wait_ready(&server2.base).await;
+
+    let (tx, mut rx) = mpsc::channel::<(String, String)>(16);
+    let reader = spawn_sse_reader(server2.base.clone(), tx);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "terminal event for {run_id} never arrived after restart\n{}",
+            log_tail(&server2)
+        );
+        let Ok(Some((event_type, got_run))) =
+            tokio::time::timeout(Duration::from_secs(30), rx.recv()).await
+        else {
+            continue;
+        };
+        if got_run != run_id {
+            continue;
+        }
+        assert_eq!(event_type, "run_completed", "restarted run outcome");
+        break;
+    }
+    reader.abort();
+    server2.child.kill().unwrap();
+    let _ = server2.child.wait();
+}


### PR DESCRIPTION
## What

Two of the issue #67 items we own, delivered as tests:

**§4 SSE broadcasts under load** — `tests/web_sse_load.rs` drives the REAL `oxo-flow-web` binary:
- 8 concurrent runs (6 success + 2 failure): every run's terminal SSE event arrives exactly once with the correct type on a connected `/api/events` stream
- crash recovery: server killed mid-run → restart → the startup re-attach path finalizes the orphaned run and broadcasts `run_completed`
- both green locally (~25s)

**§6 AI quality (deterministic half)** — extracted `match_description_tools()` from `env create --ai` and unit-tested it (4 tests): stop-word/short-word filtering, name-level-hit rule (summary-only matches rejected), dedup, version pinning from the embedded KB. The live-AI prose quality half still needs a keyed environment — documented.

## Verification

- `cargo test --test web_sse_load` 2/2 green
- `cargo test -p oxo-flow-cli --bin oxo-flow infra::tests` 4/4 green
- full `make ci` will run in CI