### PR TITLE
fix: unbound wildcard keys in when-conditions evaluate false (snparcher live incident)

### DIFF
--- a/crates/oxo-flow-core/src/config.rs
+++ b/crates/oxo-flow-core/src/config.rs
@@ -25,6 +25,11 @@ use std::sync::LazyLock;
 static VALUES_NS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\{values\.(\w+)\}").expect("valid values-namespace regex"));
 
+/// Matches a `wildcard.<key>` reference inside a `when` expression (the
+/// per-instance pair/group binding vocabulary, including metadata keys).
+static WHEN_WILDCARD_REF_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"wildcard\.(\w+)").expect("valid when-wildcard regex"));
+
 fn is_defaults_empty(d: &Defaults) -> bool {
     d.threads.is_none() && d.memory.is_none() && d.environment.is_none()
 }
@@ -2956,7 +2961,8 @@ impl WorkflowConfig {
     ///
     /// Optional pair wildcards (`experiment_type`, `tumor_type`) are filled
     /// with empty strings so `wildcard.experiment_type != ''` predicates see
-    /// a definite value instead of the permissive fallthrough.
+    /// a definite value (missing keys otherwise evaluate false). Metadata
+    /// keys flow in through the combo itself.
     fn expansion_when_context(combo: &crate::wildcard::WildcardValues) -> HashMap<String, String> {
         let mut ctx: HashMap<String, String> =
             combo.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
@@ -2974,6 +2980,71 @@ impl WorkflowConfig {
             ctx.entry(key.to_string()).or_default();
         }
         ctx
+    }
+
+    /// Resolve a kept instance's `when` wildcard references to that
+    /// instance's own bindings, so the execution-time re-check re-evaluates
+    /// the same per-instance verdict without a wildcard context.
+    ///
+    /// - `wildcard.<key>` as a comparison operand → the bound value as a
+    ///   quoted literal (the evaluator compares literals properly).
+    /// - a bare `wildcard.<key>` (truthiness position) → the literal
+    ///   `true`/`false` for the bound value.
+    /// - keys absent from the combo are left untouched: they were
+    ///   non-decisive for a kept instance, and the strict unbound→false
+    ///   semantics at execution mirror the expansion-time verdict.
+    ///
+    /// Without this, the strict missing-key semantics added to the `when`
+    /// evaluator would veto every fan-out instance at execution time (no
+    /// pair/group context exists there) — the live snparcher incident was
+    /// the reverse failure: an unbound key evaluated TRUE at expansion.
+    fn bake_wildcard_when(when: &str, combo: &crate::wildcard::WildcardValues) -> String {
+        // Longest-first so `>=` wins over `>`, `==`/`!=` are not confused
+        // with `=`/`!` (which are not comparison operators here).
+        const OPS: &[&str] = &[">=", "<=", "==", "!=", ">", "<"];
+
+        let mut result = String::with_capacity(when.len());
+        let mut cursor = 0usize;
+        for cap in WHEN_WILDCARD_REF_RE.captures_iter(when) {
+            let m = cap.get(0).expect("full match");
+            let key = cap.get(1).expect("key group").as_str();
+            let (start, end) = (m.start(), m.end());
+            result.push_str(&when[cursor..start]);
+
+            // Non-space context around the token decides its position.
+            let after = when[end..]
+                .find(|c: char| !c.is_whitespace())
+                .map(|i| &when[end + i..])
+                .unwrap_or_default();
+            let before = when[..start].trim_end();
+
+            match combo.get(key) {
+                // Comparison operand → quoted literal of the bound value.
+                Some(value)
+                    if OPS
+                        .iter()
+                        .any(|op| after.starts_with(op) || before.ends_with(op)) =>
+                {
+                    let rendered = crate::executor::process::render_wildcard_value(value);
+                    if rendered.contains('\'') {
+                        result.push_str(&format!("\"{rendered}\""));
+                    } else {
+                        result.push_str(&format!("'{rendered}'"));
+                    }
+                }
+                // Bare truthiness position → literal true/false.
+                Some(value) => {
+                    let truthy = !value.is_empty() && value != "false" && value != "0";
+                    result.push_str(if truthy { "true" } else { "false" });
+                }
+                // Unbound: leave the token for the strict execution-time
+                // evaluator (false — same verdict as expansion).
+                None => result.push_str(&when[start..end]),
+            }
+            cursor = end;
+        }
+        result.push_str(&when[cursor..]);
+        result
     }
 
     pub fn expand_wildcards(&mut self) -> Result<()> {
@@ -3250,6 +3321,16 @@ impl WorkflowConfig {
                         let mut expanded = rule.clone();
                         expanded.name = new_name;
 
+                        // Bake the per-instance wildcard bindings into the
+                        // `when` (the instance survived filtering above), so
+                        // the execution-time re-check re-evaluates this same
+                        // verdict with no wildcard context.
+                        if let Some(ref when) = rule.when
+                            && when.contains("wildcard.")
+                        {
+                            expanded.when = Some(Self::bake_wildcard_when(when, &combo));
+                        }
+
                         // Expand input/output/shell/log patterns
                         expanded.input = expand_rule_patterns(&rule.input, &combo);
                         expanded.output = expand_rule_patterns(&rule.output, &combo);
@@ -3351,6 +3432,15 @@ impl WorkflowConfig {
 
                         let mut expanded = rule.clone();
                         expanded.name = new_name;
+
+                        // Bake the per-instance wildcard bindings into the
+                        // `when` (the instance survived filtering above) —
+                        // see the pair branch for the rationale.
+                        if let Some(ref when) = rule.when
+                            && when.contains("wildcard.")
+                        {
+                            expanded.when = Some(Self::bake_wildcard_when(when, &merged));
+                        }
 
                         expanded.input = rule
                             .input
@@ -3487,6 +3577,15 @@ impl WorkflowConfig {
 
                     let mut expanded = rule.clone();
                     expanded.name = new_name.clone();
+
+                    // Bake the per-instance wildcard bindings into the
+                    // `when` (the instance survived filtering above) — see
+                    // the pair branch for the rationale.
+                    if let Some(ref when) = rule.when
+                        && when.contains("wildcard.")
+                    {
+                        expanded.when = Some(Self::bake_wildcard_when(when, combo));
+                    }
 
                     // Structure-preserving expansion (List / Map / Dir).
                     expanded.input = expand_rule_patterns(&rule.input, combo);
@@ -8573,6 +8672,235 @@ shell = "true"
             names,
             vec!["paired_step_p1".to_string(), "unpaired_step_p2".to_string()]
         );
+    }
+
+    #[test]
+    fn when_group_metadata_key_filters_instances() {
+        // Live snparcher incident (issue #85): `when = "wildcard.input_type
+        // == 'srr'"` must keep only the SRA cohort. The fastq cohort's
+        // group declares no `input_type` metadata, so the key is unbound in
+        // its combos — the unbound comparison is false and the SRA rule
+        // never enters the DAG for fastq samples.
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [[sample_groups]]
+            name = "sra_cohort"
+            samples = ["s1", "s2"]
+            [sample_groups.metadata]
+            input_type = "srr"
+
+            [[sample_groups]]
+            name = "fastq_cohort"
+            samples = ["f1"]
+
+            [[rules]]
+            name = "download_sra"
+            input = []
+            output = ["raw/{sample}/{sample}_1.fastq.gz"]
+            when = "wildcard.input_type == 'srr'"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        let mut names: Vec<String> = config.rules.iter().map(|r| r.name.clone()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "download_sra_sra_cohort_s1".to_string(),
+                "download_sra_sra_cohort_s2".to_string()
+            ],
+            "only the SRA-cohort instances survive; the fastq cohort has no input_type binding"
+        );
+    }
+
+    #[test]
+    fn when_group_metadata_key_never_bound_filters_all_instances() {
+        // No group declares `input_type` anywhere: every instance's
+        // comparison is unbound → false → the rule never enters the DAG.
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["s1"]
+
+            [[rules]]
+            name = "download_sra"
+            input = []
+            output = ["raw/{sample}.fq"]
+            when = "wildcard.input_type == 'srr'"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        assert!(
+            config.rules.is_empty(),
+            "an unbound wildcard key in when must filter every instance"
+        );
+    }
+
+    #[test]
+    fn when_pair_metadata_key_filters_instances() {
+        // Pair metadata keys participate in when evaluation the same way
+        // group metadata does.
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [[pairs]]
+            pair_id = "p1"
+            experiment = "e1"
+            control = "c1"
+            [pairs.metadata]
+            source = "sra"
+
+            [[pairs]]
+            pair_id = "p2"
+            experiment = "e2"
+
+            [[rules]]
+            name = "sra_step"
+            input = ["reads/{pair_id}.fq"]
+            output = ["out/{pair_id}.sra.txt"]
+            when = "wildcard.source == 'sra'"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        let mut names: Vec<String> = config.rules.iter().map(|r| r.name.clone()).collect();
+        names.sort();
+        assert_eq!(names, vec!["sra_step_p1".to_string()]);
+    }
+
+    #[test]
+    fn when_wildcard_baked_into_kept_instance() {
+        // Kept instances bake their per-instance bindings into `when` so
+        // the execution-time re-check (no wildcard context there) re-
+        // evaluates the same verdict instead of vetoing or re-running.
+        let toml = r#"
+            [workflow]
+            name = "t"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["s1"]
+            [sample_groups.metadata]
+            input_type = "srr"
+
+            [[rules]]
+            name = "download_sra"
+            input = []
+            output = ["raw/{sample}.fq"]
+            when = "wildcard.input_type == 'srr'"
+            shell = "touch {output[0]}"
+        "#;
+        let mut config = WorkflowConfig::parse(toml).unwrap();
+        config.expand_wildcards().unwrap();
+
+        assert_eq!(config.rules.len(), 1);
+        let baked = config.rules[0].when.as_deref().expect("when survives");
+        assert_eq!(baked, "'srr' == 'srr'");
+        // And it evaluates true with no wildcard context, so execution
+        // never vetoes the kept instance.
+        assert!(crate::executor::process::evaluate_condition(
+            baked,
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn bake_wildcard_when_resolves_bindings_by_position() {
+        let mut combo = crate::wildcard::WildcardValues::new();
+        combo.insert("input_type".to_string(), "srr".to_string());
+        combo.insert("control".to_string(), String::new());
+        combo.insert("feature".to_string(), "on".to_string());
+
+        // Comparison operands (either side) become quoted literals.
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("wildcard.input_type == 'srr'", &combo),
+            "'srr' == 'srr'"
+        );
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("'srr' != wildcard.input_type", &combo),
+            "'srr' != 'srr'"
+        );
+        // Bare truthiness becomes true/false literals (handles `!`).
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("wildcard.feature", &combo),
+            "true"
+        );
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("!wildcard.feature", &combo),
+            "!true"
+        );
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("wildcard.control == ''", &combo),
+            "'' == ''"
+        );
+        // Mixed with config predicates and unbound keys (left untouched:
+        // strict unbound→false at execution matches the expansion verdict).
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when(
+                "config.gate && wildcard.input_type == 'srr'",
+                &combo
+            ),
+            "config.gate && 'srr' == 'srr'"
+        );
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when(
+                "wildcard.input_type == 'srr' || wildcard.unbound_key == 'x'",
+                &combo
+            ),
+            "'srr' == 'srr' || wildcard.unbound_key == 'x'"
+        );
+        // Every baked kept-instance form re-evaluates true with no context:
+        // a `!=` form survives expansion only when the value differs from
+        // the literal, and `!wildcard.feature` only when the value is falsy
+        // (both baking to true forms, checked below). The config gate keeps
+        // its own semantics.
+        let mut fastq = crate::wildcard::WildcardValues::new();
+        fastq.insert("input_type".to_string(), "fastq".to_string());
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("'srr' != wildcard.input_type", &fastq),
+            "'srr' != 'fastq'"
+        );
+        let mut off = crate::wildcard::WildcardValues::new();
+        off.insert("feature".to_string(), String::new()); // falsy → kept
+        assert_eq!(
+            WorkflowConfig::bake_wildcard_when("!wildcard.feature", &off),
+            "!false"
+        );
+        let empty = HashMap::new();
+        for baked in [
+            "'srr' == 'srr'",
+            "'srr' != 'fastq'",
+            "true",
+            "!false",
+            "'' == ''",
+        ] {
+            assert!(
+                crate::executor::process::evaluate_condition(baked, &empty),
+                "baked form {baked:?} must re-evaluate true for a kept instance"
+            );
+        }
+        let mut config = HashMap::new();
+        config.insert("gate".to_string(), toml::Value::Boolean(true));
+        assert!(crate::executor::process::evaluate_condition(
+            "config.gate && 'srr' == 'srr'",
+            &config
+        ));
+        config.insert("gate".to_string(), toml::Value::Boolean(false));
+        assert!(!crate::executor::process::evaluate_condition(
+            "config.gate && 'srr' == 'srr'",
+            &config
+        ));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1159,7 +1159,13 @@ impl LocalExecutor {
                         .or_insert_with(|| toml::Value::String(v.clone()));
                 }
             }
-            if !evaluate_condition(condition, &config_values) {
+            // `wildcard.<key>` predicates resolve against the same
+            // wildcard_values map the caller rendered this rule with.
+            // Expansion-time per-instance filtering bakes each kept
+            // instance's bindings into its `when`, so an unbound key here
+            // genuinely cannot be met (false — rule skipped), never a
+            // kept instance's veto.
+            if !evaluate_condition_with_wildcards(condition, &config_values, wildcard_values) {
                 record.status = JobStatus::Skipped;
                 record.skip_reason = Some("condition evaluated to false".to_string());
                 record.finished_at = Some(Utc::now());
@@ -2665,7 +2671,7 @@ fn absolute_path(root: Option<&Path>, path: &str) -> String {
 /// Callers (CLI/web) stringify TOML config arrays as `["a", "b"]` literals;
 /// shells need the space-joined form (`a b`), matching the multi-value
 /// semantics of `{input}`. Scalar values pass through unchanged.
-fn render_wildcard_value(value: &str) -> String {
+pub(crate) fn render_wildcard_value(value: &str) -> String {
     // Cheap guard: TOML array literals always start with '['.
     if value.starts_with('[') {
         let wrapped = format!("_x = {value}");
@@ -2693,8 +2699,11 @@ pub fn evaluate_condition(condition: &str, config_values: &HashMap<String, toml:
 }
 
 /// Condition evaluation with a pair/group wildcard context (the expansion
-/// combo). `wildcard.<key>` predicates resolve against this map; with no
-/// context they evaluate permissively (see `evaluate_condition_inner`).
+/// combo). `wildcard.<key>` predicates resolve against this map; a key
+/// absent from it evaluates false (the condition cannot be met) — the
+/// expansion-time instance filter relies on this, and expansion bakes
+/// per-instance values into kept rules' `when` so the execution-time
+/// re-check never vetoes a kept instance (see `compare_wildcard_value`).
 pub fn evaluate_condition_with_wildcards(
     condition: &str,
     config_values: &HashMap<String, toml::Value>,
@@ -2746,6 +2755,15 @@ fn evaluate_condition_inner(
             if let Some(key) = lhs.strip_prefix("wildcard.") {
                 return compare_wildcard_value(wildcard_values.get(key), op, rhs);
             }
+            // Literal-vs-literal comparison: produced by expansion-time
+            // when baking (per-instance wildcard values substituted into
+            // the condition), so the execution-time re-check re-evaluates
+            // the same per-instance verdict with no wildcard context.
+            if let Some(l) = strip_quotes(lhs)
+                && let Some(r) = strip_quotes(rhs)
+            {
+                return compare_strings(l, r, op);
+            }
         }
     }
     if let Some(key) = s.strip_prefix("config.") {
@@ -2759,12 +2777,15 @@ fn evaluate_condition_inner(
         };
     }
     if let Some(key) = s.strip_prefix("wildcard.") {
-        // Permissive when the key is absent: execution-time evaluation has no
-        // pair/group context (expansion already filtered the instances), and
-        // an unknown key behaves like the unconditional fallthrough below.
+        // Truthiness of a wildcard binding. An absent key is false — an
+        // unbound wildcard reference means the condition cannot be met
+        // (W027 warns about keys no instance can ever bind). Instances
+        // expansion kept are baked with their per-instance values, so this
+        // strict rule only vetoes rules whose wildcard reference is
+        // genuinely unresolvable.
         return match wildcard_values.get(key) {
             Some(v) => !v.is_empty() && v != "false" && v != "0",
-            None => true,
+            None => false,
         };
     }
     true
@@ -2877,18 +2898,41 @@ fn compare_config_value(val: Option<&toml::Value>, op: &str, rhs: &str) -> bool 
 }
 
 /// Compare a pair/group wildcard value (a string from the expansion combo)
-/// against a literal in a `when` condition. Permissive on a missing key:
-/// execution-time evaluation has no combo context (expansion already
-/// filtered the instances), so an absent key defers to the caller's
-/// fallthrough.
+/// against a literal in a `when` condition. An unbound key evaluates to
+/// **false** for every operator — a `when` referencing a wildcard that has
+/// no binding cannot be met, so the rule must not run (live incident:
+/// snparcher's `wildcard.input_type == 'srr'` fired for a fastq cohort
+/// whose group metadata declared no `input_type`, running `download_sra`
+/// against a literal `{accession}`). Expansion-time instance filtering
+/// relies on this, and the execution-time re-check re-evaluates baked
+/// per-instance values instead of relying on missing-key fallthrough.
 fn compare_wildcard_value(val: Option<&String>, op: &str, rhs: &str) -> bool {
-    let Some(v) = val else { return true };
+    let Some(v) = val else { return false };
     let rhs = rhs.trim_matches('"').trim_matches('\'');
     match op {
         "==" => v == rhs,
         "!=" => v != rhs,
+        _ => compare_strings(v, rhs, op),
+    }
+}
+
+/// Numeric-first, then lexicographic comparison used by the wildcard and
+/// literal comparison paths of `when` evaluation (numeric values compare
+/// numerically so baked `'7' > '10'` is false, matching shell intuition).
+fn compare_strings(a: &str, b: &str, op: &str) -> bool {
+    match op {
+        "==" => a == b,
+        "!=" => a != b,
         _ => {
-            if let (Ok(a), Ok(b)) = (v.parse::<f64>(), rhs.parse::<f64>()) {
+            if let (Ok(x), Ok(y)) = (a.parse::<f64>(), b.parse::<f64>()) {
+                match op {
+                    ">=" => x >= y,
+                    "<=" => x <= y,
+                    ">" => x > y,
+                    "<" => x < y,
+                    _ => false,
+                }
+            } else {
                 match op {
                     ">=" => a >= b,
                     "<=" => a <= b,
@@ -2896,16 +2940,19 @@ fn compare_wildcard_value(val: Option<&String>, op: &str, rhs: &str) -> bool {
                     "<" => a < b,
                     _ => false,
                 }
-            } else {
-                match op {
-                    ">=" => v.as_str() >= rhs,
-                    "<=" => v.as_str() <= rhs,
-                    ">" => v.as_str() > rhs,
-                    "<" => v.as_str() < rhs,
-                    _ => false,
-                }
             }
         }
+    }
+}
+
+/// Strip a fully quoted string literal (`'v'` or `"v"`) to its content.
+/// Returns `None` when the input is not an exact quoted literal.
+fn strip_quotes(s: &str) -> Option<&str> {
+    let first = s.as_bytes().first()?;
+    let last = s.as_bytes().last()?;
+    match (first, last) {
+        (b'\'', b'\'') | (b'"', b'"') if s.len() >= 2 => Some(&s[1..s.len() - 1]),
+        _ => None,
     }
 }
 

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -769,23 +769,159 @@ fn evaluate_condition_wildcard_context_paired_control() {
 }
 
 #[test]
-fn evaluate_condition_wildcard_context_missing_key_is_permissive() {
+fn evaluate_condition_wildcard_context_missing_key_is_false() {
     use super::process::evaluate_condition_with_wildcards;
 
-    // Execution-time evaluation has no combo context — wildcard predicates
-    // must not veto an instance that expansion already kept.
+    // An unbound wildcard key cannot meet the condition: every operator
+    // evaluates false (issue #85 — snparcher's
+    // `when = "wildcard.input_type == 'srr'"` fired for a fastq cohort
+    // with no `input_type` binding and ran `download_sra` against a
+    // literal `{accession}`).
     let config = HashMap::new();
     let empty = HashMap::new();
-    assert!(evaluate_condition_with_wildcards(
+    assert!(!evaluate_condition_with_wildcards(
         "wildcard.control != ''",
         &config,
         &empty
     ));
-    assert!(evaluate_condition_with_wildcards(
+    assert!(!evaluate_condition_with_wildcards(
         "wildcard.unknown_key == 'x'",
         &config,
         &empty
     ));
+    assert!(!evaluate_condition_with_wildcards(
+        "wildcard.unknown_key != 'x'",
+        &config,
+        &empty
+    ));
+    assert!(!evaluate_condition_with_wildcards(
+        "wildcard.unknown_key > '1'",
+        &config,
+        &empty
+    ));
+    // Bare truthiness of an unbound key is false too (matches
+    // `config.missing`), and a bound key still works.
+    assert!(!evaluate_condition_with_wildcards(
+        "wildcard.unknown_key",
+        &config,
+        &empty
+    ));
+    let mut combo = HashMap::new();
+    combo.insert("unknown_key".to_string(), "x".to_string());
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.unknown_key",
+        &config,
+        &combo
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "wildcard.unknown_key == 'x'",
+        &config,
+        &combo
+    ));
+}
+
+#[test]
+fn evaluate_condition_literal_comparisons_compare_for_real() {
+    use super::process::evaluate_condition_with_wildcards;
+
+    // Expansion-time when baking substitutes per-instance wildcard values
+    // into the kept rule's `when` as quoted literals; the execution-time
+    // re-check must compare them properly (including under `!`).
+    let config = HashMap::new();
+    let empty = HashMap::new();
+    assert!(evaluate_condition_with_wildcards(
+        "'srr' == 'srr'",
+        &config,
+        &empty
+    ));
+    assert!(!evaluate_condition_with_wildcards(
+        "'srr' == 'fastq'",
+        &config,
+        &empty
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "'srr' != 'fastq'",
+        &config,
+        &empty
+    ));
+    assert!(evaluate_condition_with_wildcards(
+        "'2' > '1' && '1' <= '2'",
+        &config,
+        &empty
+    ));
+    assert!(!evaluate_condition_with_wildcards(
+        "!('srr' == 'srr')",
+        &config,
+        &empty
+    ));
+    // Baked wildcard parts compose with config predicates.
+    let mut config = HashMap::new();
+    config.insert("gate".to_string(), toml::Value::Boolean(true));
+    assert!(evaluate_condition_with_wildcards(
+        "config.gate && 'srr' == 'srr'",
+        &config,
+        &empty
+    ));
+    config.insert("gate".to_string(), toml::Value::Boolean(false));
+    assert!(!evaluate_condition_with_wildcards(
+        "config.gate && 'srr' == 'srr'",
+        &config,
+        &empty
+    ));
+}
+
+#[tokio::test]
+async fn execute_rule_skipped_when_wildcard_key_unbound() {
+    let config = ExecutorConfig {
+        max_jobs: 1,
+        dry_run: false,
+        workdir: std::env::temp_dir(),
+        ..Default::default()
+    };
+    let executor = LocalExecutor::new(config);
+
+    // A `when` referencing a wildcard key with no binding cannot be met:
+    // the rule is skipped (never executed) for every operator — ==, !=, >.
+    for condition in [
+        r#"wildcard.missing == "x""#,
+        r#"wildcard.missing != "x""#,
+        "wildcard.missing > '1'",
+    ] {
+        let mut rule = make_rule("unbound_when", "echo never");
+        rule.when = Some(condition.to_string());
+        let record = executor.execute_rule(&rule, &HashMap::new()).await.unwrap();
+        assert_eq!(
+            record.status,
+            JobStatus::Skipped,
+            "condition {condition:?} with an unbound wildcard key must skip the rule"
+        );
+        assert_eq!(
+            record.skip_reason.as_deref(),
+            Some("condition evaluated to false")
+        );
+    }
+
+    // A bound wildcard key still gates normally: matching value runs,
+    // non-matching value skips.
+    let mut rule = make_rule("bound_when", "echo hi");
+    rule.when = Some(r#"wildcard.k == "v""#.to_string());
+    let mut values = HashMap::new();
+    values.insert("k".to_string(), "v".to_string());
+    let record = executor.execute_rule(&rule, &values).await.unwrap();
+    assert_eq!(
+        record.status,
+        JobStatus::Success,
+        "bound wildcard.k == 'v' must run"
+    );
+
+    let mut values = HashMap::new();
+    values.insert("k".to_string(), "other".to_string());
+    let record = executor.execute_rule(&rule, &values).await.unwrap();
+    assert_eq!(
+        record.status,
+        JobStatus::Skipped,
+        "bound wildcard.k == 'v' with k = 'other' must skip"
+    );
 }
 
 #[test]

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -14,6 +14,11 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
+/// Matches a `wildcard.<key>` reference inside a `when` expression (the
+/// per-instance pair/group binding vocabulary, including metadata keys).
+static WHEN_WILDCARD_REF_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"wildcard\.(\w+)").expect("valid when-wildcard regex"));
+
 /// Current .oxoflow format specification version.
 pub const FORMAT_VERSION: &str = "1.0";
 
@@ -1208,6 +1213,39 @@ pub fn lint_format(
             }
         }
 
+        // W027: `when` references a wildcard key no instance can ever bind
+        // (issue #85 live incident: snparcher's
+        // `when = "wildcard.input_type == 'srr'"` fired for a fastq cohort
+        // whose group metadata declared no `input_type` — the unbound
+        // comparison used to evaluate TRUE, running `download_sra` against
+        // a literal `{accession}`). Unbound comparisons now evaluate
+        // false, so a key outside the bindable vocabulary (standard
+        // pair/group keys, declared metadata, [[values]] names) makes the
+        // rule never run — worth a warning, never an error: metadata can
+        // arrive at run time via a pairs/sample_groups file.
+        if let Some(ref when) = rule.when
+            && WHEN_WILDCARD_REF_RE.is_match(when)
+        {
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for cap in WHEN_WILDCARD_REF_RE.captures_iter(when) {
+                let key = cap[1].to_string();
+                if declared_wildcards.contains(&key) || !seen.insert(key.clone()) {
+                    continue;
+                }
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    message: format!(
+                        "when references 'wildcard.{key}' but no [[pairs]]/[[sample_groups]]/[[values]] can bind it — the condition evaluates false and the rule never runs"
+                    ),
+                    rule: Some(rule.name.clone()),
+                    code: "W027".to_string(),
+                    suggestion: Some(
+                        "declare the key in a [[pairs]]/[[sample_groups]] metadata table or a [[values]] table, or check the spelling".to_string(),
+                    ),
+                });
+            }
+        }
+
         // W024: expandable wildcard with no declared source (issue #142 H3).
         // A `{sample}`/`{group}`/pair wildcard the engine can never expand —
         // no sample_pattern, [[sample_groups]], [[pairs]], [[values]], or
@@ -2084,6 +2122,89 @@ mod tests {
         assert_eq!(w024[0].severity, Severity::Warning);
         assert_eq!(w024[0].rule.as_deref(), Some("gen"));
         assert!(w024[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn lint_when_unbound_wildcard_key_fires_w027() {
+        // Issue #85: a `when` referencing `wildcard.<key>` that no pair/
+        // group metadata or [[values]] table can bind now evaluates false
+        // (the rule never runs) — the lint must say so instead of the
+        // incident repeating silently.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "download_sra"
+            output = ["raw/{sample}.fq"]
+            when = "wildcard.input_type == 'srr'"
+            shell = "echo hi"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        let w027: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.code == "W027").collect();
+        assert_eq!(
+            w027.len(),
+            1,
+            "one W027 for unbound 'input_type', got: {diagnostics:?}"
+        );
+        assert!(w027[0].message.contains("input_type"));
+        assert_eq!(w027[0].severity, Severity::Warning);
+        assert_eq!(w027[0].rule.as_deref(), Some("download_sra"));
+    }
+
+    #[test]
+    fn lint_when_bindable_wildcard_keys_are_silent() {
+        // Standard pair/group keys, declared metadata keys, and [[values]]
+        // names are all bindable per instance — no W027.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1"]
+            metadata = { input_type = "srr" }
+
+            [[pairs]]
+            pair_id = "P1"
+            experiment = "T1"
+            control = "N1"
+            metadata = { source = "sra" }
+
+            [[values]]
+            name = "assembler"
+            values = ["spades"]
+
+            [[rules]]
+            name = "sra_download"
+            input = ["raw/{sample}.fq"]
+            output = ["out/{sample}.fq"]
+            when = "wildcard.input_type == 'srr'"
+            shell = "echo {input}"
+
+            [[rules]]
+            name = "pair_step"
+            input = ["reads/{pair_id}.fq"]
+            output = ["out/{pair_id}.bam"]
+            when = "wildcard.control != '' && wildcard.source == 'sra'"
+            shell = "echo {input}"
+
+            [[rules]]
+            name = "value_step"
+            input = ["x_{assembler}.txt"]
+            output = ["y_{assembler}.txt"]
+            when = "wildcard.assembler == 'spades'"
+            shell = "echo {input}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        let w027: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.code == "W027").collect();
+        assert_eq!(
+            w027.len(),
+            0,
+            "declared metadata and values keys must not fire W027: {diagnostics:?}"
+        );
     }
 
     #[test]

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1486,7 +1486,7 @@ samples = ["CASE_001", "CASE_002"]
 |---|---|---|---|
 | `name` | String | **Yes** | Group name |
 | `samples` | Array of strings | **Yes** | Sample identifiers in this group |
-| `metadata` | Table | No | Arbitrary group-level metadata |
+| `metadata` | Table | No | Arbitrary group-level metadata; each key is available as a wildcard in paths, shells, and `when` conditions (`wildcard.<key>`) |
 
 Any rule that references `{sample}` or `{group}` is expanded once per `(group, sample)` pair across all groups.
 
@@ -1668,11 +1668,32 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> == true\|false` | `config.skip == false` | Boolean equality |
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test |
-| `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, pair metadata keys) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
+| `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `!<expr>` | `!config.skip` | Logical NOT |
 | `<expr> && <expr>` | `config.run_qc && config.min_cov >= 20` | Logical AND |
 | `<expr> \|\| <expr>` | `config.wgs \|\| config.wes` | Logical OR |
 | `(<expr>)` | `(config.a && config.b) \|\| config.c` | Grouping |
+
+### Unbound wildcard keys evaluate false
+
+A `wildcard.<key>` predicate whose key has **no binding** for an instance —
+e.g. a group that declares no `input_type` metadata while another group
+does — evaluates to **false** for *every* operator (`==`, `!=`, `>`, `<`,
+…, and bare truthiness alike). The condition is not met, so that instance
+never runs. This keeps a rule like
+`when = "wildcard.input_type == 'srr'"` scoped to the SRA cohort even when
+other cohorts omit the key entirely.
+
+> **Note:** this is a behavioral contract, not an oversight. An unbound
+> comparison historically evaluated `true`, which ran SRA-download rules
+> against literal `{accession}` placeholders for FASTQ cohorts (live
+> incident). `oxo-flow lint` flags `when` references to keys no pair/group
+> can ever bind as a **W027** warning — such rules never run.
+
+Per-instance wildcard bindings (including metadata keys) are baked into a
+kept rule's `when` at expansion time, so the execution-time re-check
+re-evaluates the exact same per-instance verdict; config-only predicates
+continue to gate at execution as before.
 
 ### Example
 


### PR DESCRIPTION
Live incident (bioinfo-wsx, snparcher): `when = "wildcard.input_type == 'srr'"` fired for a fastq cohort, running `download_sra` with a literal `{accession}` in the shell and failing every toggle.

Root cause: `compare_wildcard_value` returned `true` for a missing key under every operator (PR #187 kept missing keys permissive), and the execution-time when-gate re-check had no per-instance wildcard context.

## Fix
- **Strict unbound semantics**: unbound `wildcard.<key>` is false for `==`, `!=`, `>`, … and bare truthiness (process.rs)
- **Execution-time consistency via baking**: `bake_wildcard_when` resolves `wildcard.<key>` tokens per instance at fan-out (pairs/groups/values); `execute_rule_with_config` re-evaluates the identical baked per-instance verdict — kept instances are never newly vetoed, unbound gates never spuriously fire
- **W027 lint**: warns when a `when` references `wildcard.<key>` outside the bindable vocabulary (standard keys + pair/group metadata + `[[values]]` names)
- **Docs**: workflow-format.md documents the unbound-false contract + metadata-key availability in `when`

## Verification
- 1186 core lib tests + 11 doctests pass; clippy + fmt clean
- Live: group-metadata workflow kept only the srr instances (fastq filtered); unbound-wildcard rule skipped at execution; W027 fires for never-bindable keys, silent for declared metadata

## Behavior change
Workflows that relied on the permissive true (the bug) will now skip those rules — the intended contract. W027 surfaces affected rules at lint time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)