### PR TITLE
feat(frontend): per-route error boundaries — one page crash no longer resets the SPA

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import Layout from './components/Layout';
+import RouteErrorBoundary from './components/RouteErrorBoundary';
 import { useI18n } from './context/I18n';
 
 const Dashboard = lazy(() => import('./pages/Dashboard'));
@@ -23,6 +24,15 @@ function PageFallback() {
   </div>;
 }
 
+/** Suspense + per-route error boundary so one page's crash stays contained. */
+function route(name: string, node: ReactNode): ReactNode {
+  return (
+    <Suspense fallback={<PageFallback />}>
+      <RouteErrorBoundary name={name}>{node}</RouteErrorBoundary>
+    </Suspense>
+  );
+}
+
 // Mount-aware routing: the server injects window.__OXO_BASE__ into
 // index.html when the app is served under a sub-path (--base-path); the
 // BrowserRouter basename must match or every route 404s the SPA fallback.
@@ -38,24 +48,24 @@ export default function App() {
     <BrowserRouter basename={appBasename}>
       <Routes>
         {/* Public share landing (issue #82 P0-6): no session, no app chrome */}
-        <Route path="/share/:token" element={<Suspense fallback={<PageFallback />}><Share /></Suspense>} />
+        <Route path="/share/:token" element={route('share', <Share />)} />
         <Route element={<Layout />}>
-          <Route path="/" element={<Suspense fallback={<PageFallback />}><Dashboard /></Suspense>} />
-          <Route path="/editor" element={<Suspense fallback={<PageFallback />}><PipelineEditor /></Suspense>} />
-          <Route path="/pipelines" element={<Suspense fallback={<PageFallback />}><Pipelines /></Suspense>} />
-          <Route path="/login" element={<Suspense fallback={<PageFallback />}><Login /></Suspense>} />
+          <Route path="/" element={route('dashboard', <Dashboard />)} />
+          <Route path="/editor" element={route('pipelineeditor', <PipelineEditor />)} />
+          <Route path="/pipelines" element={route('pipelines', <Pipelines />)} />
+          <Route path="/login" element={route('login', <Login />)} />
           <Route path="/templates" element={<Navigate to="/pipelines" replace />} />
-          <Route path="/runs" element={<Suspense fallback={<PageFallback />}><MonitorReport /></Suspense>} />
-          <Route path="/runs/:id" element={<Suspense fallback={<PageFallback />}><MonitorReport /></Suspense>} />
+          <Route path="/runs" element={route('monitorreport', <MonitorReport />)} />
+          <Route path="/runs/:id" element={route('monitorreport', <MonitorReport />)} />
           {/* /monitor merged into /runs (issue #82 P1-15) — redirect for old links */}
           <Route path="/monitor" element={<Navigate to="/runs" replace />} />
           <Route path="/monitor/:id" element={<Navigate to="/runs" replace />} />
-          <Route path="/chat" element={<Suspense fallback={<PageFallback />}><ChatUI /></Suspense>} />
-          <Route path="/settings" element={<Suspense fallback={<PageFallback />}><Settings /></Suspense>} />
-          <Route path="/docs" element={<Suspense fallback={<PageFallback />}><ApiDocs /></Suspense>} />
-          <Route path="/users" element={<Suspense fallback={<PageFallback />}><Users /></Suspense>} />
-          <Route path="/audit" element={<Suspense fallback={<PageFallback />}><Audit /></Suspense>} />
-          <Route path="/clusters" element={<Suspense fallback={<PageFallback />}><Clusters /></Suspense>} />
+          <Route path="/chat" element={route('chat', <ChatUI />)} />
+          <Route path="/settings" element={route('settings', <Settings />)} />
+          <Route path="/docs" element={route('apidocs', <ApiDocs />)} />
+          <Route path="/users" element={route('users', <Users />)} />
+          <Route path="/audit" element={route('audit', <Audit />)} />
+          <Route path="/clusters" element={route('clusters', <Clusters />)} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  /** Human-readable page name shown in the fallback UI and console logs. */
+  name: string;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Per-route boundary (issue #208): without it any render error inside a lazy
+ * page bubbled past <Suspense> to the single global boundary, tearing down
+ * the whole SPA. Scoping one boundary per route keeps other pages alive.
+ */
+export default class RouteErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(
+      `[RouteErrorBoundary:${this.props.name}] render error:`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  private reset = () => this.setState({ error: null });
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        height: '60vh',
+      }}>
+        <span style={{ fontSize: '2rem' }} role="img" aria-label="error">💥</span>
+        <p style={{ color: 'var(--color-text-secondary)', margin: 0 }}>
+          This page hit an unexpected error ({this.props.name}). Other pages are unaffected.
+        </p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn-run" onClick={this.reset}>Try again</button>
+          <Link to="/" className="btn-run btn-secondary">Go home</Link>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #208. Every lazily-loaded route element is now wrapped in Suspense + a scoped `RouteErrorBoundary` (new component, reuses the styling conventions of the global one). A render error on any page shows a per-page fallback with *Try again* / *Go home* instead of tearing down the whole SPA through the single global boundary.

Refactor detail: the repetitive `element={<Suspense…>}` JSX collapsed into a tiny `route(name, node)` helper, so all 13 routes now read uniformly.

## Verification
- `tsc -b` clean · `eslint` clean · Frontend CI (build + e2e) validates

🤖 Generated with [ZCode](https://zcode.ai)