### PR TITLE
fix(web): enforce the auth boundary on the serve path too

### DIFF
--- a/crates/oxo-flow-web/src/lib.rs
+++ b/crates/oxo-flow-web/src/lib.rs
@@ -606,12 +606,54 @@ impl IntoResponse for ApiError {
     }
 }
 
+/// The host a server should actually bind, given the requested mode and
+/// host. Single source of truth for both entry points (`oxo-flow serve`
+/// and the standalone web binary):
+///
+/// - **Personal mode has no sign-in** — a non-loopback bind would expose
+///   unauthenticated management endpoints to the network, so the bind is
+///   forced to `127.0.0.1` with a loud warning.
+/// - **`OXO_FLOW_DEV_MODE=1`** accepts `password == username` logins for
+///   any user — refusing to start on a non-loopback bind.
+pub fn effective_bind_host(mode: &str, host: &str) -> anyhow::Result<String> {
+    let dev_mode = std::env::var("OXO_FLOW_DEV_MODE").as_deref() == Ok("1");
+    effective_bind_host_with(mode, host, dev_mode)
+}
+
+/// Pure core of [`effective_bind_host`] — `dev_mode` is passed in so tests
+/// need no environment mutation.
+fn effective_bind_host_with(mode: &str, host: &str, dev_mode: bool) -> anyhow::Result<String> {
+    fn is_loopback_host(host: &str) -> bool {
+        matches!(host, "127.0.0.1" | "::1" | "localhost")
+    }
+    if mode == "personal" {
+        if is_loopback_host(host) {
+            return Ok(host.to_string());
+        }
+        tracing::warn!(
+            "personal mode requires sign-in credentials that are not \
+             enforced, forcing loopback bind instead of '{host}'"
+        );
+        return Ok("127.0.0.1".to_string());
+    }
+    if dev_mode && !is_loopback_host(host) {
+        anyhow::bail!(
+            "OXO_FLOW_DEV_MODE=1 accepts password==username logins for \
+             any user and is only safe on a loopback bind; refusing to \
+             start on '{host}'. Unset OXO_FLOW_DEV_MODE or bind to 127.0.0.1."
+        );
+    }
+    Ok(host.to_string())
+}
+
 pub async fn start_server_with_mode(
     mode: &str,
     host: &str,
     port: u16,
     base_path: &str,
 ) -> anyhow::Result<()> {
+    // Auth-boundary enforcement (shared with the standalone binary).
+    let host = effective_bind_host(mode, host)?;
     crate::db::init_db("sqlite://oxo-flow.db").await?;
     crate::db::recover_orphaned_runs().await?;
     crate::infra::db::sqlite::init_pool("sqlite://oxo-flow.db").await;
@@ -716,3 +758,38 @@ pub async fn shutdown_signal() {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+#[cfg(test)]
+mod effective_bind_host_tests {
+    use super::*;
+
+    #[test]
+    fn personal_mode_forces_loopback_for_non_loopback_hosts() {
+        assert_eq!(
+            effective_bind_host_with("personal", "0.0.0.0", false).unwrap(),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            effective_bind_host_with("personal", "192.168.1.5", false).unwrap(),
+            "127.0.0.1"
+        );
+        // Loopback hosts pass through untouched.
+        assert_eq!(
+            effective_bind_host_with("personal", "127.0.0.1", false).unwrap(),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            effective_bind_host_with("personal", "localhost", false).unwrap(),
+            "localhost"
+        );
+    }
+
+    #[test]
+    fn team_mode_binds_any_host_and_dev_mode_refuses_non_loopback() {
+        assert_eq!(
+            effective_bind_host_with("team", "0.0.0.0", false).unwrap(),
+            "0.0.0.0"
+        );
+        assert!(effective_bind_host_with("team", "0.0.0.0", true).is_err());
+        assert!(effective_bind_host_with("team", "127.0.0.1", true).is_ok());
+    }
+}

--- a/crates/oxo-flow-web/src/main.rs
+++ b/crates/oxo-flow-web/src/main.rs
@@ -95,40 +95,11 @@ async fn main() -> Result<()> {
     // Print license banner on startup
     eprintln!("{}", oxo_flow_web::infra::license::license_banner_text());
 
-    // Determine effective host based on mode
+    // Determine effective host based on mode — the enforcement itself lives
+    // in `oxo_flow_web::effective_bind_host` so `oxo-flow serve` (the web
+    // library path) and this binary share one auth boundary.
     let mode_str = cli.mode.to_string();
-    fn is_loopback_host(host: &str) -> bool {
-        matches!(host, "127.0.0.1" | "::1" | "localhost")
-    }
-    let effective_host = match cli.mode {
-        ServerMode::Personal => {
-            if is_loopback_host(&cli.host) {
-                cli.host.clone()
-            } else {
-                // Personal mode has no sign-in: any non-loopback bind would
-                // expose unauthenticated management endpoints to the network.
-                tracing::warn!(
-                    "personal mode requires sign-in credentials that are not \
-                     enforced, forcing loopback bind instead of '{}'",
-                    cli.host
-                );
-                "127.0.0.1".to_string()
-            }
-        }
-        _ => {
-            if std::env::var("OXO_FLOW_DEV_MODE").as_deref() == Ok("1")
-                && !is_loopback_host(&cli.host)
-            {
-                anyhow::bail!(
-                    "OXO_FLOW_DEV_MODE=1 accepts password==username logins for \
-                     any user and is only safe on a loopback bind; refusing to \
-                     start on '{}'. Unset OXO_FLOW_DEV_MODE or bind to 127.0.0.1.",
-                    cli.host
-                );
-            }
-            cli.host.clone()
-        }
-    };
+    let effective_host = oxo_flow_web::effective_bind_host(&mode_str, &cli.host)?;
 
     tracing::info!(
         "Starting oxo-flow-web in {} mode on {}:{}",


### PR DESCRIPTION
## What

PR #202's loopback forcing lived only in the standalone binary's `main.rs`. The primary documented entry point — `oxo-flow serve` — binds through the web **library** (`start_server_with_mode`) and kept binding `0.0.0.0` in personal mode.

**Live-verified before this fix**: `oxo-flow serve --host 0.0.0.0` in personal mode → `TCP *:PORT (LISTEN)`, unauthenticated management endpoints exposed to the network.

## Fix

- Move the enforcement into `oxo_flow_web::effective_bind_host()` — single source of truth shared by both entry points:
  - personal mode: non-loopback host → forced to `127.0.0.1` with a loud warning;
  - `OXO_FLOW_DEV_MODE=1` (password==username logins): non-loopback bind refuses to start.
- `main.rs` drops its inline duplicate and calls the shared helper (DRY).
- Pure core `effective_bind_host_with(mode, host, dev_mode)` is unit-tested without env mutation (the crate forbids `unsafe_code`); 2 tests added.

## Verification

- Live: `serve --host 0.0.0.0 --port 38889` → warning logged, `TCP 127.0.0.1:38889 (LISTEN)`, health 200.
- `make ci` green (fmt + clippy -D warnings + build + tests + schema drift + audit + frontend lint).

Note: this commit originally landed on `fix/audit-findings` right after #202 was merged from the pre-fix snapshot, so it missed that merge — re-based onto current main here.