### PR TITLE
fix(gallery): bwa read-group CL corruption + per-tool stringency flags + 14/15 copy-paste bugs

### DIFF
--- a/crates/oxo-flow-cli/templates/07_wgs_germline.oxoflow
+++ b/crates/oxo-flow-cli/templates/07_wgs_germline.oxoflow
@@ -52,7 +52,8 @@ output = ["aligned/{sample}.sorted.bam"]
 description = "Paired-end alignment with BWA-MEM2 and coordinate sorting"
 shell = """
 mkdir -p aligned
-bwa-mem2 mem -M -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tLB:WGS\tPL:ILLUMINA\tPU:{sample}' \
+rg=$(printf '@RG\tID:%s\tSM:%s\tLB:WGS\tPL:ILLUMINA\tPU:%s' '{sample}' '{sample}' '{sample}')
+bwa-mem2 mem -M -t {threads} -R "$rg" \
     {config.reference} {input[0]} {input[1]} \
     | samtools sort -@ 4 -m 2G -o {output[0]}
 samtools index {output[0]}
@@ -74,7 +75,7 @@ output = ["dedup/{sample}.dedup.bam", "dedup/{sample}.dedup.metrics.txt"]
 description = "Mark PCR and optical duplicates"
 shell = """
 mkdir -p dedup
-gatk MarkDuplicates \
+gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT \
     -I {input[0]} \
     -O {output[0]} \
     -M {output[1]} \
@@ -95,14 +96,14 @@ output = ["bqsr/{sample}.recal.bam"]
 description = "Base quality score recalibration (BQSR)"
 shell = """
 mkdir -p bqsr
-gatk BaseRecalibrator \
+gatk BaseRecalibrator --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     --known-sites {config.known_sites} \
     --known-sites {config.thousand_g} \
     --known-sites {config.known_indels} \
     -O bqsr/{sample}.recal_data.table
 
-gatk ApplyBQSR \
+gatk ApplyBQSR --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     --bqsr-recal-file bqsr/{sample}.recal_data.table \
     -O {output[0]}
@@ -122,7 +123,7 @@ output = ["variants/{sample}.g.vcf.gz"]
 description = "Per-sample variant calling in GVCF mode"
 shell = """
 mkdir -p variants
-gatk HaplotypeCaller \
+gatk HaplotypeCaller --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     -O {output[0]} \
     -ERC GVCF \

--- a/crates/oxo-flow-cli/templates/08_multiomics_integration.oxoflow
+++ b/crates/oxo-flow-cli/templates/08_multiomics_integration.oxoflow
@@ -36,7 +36,8 @@ output = ["wgs_aligned/{sample}.sorted.bam"]
 description = "WGS read alignment with BWA-MEM2"
 shell = """
 mkdir -p wgs_aligned
-bwa-mem2 mem -M -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tLB:WGS\tPL:ILLUMINA' \
+rg=$(printf '@RG\tID:%s\tSM:%s\tLB:WGS\tPL:ILLUMINA' '{sample}' '{sample}')
+bwa-mem2 mem -M -t {threads} -R "$rg" \
     {config.reference} {input[0]} {input[1]} \
     | samtools sort -@ 4 -o {output[0]}
 samtools index {output[0]}

--- a/crates/oxo-flow-cli/templates/11_conditional_workflow.oxoflow
+++ b/crates/oxo-flow-cli/templates/11_conditional_workflow.oxoflow
@@ -27,7 +27,10 @@ input = [
     "raw/sample_R2.fq.gz",
 ]
 output = ["aligned/sample.sorted.bam"]
-shell = "bwa mem -t {threads} -R '@RG\tID:sample\tSM:sample\tPL:ILLUMINA' {config.reference} {input[0]} {input[1]} | samtools sort -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' sample sample)
+bwa mem -t {threads} -R "$rg" {config.reference} {input[0]} {input[1]} | samtools sort -o {output[0]}
+"""
 
 [rules.resources]
 threads = 8
@@ -75,7 +78,7 @@ conda = "envs/mosdepth.yaml"
 name = "haplotype_caller"
 input = ["aligned/sample.sorted.bam"]
 output = ["variants/sample.g.vcf.gz"]
-shell = "gatk HaplotypeCaller -I {input[0]} -R {config.reference} -O {output[0]} -ERC GVCF"
+shell = "gatk HaplotypeCaller --read-validation-stringency SILENT -I {input[0]} -R {config.reference} -O {output[0]} -ERC GVCF"
 
 [rules.resources]
 threads = 4

--- a/crates/oxo-flow-cli/templates/13_simple_variant_calling.oxoflow
+++ b/crates/oxo-flow-cli/templates/13_simple_variant_calling.oxoflow
@@ -80,7 +80,8 @@ input = [
 ]
 output = ["aligned/{sample}.sorted.bam"]
 shell = '''
-bwa-mem2 mem -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tPL:ILLUMINA' {config.reference} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{sample}' '{sample}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
 samtools index {output[0]}
 '''
 description = "Read alignment to reference genome"
@@ -102,7 +103,7 @@ output = [
     "dedup/{sample}.metrics.txt",
 ]
 shell = """
-gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]} --CREATE_INDEX true
+gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]} --CREATE_INDEX true
 """
 description = "Mark PCR duplicate reads"
 
@@ -118,7 +119,7 @@ name = "base_recalibrator"
 input = ["dedup/{sample}.dedup.bam"]
 output = ["recal/{sample}.recal_data.table"]
 shell = """
-gatk BaseRecalibrator -I {input[0]} -R {config.reference} --known-sites {config.known_sites} -O {output[0]}
+gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference} --known-sites {config.known_sites} -O {output[0]}
 """
 description = "Base quality score recalibration table"
 
@@ -137,7 +138,7 @@ input = [
 ]
 output = ["recal/{sample}.recal.bam"]
 shell = """
-gatk ApplyBQSR -I {input[0]} -R {config.reference} --bqsr-recal-file {input[1]} -O {output[0]}
+gatk ApplyBQSR --read-validation-stringency SILENT -I {input[0]} -R {config.reference} --bqsr-recal-file {input[1]} -O {output[0]}
 """
 description = "Apply base quality score recalibration"
 
@@ -153,7 +154,7 @@ name = "haplotype_caller"
 input = ["recal/{sample}.recal.bam"]
 output = ["variants/{sample}.g.vcf.gz"]
 shell = """
-gatk HaplotypeCaller -R {config.reference} -I {input[0]} -O {output[0]} -ERC GVCF --native-pair-hmm-threads {threads}
+gatk HaplotypeCaller --read-validation-stringency SILENT -R {config.reference} -I {input[0]} -O {output[0]} -ERC GVCF --native-pair-hmm-threads {threads}
 """
 description = "Germline variant calling"
 

--- a/crates/oxo-flow-cli/templates/14_paired_experiment_control.oxoflow
+++ b/crates/oxo-flow-cli/templates/14_paired_experiment_control.oxoflow
@@ -79,7 +79,10 @@ input = [
     "trimmed/EXP_01_R2.fq.gz",
 ]
 output = ["aligned/EXP_01.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:EXP_01\tSM:EXP_01\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' EXP_01 EXP_01)
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -95,7 +98,10 @@ input = [
     "trimmed/CTRL_01_R2.fq.gz",
 ]
 output = ["aligned/CTRL_01.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:EXP_01\tSM:EXP_01\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' CTRL_01 CTRL_01)
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -111,7 +117,7 @@ output = [
     "dedup/EXP_01.dedup.bam",
     "dedup/EXP_01.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -127,7 +133,7 @@ output = [
     "dedup/CTRL_01.dedup.bam",
     "dedup/CTRL_01.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -140,7 +146,7 @@ conda = "envs/gatk.yaml"
 name = "bqsr_experiment"
 input = ["dedup/EXP_01.dedup.bam"]
 output = ["recal/EXP_01.recal.bam"]
-shell = "gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/EXP_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/EXP_01.recal.table -O {output[0]}"
+shell = "gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/EXP_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/EXP_01.recal.table -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -153,7 +159,7 @@ conda = "envs/gatk.yaml"
 name = "bqsr_control"
 input = ["dedup/CTRL_01.dedup.bam"]
 output = ["recal/CTRL_01.recal.bam"]
-shell = "gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/CTRL_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/CTRL_01.recal.table -O {output[0]}"
+shell = "gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/CTRL_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/CTRL_01.recal.table -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -169,7 +175,7 @@ input = [
     "recal/CTRL_01.recal.bam",
 ]
 output = ["variants/EXP_01.mutect2.vcf.gz"]
-shell = "gatk Mutect2 -I {input[0]} -I {input[1]} -normal CTRL_01 -R {config.reference_fasta} -O {output[0]}"
+shell = "gatk Mutect2 --read-validation-stringency SILENT -I {input[0]} -I {input[1]} -normal CTRL_01 -R {config.reference_fasta} -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -196,7 +202,7 @@ conda = "envs/gatk.yaml"
 name = "haplotype_caller"
 input = ["recal/CTRL_01.recal.bam"]
 output = ["variants/CTRL_01.g.vcf.gz"]
-shell = "gatk HaplotypeCaller -I {input[0]} -R {config.reference_fasta} -O {output[0]} -ERC GVCF"
+shell = "gatk HaplotypeCaller --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} -O {output[0]} -ERC GVCF"
 description = "Variant calling for control sample"
 
 [rules.resources]

--- a/crates/oxo-flow-cli/templates/15_paired_experiment_control_pairs.oxoflow
+++ b/crates/oxo-flow-cli/templates/15_paired_experiment_control_pairs.oxoflow
@@ -62,7 +62,10 @@ input = [
     "trimmed/{experiment}_R2.fq.gz",
 ]
 output = ["aligned/{experiment}.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:{experiment}\tSM:{experiment}\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{experiment}' '{experiment}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -78,7 +81,10 @@ input = [
     "trimmed/{control}_R2.fq.gz",
 ]
 output = ["aligned/{control}.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:{experiment}\tSM:{experiment}\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{control}' '{control}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -94,7 +100,7 @@ output = [
     "dedup/{experiment}.dedup.bam",
     "dedup/{experiment}.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -110,7 +116,7 @@ output = [
     "dedup/{control}.dedup.bam",
     "dedup/{control}.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -124,7 +130,7 @@ name = "bqsr_experiment"
 input = ["dedup/{experiment}.dedup.bam"]
 output = ["recal/{experiment}.recal.bam"]
 shell = """
-  gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{experiment}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{experiment}.recal.table -O {output[0]}
+  gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{experiment}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{experiment}.recal.table -O {output[0]}
 """
 
 [rules.resources]
@@ -139,7 +145,7 @@ name = "bqsr_control"
 input = ["dedup/{control}.dedup.bam"]
 output = ["recal/{control}.recal.bam"]
 shell = """
-  gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{control}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{control}.recal.table -O {output[0]}
+  gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{control}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{control}.recal.table -O {output[0]}
 """
 
 [rules.resources]
@@ -158,7 +164,7 @@ input = [
 output = ["variants/{pair_id}.mutect2.vcf.gz"]
 shell = """
   # Production runs should also pass --germline-resource and --panel-of-normals
-  gatk Mutect2 -I {input[0]} -I {input[1]} -normal {control} -R {config.reference_fasta} -O {output[0]}
+  gatk Mutect2 --read-validation-stringency SILENT -I {input[0]} -I {input[1]} -normal {control} -R {config.reference_fasta} -O {output[0]}
 """
 
 [rules.resources]

--- a/examples/gallery/07_wgs_germline.oxoflow
+++ b/examples/gallery/07_wgs_germline.oxoflow
@@ -52,7 +52,8 @@ output = ["aligned/{sample}.sorted.bam"]
 description = "Paired-end alignment with BWA-MEM2 and coordinate sorting"
 shell = """
 mkdir -p aligned
-bwa-mem2 mem -M -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tLB:WGS\tPL:ILLUMINA\tPU:{sample}' \
+rg=$(printf '@RG\tID:%s\tSM:%s\tLB:WGS\tPL:ILLUMINA\tPU:%s' '{sample}' '{sample}' '{sample}')
+bwa-mem2 mem -M -t {threads} -R "$rg" \
     {config.reference} {input[0]} {input[1]} \
     | samtools sort -@ 4 -m 2G -o {output[0]}
 samtools index {output[0]}
@@ -74,7 +75,7 @@ output = ["dedup/{sample}.dedup.bam", "dedup/{sample}.dedup.metrics.txt"]
 description = "Mark PCR and optical duplicates"
 shell = """
 mkdir -p dedup
-gatk MarkDuplicates \
+gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT \
     -I {input[0]} \
     -O {output[0]} \
     -M {output[1]} \
@@ -95,14 +96,14 @@ output = ["bqsr/{sample}.recal.bam"]
 description = "Base quality score recalibration (BQSR)"
 shell = """
 mkdir -p bqsr
-gatk BaseRecalibrator \
+gatk BaseRecalibrator --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     --known-sites {config.known_sites} \
     --known-sites {config.thousand_g} \
     --known-sites {config.known_indels} \
     -O bqsr/{sample}.recal_data.table
 
-gatk ApplyBQSR \
+gatk ApplyBQSR --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     --bqsr-recal-file bqsr/{sample}.recal_data.table \
     -O {output[0]}
@@ -122,7 +123,7 @@ output = ["variants/{sample}.g.vcf.gz"]
 description = "Per-sample variant calling in GVCF mode"
 shell = """
 mkdir -p variants
-gatk HaplotypeCaller \
+gatk HaplotypeCaller --read-validation-stringency SILENT \
     -I {input[0]} -R {config.reference} \
     -O {output[0]} \
     -ERC GVCF \

--- a/examples/gallery/08_multiomics_integration.oxoflow
+++ b/examples/gallery/08_multiomics_integration.oxoflow
@@ -36,7 +36,8 @@ output = ["wgs_aligned/{sample}.sorted.bam"]
 description = "WGS read alignment with BWA-MEM2"
 shell = """
 mkdir -p wgs_aligned
-bwa-mem2 mem -M -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tLB:WGS\tPL:ILLUMINA' \
+rg=$(printf '@RG\tID:%s\tSM:%s\tLB:WGS\tPL:ILLUMINA' '{sample}' '{sample}')
+bwa-mem2 mem -M -t {threads} -R "$rg" \
     {config.reference} {input[0]} {input[1]} \
     | samtools sort -@ 4 -o {output[0]}
 samtools index {output[0]}

--- a/examples/gallery/11_conditional_workflow.oxoflow
+++ b/examples/gallery/11_conditional_workflow.oxoflow
@@ -27,7 +27,10 @@ input = [
     "raw/sample_R2.fq.gz",
 ]
 output = ["aligned/sample.sorted.bam"]
-shell = "bwa mem -t {threads} -R '@RG\tID:sample\tSM:sample\tPL:ILLUMINA' {config.reference} {input[0]} {input[1]} | samtools sort -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' sample sample)
+bwa mem -t {threads} -R "$rg" {config.reference} {input[0]} {input[1]} | samtools sort -o {output[0]}
+"""
 
 [rules.resources]
 threads = 8
@@ -75,7 +78,7 @@ conda = "envs/mosdepth.yaml"
 name = "haplotype_caller"
 input = ["aligned/sample.sorted.bam"]
 output = ["variants/sample.g.vcf.gz"]
-shell = "gatk HaplotypeCaller -I {input[0]} -R {config.reference} -O {output[0]} -ERC GVCF"
+shell = "gatk HaplotypeCaller --read-validation-stringency SILENT -I {input[0]} -R {config.reference} -O {output[0]} -ERC GVCF"
 
 [rules.resources]
 threads = 4

--- a/examples/gallery/13_simple_variant_calling.oxoflow
+++ b/examples/gallery/13_simple_variant_calling.oxoflow
@@ -80,7 +80,8 @@ input = [
 ]
 output = ["aligned/{sample}.sorted.bam"]
 shell = '''
-bwa-mem2 mem -t {threads} -R '@RG\tID:{sample}\tSM:{sample}\tPL:ILLUMINA' {config.reference} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{sample}' '{sample}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
 samtools index {output[0]}
 '''
 description = "Read alignment to reference genome"
@@ -102,7 +103,7 @@ output = [
     "dedup/{sample}.metrics.txt",
 ]
 shell = """
-gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]} --CREATE_INDEX true
+gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]} --CREATE_INDEX true
 """
 description = "Mark PCR duplicate reads"
 
@@ -118,7 +119,7 @@ name = "base_recalibrator"
 input = ["dedup/{sample}.dedup.bam"]
 output = ["recal/{sample}.recal_data.table"]
 shell = """
-gatk BaseRecalibrator -I {input[0]} -R {config.reference} --known-sites {config.known_sites} -O {output[0]}
+gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference} --known-sites {config.known_sites} -O {output[0]}
 """
 description = "Base quality score recalibration table"
 
@@ -137,7 +138,7 @@ input = [
 ]
 output = ["recal/{sample}.recal.bam"]
 shell = """
-gatk ApplyBQSR -I {input[0]} -R {config.reference} --bqsr-recal-file {input[1]} -O {output[0]}
+gatk ApplyBQSR --read-validation-stringency SILENT -I {input[0]} -R {config.reference} --bqsr-recal-file {input[1]} -O {output[0]}
 """
 description = "Apply base quality score recalibration"
 
@@ -153,7 +154,7 @@ name = "haplotype_caller"
 input = ["recal/{sample}.recal.bam"]
 output = ["variants/{sample}.g.vcf.gz"]
 shell = """
-gatk HaplotypeCaller -R {config.reference} -I {input[0]} -O {output[0]} -ERC GVCF --native-pair-hmm-threads {threads}
+gatk HaplotypeCaller --read-validation-stringency SILENT -R {config.reference} -I {input[0]} -O {output[0]} -ERC GVCF --native-pair-hmm-threads {threads}
 """
 description = "Germline variant calling"
 

--- a/examples/gallery/14_paired_experiment_control.oxoflow
+++ b/examples/gallery/14_paired_experiment_control.oxoflow
@@ -79,7 +79,10 @@ input = [
     "trimmed/EXP_01_R2.fq.gz",
 ]
 output = ["aligned/EXP_01.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:EXP_01\tSM:EXP_01\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' EXP_01 EXP_01)
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -95,7 +98,10 @@ input = [
     "trimmed/CTRL_01_R2.fq.gz",
 ]
 output = ["aligned/CTRL_01.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:EXP_01\tSM:EXP_01\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' CTRL_01 CTRL_01)
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -111,7 +117,7 @@ output = [
     "dedup/EXP_01.dedup.bam",
     "dedup/EXP_01.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -127,7 +133,7 @@ output = [
     "dedup/CTRL_01.dedup.bam",
     "dedup/CTRL_01.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -140,7 +146,7 @@ conda = "envs/gatk.yaml"
 name = "bqsr_experiment"
 input = ["dedup/EXP_01.dedup.bam"]
 output = ["recal/EXP_01.recal.bam"]
-shell = "gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/EXP_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/EXP_01.recal.table -O {output[0]}"
+shell = "gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/EXP_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/EXP_01.recal.table -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -153,7 +159,7 @@ conda = "envs/gatk.yaml"
 name = "bqsr_control"
 input = ["dedup/CTRL_01.dedup.bam"]
 output = ["recal/CTRL_01.recal.bam"]
-shell = "gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/CTRL_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/CTRL_01.recal.table -O {output[0]}"
+shell = "gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/CTRL_01.recal.table && gatk ApplyBQSR -I {input[0]} -R /data/references/GRCh38/genome.fa --bqsr-recal-file recal/CTRL_01.recal.table -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -169,7 +175,7 @@ input = [
     "recal/CTRL_01.recal.bam",
 ]
 output = ["variants/EXP_01.mutect2.vcf.gz"]
-shell = "gatk Mutect2 -I {input[0]} -I {input[1]} -normal CTRL_01 -R {config.reference_fasta} -O {output[0]}"
+shell = "gatk Mutect2 --read-validation-stringency SILENT -I {input[0]} -I {input[1]} -normal CTRL_01 -R {config.reference_fasta} -O {output[0]}"
 
 [rules.resources]
 threads = 4
@@ -196,7 +202,7 @@ conda = "envs/gatk.yaml"
 name = "haplotype_caller"
 input = ["recal/CTRL_01.recal.bam"]
 output = ["variants/CTRL_01.g.vcf.gz"]
-shell = "gatk HaplotypeCaller -I {input[0]} -R {config.reference_fasta} -O {output[0]} -ERC GVCF"
+shell = "gatk HaplotypeCaller --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} -O {output[0]} -ERC GVCF"
 description = "Variant calling for control sample"
 
 [rules.resources]

--- a/examples/gallery/15_paired_experiment_control_pairs.oxoflow
+++ b/examples/gallery/15_paired_experiment_control_pairs.oxoflow
@@ -62,7 +62,10 @@ input = [
     "trimmed/{experiment}_R2.fq.gz",
 ]
 output = ["aligned/{experiment}.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:{experiment}\tSM:{experiment}\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{experiment}' '{experiment}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -78,7 +81,10 @@ input = [
     "trimmed/{control}_R2.fq.gz",
 ]
 output = ["aligned/{control}.sorted.bam"]
-shell = "bwa-mem2 mem -t {threads} -R '@RG\tID:{experiment}\tSM:{experiment}\tPL:ILLUMINA' {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}"
+shell = """
+rg=$(printf '@RG\tID:%s\tSM:%s\tPL:ILLUMINA' '{control}' '{control}')
+bwa-mem2 mem -t {threads} -R "$rg" {config.reference_fasta} {input[0]} {input[1]} | samtools sort -@ 4 -o {output[0]}
+"""
 
 [rules.resources]
 threads = 16
@@ -94,7 +100,7 @@ output = [
     "dedup/{experiment}.dedup.bam",
     "dedup/{experiment}.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -110,7 +116,7 @@ output = [
     "dedup/{control}.dedup.bam",
     "dedup/{control}.metrics.txt",
 ]
-shell = "gatk MarkDuplicates -I {input[0]} -O {output[0]} -M {output[1]}"
+shell = "gatk MarkDuplicates --VALIDATION_STRINGENCY SILENT -I {input[0]} -O {output[0]} -M {output[1]}"
 
 [rules.resources]
 threads = 4
@@ -124,7 +130,7 @@ name = "bqsr_experiment"
 input = ["dedup/{experiment}.dedup.bam"]
 output = ["recal/{experiment}.recal.bam"]
 shell = """
-  gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{experiment}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{experiment}.recal.table -O {output[0]}
+  gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{experiment}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{experiment}.recal.table -O {output[0]}
 """
 
 [rules.resources]
@@ -139,7 +145,7 @@ name = "bqsr_control"
 input = ["dedup/{control}.dedup.bam"]
 output = ["recal/{control}.recal.bam"]
 shell = """
-  gatk BaseRecalibrator -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{control}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{control}.recal.table -O {output[0]}
+  gatk BaseRecalibrator --read-validation-stringency SILENT -I {input[0]} -R {config.reference_fasta} --known-sites {config.known_sites} -O recal/{control}.recal.table && gatk ApplyBQSR -I {input[0]} -R {config.reference_fasta} --bqsr-recal-file recal/{control}.recal.table -O {output[0]}
 """
 
 [rules.resources]
@@ -158,7 +164,7 @@ input = [
 output = ["variants/{pair_id}.mutect2.vcf.gz"]
 shell = """
   # Production runs should also pass --germline-resource and --panel-of-normals
-  gatk Mutect2 -I {input[0]} -I {input[1]} -normal {control} -R {config.reference_fasta} -O {output[0]}
+  gatk Mutect2 --read-validation-stringency SILENT -I {input[0]} -I {input[1]} -normal {control} -R {config.reference_fasta} -O {output[0]}
 """
 
 [rules.resources]


### PR DESCRIPTION
## What

Live-tested with **real WGS data** on tx-ubuntu (sarek mini-germline fixture, issue #67 §3): without these fixes the GATK chain dies at MarkDuplicates, so any user copying the gallery would hit the same wall.

## The three fixes

1. **Read-group CL corruption** (07/08/11/13/14/15): bwa-mem2 records the expanded `-R` argument in the `@PG CL:` field — inline `-R '@RG\tID:...'` puts raw tabs into the SAM header and htsjdk's strict parser rejects the BAM (`ID:test clashes with ID:bwa-mem2` — live evidence). All six align rules now build the RG in a shell variable via `printf`.
2. **Per-tool stringency flags**: BAM-consuming GATK rules get the right spelling — MarkDuplicates (Picard) takes `--VALIDATION_STRINGENCY SILENT`; GATK walkers (BaseRecalibrator/ApplyBQSR/HaplotypeCaller/Mutect2) take `--read-validation-stringency SILENT` (the walkers reject the Picard spelling with `not a recognized option` — live evidence). The SILENT workaround mirrors nf-core/sarek.
3. **14/15 copy-paste bugs** found along the way: the control sample's read group was tagged `ID:EXP_01` / `{experiment}` instead of `CTRL_01` / `{control}`.

## Live verification (tx-ubuntu, real chr21 data)

- fastp → bwa-mem2 → MarkDuplicates → BQSR → HaplotypeCaller → CombineGVCFs → GenotypeGVCFs: **all exit 0**
- VQSR fails exactly as the workflow's own caveat documents (2-sample cohort, no real training resources on the box)
- the hard-filter alternative (VariantFiltration) succeeds end-to-end (`cohort.hardfiltered.snps.vcf.gz` produced)
- crate mirrors synced; drift-guard + full `make ci` green