### PR TITLE
feat(cluster): record what a cluster job actually cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,6 +2840,7 @@ name = "oxo-flow"
 version = "0.15.0"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "filetime",
  "oxo-flow-core",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ assert_cmd = "2.2.0"
 predicates = "3.1.4"
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -157,13 +157,17 @@ async fn record_outcome(
             let benchmark = BenchmarkRecord {
                 rule: record.rule.clone(),
                 wall_time_secs: duration,
-                // Real usage needs `sacct` polling — phase 4. Reporting a
-                // fabricated number here would be worse than reporting none.
-                max_memory_mb: None,
+                // Read from the scheduler's accounting store as the job
+                // settled, so this is the store's own peak rather than the
+                // sampled one the local executor reports. Still `None` when
+                // the store did not report it (LSF, and any job whose
+                // accounting row never appeared) — a fabricated number
+                // would be worse than none.
+                max_memory_mb: record.max_rss_mb,
                 memory_limit_mb: rule
                     .and_then(|r| r.effective_memory())
                     .and_then(oxo_flow_core::scheduler::parse_memory_mb),
-                cpu_seconds: None,
+                cpu_seconds: record.cpu_seconds,
                 retries: record.retries,
             };
             ck.record_run(record);

--- a/crates/oxo-flow-core/src/backend/cluster.rs
+++ b/crates/oxo-flow-core/src/backend/cluster.rs
@@ -5,7 +5,7 @@
 //! status-line parsing is shared (issue #74 comment 5): tracking and
 //! array-index mapping need the same logic.
 
-use super::{BackendJobStatus, ScheduledRule};
+use super::{BackendJobStatus, ScheduledRule, TerminalRecord};
 use crate::cluster::{
     ClusterBackend, ClusterJobConfig, generate_array_submit_script, generate_submit_script,
 };
@@ -280,7 +280,7 @@ impl super::ExecutorBackend for ClusterExecutor {
                             let state = self
                                 .terminal_status(id)
                                 .await
-                                .unwrap_or(BackendJobStatus::Unknown);
+                                .map_or(BackendJobStatus::Unknown, |r| r.status);
                             if state != BackendJobStatus::Unknown {
                                 statuses.insert(id.clone(), state);
                             }
@@ -325,7 +325,11 @@ impl super::ExecutorBackend for ClusterExecutor {
         let (program, args) = match self.backend {
             ClusterBackend::Slurm => (
                 "sacct",
-                vec!["-j", job_id, "--format=JobID,State,ExitCode,Elapsed,MaxRSS"],
+                vec![
+                    "-j",
+                    job_id,
+                    "--format=JobID,State,ExitCode,Elapsed,MaxRSS,TotalCPU",
+                ],
             ),
             ClusterBackend::Pbs => ("qstat", vec!["-x", "-f", job_id]),
             ClusterBackend::Sge => ("qacct", vec!["-j", job_id]),
@@ -335,9 +339,9 @@ impl super::ExecutorBackend for ClusterExecutor {
         Ok(String::from_utf8_lossy(&out.stdout).to_string())
     }
 
-    /// Terminal status of a job that has left the live queue, read from the
+    /// Terminal record for a job that has left the live queue, read from the
     /// scheduler's accounting store (sacct / qstat -x / qacct / bacct).
-    async fn terminal_status(&self, job_id: &str) -> Option<BackendJobStatus> {
+    async fn terminal_status(&self, job_id: &str) -> Option<TerminalRecord> {
         let text = self.logs(job_id).await.ok()?;
         parse_accounting(&self.backend, &text)
     }
@@ -349,74 +353,206 @@ impl super::ExecutorBackend for ClusterExecutor {
     }
 }
 
-/// Parse scheduler accounting output into a terminal status, or `None` when
+/// Split an accounting row on `|` when the store emitted the pipe-separated
+/// form, on whitespace otherwise. Real `sacct` pads columns with spaces; the
+/// mock scheduler and `sacct -P` both emit pipes.
+fn accounting_columns(line: &str) -> Vec<&str> {
+    if line.contains('|') {
+        line.split('|').map(str::trim).collect()
+    } else {
+        line.split_whitespace().collect()
+    }
+}
+
+/// Parse a SLURM `ExitCode` field into a process exit code.
+///
+/// The field is `<exit>:<signal>`. A signalled job reports exit `0`, so
+/// reading only the first component would record an OOM kill (`0:9`) as a
+/// clean exit — signalled jobs get the shell's `128 + signum` instead. Bare
+/// integers (PBS `Exit_status`, SGE `exit_status`) parse as themselves.
+fn parse_exit_code(raw: &str) -> Option<i32> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (exit, signal) = match raw.split_once(':') {
+        Some((e, s)) => (e.trim().parse::<i32>().ok()?, s.trim().parse::<i32>().ok()?),
+        None => (raw.parse::<i32>().ok()?, 0),
+    };
+    Some(if signal != 0 { 128 + signal } else { exit })
+}
+
+/// Parse a scheduler duration (`[DD-]HH:MM:SS`, `MM:SS`, or bare seconds)
+/// into seconds. Sub-second precision (`00:00:05.004`, common in SLURM's
+/// `TotalCPU`) truncates.
+fn parse_duration_secs(raw: &str) -> Option<u64> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw == "UNLIMITED" || raw == "INVALID" {
+        return None;
+    }
+    let (days, rest) = match raw.split_once('-') {
+        Some((d, r)) => (d.trim().parse::<u64>().ok()?, r),
+        None => (0, raw),
+    };
+    let mut secs = days * 86_400;
+    let parts: Vec<&str> = rest.split(':').collect();
+    // Trailing fractional seconds are dropped, not rounded: accounting
+    // resolution is not the point of this number.
+    let whole = |p: &str| p.split('.').next().unwrap_or(p).trim().parse::<u64>().ok();
+    match parts.as_slice() {
+        [h, m, s] => secs += whole(h)? * 3600 + whole(m)? * 60 + whole(s)?,
+        [m, s] => secs += whole(m)? * 60 + whole(s)?,
+        [s] => secs += whole(s)?,
+        _ => return None,
+    }
+    Some(secs)
+}
+
+/// Parse an accounting memory figure into MB. SLURM suffixes `K`/`M`/`G`/`T`
+/// (optionally `Kn`/`Kc` for per-node/per-core), PBS writes `1234kb`, SGE's
+/// `ru_maxrss` is bare kilobytes. An unsuffixed value is read as kilobytes,
+/// which is what every one of these stores means by a bare number.
+fn parse_rss_mb(raw: &str) -> Option<u64> {
+    let raw = raw.trim().trim_end_matches(['n', 'c']);
+    if raw.is_empty() || raw == "0" {
+        return None;
+    }
+    let lower = raw.to_ascii_lowercase();
+    let (digits, per_mb) = if let Some(v) = lower.strip_suffix("kb") {
+        (v, 1024.0)
+    } else if let Some(v) = lower.strip_suffix("mb") {
+        (v, 1.0)
+    } else if let Some(v) = lower.strip_suffix("gb") {
+        (v, 1.0 / 1024.0)
+    } else if let Some(v) = lower.strip_suffix('k') {
+        (v, 1024.0)
+    } else if let Some(v) = lower.strip_suffix('m') {
+        (v, 1.0)
+    } else if let Some(v) = lower.strip_suffix('g') {
+        (v, 1.0 / 1024.0)
+    } else if let Some(v) = lower.strip_suffix('t') {
+        (v, 1.0 / (1024.0 * 1024.0))
+    } else {
+        (lower.as_str(), 1024.0)
+    };
+    let value: f64 = digits.trim().parse().ok()?;
+    let mb = value / per_mb;
+    if mb <= 0.0 {
+        None
+    } else {
+        Some(mb.round() as u64)
+    }
+}
+
+/// Parse scheduler accounting output into a terminal record, or `None` when
 /// the record is absent or the job is not terminal.
-fn parse_accounting(backend: &ClusterBackend, text: &str) -> Option<BackendJobStatus> {
+fn parse_accounting(backend: &ClusterBackend, text: &str) -> Option<TerminalRecord> {
     match backend {
-        ClusterBackend::Slurm => {
-            // sacct rows: "<JobID> <Elapsed> <State> <ExitCode> <MaxRSS>"
-            // (header and separator rows carry no job data). The mock
-            // scheduler emits the same columns pipe-separated — accept both.
-            let line = text.lines().find(|l| {
-                let t = l.trim();
-                !t.is_empty() && !t.starts_with("JobID") && !t.starts_with('-')
-            });
-            let state = line.and_then(|l| {
-                let cols: Vec<&str> = if l.contains('|') {
-                    l.split('|').map(str::trim).collect()
-                } else {
-                    l.split_whitespace().collect()
-                };
-                cols.get(1).copied().map(str::to_string)
-            });
-            if let Some(state) = state {
-                match state.split('.').next().unwrap_or(&state) {
-                    "COMPLETED" => return Some(BackendJobStatus::Completed),
-                    "FAILED" | "TIMEOUT" | "OUT_OF_MEMORY" => {
-                        return Some(BackendJobStatus::Failed);
-                    }
-                    "CANCELLED" => return Some(BackendJobStatus::Cancelled),
-                    _ => return None,
-                }
-            }
-            None
-        }
+        ClusterBackend::Slurm => parse_sacct(text),
         ClusterBackend::Pbs => {
-            // qstat -x -f: "    job_state = C" + "    Exit_status = N"
+            // qstat -x -f: "    job_state = C" + "    Exit_status = N", with
+            // measurements under "resources_used.<field>".
             if !text.lines().any(|l| l.trim() == "job_state = C") {
                 return None;
             }
-            if text.lines().any(|l| l.trim() == "Exit_status = 0") {
-                Some(BackendJobStatus::Completed)
-            } else {
-                Some(BackendJobStatus::Failed)
-            }
+            let field = |key: &str| {
+                text.lines()
+                    .map(str::trim)
+                    .find_map(|l| l.strip_prefix(key)?.strip_prefix(" = "))
+            };
+            let exit_code = field("Exit_status").and_then(parse_exit_code);
+            Some(TerminalRecord {
+                status: if exit_code == Some(0) {
+                    BackendJobStatus::Completed
+                } else {
+                    BackendJobStatus::Failed
+                },
+                exit_code,
+                elapsed_secs: field("resources_used.walltime").and_then(parse_duration_secs),
+                max_rss_mb: field("resources_used.mem").and_then(parse_rss_mb),
+                cpu_seconds: field("resources_used.cput").and_then(parse_duration_secs),
+            })
         }
         ClusterBackend::Sge => {
-            // qacct: "exit_status 0" (success) or a non-zero value (failed).
-            for line in text.lines().map(str::trim) {
-                if let Some(rest) = line.strip_prefix("exit_status") {
-                    let v: i64 = rest.trim().parse().unwrap_or(1);
-                    return Some(if v == 0 {
-                        BackendJobStatus::Completed
-                    } else {
-                        BackendJobStatus::Failed
-                    });
-                }
-            }
-            None
+            // qacct emits "<key><padding><value>" pairs, one per line.
+            let field = |key: &str| {
+                text.lines()
+                    .map(str::trim)
+                    .find_map(|l| Some(l.strip_prefix(key)?.trim()))
+                    .filter(|v| !v.is_empty())
+            };
+            let exit_code = field("exit_status").and_then(parse_exit_code)?;
+            Some(TerminalRecord {
+                status: if exit_code == 0 {
+                    BackendJobStatus::Completed
+                } else {
+                    BackendJobStatus::Failed
+                },
+                exit_code: Some(exit_code),
+                elapsed_secs: field("ru_wallclock").and_then(parse_duration_secs),
+                max_rss_mb: field("ru_maxrss").and_then(parse_rss_mb),
+                cpu_seconds: field("cpu").and_then(parse_duration_secs),
+            })
         }
         ClusterBackend::Lsf => {
-            // bacct: "Job <id>, ..., Status <DONE|EXIT|RUN>, ..."
+            // bacct: "Job <id>, ..., Status <DONE|EXIT|RUN>, ...". The
+            // measurement columns vary too much between LSF versions to
+            // parse blind, so this stays state-only.
             if text.contains("Status <DONE>") {
-                Some(BackendJobStatus::Completed)
+                Some(TerminalRecord::status_only(BackendJobStatus::Completed))
             } else if text.contains("Status <EXIT>") {
-                Some(BackendJobStatus::Failed)
+                Some(TerminalRecord::status_only(BackendJobStatus::Failed))
             } else {
                 None
             }
         }
     }
+}
+
+/// Parse `sacct --format=JobID,State,ExitCode,Elapsed,MaxRSS,TotalCPU`.
+///
+/// A job is several rows: the allocation itself, plus `.batch`, `.extern`,
+/// and one per step. State and exit code come from the allocation row, but
+/// `MaxRSS` is only populated on the step rows, so peak memory is the max
+/// over every row — reading the first row alone (as this did) always
+/// reported no memory at all.
+fn parse_sacct(text: &str) -> Option<TerminalRecord> {
+    let rows: Vec<Vec<&str>> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with("JobID") && !l.starts_with('-'))
+        .map(accounting_columns)
+        .collect();
+    let allocation = rows.first()?;
+    let state = allocation.get(1)?.trim();
+    // The same state vocabulary the live poller maps in `parse_status_line`:
+    // a job must not settle as Failed through one path and Unknown through
+    // the other depending on whether squeue still had it.
+    let status = match state.split_whitespace().next().unwrap_or(state) {
+        "COMPLETED" => BackendJobStatus::Completed,
+        "FAILED" | "TIMEOUT" | "OUT_OF_MEMORY" | "NODE_FAIL" | "BOOT_FAIL" => {
+            BackendJobStatus::Failed
+        }
+        // "CANCELLED by <uid>" / "PREEMPTED" — sacct appends the reason.
+        "CANCELLED" | "PREEMPTED" => BackendJobStatus::Cancelled,
+        _ => return None,
+    };
+    let max_rss_mb = rows
+        .iter()
+        .filter_map(|r| r.get(4).copied().and_then(parse_rss_mb))
+        .max();
+    // TotalCPU is likewise per-step; the allocation row leaves it blank.
+    let cpu_seconds = rows
+        .iter()
+        .filter_map(|r| r.get(5).copied().and_then(parse_duration_secs))
+        .max();
+    Some(TerminalRecord {
+        status,
+        exit_code: allocation.get(2).copied().and_then(parse_exit_code),
+        elapsed_secs: allocation.get(3).copied().and_then(parse_duration_secs),
+        max_rss_mb,
+        cpu_seconds,
+    })
 }
 
 #[cfg(test)]
@@ -598,44 +734,160 @@ mod accounting_tests {
 
     #[test]
     fn parses_sacct_terminal_lines() {
-        // Arrange — real sacct --format=JobID,State,ExitCode,Elapsed,MaxRSS
+        // Arrange — real sacct
+        // --format=JobID,State,ExitCode,Elapsed,MaxRSS,TotalCPU
         // (State is the second column in that format order).
-        let text = "JobID    State      ExitCode     Elapsed    MaxRSS\n\
------------- ---------- -------- ---------- ----------\n\
-12345    COMPLETED      0:0        00:01:22    128.2M\n";
+        let text = "JobID    State      ExitCode     Elapsed    MaxRSS  TotalCPU\n\
+------------ ---------- -------- ---------- ---------- ----------\n\
+12345    COMPLETED      0:0        00:01:22    128.2M   00:02:44\n";
 
         // Act / Assert
         assert_eq!(
             parse_accounting(&ClusterBackend::Slurm, text),
-            Some(BackendJobStatus::Completed)
+            Some(TerminalRecord {
+                status: BackendJobStatus::Completed,
+                exit_code: Some(0),
+                elapsed_secs: Some(82),
+                max_rss_mb: Some(128),
+                cpu_seconds: Some(164),
+            })
         );
-        let failed = text.replace("COMPLETED", "FAILED");
+        // A non-zero exit and a multi-day walltime, written out rather than
+        // substituted: "0:0" is a substring of "00:01:22".
+        let failed = "JobID    State      ExitCode     Elapsed    MaxRSS  TotalCPU\n\
+------------ ---------- -------- ---------- ---------- ----------\n\
+12345    FAILED         7:0        1-02:00:00  128.2M   00:02:44\n";
         assert_eq!(
-            parse_accounting(&ClusterBackend::Slurm, &failed),
-            Some(BackendJobStatus::Failed)
+            parse_accounting(&ClusterBackend::Slurm, failed),
+            Some(TerminalRecord {
+                status: BackendJobStatus::Failed,
+                exit_code: Some(7),
+                elapsed_secs: Some(93_600),
+                max_rss_mb: Some(128),
+                cpu_seconds: Some(164),
+            })
         );
         // The mock scheduler pipes the same columns.
-        let piped = "JobID|State|ExitCode|Elapsed|MaxRSS\n12345|COMPLETED|0:0|00:00:05|1234K\n";
+        let piped = "JobID|State|ExitCode|Elapsed|MaxRSS|TotalCPU\n\
+12345|COMPLETED|0:0|00:00:05|1234K|00:00:04\n";
         assert_eq!(
             parse_accounting(&ClusterBackend::Slurm, piped),
-            Some(BackendJobStatus::Completed)
+            Some(TerminalRecord {
+                status: BackendJobStatus::Completed,
+                exit_code: Some(0),
+                elapsed_secs: Some(5),
+                max_rss_mb: Some(1),
+                cpu_seconds: Some(4),
+            })
         );
     }
 
     #[test]
+    fn sacct_max_rss_comes_from_the_step_rows() {
+        // Arrange — real sacct reports MaxRSS only on the step rows; the
+        // allocation row leaves it blank. Reading the first row alone (what
+        // this did) always reported no memory at all.
+        let text = "JobID|State|ExitCode|Elapsed|MaxRSS|TotalCPU\n\
+12345|COMPLETED|0:0|00:01:00||\n\
+12345.batch|COMPLETED|0:0|00:01:00|2G|00:00:30\n\
+12345.extern|COMPLETED|0:0|00:01:00|4K|00:00:00\n";
+
+        // Act
+        let rec = parse_accounting(&ClusterBackend::Slurm, text).unwrap();
+
+        // Assert — state and exit code from the allocation row, peak memory
+        // as the max over every row (not the first, and not the last).
+        assert_eq!(rec.status, BackendJobStatus::Completed);
+        assert_eq!(rec.elapsed_secs, Some(60));
+        assert_eq!(rec.max_rss_mb, Some(2048));
+    }
+
+    #[test]
+    fn sacct_states_match_the_live_poller() {
+        // A job must settle the same way whether squeue still had it or it
+        // had to come from sacct — same vocabulary, same mapping.
+        let row = |state: &str| format!("12345|{state}|0:0|00:00:05||\n");
+        for state in [
+            "FAILED",
+            "TIMEOUT",
+            "OUT_OF_MEMORY",
+            "NODE_FAIL",
+            "BOOT_FAIL",
+        ] {
+            let rec = parse_accounting(&ClusterBackend::Slurm, &row(state)).unwrap();
+            assert_eq!(rec.status, BackendJobStatus::Failed, "{state}");
+        }
+        for state in ["CANCELLED by 1001", "PREEMPTED"] {
+            let rec = parse_accounting(&ClusterBackend::Slurm, &row(state)).unwrap();
+            assert_eq!(rec.status, BackendJobStatus::Cancelled, "{state}");
+        }
+        // Non-terminal states keep the job in flight.
+        for state in ["RUNNING", "PENDING"] {
+            assert_eq!(parse_accounting(&ClusterBackend::Slurm, &row(state)), None);
+        }
+    }
+
+    #[test]
+    fn sacct_signalled_job_does_not_report_a_clean_exit() {
+        // Arrange — an OOM kill reports exit component 0 with signal 9.
+        // Reading only the exit component records a kill as success.
+        let text = "JobID|State|ExitCode|Elapsed|MaxRSS|TotalCPU\n\
+12345|OUT_OF_MEMORY|0:9|00:00:30|32000M|00:00:25\n";
+
+        // Act
+        let rec = parse_accounting(&ClusterBackend::Slurm, text).unwrap();
+
+        // Assert — the shell's 128 + signum, and a failed state.
+        assert_eq!(rec.status, BackendJobStatus::Failed);
+        assert_eq!(rec.exit_code, Some(137));
+    }
+
+    #[test]
+    fn parses_scheduler_durations_and_memory_figures() {
+        // Arrange / Act / Assert — the formats these four stores emit.
+        assert_eq!(parse_duration_secs("00:00:05"), Some(5));
+        assert_eq!(parse_duration_secs("01:02:03"), Some(3723));
+        assert_eq!(parse_duration_secs("2-00:00:00"), Some(172_800));
+        assert_eq!(parse_duration_secs("04:30"), Some(270));
+        assert_eq!(parse_duration_secs("82"), Some(82));
+        // SLURM TotalCPU carries sub-second precision; it truncates.
+        assert_eq!(parse_duration_secs("00:00:04.500"), Some(4));
+        assert_eq!(parse_duration_secs(""), None);
+        assert_eq!(parse_duration_secs("UNLIMITED"), None);
+
+        assert_eq!(parse_rss_mb("1048576K"), Some(1024));
+        assert_eq!(parse_rss_mb("128.2M"), Some(128));
+        assert_eq!(parse_rss_mb("2G"), Some(2048));
+        // SLURM's per-node / per-core suffixes.
+        assert_eq!(parse_rss_mb("512Mn"), Some(512));
+        // PBS writes kilobytes with a unit; SGE's ru_maxrss is bare KB.
+        assert_eq!(parse_rss_mb("2048kb"), Some(2));
+        assert_eq!(parse_rss_mb("4096"), Some(4));
+        assert_eq!(parse_rss_mb(""), None);
+        assert_eq!(parse_rss_mb("0"), None);
+    }
+
+    #[test]
     fn parses_pbs_qstat_x_terminal_blocks() {
-        // Arrange — qstat -x -f job block
-        let ok =
-            "Job Id: 12345.vm\n    Job_Name = fastqc\n    job_state = C\n    Exit_status = 0\n";
+        // Arrange — qstat -x -f job block with the resources_used fields a
+        // completed job carries.
+        let ok = "Job Id: 12345.vm\n    Job_Name = fastqc\n    job_state = C\n    \
+Exit_status = 0\n    resources_used.walltime = 00:02:00\n    \
+resources_used.mem = 65536kb\n    resources_used.cput = 00:03:30\n";
         assert_eq!(
             parse_accounting(&ClusterBackend::Pbs, ok),
-            Some(BackendJobStatus::Completed)
+            Some(TerminalRecord {
+                status: BackendJobStatus::Completed,
+                exit_code: Some(0),
+                elapsed_secs: Some(120),
+                max_rss_mb: Some(64),
+                cpu_seconds: Some(210),
+            })
         );
         let bad = ok.replace("Exit_status = 0", "Exit_status = 1");
-        assert_eq!(
-            parse_accounting(&ClusterBackend::Pbs, &bad),
-            Some(BackendJobStatus::Failed)
-        );
+        let rec = parse_accounting(&ClusterBackend::Pbs, &bad).unwrap();
+        assert_eq!(rec.status, BackendJobStatus::Failed);
+        assert_eq!(rec.exit_code, Some(1));
         // Still running: no terminal state.
         let running = ok.replace("job_state = C", "job_state = R");
         assert_eq!(parse_accounting(&ClusterBackend::Pbs, &running), None);
@@ -644,30 +896,38 @@ mod accounting_tests {
     #[test]
     fn parses_qacct_exit_status() {
         // Arrange — qacct -j output
-        let ok = "qname        all.q\njobnumber    12345\nexit_status  0\nru_wallclock 82\n";
+        let ok = "qname        all.q\njobnumber    12345\nexit_status  0\n\
+ru_wallclock 82\nru_maxrss    262144\ncpu          164\n";
         assert_eq!(
             parse_accounting(&ClusterBackend::Sge, ok),
-            Some(BackendJobStatus::Completed)
+            Some(TerminalRecord {
+                status: BackendJobStatus::Completed,
+                exit_code: Some(0),
+                elapsed_secs: Some(82),
+                max_rss_mb: Some(256),
+                cpu_seconds: Some(164),
+            })
         );
         let bad = ok.replace("exit_status  0", "exit_status  137");
-        assert_eq!(
-            parse_accounting(&ClusterBackend::Sge, &bad),
-            Some(BackendJobStatus::Failed)
-        );
+        let rec = parse_accounting(&ClusterBackend::Sge, &bad).unwrap();
+        assert_eq!(rec.status, BackendJobStatus::Failed);
+        assert_eq!(rec.exit_code, Some(137));
     }
 
     #[test]
     fn parses_bacct_status_lines() {
-        // Arrange — bacct output carries a Status <...> line
+        // Arrange — bacct output carries a Status <...> line. LSF's
+        // measurement columns vary between versions, so this backend stays
+        // state-only rather than guessing.
         let done = "Job <12345>, User <bioinf>, Status <DONE>, Queue <normal>, Command <fastqc>\n";
         assert_eq!(
             parse_accounting(&ClusterBackend::Lsf, done),
-            Some(BackendJobStatus::Completed)
+            Some(TerminalRecord::status_only(BackendJobStatus::Completed))
         );
         let exited = done.replace("DONE", "EXIT");
         assert_eq!(
             parse_accounting(&ClusterBackend::Lsf, &exited),
-            Some(BackendJobStatus::Failed)
+            Some(TerminalRecord::status_only(BackendJobStatus::Failed))
         );
         let running = done.replace("Status <DONE>", "Status <RUN>");
         assert_eq!(parse_accounting(&ClusterBackend::Lsf, &running), None);

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -6,7 +6,7 @@
 //! [`JobRecord`]s — the same record type the local executor produces, so
 //! checkpoint semantics are identical.
 
-use super::{BackendJobStatus, ExecutorBackend, ScheduledPlan, ScheduledRule};
+use super::{BackendJobStatus, ExecutorBackend, ScheduledPlan, ScheduledRule, TerminalRecord};
 use crate::error::{OxoFlowError, Result};
 use crate::executor::{JobRecord, JobStatus};
 use chrono::{DateTime, Utc};
@@ -607,12 +607,14 @@ impl BackendDriver {
                     .collect();
                 probes.sort();
                 probes.dedup();
+                let mut accounting: HashMap<String, TerminalRecord> = HashMap::new();
                 for probe in probes {
-                    if let Some(st) = self.backend.terminal_status(&probe).await
-                        && st != BackendJobStatus::Unknown
+                    if let Some(rec) = self.backend.terminal_status(&probe).await
+                        && rec.status != BackendJobStatus::Unknown
                     {
                         if direct {
-                            statuses.insert(probe, st);
+                            statuses.insert(probe.clone(), rec.status);
+                            accounting.insert(probe, rec);
                         } else {
                             // Base verdict expands to every element of the
                             // array (per-element accounting fidelity stays
@@ -620,7 +622,8 @@ impl BackendDriver {
                             for (id, f) in &inflight {
                                 let target = f.array_base.as_deref().unwrap_or(id);
                                 if target == probe {
-                                    statuses.insert(id.clone(), st);
+                                    statuses.insert(id.clone(), rec.status);
+                                    accounting.insert(id.clone(), rec);
                                 }
                             }
                         }
@@ -636,8 +639,45 @@ impl BackendDriver {
                     })
                     .collect();
                 settled_this_round = settled.len();
+                // Jobs the live poller settled have no accounting yet: the
+                // poller reports the state, the store reports what the job
+                // cost. One lookup per job as it finishes, not per poll.
+                for (job_id, f, _) in &settled {
+                    if accounting.contains_key(job_id) {
+                        continue;
+                    }
+                    // On backends whose accounting store never knew the
+                    // element ids, the array base is the only key that
+                    // resolves.
+                    let probe = if direct {
+                        job_id.as_str()
+                    } else {
+                        f.array_base.as_deref().unwrap_or(job_id)
+                    };
+                    if let Some(rec) = self.backend.terminal_status(probe).await {
+                        accounting.insert(job_id.clone(), rec);
+                    }
+                }
+                // When the driver NOTICED the job was terminal, which is not
+                // when the job ended: a poll interval, plus the accounting
+                // grace period for jobs that vanished from the live queue,
+                // can sit in between. One instant for the whole batch keeps
+                // `started_at`, `finished_at`, and `queue_wait_secs`
+                // consistent with each other instead of drifting apart by
+                // however long the writes took.
+                let observed_at = Utc::now();
                 for (job_id, f, status) in settled {
                     inflight.remove(&job_id);
+                    let acct = accounting.get(&job_id).copied();
+                    // The driver only ever sees submit-to-settle. When the
+                    // store reports how long the job RAN, the start time is
+                    // recomputed from it so `benchmarks.wall_time_secs`
+                    // stops silently including queue wait.
+                    let started_at = acct
+                        .and_then(|a| a.elapsed_secs)
+                        .and_then(|s| i64::try_from(s).ok())
+                        .and_then(|s| observed_at.checked_sub_signed(chrono::Duration::seconds(s)))
+                        .unwrap_or(f.submitted_at);
                     let record = match status {
                         BackendJobStatus::Completed => {
                             // Checkpoint re-entry (P3): new instances merge
@@ -682,18 +722,20 @@ impl BackendDriver {
                                     }
                                 }
                             }
-                            write_status(
+                            write_status_full(
                                 &opts.run_dir.join("jobs").join(sanitize(&f.rule)),
                                 &job_id,
                                 &plan.rules[&f.rule].shell_cmd,
                                 "COMPLETED",
+                                Some((f.submitted_at, observed_at)),
+                                acct,
                             )?;
                             JobRecord {
                                 rule: f.rule.clone(),
                                 status: JobStatus::Success,
-                                started_at: Some(f.submitted_at),
-                                finished_at: Some(Utc::now()),
-                                exit_code: Some(0),
+                                started_at: Some(started_at),
+                                finished_at: Some(observed_at),
+                                exit_code: Some(acct.and_then(|a| a.exit_code).unwrap_or(0)),
                                 stdout: None,
                                 stderr: None,
                                 command: Some(crate::executor::process::mask_sensitive(
@@ -703,23 +745,28 @@ impl BackendDriver {
                                 retries: 0,
                                 timeout: None,
                                 skip_reason: None,
-                                max_rss_mb: None,
-                                cpu_seconds: None,
+                                max_rss_mb: acct.and_then(|a| a.max_rss_mb),
+                                cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
                             }
                         }
                         BackendJobStatus::Failed => {
-                            write_status(
+                            write_status_full(
                                 &opts.run_dir.join("jobs").join(sanitize(&f.rule)),
                                 &job_id,
                                 "",
                                 "FAILED",
+                                Some((f.submitted_at, observed_at)),
+                                acct,
                             )?;
                             JobRecord {
                                 rule: f.rule.clone(),
                                 status: JobStatus::Failed,
-                                started_at: Some(f.submitted_at),
-                                finished_at: Some(Utc::now()),
-                                exit_code: Some(1),
+                                started_at: Some(started_at),
+                                finished_at: Some(observed_at),
+                                // Without accounting the code is unknown, not
+                                // 1: reporting a rule that exited 7 as 1 is a
+                                // wrong answer where none was available.
+                                exit_code: acct.and_then(|a| a.exit_code),
                                 stdout: None,
                                 stderr: None,
                                 command: Some(crate::executor::process::mask_sensitive(
@@ -729,16 +776,16 @@ impl BackendDriver {
                                 retries: 0,
                                 timeout: None,
                                 skip_reason: None,
-                                max_rss_mb: None,
-                                cpu_seconds: None,
+                                max_rss_mb: acct.and_then(|a| a.max_rss_mb),
+                                cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
                             }
                         }
                         BackendJobStatus::Cancelled => JobRecord {
                             rule: f.rule.clone(),
                             status: JobStatus::Cancelled,
-                            started_at: Some(f.submitted_at),
-                            finished_at: Some(Utc::now()),
-                            exit_code: None,
+                            started_at: Some(started_at),
+                            finished_at: Some(observed_at),
+                            exit_code: acct.and_then(|a| a.exit_code),
                             stdout: None,
                             stderr: None,
                             command: Some(crate::executor::process::mask_sensitive(
@@ -748,8 +795,8 @@ impl BackendDriver {
                             retries: 0,
                             timeout: None,
                             skip_reason: Some("cancelled".into()),
-                            max_rss_mb: None,
-                            cpu_seconds: None,
+                            max_rss_mb: acct.and_then(|a| a.max_rss_mb),
+                            cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
                         },
                         _ => unreachable!("non-terminal states filtered above"),
                     };
@@ -838,23 +885,82 @@ fn record_t(status: &JobStatus) -> &'static str {
     }
 }
 
+/// Append one event to `events.jsonl`.
+///
+/// Every line carries an RFC 3339 `ts`. Ordering alone cannot answer the
+/// questions the log exists for — how long a job waited in the queue, where
+/// a run's wall-clock actually went, what was in flight when the driver
+/// died — and the timestamp has to be written at emit time because nothing
+/// downstream can reconstruct it afterwards.
 fn emit(events: &mut std::fs::File, t: &str, rule: &str, job: Option<&str>, reason: Option<&str>) {
+    let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     let line = match (job, reason) {
         (Some(j), Some(r)) => {
-            format!(r#"{{"t":"{t}","rule":{rule:?},"job":{j:?},"reason":{r:?}}}"#)
+            format!(r#"{{"ts":"{ts}","t":"{t}","rule":{rule:?},"job":{j:?},"reason":{r:?}}}"#)
         }
-        (Some(j), None) => format!(r#"{{"t":"{t}","rule":{rule:?},"job":{j:?}}}"#),
-        (None, Some(r)) => format!(r#"{{"t":"{t}","rule":{rule:?},"reason":{r:?}}}"#),
-        (None, None) => format!(r#"{{"t":"{t}","rule":{rule:?}}}"#),
+        (Some(j), None) => format!(r#"{{"ts":"{ts}","t":"{t}","rule":{rule:?},"job":{j:?}}}"#),
+        (None, Some(r)) => format!(r#"{{"ts":"{ts}","t":"{t}","rule":{rule:?},"reason":{r:?}}}"#),
+        (None, None) => format!(r#"{{"ts":"{ts}","t":"{t}","rule":{rule:?}}}"#),
     };
     let _ = writeln!(events, "{line}");
 }
 
 fn write_status(job_dir: &Path, job_id: &str, command: &str, state: &str) -> Result<()> {
+    write_status_full(job_dir, job_id, command, state, None, None)
+}
+
+/// Write `jobs/<instance>/status.json`.
+///
+/// Terminal writes carry the accounting record plus the submit and
+/// observation timestamps, so the file answers on its own what the job cost.
+/// `queue_wait_secs` is derived here rather than left to the reader: it is
+/// submit-to-observed minus the scheduler's `Elapsed`, and that subtraction
+/// is the only way to separate time spent waiting from time spent running —
+/// the driver never sees the moment a job starts. It is an upper bound: the
+/// poll interval and the accounting grace period both land inside it.
+fn write_status_full(
+    job_dir: &Path,
+    job_id: &str,
+    command: &str,
+    state: &str,
+    times: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    acct: Option<TerminalRecord>,
+) -> Result<()> {
     std::fs::create_dir_all(job_dir).map_err(|e| OxoFlowError::Config {
         message: format!("cannot create {}: {e}", job_dir.display()),
     })?;
-    let body = format!(r#"{{"state":{state:?},"job_id":{job_id:?},"command":{command:?}}}"#);
+    let mut fields = vec![
+        format!(r#""state":{state:?}"#),
+        format!(r#""job_id":{job_id:?}"#),
+        format!(r#""command":{command:?}"#),
+    ];
+    if let Some((submitted, observed)) = times {
+        let fmt = |t: DateTime<Utc>| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        fields.push(format!(r#""submitted_at":"{}""#, fmt(submitted)));
+        fields.push(format!(r#""finished_at":"{}""#, fmt(observed)));
+        if let Some(elapsed) = acct.and_then(|a| a.elapsed_secs) {
+            let wait = (observed - submitted)
+                .num_seconds()
+                .saturating_sub(elapsed as i64)
+                .max(0);
+            fields.push(format!(r#""queue_wait_secs":{wait}"#));
+        }
+    }
+    if let Some(a) = acct {
+        if let Some(code) = a.exit_code {
+            fields.push(format!(r#""exit_code":{code}"#));
+        }
+        if let Some(secs) = a.elapsed_secs {
+            fields.push(format!(r#""elapsed_secs":{secs}"#));
+        }
+        if let Some(mb) = a.max_rss_mb {
+            fields.push(format!(r#""max_rss_mb":{mb}"#));
+        }
+        if let Some(secs) = a.cpu_seconds {
+            fields.push(format!(r#""cpu_seconds":{secs}"#));
+        }
+    }
+    let body = format!("{{{}}}", fields.join(","));
     std::fs::write(job_dir.join("status.json"), body).map_err(|e| OxoFlowError::Config {
         message: format!("cannot write status.json: {e}"),
     })

--- a/crates/oxo-flow-core/src/backend/mod.rs
+++ b/crates/oxo-flow-core/src/backend/mod.rs
@@ -18,7 +18,7 @@ pub mod cluster;
 pub mod driver;
 
 /// Scheduler-agnostic job state, mapped from each backend's native codes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BackendJobStatus {
     /// Queued, waiting to start.
     Pending,
@@ -31,7 +31,45 @@ pub enum BackendJobStatus {
     /// Cancelled by the driver or a user.
     Cancelled,
     /// Status could not be determined.
+    #[default]
     Unknown,
+}
+
+/// What a scheduler's accounting store knows about a job that has left the
+/// live queue: the terminal state, plus whatever the store measured.
+///
+/// Everything but `status` is optional on purpose. Accounting is a per-site
+/// deployment choice — a SLURM cluster without `slurmdbd` answers `sacct`
+/// with nothing, and PBS/SGE/LSF each expose a different subset — so a
+/// backend reports what it can prove and leaves the rest `None` rather than
+/// inventing a number that would land in a checkpoint as fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TerminalRecord {
+    /// Terminal state, mapped from the store's native vocabulary.
+    pub status: BackendJobStatus,
+    /// Process exit code. A job killed by a signal reports the shell's
+    /// `128 + signum` rather than the exit component, which is `0` for a
+    /// signalled job and would otherwise read as success.
+    pub exit_code: Option<i32>,
+    /// Wall-clock seconds the job spent RUNNING, excluding queue wait.
+    /// Separating the two is the whole point of reading accounting: the
+    /// driver only ever observes submit-to-settle, which on a busy queue is
+    /// mostly waiting.
+    pub elapsed_secs: Option<u64>,
+    /// Peak resident set size over every step of the job, in MB.
+    pub max_rss_mb: Option<u64>,
+    /// Total CPU seconds consumed across all cores.
+    pub cpu_seconds: Option<u64>,
+}
+
+impl TerminalRecord {
+    /// A record from a store that reports state and nothing else.
+    pub fn status_only(status: BackendJobStatus) -> Self {
+        Self {
+            status,
+            ..Self::default()
+        }
+    }
 }
 
 /// Maps a static plan onto a scheduler API.
@@ -75,11 +113,11 @@ pub trait ExecutorBackend: Send + Sync {
     /// Fetch job logs / accounting output (raw text).
     async fn logs(&self, job_id: &str) -> Result<String>;
 
-    /// Terminal status of a job that has left the live queue, read from the
+    /// Terminal record for a job that has left the live queue, read from the
     /// scheduler's accounting store. `None` means "no terminal record" —
     /// the driver keeps the job in flight. Backends without an accounting
     /// store keep the default and rely on their poller.
-    async fn terminal_status(&self, _job_id: &str) -> Option<BackendJobStatus> {
+    async fn terminal_status(&self, _job_id: &str) -> Option<TerminalRecord> {
         None
     }
 

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -134,17 +134,21 @@ pub struct BenchmarkRecord {
     pub rule: String,
     /// Wall-clock time in seconds.
     pub wall_time_secs: f64,
-    /// Sampled peak RSS in megabytes (issue #67 §4; `None` for cluster
-    /// executors and legacy checkpoints).
+    /// Peak RSS in megabytes (issue #67 §4) — sampled by the local
+    /// executor, read from the scheduler's accounting store on the cluster
+    /// path. `None` for legacy checkpoints and whenever the source did not
+    /// report it.
     pub max_memory_mb: Option<u64>,
     /// The rule's declared memory limit in megabytes (`effective_memory()`
     /// resolved at execution time) — the "limit" side of bottleneck
     /// detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_limit_mb: Option<u64>,
-    /// Sampled CPU time of the rule's process in seconds (all its
-    /// threads; child processes are not accumulated; issue #83 P1-13;
-    /// `None` for cluster executors and legacy checkpoints).
+    /// CPU time in seconds — sampled from the rule's own process by the
+    /// local executor (all its threads; child processes are not
+    /// accumulated; issue #83 P1-13), reported by the accounting store on
+    /// the cluster path, where it DOES span every step of the job. `None`
+    /// for legacy checkpoints and whenever the source did not report it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_seconds: Option<f64>,
     /// Number of retry attempts before success (0 = first attempt succeeded).

--- a/crates/oxo-flow-core/src/report.rs
+++ b/crates/oxo-flow-core/src/report.rs
@@ -1980,9 +1980,10 @@ impl ReportSectionGenerator for ExecutionStatusGenerator {
             });
         }
 
-        // Sampled CPU seconds (issue #83 P1-13): measured per sampler tick
-        // for local rules, so the column is honest now — `-` only where no
-        // sampler ever ran (cluster executors, legacy checkpoints).
+        // CPU seconds (issue #83 P1-13): sampled per tick for local rules,
+        // read from the scheduler's accounting store for cluster ones, so
+        // the column is honest now — `-` only where neither source reported
+        // a number (LSF, legacy checkpoints).
         let mut bench_names: Vec<&String> = cp.benchmarks.keys().collect();
         bench_names.sort_unstable();
         let mut bench_rows: Vec<Vec<String>> = Vec::new();

--- a/docs/guide/src/commands/report.md
+++ b/docs/guide/src/commands/report.md
@@ -355,12 +355,17 @@ a hard error — silently dropping a column would fake a complete table.
 
 ### Benchmarks CPU column
 
-The **Benchmarks** table's CPU column shows **sampled** CPU seconds: the
-executor's sampler reads each rule process's CPU time (all its threads) at
-200 ms ticks — child processes are not accumulated. `-` means the sampler
-never observed the process: very short rules, cluster executors, or legacy
-checkpoints written before sampling existed. Peak memory is sampled the
-same way.
+On **local** runs the **Benchmarks** table's CPU column shows **sampled**
+CPU seconds: the executor's sampler reads each rule process's CPU time (all
+its threads) at 200 ms ticks — child processes are not accumulated. Peak
+memory is sampled the same way.
+
+On **cluster** runs both columns come from the scheduler's accounting store
+instead, read once as each job settles, and cover every step of the job.
+
+`-` means neither source reported a number: very short local rules the
+sampler never observed, LSF, a cluster job whose accounting row never
+appeared, or legacy checkpoints written before sampling existed.
 
 ### Domain auto-detection
 

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -368,10 +368,55 @@ Each run leaves a directory you can navigate with ordinary tools:
 ```console
 .oxo-flow/runs/2026-08-17T14-30-05/   # `latest` symlinks to the newest
   events.jsonl                        # append-only submit/complete/fail log
+  index.json                          # array index → instance name
   jobs/<rule>/job.sh                  # the exact script submitted
   jobs/<rule>/job.id                  # scheduler job id
   jobs/<rule>/status.json
 ```
+
+Every `events.jsonl` line carries an RFC 3339 `ts`, so the log reconstructs
+a timeline rather than just an ordering:
+
+```json
+{"ts":"2026-08-17T14:30:05.114Z","t":"SUBMITTED","rule":"align_S1","job":"4812345"}
+{"ts":"2026-08-17T15:02:44.907Z","t":"COMPLETED","rule":"align_S1","job":"4812345"}
+```
+
+### What a finished job records
+
+When a job leaves the queue, oxo-flow reads the scheduler's accounting store
+(`sacct`, `qstat -x -f`, `qacct`, `bacct`) and writes what it found into
+`status.json`:
+
+```json
+{
+  "state": "COMPLETED",
+  "job_id": "4812345",
+  "command": "bwa mem ref.fa data/S1.fq > aln/S1.bam",
+  "submitted_at": "2026-08-17T14:30:05.114Z",
+  "finished_at": "2026-08-17T15:02:44.907Z",
+  "queue_wait_secs": 65,
+  "exit_code": 0,
+  "elapsed_secs": 1894,
+  "max_rss_mb": 24680,
+  "cpu_seconds": 14203
+}
+```
+
+`queue_wait_secs` is submit-to-finish minus the scheduler's own elapsed
+time — the driver never observes the moment a job starts, so the split
+between waiting and working is only available by subtraction. The same
+`elapsed_secs` is what `benchmarks.wall_time_secs` records in the
+checkpoint, which therefore measures runtime rather than runtime plus queue
+wait, and `max_rss_mb` / `cpu_seconds` populate the same benchmark fields a
+local run fills from its own sampler.
+
+How much of this appears depends on the site. Accounting is a deployment
+choice: a SLURM cluster without `slurmdbd` answers `sacct` with nothing, and
+LSF's `bacct` columns vary too much between versions to parse blind, so LSF
+records state only. Fields the store did not report are omitted rather than
+guessed — including `exit_code`, which stays absent for a failed job whose
+real code could not be read, instead of defaulting to `1`.
 
 Outputs, the working directory, and logs are assumed to live on storage
 shared between the submitting host and the compute nodes.

--- a/docs/guide/src/reference/execution-backends.md
+++ b/docs/guide/src/reference/execution-backends.md
@@ -102,8 +102,17 @@ the cluster path runs. `tests/cluster_run_profile.rs` pins that combination to
 what the local executor actually executes from identical state.
 
 Real-cluster validation (SLURM scheduler matrix, version quirks) is tracked
-in the cluster testing checklist; job arrays, re-attach to in-flight jobs, and
-`sacct`-based resource feedback are follow-ups.
+in the cluster testing checklist; job arrays and accounting-backed resource
+feedback have landed, re-attach to in-flight jobs is a follow-up.
+
+Accounting is read once per job as it settles, not once per poll, and feeds
+both the run directory and the checkpoint benchmarks — see
+[what a finished job records](../commands/run.md#what-a-finished-job-records).
+Backends report only what their store proves: SLURM reads exit code, elapsed
+time, peak RSS and total CPU from `sacct` (peak memory comes from the step
+rows, which is where SLURM puts it — the allocation row leaves it blank), PBS
+and SGE report the equivalent `resources_used` / `ru_*` fields, and LSF
+reports state alone.
 
 ## Assumptions
 

--- a/docs/guide/src/reference/reporting-system.md
+++ b/docs/guide/src/reference/reporting-system.md
@@ -249,14 +249,23 @@ names) are both hidden when they have no data.
 
 ### Benchmarks honesty
 
-The Benchmarks table's CPU column reports **sampled** CPU seconds: the
-executor's sampler reads each rule process's CPU time (all its threads) at
-200 ms ticks; child processes are not accumulated. `-` means the sampler
-never observed the process (very short rules, cluster executors, legacy
-checkpoints). Peak memory is sampled peak RSS over the same ticks. The
-values are measurements of a live process, not scheduler allocations, so
-they are documented — here and in the `report` command reference — as
-sampled rather than exact.
+The Benchmarks table's CPU column reports CPU seconds from whichever
+source ran the rule, and the two differ:
+
+- **Local runs** report **sampled** CPU seconds — the executor's sampler
+  reads each rule process's CPU time (all its threads) at 200 ms ticks;
+  child processes are not accumulated. Peak memory is sampled peak RSS over
+  the same ticks. These are measurements of a live process, not scheduler
+  allocations, so they are documented — here and in the `report` command
+  reference — as sampled rather than exact.
+- **Cluster runs** report what the scheduler's own accounting store
+  recorded (`sacct`/`qstat -f`/`qacct`), read once as each job settles.
+  That figure spans every step of the job rather than one sampled process.
+
+`-` means neither source reported a number: very short local rules the
+sampler never observed, LSF (whose `bacct` columns vary too much between
+versions to parse blind), a cluster job whose accounting row never
+appeared, or legacy checkpoints.
 
 ## See Also
 

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -45,10 +45,55 @@ shell = "wc -l aln/{sample}.bam > stats/{sample}.txt"
 
 fn write_workflow(dir: &Path) {
     std::fs::write(dir.join("wf.oxoflow"), WORKFLOW).unwrap();
+    write_samples(dir);
+}
+
+fn write_samples(dir: &Path) {
     for s in ["S1", "S2", "S3"] {
         let data = dir.join("data");
         std::fs::create_dir_all(&data).unwrap();
         std::fs::write(data.join(format!("{s}.fq")), format!(">{s}\nACGT\n")).unwrap();
+    }
+}
+
+/// A single-rule workflow whose shell exits with `code`.
+fn write_failing_workflow(dir: &Path, code: i32) {
+    let wf = format!(
+        r#"
+[workflow]
+name = "fail"
+version = "0.1.0"
+
+[config]
+sample_pattern = "data/{{sample}}.fq"
+
+[[rules]]
+name = "align"
+input = ["data/{{sample}}.fq"]
+output = ["aln/{{sample}}.bam"]
+shell = "exit {code}"
+"#
+    );
+    std::fs::write(dir.join("wf.oxoflow"), wf).unwrap();
+    write_samples(dir);
+}
+
+/// The `to_run` set for every rule instance in the workflow.
+fn all_rules(workdir: &Path) -> HashSet<String> {
+    let mut config = WorkflowConfig::from_file(&workdir.join("wf.oxoflow")).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    let dag = WorkflowDag::from_rules(&config.rules).unwrap();
+    dag.execution_order().unwrap().into_iter().collect()
+}
+
+fn fast_driver_config() -> DriverConfig {
+    DriverConfig {
+        max_submitted: 4,
+        max_array_size: 1001,
+        no_arrays: false,
+        poll_interval: std::time::Duration::from_millis(50),
+        poll_timeout: Some(std::time::Duration::from_secs(30)),
     }
 }
 
@@ -497,7 +542,12 @@ async fn cluster_logs_command_uses_mock_sacct() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(out.status.success(), "cluster logs failed: {stderr}");
     assert!(
-        stdout.contains("12345|COMPLETED|0:0|00:00:05|1234K"),
+        stdout.contains("12345|COMPLETED|0:0|00:00:05"),
+        "got: {stdout}"
+    );
+    // The step row is where a real sacct puts MaxRSS / TotalCPU.
+    assert!(
+        stdout.contains("12345.batch|COMPLETED|0:0|00:00:05|1234K|00:00:04"),
         "got: {stdout}"
     );
 
@@ -558,4 +608,98 @@ fn driver_settles_jobs_that_vanish_from_the_live_queue_via_accounting() {
         "{records:?}"
     );
     assert_eq!(records.len(), 6, "align+stats × 3 samples");
+}
+
+#[test]
+fn failed_cluster_job_records_the_scheduler_exit_code() {
+    // A cluster failure used to report exit code 1 whatever the rule did, so
+    // a run that died at `exit 7` was indistinguishable from one that died at
+    // `exit 1`. The accounting store knows the real code — read it.
+    let dir = tempfile::tempdir().unwrap();
+    write_failing_workflow(dir.path(), 7);
+    let state = tempfile::tempdir().unwrap();
+    let run_dir = tempfile::tempdir().unwrap();
+
+    let records = run_driver(
+        dir.path(),
+        run_dir.path(),
+        state.path(),
+        &all_rules(dir.path()),
+        fast_driver_config(),
+    )
+    .expect("driver runs to completion even when every job fails");
+
+    assert!(
+        records.iter().all(|r| r.status == JobStatus::Failed),
+        "{records:?}"
+    );
+    for r in &records {
+        assert_eq!(r.exit_code, Some(7), "{}: {:?}", r.rule, r.exit_code);
+    }
+}
+
+#[test]
+fn run_directory_records_what_each_job_cost() {
+    // Everything a failure report needs has to survive in the run directory:
+    // when each event happened, how long the job ran, how much memory it
+    // took, and how much of the elapsed time was queue wait rather than work.
+    let dir = tempfile::tempdir().unwrap();
+    write_workflow(dir.path());
+    let state = tempfile::tempdir().unwrap();
+    let run_dir = tempfile::tempdir().unwrap();
+
+    let records = run_driver_with_env(
+        dir.path(),
+        run_dir.path(),
+        state.path(),
+        &all_rules(dir.path()),
+        fast_driver_config(),
+        // A memory figure large enough that MB rounding cannot hide a
+        // parsing mistake.
+        &[
+            ("MOCK_SACCT_MAXRSS", "2G"),
+            ("MOCK_SACCT_ELAPSED", "00:00:05"),
+        ],
+    )
+    .expect("driver completes");
+
+    // Records carry the measurements, not None.
+    for r in &records {
+        assert_eq!(r.max_rss_mb, Some(2048), "{}: {:?}", r.rule, r.max_rss_mb);
+        assert_eq!(r.cpu_seconds, Some(4.0), "{}: {:?}", r.rule, r.cpu_seconds);
+        // started_at is recomputed from the scheduler's Elapsed, so the
+        // recorded wall time is the job's RUNTIME — not runtime plus the
+        // time it sat in the queue.
+        let (start, finish) = (r.started_at.unwrap(), r.finished_at.unwrap());
+        let wall = (finish - start).num_seconds();
+        assert!((4..=6).contains(&wall), "{}: wall {wall}s", r.rule);
+    }
+
+    // Every event line is timestamped.
+    let events = std::fs::read_to_string(run_dir.path().join("events.jsonl")).unwrap();
+    assert!(!events.trim().is_empty(), "no events written");
+    for line in events.lines() {
+        let v: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|e| {
+            panic!("event line is not JSON ({e}): {line}");
+        });
+        let ts = v["ts"].as_str().unwrap_or_else(|| panic!("no ts: {line}"));
+        chrono::DateTime::parse_from_rfc3339(ts)
+            .unwrap_or_else(|e| panic!("ts is not RFC 3339 ({e}): {line}"));
+    }
+
+    // status.json is self-contained: state, cost, and the queue/runtime split.
+    let status: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.path().join("jobs/align_batch_S1/status.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status["state"], "COMPLETED");
+    assert_eq!(status["exit_code"], 0);
+    assert_eq!(status["elapsed_secs"], 5);
+    assert_eq!(status["max_rss_mb"], 2048);
+    assert!(status["submitted_at"].is_string(), "{status}");
+    assert!(status["finished_at"].is_string(), "{status}");
+    assert!(
+        status["queue_wait_secs"].is_number(),
+        "queue wait must be derivable from the run dir alone: {status}"
+    );
 }

--- a/tests/cluster_run_profile.rs
+++ b/tests/cluster_run_profile.rs
@@ -176,6 +176,31 @@ fn run_profile_slurm_submits_tracks_and_records() {
     assert_eq!(completed.len(), 4, "checkpoint: {completed:?}");
     assert_eq!(ck["input_manifests"].as_object().unwrap().len(), 4);
 
+    // Benchmarks carry what the scheduler's accounting store reported, not
+    // nulls: the mock sacct answers `1234K` / `00:00:04` on the STEP row,
+    // so a parser that read the allocation row alone would record neither.
+    let benchmarks = ck["benchmarks"].as_object().unwrap();
+    assert_eq!(benchmarks.len(), 4, "benchmarks: {benchmarks:?}");
+    for (name, b) in benchmarks {
+        assert_eq!(
+            b["max_memory_mb"].as_u64(),
+            Some(1),
+            "{name} lost its peak RSS: {b}"
+        );
+        assert_eq!(
+            b["cpu_seconds"].as_f64(),
+            Some(4.0),
+            "{name} lost its CPU: {b}"
+        );
+        // Elapsed is the RUN time sacct reported (5s), so wall time is not
+        // the submit-to-settle span the driver observes.
+        let wall = b["wall_time_secs"].as_f64().unwrap();
+        assert!(
+            (4.0..=6.0).contains(&wall),
+            "{name} wall time {wall} looks like queue wait: {b}"
+        );
+    }
+
     // Report snapshot parity with the local path: the same artifacts a
     // local run leaves, so reporting pipelines cannot tell the two apart.
     let reports = dir.path().join(".oxo-flow/reports");

--- a/tests/fixtures/mock-scheduler/sacct
+++ b/tests/fixtures/mock-scheduler/sacct
@@ -1,5 +1,11 @@
 #!/bin/bash
-# Mock sacct — answers `sacct -j <id> --format=JobID,State,ExitCode,Elapsed,MaxRSS`.
+# Mock sacct — answers
+# `sacct -j <id> --format=JobID,State,ExitCode,Elapsed,MaxRSS,TotalCPU`.
+#
+# Real sacct reports a job as SEVERAL rows: the allocation, then `.batch` and
+# one per step. MaxRSS and TotalCPU are only populated on the step rows, so
+# the shim emits both rows — a parser that reads the allocation row alone
+# sees no memory, exactly as it would against a real cluster.
 set -eu
 dir="${MOCK_SCHEDULER_DIR:?MOCK_SCHEDULER_DIR not set}"
 id=""
@@ -12,5 +18,9 @@ done
 [ -d "$dir/jobs/$id" ] || { echo "slurm_load_jobs error: Invalid job id specified" >&2; exit 1; }
 state=$(cat "$dir/jobs/$id/state")
 code=$(cat "$dir/jobs/$id/exit_code" 2>/dev/null || echo "")
-echo "JobID|State|ExitCode|Elapsed|MaxRSS"
-echo "$id|$state|$code|00:00:05|1234K"
+elapsed="${MOCK_SACCT_ELAPSED:-00:00:05}"
+maxrss="${MOCK_SACCT_MAXRSS:-1234K}"
+totalcpu="${MOCK_SACCT_TOTALCPU:-00:00:04}"
+echo "JobID|State|ExitCode|Elapsed|MaxRSS|TotalCPU"
+echo "$id|$state|$code|$elapsed||"
+echo "$id.batch|$state|$code|$elapsed|$maxrss|$totalcpu"


### PR DESCRIPTION
Follow-on to #74 (the `run --profile` cluster backend, closed) and the cluster-side
counterpart to #163, which landed peak RSS + wall time for the *local* executor
only. Addresses the deferred rows in #67 §4; the checklist itself stays open.

## The problem

A cluster run could not produce a failure report. `JobRecord.exit_code` was
hardcoded to `Some(1)`, so a rule that died at `exit 7` was indistinguishable
from one that died at `exit 1`. `max_rss_mb` and `cpu_seconds` were always
`None`. `events.jsonl` carried an ordering but no clock. And `started_at` was
the submit time, so `benchmarks.wall_time_secs` silently measured queue wait
plus runtime as one number — on a busy queue, mostly the queue wait.

The data was already being requested and thrown away: `ExecutorBackend::logs`
asks `sacct` for `JobID,State,ExitCode,Elapsed,MaxRSS` and `parse_accounting`
read the state out of column 2 and dropped the rest.

## What changed

- `terminal_status` returns a `TerminalRecord` (state + exit code + elapsed +
  peak RSS + total CPU) instead of a bare status. Accounting is read once per
  job as it settles, not once per poll.
- Every `events.jsonl` line carries an RFC 3339 `ts`.
- `status.json` gains `submitted_at` / `finished_at` / `queue_wait_secs` /
  `exit_code` / `elapsed_secs` / `max_rss_mb` / `cpu_seconds`, so the run
  directory answers on its own what a job cost.
- `started_at` is recomputed as observed-minus-elapsed, so recorded wall time
  is runtime rather than runtime plus queue wait. Queue wait becomes its own
  derived field — an upper bound, since the poll interval and the accounting
  grace period both land inside it.
- `record_outcome` stops writing `max_memory_mb: None, cpu_seconds: None`
  behind its "needs sacct polling — phase 4" comment. `report`, `--json`, and
  the web diagnostics' `resource_bottlenecks` now work on cluster runs the way
  they already do locally, with no change needed on the reporting side.

## Three parsing details that only show up against a real scheduler

- SLURM reports a job as several rows and populates `MaxRSS`/`TotalCPU` only on
  the **step** rows, so peak memory is the max over every row. Reading the
  first row alone always reported no memory at all.
- `ExitCode` is `<exit>:<signal>`. A signalled job reports exit `0`, so an OOM
  kill (`0:9`) would have recorded as a clean exit. Signalled jobs now report
  the shell's `128 + signum`.
- `sacct` now maps the same state vocabulary as the live poller, so a job
  settles identically whether or not `squeue` still had it.

## What is deliberately absent

Backends report only what their store proves. Fields the store did not report
are omitted rather than guessed — including a failed job's exit code, which
stays absent when it could not be read instead of defaulting to `1`. LSF stays
state-only: its `bacct` columns vary too much between versions to parse blind.

The docs draw the distinction rather than smoothing it over: locally these
figures are sampled from the rule's own process at 200 ms ticks; on the cluster
they are the store's own figures, spanning every step of the job. `-` in the
Benchmarks table now means neither source reported a number, not "cluster run".

## Interaction with the job-array work

Rebased onto `d6d9bed`. The accounting block collided with the array polling
added since — resolved so both hold: the probe list dedups by array base on
backends whose store never knew the element ids, per element on SLURM, and a
base verdict expands its `TerminalRecord` to every element. Per-element
accounting fidelity stays SLURM-only, which is what `polls_elements_directly`
already asserts.

## Verification

`cargo build --workspace`, `cargo clippy --workspace --all-targets`, and
`cargo fmt --all` are clean. `oxo-flow-core` passes 1181 + 11; the three
cluster suites pass 20/20.

The mock scheduler now emits the two-row shape a real `sacct` does, so the
step-row behaviour is covered in CI rather than only on hardware, and
`run_profile_slurm_submits_tracks_and_records` asserts the benchmarks carry
figures that exist *only* on the step row — a regression back to
allocation-row-only parsing fails there rather than silently reporting nulls.
It also bounds `wall_time_secs`, so wall time reabsorbing queue wait fails too.

**This is mock-scheduler evidence, not hardware evidence.** I have real SLURM
access and #67 §1 is next; I'd rather land the parsing with CI coverage and
report hardware findings into #67 than hold the PR until then. If you'd prefer
it the other way round, say so and I'll keep it open until I have `sacct`
output from a real cohort run.
