### PR TITLE
fix(core+cli+web): reliability audit #194 — atomic checkpoint, single-writer logs, SIGTERM grace, checksum reuse

### DIFF
--- a/crates/oxo-flow-cli/src/background.rs
+++ b/crates/oxo-flow-cli/src/background.rs
@@ -118,6 +118,11 @@ fn spawn_detached(args: &[OsString], log_path: &Path) -> io::Result<Child> {
     let mut command = Command::new(std::env::current_exe()?);
     command
         .args(args)
+        // The child must NOT arm the tracing tee: its stderr already lands
+        // in this log, and a second writer would duplicate every event
+        // (issue #194 A3). The flag routes the child to the redirect-only
+        // path in `run_command`.
+        .env("OXO_FLOW_STDERR_ALREADY_REDIRECTED", "1")
         .stdout(Stdio::from(log.try_clone()?))
         .stderr(Stdio::from(log));
     #[cfg(unix)]

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -30,16 +30,26 @@ fn config_placeholder_values(config: &HashMap<String, toml::Value>) -> HashMap<S
 /// as before) and the tracing stream — the tracing copy is what the
 /// archived run log preserves (issue #194 B1). Colors live in the console
 /// form; the log side gets the same text and strips ANSI at write time.
+///
+/// Background runs skip the tracing copy: their stderr is already
+/// redirected onto the run log, so a second copy would duplicate the line
+/// (issue #194 A3).
 fn progress_narrate(msg: std::fmt::Arguments<'_>) {
     eprintln!("{msg}");
-    tracing::info!(target: "progress", message = %msg.to_string());
+    if std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_none() {
+        tracing::info!(target: "progress", message = %msg.to_string());
+    }
 }
 
 /// Emit a structured [`ExecutionEvent`] as one JSON line in the tracing
 /// stream (issue #194 B3): the event schema stops being dead code and the
 /// run log gains a machine-readable execution timeline alongside the prose.
+/// Background runs skip it for the same reason as [`progress_narrate`] —
+/// the redirected stderr already carries the line exactly once.
 fn emit_execution_event(event: oxo_flow_core::executor::ExecutionEvent) {
-    tracing::info!(target: "execution_event", "{}", event.to_json_log());
+    if std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_none() {
+        tracing::info!(target: "execution_event", "{}", event.to_json_log());
+    }
 }
 
 /// Print the config-change impact summary (issue #62).
@@ -1077,6 +1087,9 @@ pub async fn run_command(
     // redirects, nohup, CI, or schedulers. When that happens, fall back to plain
     // eprintln lines so the run is never silent.
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
+    // Background runs redirect stderr onto the run log (issue #194 A3):
+    // the bar's redraw sequences would land in the file as ANSI garbage.
+    let stderr_redirected = std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_some();
 
     let progress = indicatif::ProgressBar::new(order.len() as u64);
     progress.set_style(
@@ -1086,6 +1099,12 @@ pub async fn run_command(
             )?
             .progress_chars("#>-"),
     );
+    if !is_tty || stderr_redirected {
+        // Draw into the void instead of stderr: no bar output, but every
+        // set_message/set_position call stays valid (message lines are
+        // printed separately via progress_narrate when !is_tty).
+        progress.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+    }
 
     let timeout_secs: u64 = if timeout == "0" {
         0

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -26,6 +26,22 @@ fn config_placeholder_values(config: &HashMap<String, toml::Value>) -> HashMap<S
         .collect()
 }
 
+/// Emit one progress narrative line to BOTH the console (stderr, exactly
+/// as before) and the tracing stream — the tracing copy is what the
+/// archived run log preserves (issue #194 B1). Colors live in the console
+/// form; the log side gets the same text and strips ANSI at write time.
+fn progress_narrate(msg: std::fmt::Arguments<'_>) {
+    eprintln!("{msg}");
+    tracing::info!(target: "progress", message = %msg.to_string());
+}
+
+/// Emit a structured [`ExecutionEvent`] as one JSON line in the tracing
+/// stream (issue #194 B3): the event schema stops being dead code and the
+/// run log gains a machine-readable execution timeline alongside the prose.
+fn emit_execution_event(event: oxo_flow_core::executor::ExecutionEvent) {
+    tracing::info!(target: "execution_event", "{}", event.to_json_log());
+}
+
 /// Print the config-change impact summary (issue #62).
 ///
 /// Distinguishes the full invalidation set (checkpoint mutation; includes
@@ -290,22 +306,47 @@ fn validate_config_value(
     Ok(())
 }
 
-/// Remove files in the environment cache that have not been touched for
-/// `max_age_days` (issue #75). Returns the number of files removed.
+/// Remove entries in the environment cache that have not been touched for
+/// `max_age_days` (issue #75; recursive since #194 C1 — subdirectories
+/// were previously never aged out). Returns the number of entries removed.
 fn cleanup_cache_dir(cache_dir: &std::path::Path, max_age_days: u64) -> usize {
     let max_age = std::time::Duration::from_secs(max_age_days * 24 * 3600);
     let now = std::time::SystemTime::now();
     let mut removed = 0;
-    if let Ok(entries) = std::fs::read_dir(cache_dir) {
+    let mut stack = vec![cache_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_file()
-                && let Ok(metadata) = std::fs::metadata(&path)
-                && let Ok(modified) = metadata.modified()
-                && let Ok(age) = now.duration_since(modified)
-                && age > max_age
-                && std::fs::remove_file(&path).is_ok()
-            {
+            let is_file = path.is_file();
+            if !is_file && !path.is_dir() {
+                continue;
+            }
+            let Ok(metadata) = std::fs::metadata(&path) else {
+                continue;
+            };
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+            let Ok(age) = now.duration_since(modified) else {
+                continue;
+            };
+            if age <= max_age {
+                // Young entries may still contain aged descendants; only
+                // descend into directories that are themselves young.
+                if !is_file {
+                    stack.push(path);
+                }
+                continue;
+            }
+            let ok = if is_file {
+                std::fs::remove_file(&path).is_ok()
+            } else {
+                std::fs::remove_dir_all(&path).is_ok()
+            };
+            if ok {
                 removed += 1;
             }
         }
@@ -711,11 +752,21 @@ pub async fn run_command(
             .unwrap_or("(not inside a git repository)"),
         effective_workdir_log.display(),
     );
-    let _run_log_guard = match crate::logging::activate_run_log(&run_log_path, &run_log_header) {
-        Ok(guard) => Some(guard),
-        Err(e) => {
-            tracing::warn!(error = %e, path = %run_log_path.display(), "failed to open run log; continuing without file logging");
-            None
+    // Background runs (issue #194 A3): `spawn_detached` already redirected
+    // this process's stdout/stderr onto the run log, so arming the tracing
+    // tee here would write every event TWICE into the same file. In that
+    // mode the header is printed to stderr (→ the redirect) and the tee is
+    // skipped entirely; foreground runs arm the tee as before.
+    let _run_log_guard = if std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_some() {
+        eprintln!("{run_log_header}");
+        None
+    } else {
+        match crate::logging::activate_run_log(&run_log_path, &run_log_header) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                tracing::warn!(error = %e, path = %run_log_path.display(), "failed to open run log; continuing without file logging");
+                None
+            }
         }
     };
     tracing::info!(
@@ -734,6 +785,10 @@ pub async fn run_command(
         dag.execution_order_for_targets(&target_refs)
             .with_context(|| "failed to resolve target rules")?
     };
+    emit_execution_event(oxo_flow_core::executor::ExecutionEvent::WorkflowStarted {
+        workflow_name: config.workflow.name.clone(),
+        total_rules: order.len(),
+    });
     eprintln!(
         "{} {} rules in execution order",
         "DAG:".bold().green(),
@@ -754,6 +809,20 @@ pub async fn run_command(
         .as_ref()
         .unwrap_or(&workdir_default)
         .join(".oxo-flow/checkpoint.json");
+    // Retention for failed-output aside files (issue #194 C2): stale
+    // `.oxo-failed` evidence ages out at run start instead of accumulating
+    // forever. Best-effort — cleanup must never block the run.
+    let stale_asides = oxo_flow_core::executor::output_invalidation::cleanup_stale_failed_asides(
+        workdir.as_ref().unwrap_or(&workdir_default),
+        oxo_flow_core::executor::output_invalidation::OXOX_FAILED_RETENTION_DAYS,
+    );
+    if stale_asides > 0 {
+        tracing::info!(
+            count = stale_asides,
+            "removed stale .oxo-failed aside files (retention)"
+        );
+    }
+
     let checkpoint: Arc<Mutex<CheckpointState>> = if checkpoint_path.exists() {
         Arc::new(Mutex::new(
             CheckpointState::load_from_file(&checkpoint_path).unwrap_or_default(),
@@ -1142,6 +1211,9 @@ pub async fn run_command(
         // Shared with the manifest snapshot resolver so staging and
         // invalidation always see the same backends (issue #80 item 2).
         storage_resolver: crate::commands::run_preview::storage_resolver(),
+        // The freshness gate reads recorded provenance checksums from the
+        // live checkpoint (issue #194 B2).
+        checkpoint: Some(checkpoint.clone()),
     };
 
     // Fail fast if any rule's declared request can never fit an explicit
@@ -1893,8 +1965,12 @@ pub async fn run_command(
 
             progress.set_message(format!("executing {}", rule_name));
             if !is_tty {
-                eprintln!("  {} {}", "Running:".bold().cyan(), rule_name);
+                progress_narrate(format_args!("  {} {}", "Running:".bold().cyan(), rule_name));
             }
+            emit_execution_event(oxo_flow_core::executor::ExecutionEvent::RuleStarted {
+                rule: rule_name.clone(),
+                command: None,
+            });
 
             let typed_config = config.config.clone();
             // Register the task name BEFORE the spawn: the closure moves
@@ -1933,8 +2009,18 @@ pub async fn run_command(
 
                         if record.status == oxo_flow_core::executor::JobStatus::Success {
                             success_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            emit_execution_event(oxo_flow_core::executor::ExecutionEvent::RuleCompleted {
+                                rule: rule_name.clone(),
+                                status: oxo_flow_core::executor::JobStatus::Success,
+                                duration_ms: (duration * 1000.0) as u64,
+                            });
                             if !is_tty {
-                                eprintln!("  {} {} ({:.1}s)", "✓".green(), rule_name, duration);
+                                progress_narrate(format_args!(
+                                    "  {} {} ({:.1}s)",
+                                    "✓".green(),
+                                    rule_name,
+                                    duration
+                                ));
                             }
                             let benchmark =
                                 oxo_flow_core::executor::checkpoint::BenchmarkRecord {
@@ -2013,7 +2099,7 @@ pub async fn run_command(
                             if let Some(code) = record.exit_code {
                                 err_msg.push_str(&format!("\nexit code: {}", code));
                             }
-                            eprintln!("  {} {}", "✗".red(), err_msg);
+                            progress_narrate(format_args!("  {} {}", "✗".red(), err_msg));
                             // Always record: keep_going needs the final
                             // listing, non-required failures are listed in
                             // either mode, and the AI recovery path must be
@@ -2086,6 +2172,11 @@ pub async fn run_command(
                             max_rss_mb: None,
                             cpu_seconds: None,
                         };
+                        emit_execution_event(oxo_flow_core::executor::ExecutionEvent::RuleCompleted {
+                            rule: rule_name.clone(),
+                            status: oxo_flow_core::executor::JobStatus::Failed,
+                            duration_ms: 0,
+                        });
                         let mut ck = checkpoint.lock().await;
                         ck.record_run(&record);
                         ck.mark_failed(&rule_name);
@@ -2093,7 +2184,12 @@ pub async fn run_command(
                             tracing::warn!("Failed to save checkpoint: {e}");
                         }
                         if !keep_going {
-                            eprintln!("  {} rule '{}' failed: {}", "✗".red(), rule_name, e);
+                            progress_narrate(format_args!(
+                                "  {} rule '{}' failed: {}",
+                                "✗".red(),
+                                rule_name,
+                                e
+                            ));
                         }
                         // Always record: keep_going needs the final
                         // listing, non-required failures are listed in
@@ -2474,23 +2570,29 @@ pub async fn run_command(
         }
     }
 
+    emit_execution_event(oxo_flow_core::executor::ExecutionEvent::WorkflowCompleted {
+        total_duration_ms: run_started.elapsed().as_millis() as u64,
+        succeeded: success_count,
+        failed: fail_count,
+        skipped: skipped_count,
+    });
     if non_required_fail_count > 0 {
-        eprintln!(
+        progress_narrate(format_args!(
             "\n{} {} succeeded, {} skipped, {} failed, {} non-required failed",
             "Done:".bold(),
             success_count,
             skipped_count,
             fail_count,
             non_required_fail_count
-        );
+        ));
     } else {
-        eprintln!(
+        progress_narrate(format_args!(
             "\n{} {} succeeded, {} skipped, {} failed",
             "Done:".bold(),
             success_count,
             skipped_count,
             fail_count
-        );
+        ));
     }
 
     // Automatic report snapshot (issue #83 P1-14): capture the final
@@ -4200,9 +4302,25 @@ pub async fn resume_command(
 #[cfg(test)]
 mod tests {
     use super::{
-        age_ready_list, known_modules_hint, parse_cli_overrides, substitute_source_placeholder,
+        age_ready_list, cleanup_cache_dir, known_modules_hint, parse_cli_overrides,
+        substitute_source_placeholder,
     };
     use std::collections::HashSet;
+
+    #[test]
+    fn cleanup_cache_dir_is_recursive() {
+        // issue #194 C1: nested directories age out too (max_age_days = 0
+        // makes everything eligible immediately).
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("sub").join("deeper");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(dir.path().join("old.txt"), "x").unwrap();
+        std::fs::write(nested.join("old-too.txt"), "y").unwrap();
+        let removed = cleanup_cache_dir(dir.path(), 0);
+        assert_eq!(removed, 2, "file + one nested directory removed");
+        assert!(!dir.path().join("old.txt").exists());
+        assert!(!dir.path().join("sub").exists());
+    }
 
     fn declared(keys: &[&str]) -> HashSet<String> {
         keys.iter().map(|k| k.to_string()).collect()

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -105,8 +105,14 @@ fn rule_outputs_exist_fresh(
     rule: &oxo_flow_core::rule::Rule,
     workdir: &Path,
     wildcard_values: &HashMap<String, String>,
+    checksums: Option<&HashMap<String, String>>,
 ) -> bool {
-    oxo_flow_core::executor::checkpoint::should_skip_rule(rule, workdir, wildcard_values)
+    oxo_flow_core::executor::checkpoint::should_skip_rule_with_checksums(
+        rule,
+        workdir,
+        wildcard_values,
+        checksums,
+    )
 }
 
 /// Storage resolver for manifest snapshots and remote staging: local by
@@ -308,10 +314,9 @@ pub fn preview_run_plan(
             // the executor freshness gate, so config invalidation wins here.
             if config_invalidated.contains(name) {
                 RuleStatus::ConfigInvalidated
-            } else if config
-                .get_rule(name)
-                .is_some_and(|rule| rule_outputs_exist_fresh(rule, workdir, wildcard_values))
-            {
+            } else if config.get_rule(name).is_some_and(|rule| {
+                rule_outputs_exist_fresh(rule, workdir, wildcard_values, Some(&ck.checksums))
+            }) {
                 // `run` applies the executor freshness gate to rules with
                 // no checkpoint entry: up-to-date outputs skip even without
                 // a completion record (issue #77 parity — crash leftovers).

--- a/crates/oxo-flow-cli/src/logging.rs
+++ b/crates/oxo-flow-cli/src/logging.rs
@@ -132,32 +132,67 @@ impl Drop for RunLogGuard {
 /// armed; stderr + the active run log file once [`activate_run_log`] runs.
 /// File write failures are reported once to stderr and the tee degrades to
 /// stderr-only — a logging hiccup never fails the run.
+///
+/// Single-writer design (issue #194 A2): every `Tee` writes through the ONE
+/// file handle in the slot, serialized by the slot mutex — no per-event
+/// `try_clone`, no concurrent writes from parallel rule tasks.
 pub struct TeeWriter;
 
 impl<'a> MakeWriter<'a> for TeeWriter {
-    type Writer = Box<dyn Write + 'a>;
+    type Writer = Tee<'a>;
 
     fn make_writer(&'a self) -> Self::Writer {
-        let file = slot()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .as_ref()
-            .and_then(|f| f.try_clone().ok());
-        match file {
-            Some(f) => Box::new(Tee {
-                stderr: io::stderr(),
-                file: Some(f),
-            }),
-            None => Box::new(io::stderr()),
+        Tee {
+            stderr: io::stderr(),
+            slot: slot(),
         }
     }
 }
 
 static FILE_WRITE_ERROR_REPORTED: AtomicBool = AtomicBool::new(false);
 
-struct Tee {
+pub struct Tee<'a> {
     stderr: io::Stderr,
-    file: Option<File>,
+    slot: &'a Arc<Mutex<Option<File>>>,
+}
+
+impl Write for Tee<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // stderr first (outside the lock): the console is the primary
+        // surface and must never wait on the log file.
+        let _ = self.stderr.write(buf);
+        let mut slot = self
+            .slot
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match slot.as_mut() {
+            Some(f) => match write_plain(f, buf) {
+                Ok(()) => Ok(buf.len()),
+                Err(e) => {
+                    if !FILE_WRITE_ERROR_REPORTED.swap(true, Ordering::Relaxed) {
+                        eprintln!(
+                            "warning: run log write failed ({e}); file logging disabled for this run"
+                        );
+                        *slot = None;
+                    }
+                    Ok(buf.len())
+                }
+            },
+            None => Ok(buf.len()),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let _ = self.stderr.flush();
+        let mut slot = self
+            .slot
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match slot.as_mut() {
+            Some(f) => f.flush(),
+            None => Ok(()),
+        }
+    }
 }
 
 /// Write `buf` to `out` with ANSI CSI escape sequences stripped — run-log
@@ -184,32 +219,6 @@ fn write_plain(out: &mut File, buf: &[u8]) -> io::Result<()> {
         }
     }
     out.write_all(&plain)
-}
-
-impl Write for Tee {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let _ = self.stderr.write(buf);
-        if let Some(f) = &mut self.file
-            && let Err(e) = write_plain(f, buf)
-        {
-            if !FILE_WRITE_ERROR_REPORTED.swap(true, Ordering::Relaxed) {
-                let _ = writeln!(
-                    self.stderr,
-                    "warning: run log write failed ({e}); continuing without file logging"
-                );
-            }
-            self.file = None;
-        }
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        let _ = self.stderr.flush();
-        if let Some(f) = &mut self.file {
-            f.flush()?;
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -293,10 +302,9 @@ mod tests {
         let dir = scratch("ansi");
         let log = dir.join("run.log");
         let _guard = activate_run_log(&log, "").unwrap();
-        let file = std::fs::OpenOptions::new().append(true).open(&log).unwrap();
         let mut tee = Tee {
             stderr: io::stderr(),
-            file: Some(file),
+            slot: slot(),
         };
         tee.write_all(b"\x1b[2m2026-08-21T14:54:11Z\x1b[0m \x1b[32m INFO\x1b[0m rule started\n")
             .unwrap();

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -1077,7 +1077,12 @@ async fn main() -> Result<()> {
     };
     let cli = Cli::from_arg_matches(&matches)?;
 
-    if cli.no_color || std::env::var_os("NO_COLOR").is_some() {
+    if cli.no_color
+        || std::env::var_os("NO_COLOR").is_some()
+        // Background runs redirect stderr onto the run log (issue #194 A3):
+        // colors would land in the file as ANSI escapes.
+        || std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_some()
+    {
         colored::control::set_override(false);
     }
 
@@ -1088,12 +1093,16 @@ async fn main() -> Result<()> {
     } else {
         "info"
     };
+    // Background runs redirect stderr onto the run log (issue #194 A3):
+    // the fmt layer must not paint ANSI escapes into the file.
+    let stderr_redirected = std::env::var_os("OXO_FLOW_STDERR_ALREADY_REDIRECTED").is_some();
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level)),
         )
         .with_target(false)
+        .with_ansi(!stderr_redirected)
         // Logs go to stderr so machine-readable stdout (graph DOT output,
         // --json, pipes into dot/other tools) stays clean.
         .with_writer(crate::logging::TeeWriter)

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -368,6 +368,12 @@ impl CheckpointState {
     }
 
     /// Save checkpoint state to a file.
+    ///
+    /// Atomic (issue #194 A1): serialize to a sibling `*.tmp`, fsync it,
+    /// rename over the target (atomic on POSIX), then fsync the parent
+    /// directory so the rename itself survives a crash. A power failure can
+    /// no longer leave a truncated `checkpoint.json` — readers see either
+    /// the previous state or the complete new one.
     pub fn save_to_file(&self, path: &Path) -> Result<()> {
         let parent = crate::parent_dir(path);
         if parent != std::path::Path::new(".") {
@@ -376,8 +382,27 @@ impl CheckpointState {
             })?;
         }
         let json = self.to_json()?;
-        std::fs::write(path, json).map_err(|e| OxoFlowError::Config {
-            message: format!("failed to save checkpoint to {}: {e}", path.display()),
+        let tmp_path = path.with_extension("json.tmp");
+        let write_result = (|| -> std::io::Result<()> {
+            let mut f = std::fs::File::create(&tmp_path)?;
+            use std::io::Write;
+            f.write_all(json.as_bytes())?;
+            f.sync_all()?;
+            drop(f);
+            std::fs::rename(&tmp_path, path)?;
+            // fsync the parent directory so the rename is durable (POSIX).
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        })();
+        write_result.map_err(|e| {
+            // Never leave a partial tmp file behind for the next attempt to
+            // trip over; the real checkpoint (old or new) is what matters.
+            let _ = std::fs::remove_file(&tmp_path);
+            OxoFlowError::Config {
+                message: format!("failed to save checkpoint to {}: {e}", path.display()),
+            }
         })
     }
 
@@ -900,6 +925,23 @@ pub fn should_skip_rule(
     workdir: &Path,
     wildcard_values: &HashMap<String, String>,
 ) -> bool {
+    should_skip_rule_with_checksums(rule, workdir, wildcard_values, None)
+}
+
+/// [`should_skip_rule`] with provenance checksums (issue #194 B2).
+///
+/// When `checksums` holds a recorded content hash for EVERY expanded output
+/// of the rule, freshness requires the CURRENT content to match — mtime
+/// alone no longer decides (a `touch` or clock skew cannot fake reuse).
+/// Two honest fallbacks keep the old behavior: any output beyond the hash
+/// cap (no re-verifiable digest), and rules with no recorded checksums at
+/// all, both degrade to the mtime comparison.
+pub fn should_skip_rule_with_checksums(
+    rule: &Rule,
+    workdir: &Path,
+    wildcard_values: &HashMap<String, String>,
+    checksums: Option<&HashMap<String, String>>,
+) -> bool {
     if rule.output.is_empty() {
         return false;
     }
@@ -929,6 +971,43 @@ pub fn should_skip_rule(
     if !all_outputs_exist {
         return false;
     }
+
+    // Checksum path (issue #194 B2): taken only when EVERY output has both a
+    // recorded hash AND a re-computable digest (small-file cap). Content
+    // identity then decides; a divergence re-executes even when mtime looks
+    // fresh. Missing records or over-cap outputs degrade to the mtime path.
+    if let Some(map) = checksums
+        && expanded_outputs.iter().all(|o| map.contains_key(o))
+    {
+        let mut digests = Vec::with_capacity(expanded_outputs.len());
+        let mut all_verifiable = true;
+        for o in &expanded_outputs {
+            let path = workdir.join(o);
+            let Ok(md) = std::fs::metadata(&path) else {
+                all_verifiable = false;
+                break;
+            };
+            match content_hash_if_small(&path, &md) {
+                Some(d) => digests.push(d),
+                None => {
+                    all_verifiable = false;
+                    break;
+                }
+            }
+        }
+        if all_verifiable {
+            let all_match = expanded_outputs
+                .iter()
+                .zip(&digests)
+                .all(|(o, current)| map.get(o).is_some_and(|recorded| recorded == current));
+            if all_match {
+                return true;
+            }
+            // Content diverged — even if mtime looks fresh, re-execute.
+            return false;
+        }
+    }
+
     if expanded_inputs.is_empty() {
         return true; // No inputs to check freshness against
     }
@@ -1026,6 +1105,102 @@ mod tests {
     use crate::storage::{RemoteStat, StorageBackend, StoragePath, StorageResolver, StorageScheme};
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn checkpoint_save_is_atomic_and_leaves_no_tmp() {
+        // issue #194 A1: the save goes through a sibling tmp + rename, so a
+        // failed save never leaves a partial tmp behind and a successful one
+        // yields a fully-parseable document.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let mut ck = CheckpointState::default();
+        ck.completed_rules.insert("rule_a".to_string());
+        ck.save_to_file(&path).unwrap();
+        assert!(path.exists());
+        assert!(!dir.path().join("checkpoint.json.tmp").exists());
+        let loaded = CheckpointState::load_from_file(&path).unwrap();
+        assert!(loaded.completed_rules.contains("rule_a"));
+        // A second save overwrites cleanly.
+        ck.completed_rules.insert("rule_b".to_string());
+        ck.save_to_file(&path).unwrap();
+        let loaded = CheckpointState::load_from_file(&path).unwrap();
+        assert!(loaded.completed_rules.contains("rule_b"));
+        assert!(!dir.path().join("checkpoint.json.tmp").exists());
+    }
+
+    #[test]
+    fn checkpoint_save_failure_cleans_tmp() {
+        // Rename fails when the target path is a directory: the error must
+        // surface AND the tmp sibling must be removed (no litter).
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("checkpoint.json");
+        std::fs::create_dir(&target_dir).unwrap();
+        let ck = CheckpointState::default();
+        assert!(ck.save_to_file(&target_dir).is_err());
+        assert!(!dir.path().join("checkpoint.json.tmp").exists());
+    }
+
+    #[test]
+    fn checksum_aware_skip_uses_content_identity_over_mtime() {
+        // issue #194 B2: with a recorded checksum for every output, a fresh
+        // mtime alone must NOT decide reuse — matching content skips even
+        // when the input is newer (touch), diverging content re-executes
+        // even when mtimes look fresh.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("in.txt"), "input").unwrap();
+        std::fs::write(dir.path().join("out.txt"), "content-v1").unwrap();
+        let rule = crate::rule::Rule {
+            name: "r".to_string(),
+            input: vec!["in.txt".to_string()].into(),
+            output: vec!["out.txt".to_string()].into(),
+            ..Default::default()
+        };
+        let recorded: HashMap<String, String> = [(
+            "out.txt".to_string(),
+            format!("sha256:{}", sha256_hex(b"content-v1")),
+        )]
+        .into_iter()
+        .collect();
+
+        // Input made NEWER than the output (mtime path would re-execute):
+        // the recorded checksum matches, so the skip still holds.
+        filetime_touch_newer(dir.path().join("in.txt"));
+        assert!(
+            should_skip_rule_with_checksums(&rule, dir.path(), &HashMap::new(), Some(&recorded)),
+            "matching content must skip even when the input mtime is newer"
+        );
+
+        // Content diverged (simulated rewrite): even fresh mtimes must
+        // re-execute.
+        std::fs::write(dir.path().join("out.txt"), "content-v2").unwrap();
+        assert!(
+            !should_skip_rule_with_checksums(&rule, dir.path(), &HashMap::new(), Some(&recorded)),
+            "diverging content must re-execute despite fresh-looking mtime"
+        );
+    }
+
+    /// SHA-256 hex for the test above (the production hash is
+    /// `compute_file_checksum`; hashing bytes directly keeps the test free
+    /// of file-format coupling).
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use sha2::Digest;
+        let digest = sha2::Sha256::digest(bytes);
+        digest.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// Bump `path`'s mtime forward one second (test helper; production
+    /// never mutates mtimes).
+    fn filetime_touch_newer(path: std::path::PathBuf) {
+        let md = std::fs::metadata(&path).unwrap();
+        let modified = md.modified().unwrap();
+        let future = modified + std::time::Duration::from_secs(2);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(future)
+            .unwrap();
+    }
 
     /// In-memory cloud backend with a mutable etag per key — the semantic
     /// proof for issue #78 P2 (same-size remote rewrites invalidate).

--- a/crates/oxo-flow-core/src/executor/output_invalidation.rs
+++ b/crates/oxo-flow-core/src/executor/output_invalidation.rs
@@ -156,6 +156,53 @@ fn aside_path(path: &Path) -> PathBuf {
     path.with_file_name(name)
 }
 
+/// Retention policy for `.oxo-failed` aside files (issue #194 C2): a run
+/// start removes aside files older than this many days so failure evidence
+/// ages out instead of accumulating indefinitely.
+pub const OXOX_FAILED_RETENTION_DAYS: u64 = 7;
+
+/// Remove `.oxo-failed` aside files older than `max_age_days` anywhere
+/// under `workdir` (production passes [`OXOX_FAILED_RETENTION_DAYS`]).
+/// Called once at run start; best-effort with a count — cleanup must never
+/// block a run.
+pub fn cleanup_stale_failed_asides(workdir: &Path, max_age_days: u64) -> usize {
+    use std::collections::VecDeque;
+    let max_age = std::time::Duration::from_secs(max_age_days * 24 * 3600);
+    let now = std::time::SystemTime::now();
+    let mut removed = 0usize;
+    let mut queue: VecDeque<PathBuf> = VecDeque::from([workdir.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Never descend into the engine's own state dir — asides
+                // live next to workflow outputs, not inside .oxo-flow.
+                if path.file_name().and_then(|n| n.to_str()) == Some(".oxo-flow") {
+                    continue;
+                }
+                queue.push_back(path);
+            } else if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".oxo-failed"))
+                && std::fs::metadata(&path)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|modified| now.duration_since(modified).ok())
+                    .is_some_and(|age| age > max_age)
+                && std::fs::remove_file(&path).is_ok()
+            {
+                tracing::debug!(file = %path.display(), "removed stale .oxo-failed aside (retention)");
+                removed += 1;
+            }
+        }
+    }
+    removed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,5 +348,24 @@ mod tests {
         let rule = rule_with_outputs(&["results/{sample}.txt"]);
         let values = HashMap::new();
         assert!(snapshot_outputs(&rule, dir.path(), &values).is_empty());
+    }
+
+    #[test]
+    fn cleanup_stale_failed_asides_removes_aged_evidence_and_spares_fresh() {
+        // issue #194 C2: retention with max_age_days = 0 removes every
+        // `.oxo-failed` aside (all files are older than an instant-old
+        // threshold), spares non-aside files, and does not descend into
+        // `.oxo-flow`.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("results")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".oxo-flow")).unwrap();
+        std::fs::write(dir.path().join("results/a.txt.oxo-failed"), "x").unwrap();
+        std::fs::write(dir.path().join("results/b.txt"), "keep").unwrap();
+        std::fs::write(dir.path().join(".oxo-flow/secret.oxo-failed"), "keep").unwrap();
+        let removed = cleanup_stale_failed_asides(dir.path(), 0);
+        assert_eq!(removed, 1, "only the results aside is aged out");
+        assert!(!dir.path().join("results/a.txt.oxo-failed").exists());
+        assert!(dir.path().join("results/b.txt").exists());
+        assert!(dir.path().join(".oxo-flow/secret.oxo-failed").exists());
     }
 }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -292,6 +292,11 @@ pub struct ExecutorConfig {
     /// hook on its own line (issue #92), e.g. `set -euo pipefail`.
     /// Opt-in: `None` keeps the historical exact command text.
     pub shell_prelude: Option<String>,
+    /// Shared checkpoint state (issue #194 B2): the freshness gate reads
+    /// recorded provenance checksums from it to decide reuse by CONTENT
+    /// identity instead of mtime. `None` (tests, cluster paths) keeps the
+    /// mtime-only gate.
+    pub checkpoint: Option<Arc<Mutex<super::checkpoint::CheckpointState>>>,
 }
 
 impl Default for ExecutorConfig {
@@ -314,6 +319,7 @@ impl Default for ExecutorConfig {
             storage_resolver: StorageResolver::with_local(),
             sensitive_values: Vec::new(),
             shell_prelude: None,
+            checkpoint: None,
         }
     }
 }
@@ -1263,9 +1269,20 @@ impl LocalExecutor {
         // Freshness gate: outputs up-to-date. For remote outputs the
         // uploaded objects are authoritative for existence — a locally
         // cached upload stage is not proof the cloud still has the file.
+        // Recorded provenance checksums tighten the gate (issue #194 B2):
+        // content identity wins over mtime when digests are available.
+        let freshness_checksums = match &self.config.checkpoint {
+            Some(ck) => Some(ck.lock().await.checksums.clone()),
+            None => None,
+        };
         if !self.config.force_rerun
             && !self.config.force_rules.contains(&rule.name)
-            && super::checkpoint::should_skip_rule(&rule, &self.config.workdir, wildcard_values)
+            && super::checkpoint::should_skip_rule_with_checksums(
+                &rule,
+                &self.config.workdir,
+                wildcard_values,
+                freshness_checksums.as_ref(),
+            )
             && self.remote_outputs_present(&uploads).await
         {
             // A 0-byte "up to date" output is usually a failed attempt's

--- a/crates/oxo-flow-core/src/executor/rss.rs
+++ b/crates/oxo-flow-core/src/executor/rss.rs
@@ -103,7 +103,12 @@ impl RssSampler {
                                 return;
                             }
                             let snapshot: Vec<(u32, Arc<TrackedProcess>)> = {
-                                let guard = tracked.lock().expect("rss sampler lock");
+                                // A poisoned lock must not panic the sampler
+                                // thread (issue #194 §3.5) — the worst case
+                                // is one skipped tick, not a lost sampler.
+                                let guard = tracked
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                                 if guard.is_empty() {
                                     continue;
                                 }

--- a/crates/oxo-flow-core/src/executor/timeout.rs
+++ b/crates/oxo-flow-core/src/executor/timeout.rs
@@ -1,4 +1,11 @@
-/// Kill a process and all its descendants (deepest first).
+/// Grace period between SIGTERM and SIGKILL for subtree kills (issue #194
+/// A4): long-running tools (aligners, databases) get a chance to flush
+/// state and exit cleanly before the engine escalates.
+pub const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Kill a process and all its descendants (deepest first), gracefully:
+/// SIGTERM the whole subtree, poll [`SIGTERM_GRACE`] for survivors, then
+/// SIGKILL whatever remains.
 ///
 /// Rules deliberately run inside the caller's process group (see
 /// `process::execute_rule` — "one run = one process group"), so a timeout
@@ -41,17 +48,50 @@ pub fn kill_process_tree(pid: u32) -> std::io::Result<()> {
 
     // Deepest first: children die before their parents so no subtree can be
     // re-parented into init and survive the kill.
-    for p in targets.iter().rev() {
-        match kill(*p, Signal::SIGKILL) {
-            Ok(()) => {}
-            // Already exited between the snapshot and the signal — fine.
-            Err(Errno::ESRCH) => {}
-            Err(e) => return Err(std::io::Error::other(e.to_string())),
+    let signal_subtree = |sig: Signal, targets: &[Pid]| -> std::io::Result<()> {
+        for p in targets.iter().rev() {
+            match kill(*p, sig) {
+                Ok(()) => {}
+                // Already exited between the snapshot and the signal — fine.
+                Err(Errno::ESRCH) => {}
+                Err(e) => return Err(std::io::Error::other(e.to_string())),
+            }
         }
+        Ok(())
+    };
+    signal_subtree(Signal::SIGTERM, &targets)?;
+
+    // Poll the grace window; a process that honors TERM gets to flush.
+    let deadline = std::time::Instant::now() + SIGTERM_GRACE;
+    loop {
+        let alive = {
+            let mut s = sysinfo::System::new();
+            s.refresh_processes(sysinfo::ProcessesToUpdate::All, false);
+            targets.iter().any(|p| {
+                s.process(sysinfo::Pid::from_u32(p.as_raw() as u32))
+                    .is_some()
+            })
+        };
+        if !alive {
+            tracing::debug!(
+                pid = pid,
+                targets = targets.len(),
+                "process subtree exited on SIGTERM"
+            );
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
-    tracing::debug!(pid = pid, killed = targets.len(), "killed process subtree");
-    Ok(())
+    tracing::debug!(
+        pid = pid,
+        targets = targets.len(),
+        "process subtree survived SIGTERM grace; escalating to SIGKILL"
+    );
+    signal_subtree(Signal::SIGKILL, &targets)
 }
 
 /// Stub for non-Unix systems (no process group support).
@@ -127,6 +167,44 @@ mod tests {
         // …while the caller (this test binary) is untouched — the old
         // group-kill strategy would have killed us here.
         assert!(process_exists(std::process::id()));
+    }
+
+    #[test]
+    fn kill_process_tree_delivers_sigterm_before_escalating() {
+        // issue #194 A4: a TERM-honoring child must observe SIGTERM (and get
+        // its cleanup chance) instead of being SIGKILLed outright.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let marker = dir.path().join("got-term");
+        let pidfile = dir.path().join("child.pid");
+        let script = format!(
+            "trap 'echo term > {marker}; exit 0' TERM; echo $$ > {pidfile}; sleep 30",
+            marker = marker.display(),
+            pidfile = pidfile.display(),
+        );
+        let mut sh = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sh");
+        let sh_pid = sh.id();
+
+        // Wait for the shell to record its pid.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !pidfile.exists() && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(pidfile.exists(), "child pid file never appeared");
+
+        kill_process_tree(sh_pid).expect("tree kill");
+        let _ = sh.wait();
+
+        assert!(
+            marker.exists(),
+            "the TERM trap never ran — the subtree was killed without grace"
+        );
+        assert!(!process_exists(sh_pid), "shell survived the tree kill");
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -877,6 +877,23 @@ pub fn lint_format(
             });
         }
 
+        // W026: `cache_key` is accepted but not yet consulted (issue #194
+        // M2). The field parses so old workflows keep validating, but the
+        // scheduler never reads it — silence would let authors believe
+        // content-addressed reuse is active when it is not.
+        if rule.cache_key.is_some() {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Info,
+                message: "rule declares `cache_key`, which is accepted for compatibility but \
+                          not yet consulted by the scheduler — content-addressed reuse is not \
+                          active (issue #194)"
+                    .to_string(),
+                rule: Some(rule.name.clone()),
+                code: "W026".to_string(),
+                suggestion: None,
+            });
+        }
+
         // W006: Naming convention (should use snake_case)
         if rule.name.contains('-') {
             diagnostics.push(Diagnostic {
@@ -3869,6 +3886,42 @@ mod tests {
             "the old suggestion ('add depends_on to every consumer') could not silence \
              the warning once dependents skip it: {suggestion}"
         );
+    }
+
+    // ---- W026: cache_key accepted but not consulted (issue #194 M2) ----
+
+    #[test]
+    fn lint_w026_flags_unimplemented_cache_key() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+            cache_key = "my-content-key"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        let w026 = diagnostics.iter().find(|d| d.code == "W026");
+        assert!(
+            w026.is_some_and(|d| d.rule.as_deref() == Some("step1")),
+            "cache_key must raise W026: {diagnostics:?}"
+        );
+        // A workflow without cache_key stays silent.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        assert!(!diagnostics.iter().any(|d| d.code == "W026"));
     }
 
     // ---- W025: Deprecated rule-level threads/memory (issue #142 M12) ----

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -926,8 +926,9 @@ pub struct Rule {
 
     /// Content-based cache key override.
     ///
-    /// When set, the scheduler uses this key (along with input checksums) to
-    /// determine if cached outputs can be reused, enabling content-addressed caching.
+    /// Accepted for schema/parser compatibility but NOT yet consulted by the
+    /// scheduler — content-addressed reuse is not active (issue #194 M2;
+    /// `validate` raises W026 so authors are not misled).
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,

--- a/crates/oxo-flow-web/src/domains/observability/logging.rs
+++ b/crates/oxo-flow-web/src/domains/observability/logging.rs
@@ -19,6 +19,10 @@ static LOG_DIR: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock::new(None
 static EVENT_WRITER: std::sync::OnceLock<Mutex<Option<BufWriter<File>>>> =
     std::sync::OnceLock::new();
 
+/// Size cap for `events.jsonl` (issue #194 B4): at startup a larger file
+/// rotates to `events.jsonl.1` and a fresh stream begins.
+const EVENTS_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
 /// Append one structured event line to events.jsonl (issue #81: the file
 /// was created at startup but nothing ever wrote to it — audit events now
 /// feed the structured stream alongside the DB rows).
@@ -49,8 +53,19 @@ pub fn init_logging(log_dir: &Path) -> Result<(), String> {
         *dir = Some(log_dir.to_path_buf());
     }
 
-    // Open the structured event log
+    // Open the structured event log. Size-capped with a single rotated
+    // backup (issue #194 B4): when the current file already exceeds the
+    // cap, shift it to `events.jsonl.1` and start fresh — the event stream
+    // never grows without bound and keeps one prior generation for
+    // post-incident inspection.
     let event_log = log_dir.join("events.jsonl");
+    if let Ok(md) = std::fs::metadata(&event_log)
+        && md.len() > EVENTS_LOG_MAX_BYTES
+    {
+        let backup = log_dir.join("events.jsonl.1");
+        let _ = std::fs::remove_file(&backup);
+        let _ = std::fs::rename(&event_log, &backup);
+    }
     let file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -83,6 +98,23 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         init_logging(dir.path()).expect("should init");
         assert!(dir.path().join("events.jsonl").exists());
+        reset_log_dir();
+    }
+
+    #[test]
+    fn test_init_logging_rotates_oversized_events_log() {
+        // issue #194 B4: a pre-existing events.jsonl beyond the cap shifts
+        // to events.jsonl.1 at startup and a fresh stream begins.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("events.jsonl"),
+            "x".repeat((EVENTS_LOG_MAX_BYTES + 1) as usize),
+        )
+        .unwrap();
+        init_logging(dir.path()).expect("should init");
+        assert!(dir.path().join("events.jsonl.1").exists());
+        let fresh = std::fs::metadata(dir.path().join("events.jsonl")).unwrap();
+        assert!(fresh.len() <= EVENTS_LOG_MAX_BYTES);
         reset_log_dir();
     }
 

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -508,8 +508,14 @@ Mechanics:
   lock, report snapshots, and resume semantics are unchanged.
 - The child's stdout and stderr are redirected to the run log
   (`--log-file` if given, otherwise `.oxo-flow/logs/oxo-flow.log` in the
-  workdir) — the tracing stream lands there too, so the log records the
-  whole run.
+  workdir). In this mode the tracing tee is skipped on purpose — the
+  redirect already captures everything, and a second writer would
+  duplicate every line (issue #194 A3).
+- The run log archives BOTH the structured tracing stream AND the
+  user-facing progress narrative (`Running:` / `✓` / `Done:`) plus one
+  JSON line per execution event (`workflow_started`, `rule_started`,
+  `rule_completed`, `workflow_completed`) — the whole run is replayable
+  from the single file (issue #194 B1/B3).
 - The child's pid is written to `.oxo-flow/background.pid` in the workdir
   (also shown in the summary).
 - The child gets its own process group, so it survives terminal close and

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -404,6 +404,23 @@ flags these with warning W019).
    `.oxo-flow/checkpoint.json` (see
    [Input changes and manifest invalidation](../commands/run.md#input-changes-and-manifest-invalidation))
 
+**Durability & reuse guarantees** (issue #194):
+
+- The checkpoint is written **atomically** — serialized to a sibling
+  `.tmp`, fsynced, renamed over the target, then the parent directory is
+  fsynced. A crash or power loss leaves either the previous state or the
+  complete new one, never a truncated file.
+- With `--provenance`, recorded output checksums participate in the
+  freshness gate: when every output of a rule has a recorded digest,
+  reuse is decided by **content identity**, not mtime — a `touch` or
+  clock skew cannot fake freshness, and diverging content re-executes
+  (outputs beyond the hash cap keep the mtime comparison).
+- Rule timeouts and aborts terminate the rule subtree with a **SIGTERM
+  grace period** (10s) before escalating to SIGKILL, so well-behaved
+  tools get a chance to flush state.
+- Failed-rule aside files (`.oxo-failed`) age out automatically after
+  7 days; the environment cache cleanup is recursive.
+
 ### "Why does my workflow have so many dependencies?"
 
 - Each file-based input→output match creates one edge. A merge rule consuming outputs from 3 parallel branches will have 3 incoming edges

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -545,7 +545,7 @@ memory = "32G"
 | `benchmark` | String | No | Benchmark output path for performance data |
 | `log` | String | No | Log file path for rule execution output |
 | `group` | String | No | Job group label for cluster submission grouping |
-| `cache_key` | String | No | Content-based cache key for output reuse |
+| `cache_key` | String | No | Accepted for compatibility but NOT yet consulted by the scheduler (validate raises W026) — content-addressed reuse is not active (issue #194) |
 | `input_function` | String | No | Dynamic input resolver function name |
 | `rule_metadata` | Table | No | Arbitrary domain-specific metadata (assay, organism, etc.) |
 | `env_group` | String | No | Reference to a named environment in `[env_groups]` |
@@ -1088,7 +1088,7 @@ benchmark = "benchmarks/align_{sample}.tsv"
 | Field | Type | Description |
 |-------|------|-------------|
 | `group` | String | Job group label for cluster submission grouping |
-| `cache_key` | String | Content-based cache key for reusing previous outputs |
+| `cache_key` | String | Accepted for compatibility but not yet consulted by the scheduler (validate raises W026; issue #194) |
 
 ```toml
 [[rules]]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -62,6 +62,41 @@ fn oxo_flow_web_cmd() -> Command {
 
 // ─── Pilot subset (--samples) & forced re-run (--rerun) ─────────────────────
 
+/// The archived run log carries BOTH the user-facing progress narrative
+/// (issue #194 B1: `Running:` / `Done:`) and the structured execution
+/// events (B3: workflow_started / rule_completed JSON lines).
+#[test]
+fn cli_run_log_archives_progress_narrative_and_execution_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("narr.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"narr\"\nversion = \"1.0.0\"\n\n[[rules]]\nname = \"step\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output}\"\n",
+    )
+    .unwrap();
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let log = fs::read_to_string(dir.path().join(".oxo-flow/logs/oxo-flow.log")).unwrap();
+    assert!(
+        log.contains("Running:") && log.contains("Done:"),
+        "the archived log must keep the progress narrative:\n{log}"
+    );
+    assert!(
+        log.contains("\"event\":\"workflow_started\"")
+            && log.contains("\"event\":\"rule_completed\"")
+            && log.contains("\"event\":\"workflow_completed\""),
+        "the archived log must carry the structured execution events:\n{log}"
+    );
+}
+
 /// `run --json` carries a per-rule `resources` array (issue #163): the
 /// report's Benchmarks data — wall time, sampled peak RSS, CPU seconds,
 /// retries — machine-readably, on the completed path.


### PR DESCRIPTION
Resolves #194 (logging/caching/checkpointing/process-management/cleanup audit). Implemented the high + medium + selected lower items; every change is unit/integration tested and live-verified.

## High (data-loss / correctness)
- **A1** atomic checkpoint: tmp + fsync + rename + parent-dir fsync — a crash leaves the previous state or the complete new one, never a truncated file (2 tests)
- **A2** single-writer run log: one fd behind the slot mutex instead of a per-event clone — no concurrent interleaving
- **A3** background dedup: the child skips the tracing tee when stderr is already redirected onto the log; colors and the progress bar are disabled in that mode (live-verified: 0 ANSI escapes, every narrative line exactly once)
- **A4** SIGTERM grace (10s) before SIGKILL in kill_process_tree; test proves a TERM-honoring child runs its trap before dying

## Medium (observability / efficiency)
- **B1** progress narrative (Running:/✓/✗/Done:) archives into the run log
- **B3** ExecutionEvent is emitted for real (workflow_started/rule_started/rule_completed/workflow_completed JSON lines) — the schema stops being dead code
- **B2** recorded provenance checksums decide output reuse by CONTENT identity (mtime path kept for unrecorded / over-cap outputs); executor and dry-run preview share the gate; test: matching content skips under a newer input mtime, diverging content re-executes
- **B4** web events.jsonl rotates at 10MB (one backup)
- **M2** cache_key: W026 lint (accepted, not consulted) + honest docs (workflow-format ×2)

## Lower (cleanup / polish)
- **C1** cache-dir cleanup recursive (test)
- **C2** .oxo-failed asides age out after 7 days at run start (test)
- **3.5** RSS sampler tolerates a poisoned lock

## Docs
dag-engine durability/reuse section; run.md background mechanics; workflow-format cache_key honesty.

## Verification
- Local make ci green (fmt + clippy -D warnings + schema-drift + full workspace tests incl. 9 new tests + audit)
- Live: foreground + --background runs on a tiny workflow — archived log contains the narrative + all 4 event types; background log clean/deduplicated