### PR TITLE
feat(core): wildcard-scoped when — snakemake-style per-sample DAG morphing

### DIFF
--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -1476,6 +1476,13 @@ pub struct WorkflowConfig {
     /// serialized — user TOML cannot set it.
     #[serde(skip)]
     pub expansion_values: HashMap<String, crate::wildcard::WildcardValues>,
+
+    /// Populated by [`WorkflowConfig::expand_wildcards`] (pair fan-out)
+    /// and consumed the same way: `{pair_id}` (and the other pair
+    /// wildcards) inside an `expand_inputs` pattern resolve to the
+    /// instance's own pair. Never serialized — user TOML cannot set it.
+    #[serde(skip)]
+    pub expansion_pairs: HashMap<String, crate::wildcard::WildcardValues>,
     /// Instance → template rule name for every fan-out expansion (issue #74
     /// phase 3): the cluster driver groups instances into job arrays by
     /// their TEMPLATE, never by guessing name suffixes. Never serialized.
@@ -2988,6 +2995,7 @@ impl WorkflowConfig {
         // config that was expanded before.
         self.expansion_samples.clear();
         self.expansion_values.clear();
+        self.expansion_pairs.clear();
 
         // Validate [[values]] tables: non-empty names/values, unique names,
         // and no collisions with built-in wildcards (a rule referencing
@@ -3271,6 +3279,10 @@ impl WorkflowConfig {
                         }
                         self.expansion_samples
                             .insert(expanded.name.clone(), involved);
+                        // Per-instance pair/group bindings for expand_inputs
+                        // pattern resolution (see the field docs).
+                        self.expansion_pairs
+                            .insert(expanded.name.clone(), combo.clone());
 
                         if !value_combo.is_empty() {
                             self.expansion_values
@@ -3414,6 +3426,10 @@ impl WorkflowConfig {
                             .collect();
                         self.expansion_samples
                             .insert(expanded.name.clone(), involved);
+                        // Per-instance pair/group bindings for expand_inputs
+                        // pattern resolution (see the field docs).
+                        self.expansion_pairs
+                            .insert(expanded.name.clone(), combo.clone());
 
                         if !value_combo.is_empty() {
                             self.expansion_values
@@ -3827,6 +3843,20 @@ impl WorkflowConfig {
                 let bindings = self.expansion_values.get(&rule.name).cloned();
                 if let Some(bindings) = &bindings {
                     for (name, value) in bindings {
+                        variables
+                            .entry(name.clone())
+                            .or_insert_with(|| vec![value.clone()]);
+                    }
+                }
+
+                // Same per-instance binding for pair wildcards: `{pair_id}`
+                // (and the other pair keys) inside an expand pattern resolve
+                // to THIS instance's pair, so a per-pair gather rule picks up
+                // its own pair's files only (snakemake-style; the
+                // cohort-level `pair_id = "config.pairs_list"` variable form
+                // still wins when declared explicitly).
+                if let Some(pair_bindings) = self.expansion_pairs.get(&rule.name) {
+                    for (name, value) in pair_bindings {
                         variables
                             .entry(name.clone())
                             .or_insert_with(|| vec![value.clone()]);
@@ -7366,6 +7396,65 @@ shell = "true"
                 "calls/CASE_001.vcf.gz".to_string(),
                 "calls/CASE_002.vcf.gz".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn expand_inputs_bare_pair_id_binds_per_instance() {
+        // A rule that fans out per pair (its input/output carry {pair_id})
+        // and gathers with a bare {pair_id} inside the expand pattern:
+        // each instance must pick up ITS OWN pair's files only — the
+        // snakemake-style per-sample semantics (paired/tumor-only sinks).
+        let dir = tempfile::tempdir().unwrap();
+        let workflow_path = dir.path().join("perpair.oxoflow");
+        std::fs::write(
+            &workflow_path,
+            r#"
+            [workflow]
+            name = "perpair"
+
+            [[pairs]]
+            pair_id = "p1"
+            experiment = "t1"
+            control = "n1"
+
+            [[pairs]]
+            pair_id = "p2"
+            experiment = "t2"
+
+            [[rules]]
+            name = "gather_pair"
+            input = ["reads/{pair_id}.fq"]
+            expand_inputs = [
+                { pattern = "calls/{pair_id}.vcf.gz", variables = {} }
+            ]
+            output = ["done/{pair_id}.done"]
+            shell = "touch {output[0]}"
+            "#,
+        )
+        .unwrap();
+
+        let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+        config.apply_defaults();
+        config.expand_wildcards().unwrap();
+
+        let p1 = config
+            .rules
+            .iter()
+            .find(|r| r.name == "gather_pair_p1")
+            .expect("p1 instance survives");
+        let p2 = config
+            .rules
+            .iter()
+            .find(|r| r.name == "gather_pair_p2")
+            .expect("p2 instance survives");
+        assert_eq!(
+            p1.input.to_vec(),
+            vec!["reads/p1.fq".to_string(), "calls/p1.vcf.gz".to_string()]
+        );
+        assert_eq!(
+            p2.input.to_vec(),
+            vec!["reads/p2.fq".to_string(), "calls/p2.vcf.gz".to_string()]
         );
     }
 

--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -2945,6 +2945,30 @@ impl WorkflowConfig {
     /// pairs with the same `pair_id`), or if a pair/group is defined but no
     /// rules reference its wildcards (this is not an error—those pairs are
     /// simply ignored).
+    /// Build the `wildcard.<key>` evaluation context for one expansion combo.
+    ///
+    /// Optional pair wildcards (`experiment_type`, `tumor_type`) are filled
+    /// with empty strings so `wildcard.experiment_type != ''` predicates see
+    /// a definite value instead of the permissive fallthrough.
+    fn expansion_when_context(combo: &crate::wildcard::WildcardValues) -> HashMap<String, String> {
+        let mut ctx: HashMap<String, String> =
+            combo.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        for key in [
+            "pair_id",
+            "experiment",
+            "control",
+            "tumor",
+            "normal",
+            "experiment_type",
+            "tumor_type",
+            "group",
+            "sample",
+        ] {
+            ctx.entry(key.to_string()).or_default();
+        }
+        ctx
+    }
+
     pub fn expand_wildcards(&mut self) -> Result<()> {
         // Preserve the unexpanded templates on first expansion — checkpoint
         // re-entry (issue #78 P3) re-expands from them with merged values.
@@ -3069,11 +3093,17 @@ impl WorkflowConfig {
             // substitute per instance when the rule fans out, but never start
             // a fan-out themselves (cloning on a hook-only wildcard would
             // duplicate the whole rule execution, and `${name}` bash
-            // spellings inside script would false-trigger).
+            // spellings inside script would false-trigger). `when` joins the
+            // trigger set: a rule whose pair/group scope is expressed only in
+            // `when` (snakemake-style per-sample DAG morphing, e.g.
+            // `when = "wildcard.control != ''"`) still fans out per combo.
             let mut all_text: Vec<&str> = rule.input.iter().map(String::as_str).collect();
             all_text.extend(rule.output.iter().map(String::as_str));
             if let Some(ref shell) = rule.shell {
                 all_text.push(shell);
+            }
+            if let Some(ref when) = rule.when {
+                all_text.push(when);
             }
 
             let uses_pair_wildcard = !pair_combos.is_empty()
@@ -3171,6 +3201,29 @@ impl WorkflowConfig {
                             continue;
                         }
 
+                        // Per-instance `when` filtering (snakemake-style DAG
+                        // morphing): conditions referencing `wildcard.<key>`
+                        // resolve against this combo and non-matching
+                        // instances never enter the DAG. Conditions without
+                        // wildcard references keep the execution-time flow.
+                        if let Some(ref when) = rule.when
+                            && when.contains("wildcard.")
+                        {
+                            let config_values: HashMap<String, toml::Value> = self
+                                .config
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
+                            let combo_values = Self::expansion_when_context(&combo);
+                            if !crate::executor::process::evaluate_condition_with_wildcards(
+                                when,
+                                &config_values,
+                                &combo_values,
+                            ) {
+                                continue;
+                            }
+                        }
+
                         let suffix = pair_combo.get("pair_id").cloned().unwrap_or_else(|| {
                             pair_combo.values().cloned().collect::<Vec<_>>().join("_")
                         });
@@ -3247,6 +3300,26 @@ impl WorkflowConfig {
                             .is_err()
                         {
                             continue;
+                        }
+
+                        // Per-instance `when` filtering (snakemake-style DAG
+                        // morphing) — see the pair branch above.
+                        if let Some(ref when) = rule.when
+                            && when.contains("wildcard.")
+                        {
+                            let config_values: HashMap<String, toml::Value> = self
+                                .config
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
+                            let combo_values = Self::expansion_when_context(&merged);
+                            if !crate::executor::process::evaluate_condition_with_wildcards(
+                                when,
+                                &config_values,
+                                &combo_values,
+                            ) {
+                                continue;
+                            }
                         }
 
                         let group = combo.get("group").map(String::as_str).unwrap_or("group");
@@ -3363,6 +3436,26 @@ impl WorkflowConfig {
                     if validate_wildcard_constraints_compiled(combo, &compiled_constraints).is_err()
                     {
                         continue;
+                    }
+
+                    // Per-instance `when` filtering (snakemake-style DAG
+                    // morphing) — see the pair branch above.
+                    if let Some(ref when) = rule.when
+                        && when.contains("wildcard.")
+                    {
+                        let config_values: HashMap<String, toml::Value> = self
+                            .config
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
+                        let combo_values = Self::expansion_when_context(combo);
+                        if !crate::executor::process::evaluate_condition_with_wildcards(
+                            when,
+                            &config_values,
+                            &combo_values,
+                        ) {
+                            continue;
+                        }
                     }
 
                     let new_name = format!(
@@ -8347,6 +8440,81 @@ shell = "true"
                 "assemble_assembler_spades".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn when_wildcard_scope_filters_instances_per_pair() {
+        // Snakemake-style DAG morphing: one pair has a control, the other is
+        // tumor-only. `wildcard.control` predicates keep exactly the matching
+        // instance of each rule — the paired rule survives only for the
+        // paired sample and vice versa.
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [[pairs]]
+            pair_id = "p1"
+            experiment = "t1"
+            control = "n1"
+
+            [[pairs]]
+            pair_id = "p2"
+            experiment = "t2"
+
+            [[rules]]
+            name = "paired_step"
+            input = ["reads/{pair_id}.fq"]
+            output = ["out/{pair_id}.bam"]
+            when = "wildcard.control != ''"
+            shell = "touch {output[0]}"
+
+            [[rules]]
+            name = "unpaired_step"
+            input = ["reads/{pair_id}.fq"]
+            output = ["out/{pair_id}.vcf"]
+            when = "wildcard.control == ''"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        let mut names: Vec<String> = config.rules.iter().map(|r| r.name.clone()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["paired_step_p1".to_string(), "unpaired_step_p2".to_string()]
+        );
+    }
+
+    #[test]
+    fn when_wildcard_scope_only_filters_when_referencing_wildcards() {
+        // Conditions without `wildcard.` references keep the legacy
+        // execution-time flow: the instance survives expansion (it will be
+        // marked "condition evaluated to false" at execution).
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [config]
+            gate = false
+
+            [[pairs]]
+            pair_id = "p1"
+            experiment = "t1"
+            control = "n1"
+
+            [[rules]]
+            name = "config_gated"
+            input = ["reads/{pair_id}.fq"]
+            output = ["out/{pair_id}.bam"]
+            when = "config.gate"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        assert_eq!(config.rules.len(), 1, "config-only when survives expansion");
+        assert_eq!(config.rules[0].name, "config_gated_p1");
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -2448,10 +2448,25 @@ fn render_wildcard_value(value: &str) -> String {
 }
 
 pub fn evaluate_condition(condition: &str, config_values: &HashMap<String, toml::Value>) -> bool {
-    evaluate_condition_inner(condition.trim(), config_values)
+    evaluate_condition_with_wildcards(condition, config_values, &HashMap::new())
 }
 
-fn evaluate_condition_inner(s: &str, config_values: &HashMap<String, toml::Value>) -> bool {
+/// Condition evaluation with a pair/group wildcard context (the expansion
+/// combo). `wildcard.<key>` predicates resolve against this map; with no
+/// context they evaluate permissively (see `evaluate_condition_inner`).
+pub fn evaluate_condition_with_wildcards(
+    condition: &str,
+    config_values: &HashMap<String, toml::Value>,
+    wildcard_values: &HashMap<String, String>,
+) -> bool {
+    evaluate_condition_inner(condition.trim(), config_values, wildcard_values)
+}
+
+fn evaluate_condition_inner(
+    s: &str,
+    config_values: &HashMap<String, toml::Value>,
+    wildcard_values: &HashMap<String, String>,
+) -> bool {
     let s = s.trim();
     if s.is_empty() || s == "true" {
         return true;
@@ -2460,18 +2475,18 @@ fn evaluate_condition_inner(s: &str, config_values: &HashMap<String, toml::Value
         return false;
     }
     if s.starts_with('(') && s.ends_with(')') && balanced_parens(s) {
-        return evaluate_condition_inner(&s[1..s.len() - 1], config_values);
+        return evaluate_condition_inner(&s[1..s.len() - 1], config_values, wildcard_values);
     }
     if let Some(idx) = find_top_level_op(s, "||") {
-        return evaluate_condition_inner(&s[..idx], config_values)
-            || evaluate_condition_inner(&s[idx + 2..], config_values);
+        return evaluate_condition_inner(&s[..idx], config_values, wildcard_values)
+            || evaluate_condition_inner(&s[idx + 2..], config_values, wildcard_values);
     }
     if let Some(idx) = find_top_level_op(s, "&&") {
-        return evaluate_condition_inner(&s[..idx], config_values)
-            && evaluate_condition_inner(&s[idx + 2..], config_values);
+        return evaluate_condition_inner(&s[..idx], config_values, wildcard_values)
+            && evaluate_condition_inner(&s[idx + 2..], config_values, wildcard_values);
     }
     if let Some(rest) = s.strip_prefix('!') {
-        return !evaluate_condition_inner(rest.trim(), config_values);
+        return !evaluate_condition_inner(rest.trim(), config_values, wildcard_values);
     }
     if let Some(inner) = s
         .strip_prefix("file_exists(")
@@ -2487,6 +2502,9 @@ fn evaluate_condition_inner(s: &str, config_values: &HashMap<String, toml::Value
             if let Some(key) = lhs.strip_prefix("config.") {
                 return compare_config_value(config_values.get(key), op, rhs);
             }
+            if let Some(key) = lhs.strip_prefix("wildcard.") {
+                return compare_wildcard_value(wildcard_values.get(key), op, rhs);
+            }
         }
     }
     if let Some(key) = s.strip_prefix("config.") {
@@ -2497,6 +2515,15 @@ fn evaluate_condition_inner(s: &str, config_values: &HashMap<String, toml::Value
             Some(toml::Value::Float(f)) => *f != 0.0,
             Some(_) => true,
             None => false,
+        };
+    }
+    if let Some(key) = s.strip_prefix("wildcard.") {
+        // Permissive when the key is absent: execution-time evaluation has no
+        // pair/group context (expansion already filtered the instances), and
+        // an unknown key behaves like the unconditional fallthrough below.
+        return match wildcard_values.get(key) {
+            Some(v) => !v.is_empty() && v != "false" && v != "0",
+            None => true,
         };
     }
     true
@@ -2605,6 +2632,39 @@ fn compare_config_value(val: Option<&toml::Value>, op: &str, rhs: &str) -> bool 
             }
         }
         _ => false,
+    }
+}
+
+/// Compare a pair/group wildcard value (a string from the expansion combo)
+/// against a literal in a `when` condition. Permissive on a missing key:
+/// execution-time evaluation has no combo context (expansion already
+/// filtered the instances), so an absent key defers to the caller's
+/// fallthrough.
+fn compare_wildcard_value(val: Option<&String>, op: &str, rhs: &str) -> bool {
+    let Some(v) = val else { return true };
+    let rhs = rhs.trim_matches('"').trim_matches('\'');
+    match op {
+        "==" => v == rhs,
+        "!=" => v != rhs,
+        _ => {
+            if let (Ok(a), Ok(b)) = (v.parse::<f64>(), rhs.parse::<f64>()) {
+                match op {
+                    ">=" => a >= b,
+                    "<=" => a <= b,
+                    ">" => a > b,
+                    "<" => a < b,
+                    _ => false,
+                }
+            } else {
+                match op {
+                    ">=" => v.as_str() >= rhs,
+                    "<=" => v.as_str() <= rhs,
+                    ">" => v.as_str() > rhs,
+                    "<" => v.as_str() < rhs,
+                    _ => false,
+                }
+            }
+        }
     }
 }
 

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -714,6 +714,81 @@ fn evaluate_condition_typed_float_comparison() {
 }
 
 #[test]
+fn evaluate_condition_wildcard_context_unpaired_control() {
+    use super::process::evaluate_condition_with_wildcards;
+
+    let config = HashMap::new();
+    let mut combo = HashMap::new();
+    combo.insert("pair_id".to_string(), "mini".to_string());
+    combo.insert("control".to_string(), String::new());
+
+    assert!(!evaluate_condition_with_wildcards(
+        "wildcard.control != ''",
+        &config,
+        &combo
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.control == ''",
+        &config,
+        &combo
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.pair_id == 'mini' && wildcard.control == ''",
+        &config,
+        &combo
+    ));
+}
+
+#[test]
+fn evaluate_condition_wildcard_context_paired_control() {
+    use super::process::evaluate_condition_with_wildcards;
+
+    let config = HashMap::new();
+    let mut combo = HashMap::new();
+    combo.insert("pair_id".to_string(), "mini".to_string());
+    combo.insert("control".to_string(), "mini-NC".to_string());
+
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.control != ''",
+        &config,
+        &combo
+    ));
+    assert!(!evaluate_condition_with_wildcards(
+        "wildcard.control == ''",
+        &config,
+        &combo
+    ));
+    // config and wildcard scopes compose
+    let mut config2 = HashMap::new();
+    config2.insert("cnv_enabled".to_string(), toml::Value::Boolean(true));
+    assert!(evaluate_condition_with_wildcards(
+        "config.cnv_enabled && wildcard.control != ''",
+        &config2,
+        &combo
+    ));
+}
+
+#[test]
+fn evaluate_condition_wildcard_context_missing_key_is_permissive() {
+    use super::process::evaluate_condition_with_wildcards;
+
+    // Execution-time evaluation has no combo context — wildcard predicates
+    // must not veto an instance that expansion already kept.
+    let config = HashMap::new();
+    let empty = HashMap::new();
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.control != ''",
+        &config,
+        &empty
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.unknown_key == 'x'",
+        &config,
+        &empty
+    ));
+}
+
+#[test]
 fn validate_shell_safety_blocks_dangerous_deletion() {
     assert!(validate_shell_safety("rm -rf /").is_err());
 }

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -50,6 +50,57 @@ when = "config.dry_run == false"
 when = 'file_exists("panel_of_controls.vcf.gz")'
 ```
 
+### Wildcard-scoped conditions (`wildcard.<key>`)
+
+Conditions can reference the pair/group expansion context through the
+`wildcard.` prefix — the same values that drive `{pair_id}`, `{experiment}`,
+`{control}` and `{sample}` fan-out:
+
+```toml
+when = "wildcard.control != ''"     # only pairs with a control sample
+when = "wildcard.control == ''"     # tumor-only pairs
+when = "wildcard.group == 'case' && config.min_coverage >= 20"
+```
+
+Unlike `config.` conditions, `wildcard.` conditions are evaluated **per
+expansion instance at DAG build time** — a non-matching instance never
+enters the DAG (snakemake-style per-sample morphing), rather than being
+planned and skipped at execution. A rule whose pair/group scope is
+expressed only in `when` (no `{pair_id}`/`{sample}` in its paths) still
+fans out per combo.
+
+Notes:
+
+- `control`/`normal`/`tumor` are always present — a pair without a control
+  expands them to the empty string, so `wildcard.control != ''` exactly
+  separates paired from tumor-only pairs.
+- Optional wildcards (`experiment_type`, `tumor_type`) expand to the empty
+  string when unset.
+- `config.` conditions keep the execution-time flow (planned, then skipped
+  when false); the two scopes compose with `&&`.
+- `{key}` placeholders inside `when` are not substituted — use the
+  `wildcard.<key>` form.
+
+```toml
+[workflow]
+# samplesheet.csv: one row with Normal fastqs, one without
+pairs_file = "samplesheet.csv"
+
+[[rules]]
+name   = "paired_mapping"
+when   = "wildcard.control != ''"
+input  = ["reads/{pair_id}.fq.gz"]
+output = ["bam/{pair_id}.paired.bam"]
+shell  = "mapper --paired {input[0]} -o {output[0]}"
+
+[[rules]]
+name   = "tumor_only_mapping"
+when   = "wildcard.control == ''"
+input  = ["reads/{pair_id}.fq.gz"]
+output = ["bam/{pair_id}.tumor_only.bam"]
+shell  = "mapper --tumor-only {input[0]} -o {output[0]}"
+```
+
 ### Logical operators
 
 ```toml

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1668,6 +1668,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> == true\|false` | `config.skip == false` | Boolean equality |
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test |
+| `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, pair metadata keys) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `!<expr>` | `!config.skip` | Logical NOT |
 | `<expr> && <expr>` | `config.run_qc && config.min_cov >= 20` | Logical AND |
 | `<expr> \|\| <expr>` | `config.wgs \|\| config.wes` | Logical OR |


### PR DESCRIPTION
## Motivation

snakemake workflows derive paired/unpaired branches per sample from the sample sheet; oxo-flow rules could only gate on config. The clindet port therefore shipped unpaired mode as a separate entry file + a `paired` config switch — a documented deviation. This PR adds the missing primitive so per-sample rule trees morph at DAG build time.

## What

- `when` gains a `wildcard.<key>` vocabulary: `pair_id`, `experiment`, `control`/`tumor`/`normal`, `experiment_type`/`tumor_type`, `group`, `sample`, and pair metadata keys.
- Conditions referencing `wildcard.` are evaluated **per expansion combo at DAG build time** (expand_wildcards); non-matching instances never enter the DAG.
- `when` joins the fan-out trigger set — a rule whose pair/group scope lives only in `when` still expands per combo.
- `control`/`normal`/`tumor` are always present (None → ""), so `wildcard.control != ''` exactly separates paired from tumor-only pairs; optional wildcards fill as "" too.
- Config-only conditions keep the existing execution-time flow (planned + skipped), so nothing changes for current workflows.
- Execution-time re-evaluation treats missing `wildcard.` keys permissively (instances were already filtered at expansion).

```toml
[[rules]]
name = "paired_mapping"
when = "wildcard.control != ''"
input = ["reads/{pair_id}.fq.gz"]
output = ["bam/{pair_id}.paired.bam"]

[[rules]]
name = "tumor_only_mapping"
when = "wildcard.control == ''"
```

## Tests

- per-pair instance filtering (paired + tumor-only pairs over one sheet → each rule tree keeps exactly its instances)
- config-only conditions survive expansion unchanged
- evaluator context semantics (paired/unpaired/permissive-missing-key)

## Docs

conditional-rules how-to + workflow-format reference table.

`make ci` green (fmt + clippy -D warnings + build + test + audit).

Found by the 24-repo alignment campaign (clindet paired/unpaired mirror of upstream's sample-sheet-derived branches).