### PR TITLE
feat(cli): add mermaid and metro graph export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ oxo-flow run my-pipeline.oxoflow -j 8
 oxo-flow graph my-pipeline.oxoflow -f dot > dag.dot
 dot -Tpng dag.dot -o dag.png
 
+# Export a transit-map-style diagram via nf-metro
+oxo-flow graph my-pipeline.oxoflow -f metro -o pipeline.mmd
+nf-metro render pipeline.mmd -o pipeline.svg
+
 # Generate an HTML report
 oxo-flow report my-pipeline.oxoflow -f html -o report.html
 ```

--- a/crates/oxo-flow-cli/src/commands/output.rs
+++ b/crates/oxo-flow-cli/src/commands/output.rs
@@ -38,6 +38,8 @@ pub fn handle_graph(
         "dot" => Ok(dag.to_dot()),
         "dot-clustered" => dag.to_dot_clustered().map_err(|e| anyhow::anyhow!(e)),
         "tree" => dag.to_ascii_tree().map_err(|e| anyhow::anyhow!(e)),
+        "mermaid" => Ok(dag.to_mermaid()),
+        "metro" => dag.to_metro(&config.rules).map_err(|e| anyhow::anyhow!(e)),
         _ => Err(anyhow::anyhow!("unsupported graph format: {}", format)),
     }?;
 

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -417,7 +417,12 @@ pub enum Commands {
     Graph {
         #[arg(value_name = "WORKFLOW", help = "Path to the .oxoflow workflow file")]
         workflow: PathBuf,
-        #[arg(short = 'f', long, default_value = "ascii", help = "Output format")]
+        #[arg(
+            short = 'f',
+            long,
+            default_value = "ascii",
+            help = "Output format: ascii, dot, dot-clustered, tree, mermaid, metro"
+        )]
         format: String,
         #[arg(short = 'o', long, help = "Output file path")]
         output: Option<PathBuf>,

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -531,6 +531,160 @@ impl WorkflowDag {
         )
     }
 
+    /// Export the DAG as a plain Mermaid `graph LR` definition.
+    ///
+    /// Unlike [`Self::to_metro`], this emits standard Mermaid only (no
+    /// `%%metro` directives), so it renders directly on GitHub, in VS Code,
+    /// and in any Mermaid-compatible renderer without nf-metro.
+    pub fn to_mermaid(&self) -> String {
+        let mut out = String::from("graph LR\n");
+        for node in self.nodes_by_rule_index() {
+            out.push_str(&format!(
+                "    n{}[\"{}\"]\n",
+                node.index(),
+                self.graph[node].name
+            ));
+        }
+        for (src, dst) in self.sorted_edges() {
+            out.push_str(&format!("    n{} --> n{}\n", src.index(), dst.index()));
+        }
+        out
+    }
+
+    /// Export the DAG as an nf-metro "metro map" definition.
+    ///
+    /// Output is a Mermaid `graph LR` subset extended with `%%metro`
+    /// directives (colored lines and stage sections), renderable to a
+    /// transit-map-style SVG by
+    /// [`nf-metro`](https://github.com/seqeralabs/nf-metro):
+    ///
+    /// ```text
+    /// oxo-flow graph workflow.oxoflow -f metro -o workflow.mmd
+    /// nf-metro render workflow.mmd -o workflow.svg
+    /// ```
+    ///
+    /// Each rule becomes a station; each dependency becomes an edge carrying
+    /// the *source* rule's stage line. Stages are inferred per rule (see
+    /// [`crate::stage`]); distinct stages become distinct sections.
+    pub fn to_metro(&self, rules: &[Rule]) -> Result<String> {
+        // Stage per node (fallback "generic" when `rule_index` is out of
+        // range — cannot happen for a DAG built from `rules`, but stay total).
+        let mut node_stage: HashMap<NodeIndex, String> = HashMap::new();
+        for node in self.graph.node_indices() {
+            let stage = rules
+                .get(self.graph[node].rule_index)
+                .map(crate::stage::detect_stage)
+                .unwrap_or_else(|| "generic".to_string());
+            node_stage.insert(node, stage);
+        }
+
+        let nodes = self.nodes_by_rule_index();
+        let edges = self.sorted_edges();
+
+        // Stages in first-appearance order (deterministic).
+        let mut stages: Vec<String> = Vec::new();
+        for node in &nodes {
+            let stage = &node_stage[node];
+            if !stages.iter().any(|s| s == stage) {
+                stages.push(stage.clone());
+            }
+        }
+
+        let mut out = String::new();
+
+        // Line definitions.
+        for stage in &stages {
+            out.push_str(&format!(
+                "%%metro line: {} | {} | {}\n",
+                sanitize_metro_id(stage),
+                crate::stage::stage_display(stage),
+                crate::stage::stage_color(stage),
+            ));
+        }
+        out.push('\n');
+        out.push_str("graph LR\n");
+
+        let multi_stage = stages.len() > 1;
+
+        // Stations. With multiple stages, wrap each stage's stations in a
+        // section (`subgraph`) and place intra-stage edges inside it. Edges
+        // that cross sections must follow every `end` block (nf-metro rule),
+        // so we collect those and emit them last.
+        let mut inter_stage_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
+
+        for stage in &stages {
+            if multi_stage {
+                out.push_str(&format!(
+                    "    subgraph {} [{}]\n",
+                    sanitize_metro_id(stage),
+                    crate::stage::stage_display(stage)
+                ));
+            }
+
+            for node in nodes.iter().filter(|n| &node_stage[n] == stage) {
+                out.push_str(&format!(
+                    "        n{}[\"{}\"]\n",
+                    node.index(),
+                    self.graph[*node].name
+                ));
+            }
+
+            for &(src, dst) in &edges {
+                if node_stage[&src] != *stage {
+                    continue;
+                }
+                if node_stage[&dst] == *stage {
+                    // Intra-stage edge — inside this section.
+                    let indent = if multi_stage { "        " } else { "    " };
+                    out.push_str(&format!(
+                        "{indent}n{} -->|{}| n{}\n",
+                        src.index(),
+                        sanitize_metro_id(&node_stage[&src]),
+                        dst.index()
+                    ));
+                } else {
+                    // Edge leaving this stage — emit after all sections.
+                    inter_stage_edges.push((src, dst));
+                }
+            }
+
+            if multi_stage {
+                out.push_str("    end\n");
+            }
+        }
+
+        // Inter-stage edges.
+        for (src, dst) in inter_stage_edges {
+            out.push_str(&format!(
+                "    n{} -->|{}| n{}\n",
+                src.index(),
+                sanitize_metro_id(&node_stage[&src]),
+                dst.index()
+            ));
+        }
+
+        Ok(out)
+    }
+
+    /// Node indices ordered by the rule's position in the workflow file —
+    /// deterministic output for tests and diffs.
+    fn nodes_by_rule_index(&self) -> Vec<NodeIndex> {
+        let mut nodes: Vec<NodeIndex> = self.graph.node_indices().collect();
+        nodes.sort_by_key(|&n| self.graph[n].rule_index);
+        nodes
+    }
+
+    /// Edge endpoints ordered by `(source rule index, target rule index)`.
+    fn sorted_edges(&self) -> Vec<(NodeIndex, NodeIndex)> {
+        let mut edges: Vec<(NodeIndex, NodeIndex)> = self
+            .graph
+            .edge_indices()
+            .map(|e| self.graph.edge_endpoints(e).expect("edge endpoints exist"))
+            .collect();
+        edges.sort_by_key(|&(s, d)| (self.graph[s].rule_index, self.graph[d].rule_index));
+        edges
+    }
+
     /// Returns whether a given output pattern is produced by any rule.
     pub fn has_producer(&self, output: &str) -> bool {
         self.output_to_node.contains_key(output)
@@ -715,6 +869,25 @@ fn looks_like_directory(path: &str) -> bool {
             !KNOWN_FILE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
         }
     }
+}
+
+/// Sanitize a stage name into a safe nf-metro/Mermaid identifier (line ID or
+/// section ID): non-alphanumeric characters become underscores.
+fn sanitize_metro_id(s: &str) -> String {
+    let mut out: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if out.is_empty() {
+        out = "stage".to_string();
+    }
+    out
 }
 
 /// Complexity metrics for a workflow DAG.
@@ -1895,5 +2068,91 @@ mod tests {
         let c = make_rule("cons", vec!["results/other.txt"], vec!["out.txt"]);
         let dag = WorkflowDag::from_rules(&[p, c]).unwrap();
         assert!(dag.dependencies("cons").unwrap().is_empty());
+    }
+
+    // ---- Mermaid / metro export tests -------------------------------------
+
+    #[test]
+    fn mermaid_export_has_nodes_and_edges() {
+        let rules = vec![
+            make_rule("a", vec!["in.txt"], vec!["mid.txt"]),
+            make_rule("b", vec!["mid.txt"], vec!["out.txt"]),
+        ];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_mermaid();
+        assert!(mmd.starts_with("graph LR\n"));
+        assert!(mmd.contains("n0[\"a\"]"));
+        assert!(mmd.contains("n1[\"b\"]"));
+        assert!(mmd.contains("n0 --> n1"));
+        // Plain Mermaid must not carry %%metro directives.
+        assert!(!mmd.contains("%%metro"));
+    }
+
+    #[test]
+    fn metro_export_single_stage_is_flat() {
+        // `make_rule` uses `echo <name>` shells — no stage keywords — so both
+        // rules collapse to the generic line and no section is emitted.
+        let rules = vec![
+            make_rule("a", vec!["in.txt"], vec!["mid.txt"]),
+            make_rule("b", vec!["mid.txt"], vec!["out.txt"]),
+        ];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules).unwrap();
+        assert!(mmd.contains("%%metro line: generic | Analysis | #79706E"));
+        assert!(mmd.contains("graph LR"));
+        assert!(mmd.contains("n0[\"a\"]"));
+        assert!(mmd.contains("n0 -->|generic| n1"));
+        assert!(!mmd.contains("subgraph"));
+    }
+
+    #[test]
+    fn metro_export_multi_stage_emits_sections() {
+        let mut qc = make_rule("fastqc", vec!["reads.fq"], vec!["reads_fastqc.html"]);
+        qc.shell = Some("fastqc reads.fq".to_string());
+        let mut align = make_rule("align", vec!["reads.fq"], vec!["mapped.bam"]);
+        align.shell = Some("bwa mem ref.fa reads.fq > mapped.sam".to_string());
+        let rules = vec![qc, align];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules).unwrap();
+        assert!(mmd.contains("%%metro line: qc | Read QC | #4C78A8"));
+        assert!(mmd.contains("%%metro line: align | Alignment | #54A24B"));
+        assert!(mmd.contains("subgraph qc [Read QC]"));
+        assert!(mmd.contains("subgraph align [Alignment]"));
+    }
+
+    #[test]
+    fn metro_export_cross_stage_edge_follows_sections() {
+        // qc → trim dependency: the edge must carry the source (qc) line and
+        // appear after all `end` blocks (nf-metro's inter-section rule).
+        let mut qc = make_rule("fastqc", vec!["reads.fq"], vec!["reads_fastqc.html"]);
+        qc.shell = Some("fastqc reads.fq".to_string());
+        let mut trim = make_rule("trim", vec!["reads_fastqc.html"], vec!["trimmed.fq"]);
+        trim.shell = Some("fastp -i reads.fastq.gz".to_string());
+        let rules = vec![qc, trim];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules).unwrap();
+        assert!(mmd.contains("n0 -->|qc| n1"));
+        let last_end = mmd
+            .rfind("    end\n")
+            .expect("multi-stage map has sections");
+        let edge_pos = mmd.rfind("-->|qc|").expect("cross-stage edge exists");
+        assert!(
+            edge_pos > last_end,
+            "cross-stage edge must follow all `end` blocks:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_export_explicit_tag_overrides_inference() {
+        // The rule's `tags` categorize it as QC even though its shell says
+        // `bwa` (an aligner) — explicit tags win over keyword inference.
+        let mut rule = make_rule("align_as_qc", vec!["reads.fq"], vec!["out.bam"]);
+        rule.shell = Some("bwa mem ref.fa reads.fq".to_string());
+        rule.tags = vec!["qc".to_string()];
+        let rules = vec![rule];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules).unwrap();
+        assert!(mmd.contains("%%metro line: qc | Read QC | #4C78A8"));
+        assert!(!mmd.contains("%%metro line: align"));
     }
 }

--- a/crates/oxo-flow-core/src/lib.rs
+++ b/crates/oxo-flow-core/src/lib.rs
@@ -67,6 +67,7 @@ pub mod report_metrics;
 pub mod rule;
 pub mod scheduler;
 pub mod scientific_preflight;
+pub mod stage;
 pub mod storage;
 #[cfg(feature = "webhook")]
 pub mod webhook;

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -1,0 +1,238 @@
+//! Workflow-stage inference for metro-map diagram generation.
+//!
+//! Assigns each rule a *stage* (a named analysis phase such as "qc", "align",
+//! "quantify") that becomes a colored "metro line" in the exported diagram.
+//! Stages come from two sources, in priority order:
+//!
+//! 1. **Explicit**: the rule's first `tags` entry, normalized through
+//!    [`canonical_stage`]. Unknown tags are kept verbatim (lowercased) so a
+//!    custom stage still produces its own line.
+//! 2. **Inferred**: keyword matching against the rule's `shell`/`script`
+//!    commands (the same idea as `WorkflowDomain::detect`, at rule
+//!    granularity).
+//!
+//! Rules that match nothing fall back to `"generic"`.
+
+use crate::rule::Rule;
+
+/// Canonical stage names in the order the palette assigns colors.
+const PALETTE: &[(&str, &str, &str)] = &[
+    // (stage, display name, color)
+    ("qc", "Read QC", "#4C78A8"),
+    ("trim", "Read Trimming", "#F58518"),
+    ("align", "Alignment", "#54A24B"),
+    ("quantify", "Quantification", "#E45756"),
+    ("variant", "Variant Calling", "#B279A2"),
+    ("annotate", "Annotation", "#72B7B2"),
+    ("merge", "Merge / Combine", "#9D755D"),
+    ("report", "Reporting", "#F2CF5B"),
+    ("generic", "Analysis", "#79706E"),
+];
+
+/// Fallback colors for custom (non-canonical) stages, selected by stable hash.
+const EXTRA_COLORS: &[&str] = &[
+    "#9C755F", "#BAB0AC", "#FF9DA7", "#D4A6C8", "#86BCB6", "#59A14F", "#EDC948", "#8CD17D",
+    "#B6992D", "#6E6E6E",
+];
+
+/// `(stage, keyword)` pairs for shell/script inference, matched against the
+/// lowercased command text. Order matters: more specific signals (a variant
+/// caller) win over generic ones (an aligner), mirroring `WorkflowDomain`.
+const KEYWORDS: &[(&str, &str)] = &[
+    // Reporting / aggregation — must precede QC so MultiQC is not misread as QC.
+    ("report", "multiqc"),
+    // Variant calling (specific callers before the broad "gatk").
+    ("variant", "haplotypecaller"),
+    ("variant", "mutect2"),
+    ("variant", "freebayes"),
+    ("variant", "strelka"),
+    ("variant", "vardict"),
+    ("variant", "bcftools call"),
+    ("variant", "bcftools mpileup"),
+    ("variant", "gatk"),
+    // Annotation.
+    ("annotate", "snpeff"),
+    ("annotate", "snpsift"),
+    ("annotate", "annovar"),
+    ("annotate", "vep"),
+    // Quantification.
+    ("quantify", "featurecounts"),
+    ("quantify", "htseq"),
+    ("quantify", "salmon"),
+    ("quantify", "kallisto"),
+    ("quantify", "rsem"),
+    ("quantify", "stringtie"),
+    // Alignment.
+    ("align", "bwa"),
+    ("align", "star"),
+    ("align", "hisat2"),
+    ("align", "minimap2"),
+    ("align", "bowtie"),
+    ("align", "tophat"),
+    // Trimming.
+    ("trim", "trimmomatic"),
+    ("trim", "trim_galore"),
+    ("trim", "cutadapt"),
+    ("trim", "fastp"),
+    // QC.
+    ("qc", "fastqc"),
+    ("qc", "fastq_screen"),
+    // Merge / concatenation (substring " cat"/" merge"/" concat" to avoid
+    // matching "scatter" or "concatenate" noise).
+    ("merge", "samtools merge"),
+    ("merge", "samtools cat"),
+    ("merge", "bcftools merge"),
+    ("merge", "bcftools concat"),
+    ("merge", "picard merge"),
+];
+
+/// Normalize a user-supplied tag into a canonical stage name.
+///
+/// Recognized synonyms collapse onto the canonical set so that a tag like
+/// `alignment` and inferred `align` share one line. Unrecognized tags are
+/// returned lowercased as custom stages.
+pub fn canonical_stage(tag: &str) -> String {
+    let t = tag.trim().to_lowercase();
+    let canonical = match t.as_str() {
+        "qc" | "quality" | "quality_control" | "quality-control" | "read_qc" | "readqc"
+        | "fastqc" => "qc",
+        "trim" | "trimming" | "trimmer" => "trim",
+        "align" | "alignment" | "mapping" | "map" => "align",
+        "quant" | "quantify" | "quantification" | "count" | "counting" | "expression"
+        | "counts" => "quantify",
+        "variant" | "variant_calling" | "variant-calling" | "calling" | "snv" | "germline"
+        | "somatic" => "variant",
+        "annotate" | "annotation" | "annovar" => "annotate",
+        "merge" | "combine" | "gather" | "concatenate" | "concat" => "merge",
+        "report" | "reporting" | "summary" | "multiqc" => "report",
+        "generic" | "analysis" => "generic",
+        _ => return t,
+    };
+    canonical.to_string()
+}
+
+/// Infer a rule's stage: explicit `tags` first, then shell/script keywords,
+/// then `"generic"`.
+pub fn detect_stage(rule: &Rule) -> String {
+    // 1. Explicit tag (the rule's own categorization wins over inference).
+    if let Some(tag) = rule.tags.first() {
+        let t = tag.trim();
+        if !t.is_empty() {
+            return canonical_stage(t);
+        }
+    }
+
+    // 2. Command keyword inference.
+    let mut text = String::new();
+    if let Some(shell) = &rule.shell {
+        text.push_str(shell);
+        text.push(' ');
+    }
+    if let Some(script) = &rule.script {
+        text.push_str(script);
+    }
+    let text = text.to_lowercase();
+    for (stage, keyword) in KEYWORDS {
+        if text.contains(keyword) {
+            return (*stage).to_string();
+        }
+    }
+
+    // 3. Fallback.
+    "generic".to_string()
+}
+
+/// Human-readable display name for a stage.
+pub fn stage_display(stage: &str) -> String {
+    PALETTE
+        .iter()
+        .find(|(s, _, _)| *s == stage)
+        .map(|(_, display, _)| (*display).to_string())
+        .unwrap_or_else(|| stage.to_string())
+}
+
+/// A stable color for a stage. Canonical stages use a fixed palette; custom
+/// stages hash into the fallback palette so the same name always gets the
+/// same color.
+pub fn stage_color(stage: &str) -> &'static str {
+    if let Some((_, _, color)) = PALETTE.iter().find(|(s, _, _)| *s == stage) {
+        return color;
+    }
+    EXTRA_COLORS[stable_hash(stage) % EXTRA_COLORS.len()]
+}
+
+/// DJB2-style hash — deterministic across runs, so diagram colors are stable.
+fn stable_hash(s: &str) -> usize {
+    let mut h: usize = 5381;
+    for b in s.bytes() {
+        h = h.wrapping_mul(33).wrapping_add(usize::from(b));
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rule::{EnvironmentSpec, Resources};
+    use std::collections::HashMap;
+
+    fn rule(name: &str, shell: &str, tags: Vec<&str>) -> Rule {
+        Rule {
+            name: name.to_string(),
+            shell: Some(shell.to_string()),
+            tags: tags.into_iter().map(String::from).collect(),
+            resources: Resources::default(),
+            environment: EnvironmentSpec::default(),
+            params: HashMap::new(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn explicit_tag_wins() {
+        let r = rule("align_step", "bwa mem ref.fa in.fq > out.sam", vec!["qc"]);
+        assert_eq!(detect_stage(&r), "qc");
+    }
+
+    #[test]
+    fn tag_synonym_normalizes() {
+        let r = rule("align_step", "bwa mem ref.fa in.fq", vec!["alignment"]);
+        assert_eq!(detect_stage(&r), "align");
+    }
+
+    #[test]
+    fn unknown_tag_kept_as_custom_stage() {
+        let r = rule("impute_step", "impute2", vec!["imputation"]);
+        assert_eq!(detect_stage(&r), "imputation");
+    }
+
+    #[test]
+    fn shell_inference() {
+        assert_eq!(detect_stage(&rule("a", "fastqc reads.fq", vec![])), "qc");
+        assert_eq!(
+            detect_stage(&rule("b", "bwa mem ref.fa r.fq", vec![])),
+            "align"
+        );
+        assert_eq!(
+            detect_stage(&rule("c", "featureCounts -a gtf -o c.txt", vec![])),
+            "quantify"
+        );
+        assert_eq!(
+            detect_stage(&rule("d", "gatk HaplotypeCaller -R ref", vec![])),
+            "variant"
+        );
+        assert_eq!(detect_stage(&rule("e", "multiqc .", vec![])), "report");
+    }
+
+    #[test]
+    fn no_signal_falls_back_to_generic() {
+        let r = rule("mystery", "echo hello", vec![]);
+        assert_eq!(detect_stage(&r), "generic");
+    }
+
+    #[test]
+    fn canonical_colors_are_stable() {
+        assert_eq!(stage_color("qc"), "#4C78A8");
+        assert_eq!(stage_color("custom_thing"), stage_color("custom_thing"));
+    }
+}

--- a/docs/guide/src/commands/graph.md
+++ b/docs/guide/src/commands/graph.md
@@ -24,7 +24,7 @@ oxo-flow graph [OPTIONS] <WORKFLOW>
 
 | Option | Short | Description |
 |---|---|---|
-| `--format <FORMAT>` | `-f` | Output format: `ascii` (terminal), `dot` (Graphviz), `dot-clustered` (level-grouped), `tree` (indented tree). Default: `ascii` |
+| `--format <FORMAT>` | `-f` | Output format: `ascii` (terminal), `dot` (Graphviz), `dot-clustered` (level-grouped), `tree` (indented tree), `mermaid` (Mermaid `graph LR`), `metro` (nf-metro metro map). Default: `ascii` |
 | `--output <FILE>` | `-o` | Save output to a file (useful for dot/svg generation) |
 | `--expanded` | | Show the DAG after wildcard/sample/scatter expansion (the actual runtime DAG) |
 | `--verbose` | `-v` | Enable debug-level logging |
@@ -67,6 +67,24 @@ oxo-flow graph pipeline.oxoflow -f dot -o graph.dot
 
 ```bash
 oxo-flow graph pipeline.oxoflow -f dot-clustered -o clustered.dot
+```
+
+### Export a Mermaid diagram
+
+`mermaid` emits standard Mermaid `graph LR` — no `%%metro` directives — so it renders directly on GitHub, in VS Code, and in any Mermaid renderer:
+
+```bash
+oxo-flow graph pipeline.oxoflow -f mermaid -o pipeline.mmd
+```
+
+### Export an nf-metro metro map
+
+`metro` emits an [nf-metro](https://github.com/seqeralabs/nf-metro) definition — Mermaid `graph LR` extended with `%%metro` line/section directives — that renders as a transit-map-style SVG. Rules are grouped into colored "lines" by their analysis stage (inferred from shell keywords, or set explicitly via each rule's `tags`):
+
+```bash
+oxo-flow graph pipeline.oxoflow -f metro -o pipeline.mmd
+pip install nf-metro
+nf-metro render pipeline.mmd -o pipeline.svg
 ```
 
 ### View the expanded runtime DAG
@@ -168,6 +186,55 @@ digraph workflow {
   "transform" -> "summarize";
 }
 ```
+
+### Mermaid
+
+The `mermaid` format emits standard Mermaid `graph LR` — a node per rule, an
+edge per dependency:
+
+```mermaid
+graph LR
+    n0["generate_data"]
+    n1["transform"]
+    n2["summarize"]
+    n0 --> n1
+    n1 --> n2
+```
+
+This renders directly in any Mermaid renderer (GitHub, VS Code, MkDocs) with no
+extra tooling.
+
+### Metro map (nf-metro)
+
+The `metro` format emits an
+[nf-metro](https://github.com/seqeralabs/nf-metro) definition — Mermaid
+`graph LR` extended with `%%metro` directives — that renders as a
+transit-map-style SVG:
+
+```mmd
+%%metro line: generic | Analysis | #79706E
+
+graph LR
+    n0["generate_data"]
+    n1["transform"]
+    n2["summarize"]
+    n0 -->|generic| n1
+    n1 -->|generic| n2
+```
+
+Each rule is assigned a *stage* that becomes a colored "metro line":
+
+- **Explicit**: the rule's first `tags` entry (e.g. `tags = ["align"]`),
+  normalized through a small synonym table (`alignment` → `align`, etc.).
+  Unknown tags become their own custom line.
+- **Inferred**: keyword matching against the rule's `shell`/`script`
+  commands — `fastqc`/`fastp` → QC/trim, `bwa`/`STAR` → align,
+  `featureCounts`/`salmon` → quantify, `gatk`/`bcftools call` → variant,
+  `multiqc` → report, and so on — with no match falling back to `generic`.
+
+With more than one stage, stations are grouped into `subgraph` sections (one
+per stage) and cross-stage edges are placed outside the sections as nf-metro
+requires.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two new graph export formats to `oxo-flow graph` so workflows can be visualised as a transit-map ("metro") diagram — the style popularised by nf-core pipeline diagrams — as well as a plain Mermaid flowchart.

```bash
# Standard Mermaid (renders on GitHub / VS Code / any Mermaid renderer)
oxo-flow graph workflow.oxoflow -f mermaid -o workflow.mmd

# nf-metro "metro map" (transit-style SVG)
oxo-flow graph workflow.oxoflow -f metro -o workflow.mmd
nf-metro render workflow.mmd -o workflow.svg
```

## What changed

- **`crate::stage`** (new, `crates/oxo-flow-core/src/stage.rs`): per-rule stage inference.
  - Explicit `tags` win: the first tag is used as the stage (after canonicalisation, e.g. `alignment` → `align`); unknown tags are kept as custom stages.
  - Otherwise the rule's shell/script is matched against a keyword table (`fastqc`, `fastp`, `bwa`, `star`, `gatk`, `salmon`, `featurecounts`, `multiqc`, …) → `qc` / `trim` / `align` / `quantify` / `variant` / `annotate` / `merge` / `report`.
  - Falls back to `generic`.
  - Stable colour palette (canonical stages have fixed colours; custom stages get a deterministic hash-based colour).
- **`WorkflowDag::to_mermaid`**: standard `graph LR` (nodes + edges, no directives).
- **`WorkflowDag::to_metro`**: nf-metro definition — `%%metro line:` definitions, per-stage `subgraph` sections, and cross-stage edges emitted after all `end` blocks (nf-metro's inter-section rule).
- **CLI**: `graph -f` now accepts `mermaid` and `metro`; help text updated.
- **Docs**: README + graph command guide.

## Testing

- `cargo test -p oxo-flow-core --lib` — 1137 passed, 0 failed (6 new `stage` tests + 5 new metro/mermaid tests).
- `cargo clippy --all-targets` clean; `cargo fmt` clean.
- End-to-end: rendered `13_simple_variant_calling.oxoflow` to `-f metro` and verified the output with `nf-metro render` (11 stations, 10 edges, 4 lines → SVG).

## Example output

`06_rnaseq_quantification.oxoflow` auto-detects five stages:

```text
%%metro line: trim | Read Trimming | #F58518
%%metro line: align | Alignment | #54A24B
%%metro line: generic | Analysis | #79706E
%%metro line: quantify | Quantification | #E45756
%%metro line: report | Reporting | #F2CF5B

graph LR
    subgraph trim [Read Trimming]
        n0["fastp_trim"]
    end
    ...
```
