### PR TITLE
fix(cli): batch/pull robustness — TOML-safe escaping, bounded downloads, graceful join errors

### DIFF
--- a/crates/oxo-flow-cli/src/commands/batch.rs
+++ b/crates/oxo-flow-cli/src/commands/batch.rs
@@ -86,7 +86,9 @@ pub async fn batch_command(
             .clone()
             .acquire_owned()
             .await
-            .expect("semaphore should remain open during batch execution");
+            // Safe: the semaphore is never closed; acquire only fails on a
+            // closed semaphore, and we hold Arc clones for the whole run.
+            .expect("batch semaphore closed unexpectedly");
         let cmd = expand_batch_template(&template, item, nr + 1);
 
         let item_clone = item.clone();
@@ -127,7 +129,12 @@ pub async fn batch_command(
             })
             .await;
 
-            let exit_result = result.expect("spawn_blocking failed");
+            // Join failure means the blocking thread died (panic/pressure) —
+            // record it as this item's error instead of panicking the task.
+            let exit_result = match result {
+                Ok(r) => r,
+                Err(join_err) => Err(anyhow::anyhow!("batch worker crashed: {join_err}")),
+            };
 
             // Record result
             if let Ok(mut results_lock) = results_clone.lock() {
@@ -225,6 +232,19 @@ pub async fn batch_command(
     Ok(())
 }
 
+/// Render `shell = <cmd>` as a TOML table line (with a trailing blank line).
+/// Serializing through the toml crate handles backslashes, quotes and
+/// newlines correctly, unlike manual escaping which produced invalid TOML for
+/// commands containing literal `\n` or trailing `\`.
+fn format_shell_line(cmd: &str) -> Result<String> {
+    let mut table = toml::map::Map::new();
+    table.insert("shell".to_string(), toml::Value::String(cmd.to_string()));
+    let rendered = toml::to_string(&toml::Value::Table(table))
+        .with_context(|| format!("serialize shell command {cmd:?} as TOML"))?;
+    // rendered ends with one newline from the serializer.
+    Ok(format!("{rendered}\n"))
+}
+
 pub fn generate_batch_workflow(
     template: &str,
     items: &[String],
@@ -247,7 +267,7 @@ pub fn generate_batch_workflow(
         if let Some(env) = environment {
             content.push_str(&format!("environment = \"{}\"\n", env));
         }
-        content.push_str(&format!("shell = \"{}\"\n\n", cmd.replace('"', "\\\"")));
+        content.push_str(&format_shell_line(&cmd)?);
     }
 
     std::fs::write(&output_path, content)
@@ -259,4 +279,48 @@ pub fn generate_batch_workflow(
         output_path.display()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_line_roundtrips_hostile_commands() {
+        for cmd in [
+            "echo 'single'",
+            "awk '{print $1}'",
+            "printf \"tab\\there\"",
+            "echo back\\slash",
+            "trailing\\",
+            "multi\nline\ncmd",
+            "quote \" in middle",
+        ] {
+            let line = format_shell_line(cmd).expect("serialization");
+            let doc = format!("[r]\n{line}");
+            let parsed: toml::Value =
+                toml::from_str(&doc).unwrap_or_else(|e| panic!("invalid TOML for {cmd:?}: {e}"));
+            assert_eq!(
+                parsed["r"]["shell"].as_str().unwrap(),
+                cmd,
+                "roundtrip mismatch for {cmd:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_workflow_parses_with_hostile_template() {
+        let out = std::env::temp_dir().join(format!("batch-test-{}.toml", std::process::id()));
+        generate_batch_workflow(
+            "echo {}",
+            &["we\"ird".to_string(), "back\\slash".to_string()],
+            Some(&out),
+            None,
+        )
+        .unwrap();
+        let text = std::fs::read_to_string(&out).unwrap();
+        let _parsed: toml::Value = toml::from_str(&text)
+            .unwrap_or_else(|e| panic!("generated file must be valid TOML: {e}\n{text}"));
+        std::fs::remove_file(&out).ok();
+    }
 }

--- a/crates/oxo-flow-cli/src/commands/pull.rs
+++ b/crates/oxo-flow-cli/src/commands/pull.rs
@@ -337,6 +337,36 @@ async fn pull_bundle(
 /// Format: `gh:owner/repo@tag`
 ///
 /// Resolves the GitHub release by tag, then downloads the first `.tar.zst` asset.
+/// Default upper bound for bundle downloads (1 GiB).
+///
+/// Bundles are buffered before their checksums are verified, so an
+/// unbounded read lets a hostile URL exhaust disk/memory first. Override
+/// via `OXO_FLOW_PULL_MAX_BYTES`.
+const DEFAULT_MAX_PULL_BYTES: u64 = 1 << 30;
+
+/// Stream `response` into memory with a hard size cap.
+async fn download_bounded(mut response: reqwest::Response, what: &str) -> Result<Vec<u8>> {
+    let max = std::env::var("OXO_FLOW_PULL_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_PULL_BYTES);
+    let mut data: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .with_context(|| format!("failed to read {what}"))?
+    {
+        if data.len() as u64 + chunk.len() as u64 > max {
+            anyhow::bail!(
+                "{what} exceeds the {max}-byte download limit \
+                 (raise it with OXO_FLOW_PULL_MAX_BYTES)"
+            );
+        }
+        data.extend_from_slice(&chunk);
+    }
+    Ok(data)
+}
+
 async fn pull_github_release(url: &str) -> Result<Vec<u8>> {
     let spec = url.trim_start_matches("gh:");
     let (repo, tag) = spec
@@ -376,17 +406,18 @@ async fn pull_github_release(url: &str) -> Result<Vec<u8>> {
     let asset_name = asset["name"].as_str().unwrap_or("bundle.tar.zst");
 
     eprintln!("  Downloading {}...", asset_name);
-    let data = client
-        .get(download_url)
-        .header("User-Agent", "oxo-flow")
-        .send()
-        .await
-        .context("failed to download release asset")?
-        .bytes()
-        .await
-        .context("failed to read release asset")?;
+    let data = download_bounded(
+        client
+            .get(download_url)
+            .header("User-Agent", "oxo-flow")
+            .send()
+            .await
+            .context("failed to download release asset")?,
+        "release asset",
+    )
+    .await?;
 
-    Ok(data.to_vec())
+    Ok(data)
 }
 
 /// Download a bundle from an HTTP(S) URL.
@@ -402,11 +433,7 @@ async fn pull_http(url: &str) -> Result<Vec<u8>> {
         anyhow::bail!("HTTP {} downloading bundle", response.status());
     }
 
-    let data = response
-        .bytes()
-        .await
-        .context("failed to read bundle data")?;
-    Ok(data.to_vec())
+    download_bounded(response, "bundle").await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes #210 — three localized robustness gaps in the batch/pull subsystem.

1. **TOML-safe shell escaping** (`batch.rs`): generated workflows escaped only double quotes, so a command containing a literal newline or trailing backslash produced invalid TOML. `shell =` lines now serialize through the `toml` crate with round-trip unit tests covering quotes/backslashes/newlines/trailing-`\`, plus an end-to-end parse test of the generated file with a hostile template.
2. **Bounded bundle downloads** (`pull.rs`): http and GitHub-release pulls buffered unbounded bytes before checksum verification — a multi-GB hostile URL exhausted disk/memory first. Both paths stream through `download_bounded()` (1 GiB default cap, `OXO_FLOW_PULL_MAX_BYTES` override) so failures surface early as actionable errors.
3. **No panic on worker crash** (`batch.rs`): `spawn_blocking` join failure previously `.expect()`-crashed the task; it is now recorded as that item's `BatchResult::error`. The semaphore expect remains, now documented why it's a real invariant (semaphore is never closed).

## Verification

- New tests green: `cargo test -p oxo-flow-cli --bin oxo-flow commands::batch`
- `cargo check`/`clippy` clean for `-p oxo-flow-cli`

🤖 Generated with [ZCode](https://zcode.ai)
