### PR TITLE
feat: issue #194 round 2 — all remaining medium/high-value items

### DIFF
--- a/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
+++ b/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
@@ -370,7 +370,7 @@
         "format_hint": { "type": "array", "items": { "type": "string" }, "description": "File format hints (e.g., 'bam', 'vcf')" },
         "pipe": { "type": "boolean", "default": false, "description": "Enable FIFO streaming mode" },
         "checksum": { "type": "string", "enum": ["md5", "sha256"], "description": "Output integrity verification algorithm" },
-        "cache_key": { "type": "string", "description": "Content-based cache key for output reuse" },
+        "cache_key": { "type": "string", "description": "Content-based cache key: enables content-addressed output reuse across runs (issue #194)" },
         "input_function": { "type": "string", "description": "Dynamic input resolver function name" },
         "benchmark": { "type": "string", "description": "Benchmark output path for performance data" },
         "log": { "type": "string", "description": "Log file path for execution output" },

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2019,7 +2019,7 @@ pub async fn run_command(
                     .await;
 
                 match result {
-                    Ok(record) => {
+                    Ok(mut record) => {
                         let duration = record
                             .finished_at
                             .and_then(|f| record.started_at.map(|s| f.signed_duration_since(s)))
@@ -2034,12 +2034,22 @@ pub async fn run_command(
                                 duration_ms: (duration * 1000.0) as u64,
                             });
                             if !is_tty {
-                                progress_narrate(format_args!(
-                                    "  {} {} ({:.1}s)",
-                                    "✓".green(),
-                                    rule_name,
-                                    duration
-                                ));
+                                if record.skip_reason.as_deref()
+                                    == Some("restored from content cache")
+                                {
+                                    progress_narrate(format_args!(
+                                        "  {} {} (restored from content cache)",
+                                        "↺".cyan(),
+                                        rule_name,
+                                    ));
+                                } else {
+                                    progress_narrate(format_args!(
+                                        "  {} {} ({:.1}s)",
+                                        "✓".green(),
+                                        rule_name,
+                                        duration
+                                    ));
+                                }
                             }
                             let benchmark =
                                 oxo_flow_core::executor::checkpoint::BenchmarkRecord {
@@ -2052,6 +2062,54 @@ pub async fn run_command(
                                     cpu_seconds: record.cpu_seconds,
                                     retries: record.retries,
                                 };
+                            // Post-run manifest re-verification
+                            // (issue #194 §2.10): an external writer
+                            // touching an input mid-run is invisible to the
+                            // pre-run snapshot alone. Re-snapshot now; on
+                            // any change, warn loudly and keep the PRE-run
+                            // manifest recorded — the next run's comparison
+                            // then sees the mismatch and re-executes this
+                            // rule instead of serving outputs built from a
+                            // mixed file state.
+                            let post_manifest = oxo_flow_core::executor::checkpoint::snapshot_input_manifest(
+                                &rule,
+                                workdir_actual.as_ref(),
+                                &wildcard_values,
+                                &crate::commands::run_preview::storage_resolver(),
+                            )
+                            .ok()
+                            .flatten();
+                            if let (Some(pre), Some(post)) = (&input_manifest, &post_manifest) {
+                                let changes =
+                                    oxo_flow_core::executor::checkpoint::manifest_changes(
+                                        pre, post,
+                                    );
+                                if !changes.is_empty() {
+                                    let note = format!(
+                                        "\n[oxo-flow] WARNING: an input changed while this rule was running ({}); outputs may be inconsistent — the next run will re-execute this rule",
+                                        changes.join(", ")
+                                    );
+                                    tracing::warn!(
+                                        rule = %rule_name,
+                                        changes = ?changes,
+                                        "input changed while the rule was running; outputs may be inconsistent"
+                                    );
+                                    if let Some(ref mut stderr) = record.stderr {
+                                        stderr.push_str(&oxo_flow_core::executor::process::mask_sensitive(
+                                            &note,
+                                            &sensitive_values,
+                                        ));
+                                    } else {
+                                        record.stderr = Some(
+                                            oxo_flow_core::executor::process::mask_sensitive(
+                                                &note,
+                                                &sensitive_values,
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+
                             let mut ck = checkpoint.lock().await;
                             ck.record_run(&record);
                             ck.mark_completed(&rule_name, benchmark);

--- a/crates/oxo-flow-core/Cargo.toml
+++ b/crates/oxo-flow-core/Cargo.toml
@@ -12,7 +12,7 @@ description = "Core library for the oxo-flow bioinformatics pipeline engine"
 default = ["container", "webhook", "report", "cluster"]
 # Cloud storage backends (opt-in)
 s3-storage = ["aws-sdk-s3", "dep:aws-config"]
-gcs-storage = ["dep:sha1", "dep:base64", "dep:md-5"]
+gcs-storage = ["dep:sha1"]
 # Optional modules - compile-time feature gates for minimal builds
 container = []
 webhook = []
@@ -45,8 +45,8 @@ aws-sdk-s3 = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }
 hmac = { workspace = true }
 sha1 = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
-md-5 = { workspace = true, optional = true }
+base64 = { workspace = true }
+md-5 = { workspace = true }
 # File locking (.oxo-flow/lock) is cross-platform; available_space (scheduler)
 # is unix-only and stays inside cfg(unix) code.
 fs2 = { workspace = true }

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -64,30 +64,67 @@ pub fn manifests_match(recorded: &[InputManifestEntry], current: &[InputManifest
     recorded
         .iter()
         .zip(current)
-        .all(|(r, c)| match (&r.remote, &c.remote) {
-            // Local entries: the existing size+mtime(+sha256) policy.
-            (None, None) => {
-                r.path == c.path
-                    && r.size == c.size
-                    && match &r.hash {
-                        Some(rec_hash) => c.hash.as_deref() == Some(rec_hash.as_str()),
-                        None => r.mtime_nanos == c.mtime_nanos,
-                    }
+        .all(|(r, c)| entry_matches(r, c))
+}
+
+/// Whether one manifest entry still describes the current file state.
+fn entry_matches(recorded: &InputManifestEntry, current: &InputManifestEntry) -> bool {
+    match (&recorded.remote, &current.remote) {
+        // Local entries: the existing size+mtime(+sha256) policy.
+        (None, None) => {
+            recorded.path == current.path
+                && recorded.size == current.size
+                && match &recorded.hash {
+                    Some(rec_hash) => current.hash.as_deref() == Some(rec_hash.as_str()),
+                    None => recorded.mtime_nanos == current.mtime_nanos,
+                }
+        }
+        // Remote entries (issue #78 P2): scheme+key+size+etag. When neither
+        // side has an etag, size is the only identity left (documented
+        // conservative-for-availability fallback).
+        (Some(rr), Some(rc)) => {
+            rr.scheme == rc.scheme
+                && rr.key == rc.key
+                && rr.size == rc.size
+                && match (&rr.etag, &rc.etag) {
+                    (Some(a), Some(b)) => a == b,
+                    _ => true,
+                }
+        }
+        _ => false,
+    }
+}
+
+/// Human-readable description of what changed between a recorded manifest
+/// and the current file set — `"<path> (changed)"`, `"<path> (added)"`,
+/// `"<path> (removed)"` — the explanatory side of [`manifests_match`]
+/// (issue #194 §2.10: post-run re-verification reports WHICH inputs moved).
+pub fn manifest_changes(
+    recorded: &[InputManifestEntry],
+    current: &[InputManifestEntry],
+) -> Vec<String> {
+    let mut changes = Vec::new();
+    let recorded_by_path: HashMap<&str, &InputManifestEntry> =
+        recorded.iter().map(|e| (e.path.as_str(), e)).collect();
+    let current_by_path: HashMap<&str, &InputManifestEntry> =
+        current.iter().map(|e| (e.path.as_str(), e)).collect();
+
+    for (path, recorded_entry) in &recorded_by_path {
+        match current_by_path.get(path) {
+            Some(current_entry) if !entry_matches(recorded_entry, current_entry) => {
+                changes.push(format!("{path} (changed)"));
             }
-            // Remote entries (issue #78 P2): scheme+key+size+etag. When neither
-            // side has an etag, size is the only identity left (documented
-            // conservative-for-availability fallback).
-            (Some(rr), Some(rc)) => {
-                rr.scheme == rc.scheme
-                    && rr.key == rc.key
-                    && rr.size == rc.size
-                    && match (&rr.etag, &rc.etag) {
-                        (Some(a), Some(b)) => a == b,
-                        _ => true,
-                    }
-            }
-            _ => false,
-        })
+            Some(_) => {}
+            None => changes.push(format!("{path} (removed)")),
+        }
+    }
+    for path in current_by_path.keys() {
+        if !recorded_by_path.contains_key(path) {
+            changes.push(format!("{path} (added)"));
+        }
+    }
+    changes.sort();
+    changes
 }
 
 /// Performance metrics recorded after executing a rule.
@@ -1486,6 +1523,37 @@ mod tests {
         }];
         // Content identical: an mtime-only touch no longer invalidates.
         assert!(manifests_match(&recorded, &current));
+    }
+
+    #[test]
+    fn manifest_changes_lists_added_removed_and_changed_paths() {
+        fn local(path: &str, size: u64, mtime: i128, hash: Option<&str>) -> InputManifestEntry {
+            InputManifestEntry {
+                path: path.to_string(),
+                size,
+                mtime_nanos: mtime,
+                hash: hash.map(str::to_string),
+                remote: None,
+            }
+        }
+        let recorded = vec![
+            local("a.txt", 10, 100, Some("sha256:aaa")),
+            local("b.txt", 20, 200, Some("sha256:bbb")),
+            local("gone.txt", 5, 50, None),
+        ];
+        let current = vec![
+            // mtime moved but the content hash matches — not a change.
+            local("a.txt", 10, 999, Some("sha256:aaa")),
+            // Same path, different content — a real change.
+            local("b.txt", 20, 200, Some("sha256:CHANGED")),
+            local("new.txt", 1, 1, None),
+        ];
+        let changes = manifest_changes(&recorded, &current);
+        assert_eq!(
+            changes,
+            vec!["b.txt (changed)", "gone.txt (removed)", "new.txt (added)"]
+        );
+        assert!(!manifests_match(&recorded, &current));
     }
 
     #[tokio::test]

--- a/crates/oxo-flow-core/src/executor/content_cache.rs
+++ b/crates/oxo-flow-core/src/executor/content_cache.rs
@@ -1,0 +1,360 @@
+//! Content-addressed output reuse for rules that declare `cache_key`
+//! (issue #194 §2.3, previously W026 "not yet consulted").
+//!
+//! A rule instance's cache identity is the hash of everything that
+//! determines its output: the declared `cache_key`, the expanded output
+//! patterns, the fully rendered command (environment wrapper included),
+//! and the content identity of every resolved input (sha256 for local
+//! files, etag for remote objects). An entry with a matching identity can
+//! only have been produced from the same content, so restoring its outputs
+//! is safe across workdirs and across runs — invalidation is structural,
+//! not time-based.
+//!
+//! Safety rails:
+//! - Local inputs over [`super::checkpoint::MANIFEST_HASH_MAX_BYTES`] have
+//!   no content hash, and remote inputs without an etag have no remote
+//!   identity — such rule instances simply do not participate (no reuse is
+//!   better than unprovable reuse).
+//! - Rules with remote outputs never participate: the cached local copy
+//!   cannot stand in for the cloud object.
+//! - Entries are written atomically (populate into a temp sibling, rename,
+//!   write `entry.json` last as the completeness marker), so a restore
+//!   sees a complete entry or none — parallel instances of the same rule
+//!   with identical content cannot corrupt each other.
+
+use crate::error::Result;
+use crate::executor::checkpoint::InputManifestEntry;
+use crate::rule::Rule;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Version tag mixed into every cache identity — bump to invalidate all
+/// entries when the key material or restore semantics change.
+const CACHE_FORMAT_VERSION: &str = "oxo-flow content cache v1";
+
+/// Root of all content-cache entries under a workdir.
+fn cache_root(workdir: &Path) -> PathBuf {
+    workdir.join(".oxo-flow/content-cache")
+}
+
+/// The entry directory for a rule instance's cache identity.
+pub fn cache_entry_dir(workdir: &Path, rule_name: &str, key: &str) -> PathBuf {
+    cache_root(workdir)
+        .join(super::process::sanitize_dir_component(rule_name))
+        .join(key)
+}
+
+/// The content-addressed identity of a rule instance — everything that
+/// determines its outputs: the declared `cache_key`, the expanded output
+/// patterns, the fully rendered command, and the content identity of every
+/// resolved input. Returns `None` when the rule declares no `cache_key`
+/// or when any input cannot be content-addressed (a local file over the
+/// hash cap, or a remote object without an etag): reuse would not be
+/// provably safe, so the instance does not participate.
+pub fn cache_entry_key(
+    rule: &Rule,
+    wildcard_values: &HashMap<String, String>,
+    rendered_command: &str,
+    manifest: &[InputManifestEntry],
+) -> Option<String> {
+    let cache_key = rule.cache_key.as_deref()?;
+    let mut hasher = Sha256::new();
+    hasher.update(CACHE_FORMAT_VERSION.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(cache_key.as_bytes());
+    hasher.update(b"\n");
+    for output in &rule.output {
+        let expanded = super::checkpoint::expand_config_in_path(output, wildcard_values);
+        hasher.update(expanded.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.update(rendered_command.as_bytes());
+    hasher.update(b"\n");
+    for entry in manifest {
+        hasher.update(entry.path.as_bytes());
+        hasher.update(b"|");
+        match (&entry.remote, &entry.hash) {
+            // Local content identity: the manifest's sha256 for files
+            // under the hash cap.
+            (None, Some(hash)) => hasher.update(hash.as_bytes()),
+            // Remote identity: the object's etag stands for its content.
+            (Some(remote), _) => {
+                let etag = remote.etag.as_ref()?;
+                hasher.update(etag.as_bytes());
+            }
+            // Local file over the hash cap, or a legacy hash-less entry —
+            // content is unknown, refuse participation.
+            (None, None) => return None,
+        }
+        hasher.update(b"\n");
+    }
+    Some(hex::encode(hasher.finalize()))
+}
+
+/// Restore a cache entry's outputs into the workdir. Returns `Ok(true)`
+/// when the entry existed and its outputs were restored, `Ok(false)` when
+/// no complete entry is present (no `entry.json` marker).
+///
+/// Output files are copied with the same atomic pattern as cross-filesystem
+/// moves (`copy_tree_atomic`), so a crash mid-restore leaves no truncated
+/// output. Unresolved wildcard outputs are skipped, mirroring scratch
+/// collection.
+pub async fn restore_outputs(
+    rule: &Rule,
+    workdir: &Path,
+    wildcard_values: &HashMap<String, String>,
+    entry_dir: &Path,
+) -> Result<bool> {
+    if !entry_dir.join("entry.json").exists() {
+        return Ok(false);
+    }
+    for output in &rule.output {
+        let expanded = super::checkpoint::expand_config_in_path(output, wildcard_values);
+        if crate::wildcard::has_wildcards(&expanded) {
+            continue;
+        }
+        let src = entry_dir.join(&expanded);
+        if !src.exists() {
+            continue;
+        }
+        let dest = workdir.join(&expanded);
+        if let Some(parent) = dest.parent()
+            && !parent.as_os_str().is_empty()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        super::process::copy_tree_atomic(&src, &dest)?;
+    }
+    Ok(true)
+}
+
+/// Copy a rule's resolved outputs into its cache entry — atomically: a
+/// temp sibling directory is filled, renamed over the entry, and
+/// `entry.json` written last as the completeness marker. A failed
+/// populate leaves no partial entry behind.
+///
+/// Outputs that do not exist (declared patterns validation skipped) are
+/// not cached; if nothing at all is copied, no entry is created.
+pub async fn populate_outputs(
+    rule: &Rule,
+    workdir: &Path,
+    wildcard_values: &HashMap<String, String>,
+    entry_dir: &Path,
+    manifest: &[InputManifestEntry],
+    rendered_command: &str,
+    key: &str,
+) -> Result<()> {
+    let tmp = sibling_tmp_dir(entry_dir);
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    let mut copied_any = false;
+    for output in &rule.output {
+        let expanded = super::checkpoint::expand_config_in_path(output, wildcard_values);
+        if crate::wildcard::has_wildcards(&expanded) {
+            continue;
+        }
+        let src = workdir.join(&expanded);
+        if !src.exists() {
+            continue;
+        }
+        copied_any = true;
+        let dest = tmp.join(&expanded);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        super::process::copy_tree(&src, &dest)?;
+    }
+    if !copied_any {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return Ok(());
+    }
+
+    // Replace any previous entry with identical content (parallel
+    // instances of the same rule race here; both write identical bytes).
+    if entry_dir.exists() {
+        std::fs::remove_dir_all(entry_dir)?;
+    }
+    std::fs::rename(&tmp, entry_dir)?;
+
+    // Completeness marker, last: restores require it.
+    let meta = serde_json::json!({
+        "rule": rule.name,
+        "cache_key": rule.cache_key.as_deref().unwrap_or(""),
+        "key": key,
+        "command": rendered_command,
+        "inputs": manifest.iter().map(|e| &e.path).collect::<Vec<_>>(),
+    });
+    std::fs::write(
+        entry_dir.join("entry.json"),
+        serde_json::to_vec_pretty(&meta)?,
+    )?;
+    Ok(())
+}
+
+/// `{entry}.oxo-tmp` — a sibling of the entry dir, so the final rename
+/// never crosses filesystems.
+fn sibling_tmp_dir(entry_dir: &Path) -> PathBuf {
+    let mut name = entry_dir
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".oxo-tmp");
+    entry_dir.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rule::FilePatterns;
+
+    fn rule_with_cache_key(key: &str) -> Rule {
+        Rule {
+            name: "cacheable".to_string(),
+            cache_key: Some(key.to_string()),
+            input: FilePatterns::List(vec!["input.txt".to_string()]),
+            output: vec!["out/result.txt".to_string()].into(),
+            ..Default::default()
+        }
+    }
+
+    fn manifest_entry(path: &str, hash: Option<&str>) -> InputManifestEntry {
+        InputManifestEntry {
+            path: path.to_string(),
+            size: 0,
+            mtime_nanos: 0,
+            hash: hash.map(str::to_string),
+            remote: None,
+        }
+    }
+
+    #[test]
+    fn cache_entry_key_is_stable_and_content_sensitive() {
+        let rule = rule_with_cache_key("align-v1");
+        let manifest = vec![manifest_entry("input.txt", Some("sha256:aaa"))];
+        let a = cache_entry_key(&rule, &HashMap::new(), "bwa mem", &manifest).unwrap();
+        let b = cache_entry_key(&rule, &HashMap::new(), "bwa mem", &manifest).unwrap();
+        assert_eq!(a, b, "identical content has an identical identity");
+
+        // Any of the four dimensions changing changes the identity.
+        let other_key = Rule {
+            cache_key: Some("align-v2".to_string()),
+            ..rule.clone()
+        };
+        assert_ne!(
+            a,
+            cache_entry_key(&other_key, &HashMap::new(), "bwa mem", &manifest).unwrap()
+        );
+        assert_ne!(
+            a,
+            cache_entry_key(&rule, &HashMap::new(), "bwa mem -t 8", &manifest).unwrap()
+        );
+        assert_ne!(
+            a,
+            cache_entry_key(
+                &rule,
+                &HashMap::new(),
+                "bwa mem",
+                &[manifest_entry("input.txt", Some("sha256:bbb"))],
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn cache_entry_key_refuses_unhashable_inputs() {
+        let rule = rule_with_cache_key("k");
+        // Local file over the hash cap: no content identity.
+        assert!(
+            cache_entry_key(
+                &rule,
+                &HashMap::new(),
+                "cmd",
+                &[manifest_entry("big.bam", None)]
+            )
+            .is_none()
+        );
+        // Remote object without an etag: no remote identity.
+        let remote = InputManifestEntry {
+            path: "s3://b/o".to_string(),
+            size: 1,
+            mtime_nanos: 0,
+            hash: None,
+            remote: Some(crate::executor::checkpoint::RemoteManifestEntry {
+                scheme: "s3".to_string(),
+                key: "s3://b/o".to_string(),
+                size: 1,
+                etag: None,
+            }),
+        };
+        assert!(cache_entry_key(&rule, &HashMap::new(), "cmd", &[remote]).is_none());
+        // Rules without cache_key never participate.
+        let plain = Rule {
+            cache_key: None,
+            ..rule
+        };
+        let manifest = vec![manifest_entry("input.txt", Some("sha256:aaa"))];
+        assert!(cache_entry_key(&plain, &HashMap::new(), "cmd", &manifest).is_none());
+    }
+
+    #[tokio::test]
+    async fn populate_and_restore_roundtrip_outputs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workdir = dir.path();
+        let rule = rule_with_cache_key("k");
+        let manifest = vec![manifest_entry("input.txt", Some("sha256:aaa"))];
+        let key = cache_entry_key(&rule, &HashMap::new(), "cmd", &manifest).unwrap();
+        let entry = cache_entry_dir(workdir, &rule.name, &key);
+
+        // Populate requires the outputs to exist in the workdir.
+        std::fs::create_dir_all(workdir.join("out")).unwrap();
+        std::fs::write(workdir.join("out/result.txt"), b"result-bytes").unwrap();
+        populate_outputs(
+            &rule,
+            workdir,
+            &HashMap::new(),
+            &entry,
+            &manifest,
+            "cmd",
+            &key,
+        )
+        .await
+        .expect("populate");
+        assert!(entry.join("entry.json").exists(), "entry marker written");
+        assert!(
+            !entry
+                .with_file_name(format!(
+                    "{}.oxo-tmp",
+                    entry.file_name().unwrap().to_string_lossy()
+                ))
+                .exists(),
+            "no temp sibling litter"
+        );
+
+        // Remove the workdir outputs, then restore from the entry.
+        std::fs::remove_file(workdir.join("out/result.txt")).unwrap();
+        assert!(
+            restore_outputs(&rule, workdir, &HashMap::new(), &entry)
+                .await
+                .expect("restore")
+        );
+        assert_eq!(
+            std::fs::read(workdir.join("out/result.txt")).unwrap(),
+            b"result-bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_without_complete_entry_reports_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rule = rule_with_cache_key("k");
+        let entry = cache_entry_dir(dir.path(), &rule.name, "some-key");
+        std::fs::create_dir_all(&entry).unwrap(); // no entry.json marker
+        assert!(
+            !restore_outputs(&rule, dir.path(), &HashMap::new(), &entry)
+                .await
+                .expect("restore")
+        );
+    }
+}

--- a/crates/oxo-flow-core/src/executor/mod.rs
+++ b/crates/oxo-flow-core/src/executor/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use sysinfo::System;
 
 pub mod checkpoint;
+pub mod content_cache;
 pub mod env_create_lock;
 pub mod output_invalidation;
 pub mod process;

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1347,6 +1347,78 @@ impl LocalExecutor {
             validate_path_safety(&self.config.workdir, &output_pattern)?;
         }
 
+        // Content-addressed reuse (issue #194 §2.3): when the rule declares
+        // `cache_key`, its outputs are not already fresh, and no forced
+        // re-run is requested, an existing cache entry whose identity
+        // matches the current inputs, outputs, and rendered command is
+        // restored instead of executing the shell. Remote outputs and
+        // chunk-cleanup rules never participate; cache failures degrade to
+        // normal execution (reuse is an optimization, never a gate).
+        let cache_manifest = if rule.cache_key.is_none()
+            || self.config.force_rerun
+            || self.config.force_rules.contains(&rule.name)
+            || !uploads.is_empty()
+            || rule.cleanup_chunks
+        {
+            None
+        } else {
+            match super::checkpoint::snapshot_input_manifest(
+                &rule,
+                &self.config.workdir,
+                wildcard_values,
+                &self.config.storage_resolver,
+            ) {
+                Ok(manifest) => Some(manifest.unwrap_or_default()),
+                Err(e) => {
+                    tracing::debug!(
+                        rule = %rule.name,
+                        error = %e,
+                        "input manifest unavailable — content cache lookup skipped"
+                    );
+                    None
+                }
+            }
+        };
+        let cache_plan = cache_manifest.as_ref().and_then(|manifest| {
+            let command = resolved_commands.first().map(String::as_str)?;
+            let key =
+                super::content_cache::cache_entry_key(&rule, wildcard_values, command, manifest)?;
+            Some((
+                key.clone(),
+                super::content_cache::cache_entry_dir(&self.config.workdir, &rule.name, &key),
+            ))
+        });
+        if let Some((_, entry_dir)) = &cache_plan {
+            match super::content_cache::restore_outputs(
+                &rule,
+                &self.config.workdir,
+                wildcard_values,
+                entry_dir,
+            )
+            .await
+            {
+                Ok(true) => {
+                    tracing::info!(
+                        rule = %rule.name,
+                        cache_key = rule.cache_key.as_deref().unwrap_or(""),
+                        "restored outputs from content cache"
+                    );
+                    record.status = JobStatus::Success;
+                    record.skip_reason = Some("restored from content cache".to_string());
+                    record.finished_at = Some(Utc::now());
+                    return Ok(record);
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        rule = %rule.name,
+                        error = %e,
+                        "content cache restore failed — executing instead"
+                    );
+                }
+            }
+        }
+
         // Warn if GPU is requested but running on local executor (no GPU scheduling)
         if rule.resources.gpu_spec.is_some() {
             tracing::warn!(
@@ -1730,6 +1802,29 @@ impl LocalExecutor {
                         }
                         true
                     };
+                // Best-effort populate (issue #194 §2.3): a later run with
+                // identical content skips the shell entirely. Failure only
+                // warns — caching must never fail a successful rule.
+                if let (Some((key, entry_dir)), Some(manifest)) = (&cache_plan, &cache_manifest)
+                    && let Some(command) = resolved_commands.first()
+                    && let Err(e) = super::content_cache::populate_outputs(
+                        &rule,
+                        &self.config.workdir,
+                        wildcard_values,
+                        entry_dir,
+                        manifest,
+                        command,
+                        key,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        rule = %rule.name,
+                        error = %e,
+                        "content cache populate failed"
+                    );
+                }
+
                 // Scratch is transient: a fully successful rule drops it.
                 // Failures (command, validation, upload) keep it around for
                 // debugging, and the error message names its path.
@@ -1855,6 +1950,16 @@ impl LocalExecutor {
                 .map_err(|e| OxoFlowError::Execution {
                     rule: rule_name.to_string(),
                     message: format!("failed to upload remote output '{}': {e}", remote.raw),
+                })?;
+            // Post-upload verification (issue #194 §2.11): the remote copy
+            // must match the local file before the rule is checkpointed as
+            // complete — a silently truncated transfer would otherwise be
+            // recorded as a healthy output.
+            crate::storage::verify_upload(backend.as_ref(), local, remote)
+                .await
+                .map_err(|e| OxoFlowError::Execution {
+                    rule: rule_name.to_string(),
+                    message: format!("verification of remote output '{}' failed: {e}", remote.raw),
                 })?;
         }
         Ok(())
@@ -2072,7 +2177,7 @@ fn create_rule_dir(path: &Path, rule: &Rule, what: &str) -> Result<()> {
 /// Directory-name-safe rule names: alphanumerics plus `. _ -` survive,
 /// everything else becomes `_` (rule names admit `:` per `Rule::validate`,
 /// which is not a safe directory character everywhere).
-fn sanitize_dir_component(name: &str) -> String {
+pub(super) fn sanitize_dir_component(name: &str) -> String {
     name.chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
@@ -2144,22 +2249,92 @@ pub(super) fn fixup_container_wrapper(
     format!("{fixed}{rest}")
 }
 
-/// Move a file or directory, falling back to copy+delete when a plain
-/// rename fails (e.g. scratch and workdir live on different filesystems).
+/// Move a file or directory, falling back to an atomic copy+delete when a
+/// plain rename fails (e.g. scratch and workdir live on different
+/// filesystems).
+///
+/// The fallback is crash-safe (issue #194 §2.5): content lands in a
+/// temporary sibling of `dest` on the DESTINATION filesystem, is fsynced,
+/// then renamed into place with the parent directory fsynced. A crash at
+/// any point leaves either nothing at `dest` or the complete copy — never
+/// a truncated output, which the direct copy this replaced could leave
+/// behind when the run died mid-copy.
 async fn move_path(src: &Path, dest: &Path) -> std::io::Result<()> {
     match tokio::fs::rename(src, dest).await {
         Ok(()) => Ok(()),
         Err(_) => {
-            copy_tree(src, dest)?;
+            copy_tree_atomic(src, dest)?;
             remove_tree(src).await
         }
+    }
+}
+
+/// Copy a file or directory tree onto `dest` atomically: into a temporary
+/// sibling first, fsync, rename over the target, fsync the parent dir.
+pub(super) fn copy_tree_atomic(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let tmp = sibling_tmp_path(dest);
+    if let Err(e) = copy_tree(src, &tmp) {
+        discard_tmp(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = sync_path(&tmp) {
+        discard_tmp(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = std::fs::rename(&tmp, dest) {
+        discard_tmp(&tmp);
+        return Err(e);
+    }
+    sync_parent_dir(dest)
+}
+
+/// `{dest}.oxo-tmp` — a sibling of the destination, so the final rename
+/// never crosses filesystems. Concurrent moves to the same destination do
+/// not occur (scratch dirs are per-instance unique), so the fixed suffix
+/// cannot collide.
+fn sibling_tmp_path(dest: &Path) -> PathBuf {
+    let mut name = dest
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".oxo-tmp");
+    dest.with_file_name(name)
+}
+
+/// Best-effort removal of a failed atomic-copy temporary path (file or
+/// directory) — cleanup failure must never mask the original error.
+fn discard_tmp(path: &Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_dir_all(path);
+}
+
+/// fsync a path's contents. Opening a directory handle is not portable
+/// (Windows), so a failed open of a directory degrades to a debug note
+/// instead of failing the move.
+fn sync_path(path: &Path) -> std::io::Result<()> {
+    match std::fs::File::open(path) {
+        Ok(file) => file.sync_all(),
+        Err(e) if path.is_dir() => {
+            tracing::debug!(path = %path.display(), error = %e, "skipping fsync of directory (unsupported on this platform)");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// fsync the parent directory so the rename itself is durable; on
+/// platforms that cannot open a directory handle this is best-effort.
+fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
+    match path.parent() {
+        Some(parent) => sync_path(parent),
+        None => Ok(()),
     }
 }
 
 /// Recursively copy a file or directory tree (synchronous: output moves
 /// touch bounded local files; `std::fs` avoids an infinitely sized future
 /// that a recursive `async fn` would need to box).
-fn copy_tree(src: &Path, dest: &Path) -> std::io::Result<()> {
+pub(super) fn copy_tree(src: &Path, dest: &Path) -> std::io::Result<()> {
     let meta = std::fs::metadata(src)?;
     if meta.is_dir() {
         std::fs::create_dir_all(dest)?;
@@ -2196,20 +2371,69 @@ async fn remove_tree(path: &Path) -> std::io::Result<()> {
 /// (checkpoint, report, AI recovery, web). Every NON-EMPTY value is
 /// masked — 3-character credentials are rare but real, and masking has no
 /// false-positive cost for keys the user declared sensitive (issue #136).
-/// Structured forms of a secret (JSON/YAML serialization, base64) do not
-/// match the exact value and pass through — the documented limitation of
-/// exact-match masking.
+/// Values of [`MASK_VARIANT_MIN_LEN`]+ characters also mask their encoded
+/// forms — base64 (standard and URL-safe), percent-encoding, and JSON
+/// string escaping — so a secret embedded in structured output is
+/// redacted too (issue #194 §1.4).
 pub fn mask_sensitive(text: &str, values: &[String]) -> String {
     if text.is_empty() || values.is_empty() {
         return text.to_string();
     }
     let mut masked = text.to_string();
     for value in values {
-        if !value.is_empty() {
-            masked = masked.replace(value.as_str(), "***");
+        if value.is_empty() {
+            continue;
+        }
+        masked = masked.replace(value.as_str(), "***");
+        if value.len() >= MASK_VARIANT_MIN_LEN {
+            for variant in sensitive_variants(value) {
+                masked = masked.replace(&variant, "***");
+            }
         }
     }
     masked
+}
+
+/// Values shorter than this only mask in plaintext form: their encoded
+/// variants are too collision-prone to redact (a 3-char secret
+/// base64-encodes to a 4-char token that can appear legitimately in a
+/// log). The plaintext itself is still masked per the issue #136 policy.
+const MASK_VARIANT_MIN_LEN: usize = 4;
+
+/// Encoded forms of a secret that surface in structured output: base64
+/// (standard and URL-safe, padding kept), percent-encoding, and the
+/// JSON-string form without its surrounding quotes (issue #194 §1.4).
+fn sensitive_variants(value: &str) -> Vec<String> {
+    use base64::Engine as _;
+    let mut variants = vec![
+        base64::engine::general_purpose::STANDARD.encode(value.as_bytes()),
+        base64::engine::general_purpose::URL_SAFE.encode(value.as_bytes()),
+        percent_encode(value),
+    ];
+    if let Ok(json) = serde_json::to_string(value) {
+        variants.push(json.trim_matches('"').to_string());
+    }
+    variants
+}
+
+/// RFC 3986 percent-encoding: unreserved characters stay literal, every
+/// other byte becomes `%XX` (uppercase hex).
+fn percent_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(*byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(HEX[(byte >> 4) as usize] as char);
+                out.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    out
 }
 
 fn push_stderr_note(record: &mut JobRecord, note: &str) {
@@ -2796,6 +3020,115 @@ mod tests {
         // Empty input and empty value list are no-ops.
         assert_eq!(mask_sensitive("plain", &[]), "plain");
         assert_eq!(mask_sensitive("plain", &["".to_string()]), "plain");
+    }
+
+    #[test]
+    fn mask_sensitive_redacts_encoded_variants() {
+        // Expected encodings cross-checked against Python
+        // base64/urllib.parse.quote/json.dumps (issue #194 §1.4).
+        let values = vec!["s3cr*t!".to_string(), "say\"hi".to_string()];
+        let text = concat!(
+            "plain s3cr*t! b64 czNjcip0IQ== url s3cr%2At%21 ",
+            "plain2 say\"hi b64 c2F5Imhp url say%22hi json say\\\"hi"
+        );
+        let masked = mask_sensitive(text, &values);
+        assert_eq!(
+            masked,
+            "plain *** b64 *** url *** plain2 *** b64 *** url *** json ***"
+        );
+        assert!(!masked.contains("czNjcip0IQ=="));
+        assert!(!masked.contains("c2F5Imhp"));
+        assert!(!masked.contains("%2A"));
+        assert!(!masked.contains("%22"));
+    }
+
+    #[test]
+    fn mask_sensitive_keeps_short_values_plaintext_only() {
+        // Below MASK_VARIANT_MIN_LEN the encoded forms are too
+        // collision-prone to redact ("ab" base64-encodes to "YWI=" — a
+        // token that can appear in any log); the plaintext still masks.
+        let text = "ab here, b64 YWI= stays";
+        assert_eq!(
+            mask_sensitive(text, &["ab".to_string()]),
+            "*** here, b64 YWI= stays"
+        );
+    }
+
+    #[test]
+    fn percent_encode_keeps_unreserved_and_encodes_the_rest() {
+        assert_eq!(percent_encode("s3cr*t!"), "s3cr%2At%21");
+        assert_eq!(percent_encode("a b/c+d~.-_"), "a%20b%2Fc%2Bd~.-_");
+        assert_eq!(percent_encode("plain"), "plain");
+        assert_eq!(percent_encode(""), "");
+    }
+
+    // ── Cross-filesystem atomic output moves (issue #194 §2.5) ─────────
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Runtime::new().unwrap().block_on(future)
+    }
+
+    #[test]
+    fn move_path_renames_within_one_filesystem() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("a");
+        let dest = dir.path().join("b");
+        std::fs::write(&src, b"content").expect("write src");
+        block_on(move_path(&src, &dest)).expect("move");
+        assert_eq!(std::fs::read(&dest).expect("read dest"), b"content");
+        assert!(!src.exists(), "source removed after rename");
+    }
+
+    #[test]
+    fn copy_tree_atomic_writes_complete_content_and_leaves_no_tmp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("a");
+        let dest = dir.path().join("b");
+        std::fs::write(&src, b"content").expect("write src");
+        copy_tree_atomic(&src, &dest).expect("atomic copy");
+        assert_eq!(std::fs::read(&dest).expect("read dest"), b"content");
+        assert!(
+            !dir.path().join("b.oxo-tmp").exists(),
+            "the temporary sibling is gone — no .oxo-tmp litter"
+        );
+    }
+
+    #[test]
+    fn copy_tree_atomic_copies_directories_recursively() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("tree");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("f1"), b"one").unwrap();
+        std::fs::create_dir(src.join("sub")).unwrap();
+        std::fs::write(src.join("sub").join("f2"), b"two").unwrap();
+        let dest = dir.path().join("moved");
+        copy_tree_atomic(&src, &dest).expect("atomic dir copy");
+        assert_eq!(std::fs::read(dest.join("f1")).unwrap(), b"one");
+        assert_eq!(std::fs::read(dest.join("sub").join("f2")).unwrap(), b"two");
+        assert!(!dir.path().join("moved.oxo-tmp").exists());
+    }
+
+    #[test]
+    fn copy_tree_atomic_replaces_existing_dest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("a");
+        let dest = dir.path().join("b");
+        std::fs::write(&src, b"new").unwrap();
+        std::fs::write(&dest, b"old").unwrap();
+        copy_tree_atomic(&src, &dest).expect("atomic copy over existing dest");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"new");
+    }
+
+    #[test]
+    fn move_path_missing_source_errors_and_leaves_no_tmp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("missing");
+        let dest = dir.path().join("dest");
+        // Plain rename fails (ENOENT), the copy fallback fails too — the
+        // error surfaces and no temporary sibling remains.
+        block_on(move_path(&src, &dest)).expect_err("missing src must fail");
+        assert!(!dest.exists());
+        assert!(!dir.path().join("dest.oxo-tmp").exists(), "no tmp litter");
     }
 
     fn executor_with(max_threads: u32, max_memory_mb: u64) -> LocalExecutor {

--- a/crates/oxo-flow-core/src/executor/timeout.rs
+++ b/crates/oxo-flow-core/src/executor/timeout.rs
@@ -4,8 +4,9 @@
 pub const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Kill a process and all its descendants (deepest first), gracefully:
-/// SIGTERM the whole subtree, poll [`SIGTERM_GRACE`] for survivors, then
-/// SIGKILL whatever remains.
+/// SIGTERM the whole subtree, poll [`SIGTERM_GRACE`] for survivors,
+/// re-scan for descendants spawned during the window, then SIGKILL
+/// whatever remains.
 ///
 /// Rules deliberately run inside the caller's process group (see
 /// `process::execute_rule` — "one run = one process group"), so a timeout
@@ -15,36 +16,19 @@ pub const SIGTERM_GRACE: std::time::Duration = std::time::Duration::from_secs(10
 /// that detached from the group. Only available on Unix systems.
 #[cfg(unix)]
 pub fn kill_process_tree(pid: u32) -> std::io::Result<()> {
+    kill_process_tree_with_grace(pid, SIGTERM_GRACE)
+}
+
+/// [`kill_process_tree`] with an explicit grace window (tests use a short
+/// one; production passes [`SIGTERM_GRACE`]).
+#[cfg(unix)]
+pub fn kill_process_tree_with_grace(pid: u32, grace: std::time::Duration) -> std::io::Result<()> {
     use nix::errno::Errno;
     use nix::sys::signal::{Signal, kill};
     use nix::unistd::Pid;
 
     let root = Pid::from_raw(pid as i32);
-
-    // Snapshot parent→child links, then walk outward from the root pid.
-    let mut system = sysinfo::System::new();
-    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-
-    let mut targets: Vec<Pid> = vec![root];
-    loop {
-        let mut found = false;
-        for (child_pid, proc) in system.processes() {
-            let child = Pid::from_raw(child_pid.as_u32() as i32);
-            if targets.contains(&child) {
-                continue;
-            }
-            if let Some(parent) = proc.parent() {
-                let parent = Pid::from_raw(parent.as_u32() as i32);
-                if targets.contains(&parent) {
-                    targets.push(child);
-                    found = true;
-                }
-            }
-        }
-        if !found {
-            break;
-        }
-    }
+    let mut targets = collect_descendants(root);
 
     // Deepest first: children die before their parents so no subtree can be
     // re-parented into init and survive the kill.
@@ -62,7 +46,7 @@ pub fn kill_process_tree(pid: u32) -> std::io::Result<()> {
     signal_subtree(Signal::SIGTERM, &targets)?;
 
     // Poll the grace window; a process that honors TERM gets to flush.
-    let deadline = std::time::Instant::now() + SIGTERM_GRACE;
+    let deadline = std::time::Instant::now() + grace;
     loop {
         let alive = {
             let mut s = sysinfo::System::new();
@@ -86,12 +70,56 @@ pub fn kill_process_tree(pid: u32) -> std::io::Result<()> {
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
+    // Re-snapshot before escalating (issue #194 §3.4): a descendant
+    // spawned after the first walk — whose spawner survived the TERM sweep
+    // and is therefore still reachable through live parent links — missed
+    // the TERM signal; it must not miss the KILL sweep too. Descendants
+    // whose spawner died and re-parented into init are unreachable by
+    // design (the documented limit of parent-chain killing).
+    let refreshed = collect_descendants(root);
+    for p in refreshed {
+        if !targets.contains(&p) {
+            targets.push(p);
+        }
+    }
+
     tracing::debug!(
         pid = pid,
         targets = targets.len(),
         "process subtree survived SIGTERM grace; escalating to SIGKILL"
     );
     signal_subtree(Signal::SIGKILL, &targets)
+}
+
+/// Snapshot parent→child links and walk outward from `root` to collect
+/// every descendant pid (including `root` itself).
+#[cfg(unix)]
+fn collect_descendants(root: nix::unistd::Pid) -> Vec<nix::unistd::Pid> {
+    use nix::unistd::Pid;
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+
+    let mut targets: Vec<Pid> = vec![root];
+    loop {
+        let mut found = false;
+        for (child_pid, proc) in system.processes() {
+            let child = Pid::from_raw(child_pid.as_u32() as i32);
+            if targets.contains(&child) {
+                continue;
+            }
+            if let Some(parent) = proc.parent() {
+                let parent = Pid::from_raw(parent.as_u32() as i32);
+                if targets.contains(&parent) {
+                    targets.push(child);
+                    found = true;
+                }
+            }
+        }
+        if !found {
+            break;
+        }
+    }
+    targets
 }
 
 /// Stub for non-Unix systems (no process group support).
@@ -205,6 +233,60 @@ mod tests {
             "the TERM trap never ran — the subtree was killed without grace"
         );
         assert!(!process_exists(sh_pid), "shell survived the tree kill");
+    }
+
+    #[test]
+    fn kill_process_tree_reaches_descendants_spawned_during_the_grace_window() {
+        // issue #194 §3.4: a grandchild spawned AFTER the initial
+        // snapshot, whose spawner ignores SIGTERM and is still alive at
+        // escalation time, must be caught by the re-scan before SIGKILL.
+        // The old single-snapshot walk let it survive.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spawner_pidfile = dir.path().join("spawner.pid");
+        let grandchild_pidfile = dir.path().join("grandchild.pid");
+        let script = format!(
+            "trap '' TERM; (trap '' TERM; echo $$ > {spawner}; sleep 0.5; sleep 30 & echo $! > {grandchild}; wait) & wait",
+            spawner = spawner_pidfile.display(),
+            grandchild = grandchild_pidfile.display(),
+        );
+        let mut sh = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sh");
+        let sh_pid = sh.id();
+
+        // Wait for the TERM-ignoring spawner subshell to record its pid.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !spawner_pidfile.exists() && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(spawner_pidfile.exists(), "spawner pid file never appeared");
+
+        // Grace of 1.2s: the grandchild spawns at +0.5s, inside the window.
+        kill_process_tree_with_grace(sh_pid, Duration::from_millis(1200))
+            .expect("tree kill with grace");
+
+        // The shell and spawner are gone…
+        let _ = sh.wait();
+        assert!(!process_exists(sh_pid), "shell survived the tree kill");
+
+        // …and the late grandchild was caught by the re-scan.
+        let grandchild_pid = std::fs::read_to_string(&grandchild_pidfile)
+            .expect("grandchild pid file")
+            .trim()
+            .parse::<u32>()
+            .expect("valid pid");
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while process_exists(grandchild_pid) && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            !process_exists(grandchild_pid),
+            "grandchild spawned during the grace window survived the kill"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -877,23 +877,6 @@ pub fn lint_format(
             });
         }
 
-        // W026: `cache_key` is accepted but not yet consulted (issue #194
-        // M2). The field parses so old workflows keep validating, but the
-        // scheduler never reads it — silence would let authors believe
-        // content-addressed reuse is active when it is not.
-        if rule.cache_key.is_some() {
-            diagnostics.push(Diagnostic {
-                severity: Severity::Info,
-                message: "rule declares `cache_key`, which is accepted for compatibility but \
-                          not yet consulted by the scheduler — content-addressed reuse is not \
-                          active (issue #194)"
-                    .to_string(),
-                rule: Some(rule.name.clone()),
-                code: "W026".to_string(),
-                suggestion: None,
-            });
-        }
-
         // W006: Naming convention (should use snake_case)
         if rule.name.contains('-') {
             diagnostics.push(Diagnostic {
@@ -3888,10 +3871,12 @@ mod tests {
         );
     }
 
-    // ---- W026: cache_key accepted but not consulted (issue #194 M2) ----
+    // ---- cache_key is now consulted (issue #194 §2.3) — the former W026 ----
+    // lint was removed when content-addressed reuse became real; a rule
+    // declaring `cache_key` must stay lint-silent.
 
     #[test]
-    fn lint_w026_flags_unimplemented_cache_key() {
+    fn lint_cache_key_is_consulted_and_silent() {
         let toml = r#"
             [workflow]
             name = "test"
@@ -3904,24 +3889,10 @@ mod tests {
         "#;
         let config = WorkflowConfig::parse(toml).unwrap();
         let diagnostics = lint_format(&config, None);
-        let w026 = diagnostics.iter().find(|d| d.code == "W026");
         assert!(
-            w026.is_some_and(|d| d.rule.as_deref() == Some("step1")),
-            "cache_key must raise W026: {diagnostics:?}"
+            !diagnostics.iter().any(|d| d.code == "W026"),
+            "W026 was removed with the cache_key implementation: {diagnostics:?}"
         );
-        // A workflow without cache_key stays silent.
-        let toml = r#"
-            [workflow]
-            name = "test"
-
-            [[rules]]
-            name = "step1"
-            output = ["out.txt"]
-            shell = "echo hi > out.txt"
-        "#;
-        let config = WorkflowConfig::parse(toml).unwrap();
-        let diagnostics = lint_format(&config, None);
-        assert!(!diagnostics.iter().any(|d| d.code == "W026"));
     }
 
     // ---- W025: Deprecated rule-level threads/memory (issue #142 M12) ----

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -924,11 +924,16 @@ pub struct Rule {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub rule_metadata: HashMap<String, toml::Value>,
 
-    /// Content-based cache key override.
+    /// Content-based cache key (issue #194 §2.3).
     ///
-    /// Accepted for schema/parser compatibility but NOT yet consulted by the
-    /// scheduler — content-addressed reuse is not active (issue #194 M2;
-    /// `validate` raises W026 so authors are not misled).
+    /// When set, the rule participates in content-addressed output reuse:
+    /// the executor hashes this key together with the expanded outputs,
+    /// the rendered command, and the content identity of every resolved
+    /// input; on a later run with a matching identity the cached outputs
+    /// are restored and the shell is skipped. Local inputs over 64 MiB and
+    /// remote objects without an etag cannot be content-addressed — such
+    /// instances silently execute instead of reusing. See
+    /// `executor/content_cache.rs`.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,

--- a/crates/oxo-flow-core/src/storage/mod.rs
+++ b/crates/oxo-flow-core/src/storage/mod.rs
@@ -128,6 +128,116 @@ pub struct RemoteStat {
 }
 
 // ---------------------------------------------------------------------------
+// Post-upload verification (issue #194 §2.11): after an upload, the remote
+// store is asked what it holds and its identity is compared with the local
+// file — a silently truncated transfer would otherwise be checkpointed as
+// complete.
+// ---------------------------------------------------------------------------
+
+/// Verify a just-uploaded object against the local file it came from:
+/// size always, content digest when the remote store exposes a comparable
+/// one (S3 single-part ETag = md5 hex; GCS `md5Hash` = base64 md5).
+///
+/// Composite identities (S3 multipart ETags, `hash-N`) and objects without
+/// a digest are skipped with a debug note — they are not comparable to a
+/// plain md5. Any comparable mismatch is an [`OxoFlowError::Integrity`]
+/// error: the remote copy cannot be trusted and the rule must fail.
+pub async fn verify_upload(
+    backend: &dyn StorageBackend,
+    local: &Path,
+    remote: &StoragePath,
+) -> Result<()> {
+    let Some(stat) = backend.head(remote).await? else {
+        tracing::debug!(remote = %remote.raw, "uploaded object has no HEAD result — skipping verification");
+        return Ok(());
+    };
+
+    let local_size = tokio::fs::metadata(local).await?.len();
+    if stat.size != local_size {
+        return Err(OxoFlowError::Integrity {
+            message: format!(
+                "uploaded object '{}' reports {} bytes but the local file is {local_size}",
+                remote.raw, stat.size
+            ),
+            failed_files: vec![remote.raw.clone()],
+        });
+    }
+
+    let Some(etag) = stat.etag.as_deref() else {
+        tracing::debug!(remote = %remote.raw, "remote store reported no content digest — skipping checksum verification");
+        return Ok(());
+    };
+
+    match remote.scheme {
+        StorageScheme::S3 => {
+            // Multipart/SSE etags (`hash-N`) are not md5 digests — nothing
+            // local to compare against a plain md5, so skip rather than
+            // fail a healthy upload.
+            if !is_md5_hex(etag) {
+                tracing::debug!(remote = %remote.raw, etag, "composite S3 etag is not a plain md5 — skipping checksum verification");
+                return Ok(());
+            }
+            let local_md5 = md5_hex_of_file(local).await?;
+            if !local_md5.eq_ignore_ascii_case(etag) {
+                return Err(upload_mismatch(remote, &local_md5, etag));
+            }
+        }
+        StorageScheme::Gcs => {
+            let local_md5 = md5_base64_of_file(local).await?;
+            if local_md5 != etag {
+                return Err(upload_mismatch(remote, &local_md5, etag));
+            }
+        }
+        StorageScheme::Local => {}
+    }
+    Ok(())
+}
+
+/// A 32-char hex md5 digest (what a single-part S3 ETag is).
+fn is_md5_hex(s: &str) -> bool {
+    s.len() == 32 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn upload_mismatch(remote: &StoragePath, local_digest: &str, remote_digest: &str) -> OxoFlowError {
+    OxoFlowError::Integrity {
+        message: format!(
+            "uploaded object '{}' checksum mismatch: remote reports {remote_digest}, local file computes {local_digest}",
+            remote.raw
+        ),
+        failed_files: vec![remote.raw.clone()],
+    }
+}
+
+/// Streamed md5 of a local file, hex-encoded (the S3 single-part ETag form).
+async fn md5_hex_of_file(path: &Path) -> std::io::Result<String> {
+    Ok(hex::encode(md5_of_file(path).await?))
+}
+
+/// Streamed md5 of a local file, base64-encoded (the GCS `md5Hash` form).
+async fn md5_base64_of_file(path: &Path) -> std::io::Result<String> {
+    use base64::Engine as _;
+    Ok(base64::engine::general_purpose::STANDARD.encode(md5_of_file(path).await?))
+}
+
+/// Streamed md5 of a local file in bounded chunks (outputs can be large;
+/// never buffer the whole file).
+async fn md5_of_file(path: &Path) -> std::io::Result<[u8; 16]> {
+    use md5::Digest as _;
+    use tokio::io::AsyncReadExt as _;
+    let mut hasher = md5::Md5::new();
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+// ---------------------------------------------------------------------------
 // Engine-managed staging paths and the etag-keyed download cache (issue #80
 // item 2). Staged files live under `.oxo-flow/staged/` — engine-internal,
 // invisible to checkpoints, safe to delete (a later run re-downloads).
@@ -395,6 +505,152 @@ impl Default for StorageResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A backend stub whose only live method is `head` — everything else
+    /// is unreachable in upload-verification tests.
+    struct HeadOnlyBackend {
+        stat: std::sync::Mutex<Option<RemoteStat>>,
+    }
+
+    #[async_trait::async_trait]
+    impl StorageBackend for HeadOnlyBackend {
+        async fn exists(&self, _path: &StoragePath) -> Result<bool> {
+            unreachable!("exists")
+        }
+        async fn head(&self, _path: &StoragePath) -> Result<Option<RemoteStat>> {
+            Ok(self.stat.lock().unwrap().clone())
+        }
+        async fn read_to_string(&self, _path: &StoragePath) -> Result<String> {
+            unreachable!("read_to_string")
+        }
+        async fn write(&self, _path: &StoragePath, _data: &[u8]) -> Result<()> {
+            unreachable!("write")
+        }
+        async fn stage(&self, _path: &StoragePath, _workdir: &Path) -> Result<PathBuf> {
+            unreachable!("stage")
+        }
+        async fn upload(&self, _local: &Path, _remote: &StoragePath) -> Result<()> {
+            unreachable!("upload")
+        }
+        fn name(&self) -> &'static str {
+            "head-only-test"
+        }
+    }
+
+    fn remote_uri(raw: &str) -> StoragePath {
+        StoragePath::parse(raw)
+    }
+
+    #[test]
+    fn is_md5_hex_accepts_plain_digests_only() {
+        assert!(is_md5_hex("5d41402abc4b2a76b9719d911017c592"));
+        assert!(is_md5_hex("5D41402ABC4B2A76B9719D911017C592"));
+        assert!(!is_md5_hex("5d41402abc4b2a76b9719d911017c592-2")); // multipart
+        assert!(!is_md5_hex("5d41402abc4b2a76b9719d911017c59")); // short
+        assert!(!is_md5_hex("5d41402abc4b2a76b9719d911017c59z")); // non-hex
+    }
+
+    #[test]
+    fn md5_file_digests_match_known_vectors() {
+        // md5("hello") = 5d41402abc4b2a76b9719d911017c592 (hex) /
+        // XUFAKrxLKna5cZ2REBfFkg== (base64).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(
+            rt.block_on(md5_hex_of_file(&file)).expect("hex digest"),
+            "5d41402abc4b2a76b9719d911017c592"
+        );
+        assert_eq!(
+            rt.block_on(md5_base64_of_file(&file)).expect("b64 digest"),
+            "XUFAKrxLKna5cZ2REBfFkg=="
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_upload_passes_when_s3_etag_matches_local_md5() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("out.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let backend = HeadOnlyBackend {
+            stat: std::sync::Mutex::new(Some(RemoteStat {
+                size: 5,
+                etag: Some("5d41402abc4b2a76b9719d911017c592".to_string()),
+            })),
+        };
+        verify_upload(&backend, &file, &remote_uri("s3://b/out.txt"))
+            .await
+            .expect("matching etag must pass");
+    }
+
+    #[tokio::test]
+    async fn verify_upload_fails_when_s3_etag_diverges() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("out.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let backend = HeadOnlyBackend {
+            stat: std::sync::Mutex::new(Some(RemoteStat {
+                size: 5,
+                etag: Some("00000000000000000000000000000000".to_string()),
+            })),
+        };
+        let err = verify_upload(&backend, &file, &remote_uri("s3://b/out.txt"))
+            .await
+            .expect_err("diverging etag must fail");
+        assert!(matches!(err, OxoFlowError::Integrity { .. }), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn verify_upload_skips_composite_s3_etags() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("out.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let backend = HeadOnlyBackend {
+            stat: std::sync::Mutex::new(Some(RemoteStat {
+                size: 5,
+                etag: Some("5d41402abc4b2a76b9719d911017c592-2".to_string()),
+            })),
+        };
+        // A multipart etag is not comparable to a plain md5 — a healthy
+        // upload must not be failed over it.
+        verify_upload(&backend, &file, &remote_uri("s3://b/out.txt"))
+            .await
+            .expect("composite etag is skipped, not an error");
+    }
+
+    #[tokio::test]
+    async fn verify_upload_fails_on_size_mismatch() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("out.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let backend = HeadOnlyBackend {
+            stat: std::sync::Mutex::new(Some(RemoteStat {
+                size: 3, // truncated transfer
+                etag: None,
+            })),
+        };
+        let err = verify_upload(&backend, &file, &remote_uri("s3://b/out.txt"))
+            .await
+            .expect_err("size mismatch must fail even without a digest");
+        assert!(matches!(err, OxoFlowError::Integrity { .. }), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn verify_upload_passes_for_gcs_base64_md5() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("out.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let backend = HeadOnlyBackend {
+            stat: std::sync::Mutex::new(Some(RemoteStat {
+                size: 5,
+                etag: Some("XUFAKrxLKna5cZ2REBfFkg==".to_string()),
+            })),
+        };
+        verify_upload(&backend, &file, &remote_uri("gs://b/out.txt"))
+            .await
+            .expect("matching gcs md5Hash must pass");
+    }
 
     #[test]
     fn parse_local_path() {

--- a/docs/guide/src/how-to/troubleshooting.md
+++ b/docs/guide/src/how-to/troubleshooting.md
@@ -326,9 +326,11 @@ much completed work stays protected.
 2. **Check resource constraints**: Use `oxo-flow debug` to verify that
    resource requirements are reasonable.
 
-3. **Use streaming / caching**: the `pipe` and `cache_key` rule fields are
-   parsed but their execution features are not wired up yet — do not rely
-   on them for performance.
+3. **Use caching**: a rule with `cache_key` reuses its outputs from the
+   content cache when the key, inputs, outputs, and rendered command hash
+   identically to a previous run — bump the key when a dependency's
+   behavior changes without touching the declared inputs. (`pipe` is
+   parsed but not wired up yet — do not rely on it.)
 
 ### Memory issues with large workflows
 

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -417,7 +417,25 @@ flags these with warning W019).
   (outputs beyond the hash cap keep the mtime comparison).
 - Rule timeouts and aborts terminate the rule subtree with a **SIGTERM
   grace period** (10s) before escalating to SIGKILL, so well-behaved
-  tools get a chance to flush state.
+  tools get a chance to flush state; descendants spawned during the
+  grace window are caught by a re-scan before the KILL sweep.
+- Scratch outputs move back to the workdir **atomically even across
+  filesystems**: the copy lands in a temp sibling, is fsynced, renamed
+  into place, and the parent directory fsynced — a crash leaves either
+  nothing or the complete output, never a truncated one.
+- Input manifests are **re-verified after each rule completes**: if an
+  external writer changed an input mid-run, the run warns loudly and the
+  next run re-executes the rule instead of trusting outputs built from a
+  mixed file state.
+- Uploaded remote outputs are **verified against the local file** before
+  the rule is recorded as complete (size always; md5 when the store
+  exposes a comparable digest — S3 single-part ETag or GCS `md5Hash`).
+- Rules with `cache_key` participate in **content-addressed reuse**: a
+  cache entry whose key-plus-inputs-plus-command identity matches a
+  previous run is restored instead of executing the shell (see
+  [workflow format](workflow-format.md) for the participation limits).
+- Declared sensitive values are masked in captured output in **plaintext
+  and encoded forms** (base64, percent-encoding, JSON string escaping).
 - Failed-rule aside files (`.oxo-failed`) age out automatically after
   7 days; the environment cache cleanup is recursive.
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -268,7 +268,7 @@ samples   = { required = true, type = "path", must_exist = true }
 | `default` | String | Default value when not provided via CLI |
 | `required` | Bool | If `true`, the value must be provided at runtime (default: `false`) |
 | `help` | String | Human-readable description shown in error messages |
-| `sensitive` | Bool | Mask the value as `***` in captured rule output, recorded commands, checkpoint/report snapshots, and error summaries — before they reach the web UI or AI recovery (default: `false`). Values shorter than 4 characters are not masked, and structured or derived forms of the value (JSON/base64) pass through — exact-match masking only |
+| `sensitive` | Bool | Mask the value as `***` in captured rule output, recorded commands, checkpoint/report snapshots, and error summaries — before they reach the web UI or AI recovery (default: `false`). Every non-empty value is masked; values of 4+ characters also mask their base64, percent-encoded, and JSON-escaped forms |
 | `type` | String | Expected value type for validation: `"string"`, `"int"`, `"float"`, `"bool"`, `"path"` |
 | `choices` | Array of String | Allowed values (requires `type = "string"`) |
 | `range` | String | Numeric range `"min..max"` (requires `type = "int"` or `"float"`) |
@@ -545,7 +545,7 @@ memory = "32G"
 | `benchmark` | String | No | Benchmark output path for performance data |
 | `log` | String | No | Log file path for rule execution output |
 | `group` | String | No | Job group label for cluster submission grouping |
-| `cache_key` | String | No | Accepted for compatibility but NOT yet consulted by the scheduler (validate raises W026) — content-addressed reuse is not active (issue #194) |
+| `cache_key` | String | No | Content-addressed output reuse: cached outputs are restored when the key, inputs, outputs, and rendered command hash identically to a previous run (issue #194 §2.3) |
 | `input_function` | String | No | Dynamic input resolver function name |
 | `rule_metadata` | Table | No | Arbitrary domain-specific metadata (assay, organism, etc.) |
 | `env_group` | String | No | Reference to a named environment in `[env_groups]` |
@@ -1088,13 +1088,13 @@ benchmark = "benchmarks/align_{sample}.tsv"
 | Field | Type | Description |
 |-------|------|-------------|
 | `group` | String | Job group label for cluster submission grouping |
-| `cache_key` | String | Accepted for compatibility but not yet consulted by the scheduler (validate raises W026; issue #194) |
+| `cache_key` | String | Content-addressed output reuse: cached outputs are restored when the key, inputs, outputs, and rendered command hash identically to a previous run (issue #194 §2.3) |
 
 ```toml
 [[rules]]
 name = "variant_call"
 group = "variant_calling"       # Submit as a group on cluster
-cache_key = "vc_v2.0"           # Cache key for output reuse
+cache_key = "vc_v2.0"           # Content cache key — outputs are reused when content is identical
 ```
 
 ### Dynamic Input Resolution

--- a/docs/schema/oxoflow-v1.schema.json
+++ b/docs/schema/oxoflow-v1.schema.json
@@ -370,7 +370,7 @@
         "format_hint": { "type": "array", "items": { "type": "string" }, "description": "File format hints (e.g., 'bam', 'vcf')" },
         "pipe": { "type": "boolean", "default": false, "description": "Enable FIFO streaming mode" },
         "checksum": { "type": "string", "enum": ["md5", "sha256"], "description": "Output integrity verification algorithm" },
-        "cache_key": { "type": "string", "description": "Content-based cache key for output reuse" },
+        "cache_key": { "type": "string", "description": "Content-based cache key: enables content-addressed output reuse across runs (issue #194)" },
         "input_function": { "type": "string", "description": "Dynamic input resolver function name" },
         "benchmark": { "type": "string", "description": "Benchmark output path for performance data" },
         "log": { "type": "string", "description": "Log file path for execution output" },


### PR DESCRIPTION
## What

Implements the six medium-high / high-value items left out of scope in the #194 resolution (all previously recorded as out-of-scope in the issue):

| # | Item | Severity | Fix |
|---|------|----------|-----|
| 2.3 | `cache_key` unimplemented (W026) | HIGH | Real content-addressed output cache — see below |
| 2.5 | Cross-filesystem scratch→output move is copy+delete, not atomic | HIGH | Temp-sibling copy + fsync + rename + parent-dir fsync |
| 2.11 | No post-upload verification of remote outputs | HIGH | Size always; md5 vs S3 single-part ETag / GCS md5Hash; composite etags skipped; mismatch = `Integrity` failure |
| 1.4 | Masking misses encoded secret forms | MED-HIGH | base64 (std+URL-safe), percent-encoding, JSON string escaping for 4+-char values |
| 3.4 | kill_process_tree snapshot race | MED | Re-scan the subtree before the SIGKILL sweep |
| 2.10 | Input manifest snapshot race | MED | Post-run re-verification: warn + note in job record; recorded pre-run manifest forces next-run re-execution |

### `cache_key` semantics (2.3)

- Identity = sha256(cache_key + expanded output patterns + fully rendered command + content identity of every resolved input — sha256 local, etag remote).
- Entries live under `.oxo-flow/content-cache/<rule>/<key>/`; populate is atomic (tmp sibling → rename → `entry.json` completeness marker), restore reuses the atomic-copy pattern, so parallel instances of the same rule cannot corrupt each other.
- **Conservative rails:** instances with unhashable inputs (local files > 64 MiB, remote objects without an etag) or remote outputs never participate; restore failure falls back to execution.
- Run log shows `↺ rule (restored from content cache)`; W026 lint removed.

## Tests

- 16 new unit tests (atomic moves, masking variants, kill re-scan, manifest changes, upload verification with a mock backend, content-cache key/roundtrip/refusal).
- `make ci` green (fmt + clippy -D warnings + build + schema drift + full test suite + audit).

## Live verification (real runs)

- Content cache matrix: execute+populate → wipe outputs → `↺` restore without shell (side-effect marker absent) → changed input re-executes (no wrong reuse) → fresh outputs skip normally.
- Mid-run input modification: `WARN input changed while the rule was running; changes=["input.txt (changed)"]` in the log, note in `checkpoint.json` stderr_tail, and the **next run re-executed** the rule.
- Encoded masking: checkpoint `stderr_tail` shows `plain *** b64 *** url ***` for a `s3cr*t!` secret (inline `{ sensitive = true }` declarative form).
- Scratch move-back sanity (rename path); the cross-fs fallback itself is unit-tested (EXDEV cannot be forced on a single volume). Post-upload verification is unit-tested with a mock backend; a MinIO live check remains gated as before.

Closes the out-of-scope follow-ups in #194.