### PR TITLE
fix: singularity %-encoded URI artifact naming (#185) + mike deploy idempotency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,5 +1077,11 @@ jobs:
           cp -r /tmp/pages-extra/schema schema
           cp -r /tmp/pages-extra/superpowers superpowers
           git add -A
-          git commit -m "chore: preserve landing page + static assets (${GITHUB_SHA:0:7})" \
-            && git push origin gh-pages
+          # The tree is often unchanged (idempotent re-runs, deploy-only
+          # changes) — an empty commit fails the job for no reason.
+          if git diff --cached --quiet; then
+            echo "landing page + static assets already in place — nothing to commit"
+          else
+            git commit -m "chore: preserve landing page + static assets (${GITHUB_SHA:0:7})" \
+              && git push origin gh-pages
+          fi

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -699,7 +699,7 @@ impl EnvironmentBackend for SingularityBackend {
         //   is decoded on purpose: decoding %2F would introduce path
         //   separators into the segment-derived filename.
         Ok(format!(
-            "case '{spec}' in *://*) IMG=$(printf '%s' '{spec}' | sed 's#^docker://##; s#.*/##; s#%3A#:#g; s#%3a#:#g; s#:#_#g'); case \"$IMG\" in *.sif) ;; *) IMG=\"$IMG.sif\" ;; esac; [ -f \"$IMG\" ] || {b} pull {spec} ;; *) [ -f '{spec}' ] || {{ echo \"singularity spec '{spec}' is neither a pull URI nor an existing file\" >&2; exit 1; }} ;; esac",
+            "case '{spec}' in *://*) IMG=$(printf '%s' '{spec}' | sed 's#^docker://##; s#.*/##; s#%3A#:#g; s#%3a#:#g; s#:#_#g'); case \"$IMG\" in *.sif) ;; *) IMG=\"$IMG.sif\" ;; esac; [ -f \"$IMG\" ] || {b} pull \"$IMG\" {spec} ;; *) [ -f '{spec}' ] || {{ echo \"singularity spec '{spec}' is neither a pull URI nor an existing file\" >&2; exit 1; }} ;; esac",
             b = self.binary,
         ))
     }
@@ -1827,7 +1827,7 @@ mod tests {
     fn singularity_setup_command() {
         let backend = SingularityBackend::new();
         let cmd = backend.setup_command("docker://ubuntu:22.04").unwrap();
-        assert!(cmd.contains(" pull docker://ubuntu:22.04"));
+        assert!(cmd.contains(r#" pull "$IMG" docker://ubuntu:22.04"#));
         // inspect-first guard for the SIF naming
         assert!(cmd.starts_with("case 'docker://ubuntu:22.04' in *://*)"));
         assert!(cmd.contains("IMG=$(printf '%s' 'docker://ubuntu:22.04'"));
@@ -1853,6 +1853,26 @@ mod tests {
             "a final segment already ending in .sif must not get a second .sif: {cmd}"
         );
         assert!(cmd.contains("[ -f \"$IMG\" ] || "));
+    }
+
+    #[test]
+    fn singularity_setup_pulls_into_the_derived_artifact_name() {
+        // %-encoded HTTP URIs (issue #185): apptainer writes the URI's
+        // raw final segment (delly%3A1.7.2--h4d20210_0, no .sif) when
+        // pulling without an output argument, so the derived-name
+        // existence guard never matches and a second rule re-pulls —
+        // and apptainer refuses to overwrite the stale artifact, killing
+        // the run (live: clindet SV_delly_mini on tx-ubuntu). The pull
+        // must write into $IMG explicitly so check and artifact agree.
+        let backend = SingularityBackend::new();
+        let cmd = backend
+            .setup_command("https://depot.galaxyproject.org/singularity/delly%3A1.7.2--h4d20210_0")
+            .unwrap();
+        assert!(
+            cmd.contains(r#"[ -f "$IMG" ] || "#)
+                && cmd.contains(r#" pull "$IMG" https://depot.galaxyproject.org/singularity/delly%3A1.7.2--h4d20210_0"#),
+            "the pull must write into the derived $IMG name: {cmd}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-web/src/executor.rs
+++ b/crates/oxo-flow-web/src/executor.rs
@@ -746,19 +746,33 @@ async fn append_metrics(workdir: &std::path::Path, line: &str, existing_lines: u
 
     if existing_lines < MAX_METRICS_LINES {
         use tokio::io::AsyncWriteExt;
-        let Ok(mut file) = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .await
-        else {
-            return existing_lines;
-        };
-        return if file.write_all(format!("{line}\n").as_bytes()).await.is_ok() {
-            existing_lines + 1
-        } else {
-            existing_lines
-        };
+        // One retry absorbs transient open failures under parallel load
+        // (CI flake: append_metrics_appends_below_cap saw the second
+        // append silently dropped — the old code swallowed open errors).
+        for attempt in 0..2 {
+            let Ok(mut file) = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .await
+            else {
+                if attempt == 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    continue;
+                }
+                tracing::warn!(
+                    "failed to open metrics file {} for append — dropping one metrics line",
+                    path.display()
+                );
+                return existing_lines;
+            };
+            return if file.write_all(format!("{line}\n").as_bytes()).await.is_ok() {
+                existing_lines + 1
+            } else {
+                existing_lines
+            };
+        }
+        unreachable!("the loop always returns");
     }
 
     // Over the cap: trim to the newest MAX_METRICS_LINES and rewrite once.


### PR DESCRIPTION
## What

Two fixes needed before the v0.15.0 release:

**1. singularity %-encoded HTTP URIs (issue #185)** — `apptainer pull <http-uri>` writes the URI's raw final segment (`delly%3A1.7.2--h4d20210_0`, no .sif), while the existence guard derives the decoded name (`delly_1.7.2--h4d20210_0.sif`) — mismatch → re-pull on every rule → apptainer refuses to overwrite → fatal (live: clindet SV_delly_mini, tx-ubuntu). The pull now writes into `$IMG` explicitly (`apptainer pull \$IMG\ <uri>`), so check and artifact always agree.

**2. mike docs deploy idempotency** — the landing-page preservation step failed every idempotent re-run (`nothing to commit` → exit 1; main CI red after #178). Commit+push only when there is a diff.

## Verification

- TDD: new test (RED first) + updated docker:// assertion; 18/18 singularity tests green
- ci.yml YAML re-validated
- Live re-verification of the delly case on tx-ubuntu will follow after merge