### PR TITLE
feat(core): optional="any" alternative-input mode + skip propagation

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1290,6 +1290,13 @@ pub async fn run_command(
     let skipped_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let failed_rules_set: Arc<Mutex<std::collections::HashSet<String>>> =
         Arc::new(Mutex::new(std::collections::HashSet::new()));
+    // Rules skipped at execution time without producing outputs (e.g.
+    // "optional inputs missing"). Non-optional dependents are blocked from
+    // running on them — the declared input files can never exist, so
+    // executing them would just produce a missing-file shell error
+    // (issue #200, live: eager's samtools_flagstat after a skipped filter).
+    let skipped_no_output: Arc<Mutex<std::collections::HashSet<String>>> =
+        Arc::new(Mutex::new(std::collections::HashSet::new()));
     let failures: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
     // Rules that never ran because an upstream dependency failed, paired with the
     // dependency that blocked them. Reported separately from genuine failures so
@@ -1916,16 +1923,34 @@ pub async fn run_command(
             *waited_rounds.entry(name.clone()).or_insert(0) += AGING_STEP;
         }
         for rule_name in &to_submit {
-            // Skip rules blocked by a failed upstream dependency.
-            let blocked_by = {
+            // Skip rules blocked by a failed — or no-output-skipped — upstream
+            // dependency. Optional rules are exempt: they evaluate their own
+            // inputs and skip gracefully when they're absent (issue #200).
+            let rule_is_optional = config
+                .get_rule(rule_name)
+                .is_some_and(|r| r.optional.is_optional());
+            let blocked_by = if rule_is_optional {
+                None
+            } else {
                 let frs = failed_rules_set.lock().await;
-                dag.dependencies(rule_name)
-                    .ok()
-                    .and_then(|deps| deps.into_iter().find(|d| frs.contains(d.as_str())))
+                let sno = skipped_no_output.lock().await;
+                dag.dependencies(rule_name).ok().and_then(|deps| {
+                    deps.into_iter()
+                        .find(|d| frs.contains(d.as_str()) || sno.contains(d.as_str()))
+                })
             };
             if let Some(dep) = blocked_by {
                 skipped_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                {
+                // Propagate transitively: this rule produced nothing, so its
+                // own dependents are blocked the same way.
+                let dep_skipped = {
+                    let sno = skipped_no_output.lock().await;
+                    sno.contains(dep.as_str())
+                };
+                if dep_skipped {
+                    let mut sno = skipped_no_output.lock().await;
+                    sno.insert(rule_name.clone());
+                } else {
                     let mut frs = failed_rules_set.lock().await;
                     frs.insert(rule_name.clone());
                 }
@@ -1942,15 +1967,23 @@ pub async fn run_command(
                     command: None,
                     retries: 0,
                     timeout: None,
-                    skip_reason: Some("blocked by failed upstream dependency".into()),
+                    skip_reason: Some(
+                        if dep_skipped {
+                            "blocked by skipped upstream dependency"
+                        } else {
+                            "blocked by failed upstream dependency"
+                        }
+                        .into(),
+                    ),
                     max_rss_mb: None,
                     cpu_seconds: None,
                 });
                 if !is_tty {
                     eprintln!(
-                        "  {} {} (blocked by failed dependency)",
+                        "  {} {} (blocked by {} dependency)",
                         "⊘".yellow(),
-                        rule_name
+                        rule_name,
+                        if dep_skipped { "skipped" } else { "failed" }
                     );
                 }
                 progress.inc(1);
@@ -1971,6 +2004,7 @@ pub async fn run_command(
             let checkpoint = checkpoint.clone();
             let checkpoint_path = checkpoint_path.clone();
             let failed_rules_set = failed_rules_set.clone();
+            let skipped_no_output = skipped_no_output.clone();
             let failures = failures.clone();
             let success_count = success_count.clone();
             let fail_count = fail_count.clone();
@@ -2133,6 +2167,13 @@ pub async fn run_command(
                             (rule_name, oxo_flow_core::executor::JobStatus::Success, record)
                         } else if record.status == oxo_flow_core::executor::JobStatus::Skipped {
                             skipped_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            if record.skip_reason.as_deref() == Some("optional inputs missing") {
+                                // No outputs will exist — block non-optional
+                                // dependents instead of letting them run into
+                                // a missing-file shell error (issue #200).
+                                let mut sno = skipped_no_output.lock().await;
+                                sno.insert(rule_name.clone());
+                            }
                             // Surface the executor's skip reason (condition
                             // false, optional inputs missing, outputs
                             // up-to-date) — otherwise a submitted rule that

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -929,27 +929,38 @@ pub fn optional_inputs_missing(
     workdir: &Path,
     wildcard_values: &HashMap<String, String>,
 ) -> bool {
-    if !rule.optional || rule.input.is_empty() {
+    if !rule.optional.is_optional() || rule.input.is_empty() {
         return false;
     }
+    let any_mode = rule.optional.is_any();
     for input in rule.input.to_vec() {
         let expanded = expand_config_in_path(&input, wildcard_values);
         if expanded.contains('{') {
-            continue; // engine wildcard — assume present
-        }
-        if is_glob_pattern(&expanded) {
-            let pattern = workdir.join(&expanded);
-            let matched = glob::glob(&pattern.to_string_lossy())
-                .map(|paths| paths.filter_map(|p| p.ok()).next().is_some())
-                .unwrap_or(false);
-            if !matched {
-                return true;
+            // Engine wildcard — assume present. In "any" mode one assumed
+            // present is enough to run the rule.
+            if any_mode {
+                return false;
             }
-        } else if !workdir.join(&expanded).exists() {
-            return true;
+            continue;
+        }
+        let exists = if is_glob_pattern(&expanded) {
+            let pattern = workdir.join(&expanded);
+            glob::glob(&pattern.to_string_lossy())
+                .map(|paths| paths.filter_map(|p| p.ok()).next().is_some())
+                .unwrap_or(false)
+        } else {
+            workdir.join(&expanded).exists()
+        };
+        if any_mode {
+            if exists {
+                return false; // at least one input exists — run
+            }
+        } else if !exists {
+            return true; // "all" mode — any missing input skips the rule
         }
     }
-    false
+    // "any" mode: none of the inputs existed — skip.
+    any_mode
 }
 
 /// Check if a rule should be skipped based on output freshness.
@@ -1982,7 +1993,16 @@ mod optional_tests {
         Rule {
             name: name.to_string(),
             input: FilePatterns::List(inputs.iter().map(|s| s.to_string()).collect()),
-            optional: true,
+            optional: crate::rule::OptionalMode::All(true),
+            ..Default::default()
+        }
+    }
+
+    fn rule_optional_any(name: &str, inputs: &[&str]) -> Rule {
+        Rule {
+            name: name.to_string(),
+            input: FilePatterns::List(inputs.iter().map(|s| s.to_string()).collect()),
+            optional: crate::rule::OptionalMode::Any,
             ..Default::default()
         }
     }
@@ -2018,7 +2038,7 @@ mod optional_tests {
         let rule = Rule {
             name: "r".to_string(),
             input: FilePatterns::List(vec!["missing.txt".to_string()]),
-            optional: false,
+            optional: crate::rule::OptionalMode::All(false),
             ..Default::default()
         };
         assert!(!optional_inputs_missing(&rule, &dir, &HashMap::new()));
@@ -2053,6 +2073,48 @@ mod optional_tests {
         let mut values = HashMap::new();
         values.insert("config.datadir".to_string(), "real".to_string());
         assert!(!optional_inputs_missing(&rule, &dir, &values));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── "any" mode (alternative-input pattern, issue #200) ────────────────
+
+    #[test]
+    fn all_mode_skips_when_one_of_several_inputs_is_missing() {
+        // Regression guard: optional = true keeps "skip when ANY input is
+        // missing" (e.g. chipseq macs3 whose control BAM may not exist).
+        let dir = wd("allmulti");
+        std::fs::create_dir_all(dir.join("data")).unwrap();
+        std::fs::write(dir.join("data/a.txt"), "x").unwrap();
+        let rule = rule_optional("r", &["data/a.txt", "data/b.txt"]);
+        assert!(optional_inputs_missing(&rule, &dir, &HashMap::new()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn any_mode_runs_when_one_of_several_inputs_exists() {
+        // live: eager's samtools_filter across mapper naming schemes —
+        // only the configured mapper's BAM exists, yet the rule must run.
+        let dir = wd("anyone");
+        std::fs::create_dir_all(dir.join("data")).unwrap();
+        std::fs::write(dir.join("data/b.txt"), "x").unwrap();
+        let rule = rule_optional_any("r", &["data/a.txt", "data/b.txt", "data/c.txt"]);
+        assert!(!optional_inputs_missing(&rule, &dir, &HashMap::new()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn any_mode_skips_when_no_input_exists() {
+        let dir = wd("anynone");
+        let rule = rule_optional_any("r", &["data/a.txt", "data/b.txt"]);
+        assert!(optional_inputs_missing(&rule, &dir, &HashMap::new()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn any_mode_with_engine_wildcard_runs() {
+        let dir = wd("anyengine");
+        let rule = rule_optional_any("r", &["out/{sample}.txt"]);
+        assert!(!optional_inputs_missing(&rule, &dir, &HashMap::new()));
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1193,7 +1193,7 @@ impl LocalExecutor {
         .await
         {
             Ok(Some(prep)) => {
-                if prep.missing_optional_input && rule.optional {
+                if prep.missing_optional_input && rule.optional.is_optional() {
                     record.status = JobStatus::Skipped;
                     record.skip_reason = Some("optional inputs missing".to_string());
                     record.finished_at = Some(Utc::now());

--- a/crates/oxo-flow-core/src/executor/staging.rs
+++ b/crates/oxo-flow-core/src/executor/staging.rs
@@ -122,7 +122,7 @@ pub async fn stage_remote_io(
                 tracing::debug!(input = %expanded, staged = %rel, "staged remote input");
                 input_map.insert(pattern, rel);
             }
-            Err(e) if rule.optional => {
+            Err(e) if rule.optional.is_optional() => {
                 tracing::warn!(
                     input = %expanded,
                     error = %e,
@@ -397,7 +397,7 @@ output = { result = "s3://b/out.txt" }
     async fn missing_optional_input_marks_skip_candidate() {
         let (resolver, _) = resolver_with("s3://b/other.fq", b"x", "e1");
         let mut rule = rule_with(r#"["s3://b/gone.fq"]"#);
-        rule.optional = true;
+        rule.optional = crate::rule::OptionalMode::All(true);
         let dir = tempfile::tempdir().unwrap();
         let prep = stage_remote_io(&rule, dir.path(), &HashMap::new(), &resolver)
             .await

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -518,7 +518,7 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
                 if !generated_by_upstream {
                     let is_absolute = input.starts_with('/');
                     // Optional rules treat missing inputs as warnings, not errors
-                    let severity = if rule.optional {
+                    let severity = if rule.optional.is_optional() {
                         Severity::Warning
                     } else if is_absolute {
                         Severity::Error
@@ -535,7 +535,7 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
                             "W020".to_string()
                         },
                         suggestion: Some(
-                            if rule.optional {
+                            if rule.optional.is_optional() {
                                 "this rule is optional — missing input will cause it to be skipped at execution time"
                             } else if is_absolute {
                                 "verify the absolute file path; this file must exist before workflow execution"

--- a/crates/oxo-flow-core/src/readiness.rs
+++ b/crates/oxo-flow-core/src/readiness.rs
@@ -94,7 +94,7 @@ pub fn compute_readiness(config: &WorkflowConfig, base_dir: &std::path::Path) ->
     for rule in &config.rules {
         // Optional rules are skipped by the executor when their inputs are
         // absent, so they must not block readiness.
-        if rule.optional {
+        if rule.optional.is_optional() {
             continue;
         }
         let scoped: &[String] = config

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -38,6 +38,67 @@ impl AutoScale {
     }
 }
 
+/// How a rule treats missing inputs (`optional = ...` in the workflow).
+///
+/// TOML forms: `optional = true` / `optional = false` map to [`OptionalMode::All`]
+/// (default false), `optional = "any"` maps to [`OptionalMode::Any`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionalMode {
+    /// `true`/`false`: every declared input must exist; a rule declared
+    /// `optional = true` is skipped when ANY input is missing.
+    All(bool),
+    /// `"any"`: run when at least one declared input exists; skip only
+    /// when none do (alternative-input pattern).
+    Any,
+}
+
+impl Default for OptionalMode {
+    fn default() -> Self {
+        Self::All(false)
+    }
+}
+
+impl OptionalMode {
+    /// Whether the rule may be skipped at execution time for missing inputs.
+    #[must_use]
+    pub fn is_optional(self) -> bool {
+        !matches!(self, Self::All(false))
+    }
+
+    /// Whether the alternative-input ("any") mode is active.
+    #[must_use]
+    pub fn is_any(self) -> bool {
+        matches!(self, Self::Any)
+    }
+}
+
+/// `skip_serializing_if` helper for [`Rule::optional`].
+fn optional_is_false(value: &OptionalMode) -> bool {
+    matches!(value, OptionalMode::All(false))
+}
+
+impl Serialize for OptionalMode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::All(b) => serializer.serialize_bool(*b),
+            Self::Any => serializer.serialize_str("any"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OptionalMode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = toml::Value::deserialize(deserializer)?;
+        match value {
+            toml::Value::Boolean(b) => Ok(Self::All(b)),
+            toml::Value::String(s) if s == "any" => Ok(Self::Any),
+            other => Err(serde::de::Error::custom(format!(
+                "optional must be true, false, or \"any\" — got {other}"
+            ))),
+        }
+    }
+}
+
 /// Parse a duration string like "5s", "30s", "2m", "1h", "1d" into seconds.
 ///
 /// Returns `None` if the format is invalid or would overflow.
@@ -698,13 +759,18 @@ pub struct Rule {
     #[serde(skip_serializing_if = "is_false")]
     pub target: bool,
 
-    /// Whether this rule is optional (skip if inputs missing).
+    /// How the rule treats missing inputs.
     ///
-    /// When true, the rule is skipped if any input files don't exist.
-    /// Useful for optional analysis steps that may not apply to all samples.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "is_false")]
-    pub optional: bool,
+    /// - `false` (default): every declared input must exist (hard inputs).
+    /// - `true`: the rule is skipped when ANY declared input is missing —
+    ///   useful for optional analysis steps that may not apply to all samples.
+    /// - `"any"`: the rule runs when AT LEAST ONE declared input exists and
+    ///   is skipped only when none do — the alternative-input pattern, e.g.
+    ///   a consumer that accepts whichever mapper/aligner wrote the file
+    ///   (live: nf-core/eager's samtools_filter across bwa/bwamem/bt2/
+    ///   circularmapper naming schemes).
+    #[serde(default, skip_serializing_if = "optional_is_false")]
+    pub optional: OptionalMode,
 
     /// Group label for grouping jobs on cluster execution.
     #[serde(default)]
@@ -1605,6 +1671,50 @@ mod tests {
 
         let rule: Rule = toml::from_str(toml_str).unwrap();
         assert_eq!(rule.when.as_deref(), Some("config.enable_qc"));
+    }
+
+    #[test]
+    fn rule_optional_parses_bool_and_any_modes() {
+        for (toml_str, expected) in [
+            (
+                "name = \"a\"\noutput = [\"x\"]\nshell = \"echo x\"",
+                OptionalMode::All(false),
+            ),
+            (
+                "name = \"a\"\noutput = [\"x\"]\nshell = \"echo x\"\noptional = true",
+                OptionalMode::All(true),
+            ),
+            (
+                "name = \"a\"\noutput = [\"x\"]\nshell = \"echo x\"\noptional = \"any\"",
+                OptionalMode::Any,
+            ),
+        ] {
+            let rule: Rule = toml::from_str(toml_str).unwrap();
+            assert_eq!(rule.optional, expected, "toml: {toml_str}");
+        }
+    }
+
+    #[test]
+    fn rule_optional_rejects_unknown_string() {
+        let toml_str = "name = \"a\"\noutput = [\"x\"]\nshell = \"echo x\"\noptional = \"yes\"";
+        let err = toml::from_str::<Rule>(toml_str).unwrap_err().to_string();
+        assert!(
+            err.contains("optional must be true, false, or \"any\""),
+            "err: {err}"
+        );
+    }
+
+    #[test]
+    fn rule_optional_serializes_any_as_string() {
+        let rule = Rule {
+            name: "a".to_string(),
+            output: FilePatterns::List(vec!["x".to_string()]),
+            shell: Some("echo x".to_string()),
+            optional: OptionalMode::Any,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&rule).unwrap();
+        assert!(toml_str.contains("optional = \"any\""), "toml: {toml_str}");
     }
 
     #[test]

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1059,7 +1059,7 @@ target = true   # Included when running without -t
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `optional` | Boolean | If `true`, missing inputs become warnings instead of errors |
+| `optional` | Boolean or `"any"` | `true`: the rule is skipped (no error) when ANY declared input is missing — literal globs count as missing only when they match nothing. `"any"`: the rule runs when AT LEAST ONE declared input exists and is skipped only when none do — the alternative-input pattern, e.g. a consumer that accepts whichever mapper/aligner wrote the file. `false` (default): every input must exist |
 | `required` | Boolean | If `false`, a failure of this rule does not fail the run: the failure is recorded and listed, its dependents are blocked, and the run exits 0 (best-effort / continue-on-error, e.g. QC steps). Defaults to `true` — required failures fail the run (or, with `--keep-going`, keep it running but still exit non-zero with the failures listed: keep-going changes scheduling, never the verdict) |
 
 ```toml
@@ -1067,7 +1067,22 @@ target = true   # Included when running without -t
 name = "experimental"
 optional = true     # Skip if input data is absent
 required = false    # Failure is reported but does not fail the run
+
+[[rules]]
+name = "filter_bam"
+# Run when any of the mapper-specific BAMs exists (bwa writes *_PE.mapped.bam,
+# bwamem/bt2/circularmapper write {sample}.mapped.bam); skip only when none do.
+optional = "any"
+input = [
+    "results/mapping/bwa/{sample}_PE.mapped.bam",
+    "results/mapping/bwa/{sample}.mapped.bam",
+    "results/mapping/bt2/{sample}.mapped.bam",
+]
 ```
+
+When a rule is skipped because none of its optional inputs exist, non-optional
+dependents are skipped too ("blocked by skipped upstream dependency") instead of
+executing a doomed shell command on missing files.
 
 ### Logging and Benchmarking
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -8137,6 +8137,109 @@ fn cli_optional_rule_skips_when_inputs_missing() {
     );
 }
 
+/// `optional = "any"` rules run when at least one alternative input exists
+/// and skip only when none do (issue #200, live: eager's mapper-specific BAM
+/// naming). `optional = true` keeps skip-when-ANY-missing semantics.
+#[test]
+fn cli_optional_any_runs_when_one_alternative_exists() {
+    // One of several alternative inputs exists -> the rule runs.
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("any200.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"any200\"\n\n\
+         [[rules]]\nname = \"pick\"\n\
+         input = [\"data/a.txt\", \"data/b.txt\"]\n\
+         output = [\"picked.txt\"]\noptional = \"any\"\n\
+         shell = \"cat data/a.txt data/b.txt > picked.txt 2>/dev/null || true\"\n",
+    )
+    .unwrap();
+    fs::create_dir(dir.path().join("data")).unwrap();
+    fs::write(dir.path().join("data/b.txt"), "B").unwrap();
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "any-mode run must succeed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stderr).contains("Running: pick"),
+        "any-mode rule must run when one alternative exists"
+    );
+    assert!(dir.path().join("picked.txt").exists());
+
+    // No alternative exists -> the rule skips with a clear reason.
+    let dir2 = tempfile::tempdir().unwrap();
+    let wf2 = dir2.path().join("any200b.oxoflow");
+    fs::write(
+        &wf2,
+        "[workflow]\nname = \"any200b\"\n\n\
+         [[rules]]\nname = \"pick\"\n\
+         input = [\"data/a.txt\", \"data/b.txt\"]\n\
+         output = [\"picked.txt\"]\noptional = \"any\"\n\
+         shell = \"cat data/a.txt data/b.txt > picked.txt\"\n",
+    )
+    .unwrap();
+    let run2 = oxo_flow_cmd()
+        .args(["run", wf2.to_str().unwrap()])
+        .current_dir(dir2.path())
+        .output()
+        .unwrap();
+    assert!(run2.status.success());
+    let stderr2 = String::from_utf8_lossy(&run2.stderr);
+    assert!(
+        stderr2.contains("optional inputs missing"),
+        "any-mode rule must skip when no alternative exists: {stderr2}"
+    );
+    assert!(!dir2.path().join("picked.txt").exists());
+}
+
+/// When an optional rule skips without producing outputs, non-optional
+/// dependents are skipped too instead of executing a doomed shell command
+/// on missing files (issue #200).
+#[test]
+fn cli_optional_skip_blocks_nonoptional_dependents() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("block200.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"block200\"\n\n\
+         [[rules]]\nname = \"baseline\"\noutput = [\"base.txt\"]\n\
+         shell = \"echo base > base.txt\"\n\n\
+         [[rules]]\nname = \"optional_step\"\ninput = [\"data/absent.txt\"]\n\
+         output = [\"opt.txt\"]\noptional = true\n\
+         shell = \"cp data/absent.txt opt.txt\"\n\n\
+         [[rules]]\nname = \"consumer\"\ninput = [\"opt.txt\"]\n\
+         output = [\"cons.txt\"]\n\
+         shell = \"cp opt.txt cons.txt\"\n",
+    )
+    .unwrap();
+    let run = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "run with skipped upstream must succeed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("blocked by skipped dependency"),
+        "dependent must be blocked, not executed: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Running: consumer"),
+        "blocked dependent must not run its shell: {stderr}"
+    );
+    assert!(!dir.path().join("cons.txt").exists());
+}
+
 /// Hook commands expand {config.x} / {input} / {output} placeholders like
 /// the main shell command (issue #75).
 #[test]


### PR DESCRIPTION
Live failure discovered porting nf-core/eager (bamfilter toggle, engine 0.15.0):

- samtools_filter declares the four mapper-specific BAM names as optional inputs, but bwa_aln writes {sample}_PE.mapped.bam while the rule was declared against the bwamem name. With optional = true the rule skips when ANY input is missing, so it always skipped; the downstream flagstat then executed on a missing file and failed the run.

Two engine changes:

1. **optional = "any"** — run when at least one declared input exists, skip only when none do (alternative-input pattern). optional = true/false keeps its current semantics (chipseq relies on skip-when-any-missing). Unknown strings fail fast at parse time.
2. **Skip propagation** — when a rule skips with "optional inputs missing", non-optional dependents are skipped transitively ("blocked by skipped upstream dependency") instead of executing a doomed shell command. Optional dependents are exempt (they self-evaluate).

Verified: make ci locally; 4 new unit tests (parse/roundtrip/semantics) + 2 CLI integration tests (any-mode run/skip; dependent blocking). Live verification of the eager bamfilter chain with this binary on tx-ubuntu pending.