### PR TITLE
docs: clear stale version markers and pin bioconda counts to their source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ AI features stay disabled (config via env vars or `~/.oxo-flow/ai_config.json`).
 
 Providers are selected at startup via `OXO_FLOW_AI_PROVIDER` env var and initialized once through `AiProviderRegistry::global()` (web crate, `src/ai_provider.rs`). Workflow generation lives in `domains/ai/service.rs` and uses the configured provider, falling back to template matching if AI is disabled or fails.
 
-## 🤖 AI CLI Integration (v0.10.0+)
+## 🤖 AI CLI Integration
 
 The `oxo-flow-ai` crate provides shared AI infrastructure for CLI and web.
 

--- a/crates/oxo-flow-ai/src/knowledge/bioconda.rs
+++ b/crates/oxo-flow-ai/src/knowledge/bioconda.rs
@@ -1,6 +1,8 @@
 //! Embedded Bioconda CLI tool database.
 //!
-//! The full Bioconda channel metadata (6103 CLI tools, curated by the
+//! The full Bioconda channel metadata: 6,470 raw registry entries filtered
+//! down to 6,103 curated CLI tools at refresh time (counts recorded in
+//! knowledge_meta.json; keep this comment in sync when refreshing).
 //! oxo-call-extends project) is embedded into the binary at build time
 //! via `include_str!` and exposed as a searchable database. AI agents
 //! query it through the `lookup_tool` to find real tools, their purposes,

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -289,7 +289,7 @@ model = "deepseek-v4-flash"
 The AI agent combines four embedded knowledge sources (all compiled into the binary at build time):
 
 1. **Tool Reference Table**: 40 curated bioinformatics tools with resource allocations (threads, memory)
-2. **Bioconda Tool Database**: 6,103 CLI tools with current versions and descriptions — queried on demand via `lookup_tool`
+2. **Bioconda Tool Database**: 6,103 curated CLI tools with current versions and descriptions (filtered from 6,470 raw registry entries; see `knowledge_meta.json`) — queried on demand via `lookup_tool`
 3. **bioSkills Library**: 562 curated Agent Skills (the emerging SKILL.md standard) with domain procedures, commands, and caveats — matched by assay type and injected into generation prompts, or queried via `lookup_skill`
 4. **Pipeline Knowledge Graph**: 79 workflow skills and 469 literature-backed data-flow transitions (BAM → VCF → annotated VCF chains) — queried via `lookup_pipeline` to design correct multi-step topologies
 

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -186,7 +186,7 @@ All configuration is TOML-based, parsed with `serde` and the `toml` crate. Repor
 
 ---
 
-## Web Crate Architecture (v0.8+)
+## Web Crate Architecture
 
 The `oxo-flow-web` crate follows a **domain-driven modular monolith** pattern:
 

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -1,4 +1,4 @@
-# Web API (v0.8+)
+# Web API
 
 oxo-flow includes a built-in REST API server for building, validating, running, and monitoring bioinformatics workflows. The server is built with [axum](https://github.com/tokio-rs/axum) and follows a **domain-driven modular monolith** architecture.
 

--- a/docs/guide/src/reference/web-system-architecture.md
+++ b/docs/guide/src/reference/web-system-architecture.md
@@ -37,7 +37,7 @@ The execution backend is a dropdown — local, HPC queue, Docker, cloud batch. E
 
 ---
 
-## Architecture Overview (v0.8+)
+## Architecture Overview
 
 The web crate follows a **domain-driven modular monolith** pattern. Each domain has:
 - `types.rs` — request/response structs
@@ -131,7 +131,7 @@ Rate limiting and SSE:
 
 ---
 
-## Domain-Driven Module Structure (v0.8+)
+## Domain-Driven Module Structure
 
 | Domain | Path | Responsibility |
 |--------|------|---------------|
@@ -151,7 +151,7 @@ Rate limiting and SSE:
 
 ---
 
-## API Namespace (v0.8+)
+## API Namespace
 
 ```
 /api


### PR DESCRIPTION
## Summary

Fixes #211 (AiProviderRegistry attribution item was already resolved by #202).

- Dropped historical `(v0.8+)`/`(v0.10.0+)` header markers that read as current-state across AGENTS.md, web-api.md, architecture.md, web-system-architecture.md
- Bioconda tool count now states both numbers with provenance everywhere: **6,470 raw registry entries → 6,103 curated CLI tools**, citing `knowledge_meta.json`; the loader doc-comment instructs refreshes to keep it synced

Docs-only change (md + one rust doc-comment); no behavior.
CI: docs don't gate on tests; Test job will still validate the crate builds.

🤖 Generated with [ZCode](https://zcode.ai)