### PR TITLE
ci(frontend): npm audit gate + drop duplicate playwright dep; zero current advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,6 +1009,17 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      # Dependency-vulnerability gate (issue #209): the local npm mirror
+      # does not implement the audit endpoint, so this must query the
+      # canonical registry explicitly. Prod deps gate hard; dev deps are
+      # reported until a baseline is established.
+      - name: Audit npm dependencies
+        working-directory: frontend
+        run: |
+          npm audit --omit=dev --registry=https://registry.npmjs.org
+          npm audit --registry=https://registry.npmjs.org || \
+            echo "::warning::dev-dependency advisories present — triage before merging"
+
       - name: Lint the SPA
         working-directory: frontend
         run: npm run lint

--- a/crates/oxo-flow-web/static/index.html
+++ b/crates/oxo-flow-web/static/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>oxo-flow — Command Center</title>
-    <script type="module" crossorigin src="./assets/index-BYsNzFze.js"></script>
+    <script type="module" crossorigin src="./assets/index-BFPLEpIF.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/rolldown-runtime-Bh1tDfsg.js">
     <link rel="modulepreload" crossorigin href="./assets/dag-B0cyNosi.js">
-    <link rel="modulepreload" crossorigin href="./assets/react-uohav-c5.js">
+    <link rel="modulepreload" crossorigin href="./assets/react-D2IhTsoC.js">
     <link rel="modulepreload" crossorigin href="./assets/vendor-VQinhYo2.js">
     <link rel="stylesheet" crossorigin href="./assets/dag-DLioOiRN.css">
     <link rel="stylesheet" crossorigin href="./assets/index-DEiAKF7C.css">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
-        "playwright": "^1.60.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
         "vite": "^8.0.12"
@@ -1455,16 +1454,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1625,7 +1624,7 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
@@ -2772,9 +2771,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2972,9 +2971,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2992,7 +2991,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3051,9 +3050,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3073,12 +3072,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3152,7 +3151,7 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmmirror.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
-    "playwright": "^1.60.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.0.12"


### PR DESCRIPTION
## Summary

Fixes #209.

- **Advisories zeroed and gated**: `npm audit` found 4 high + 1 moderate (brace-expansion DoS chain, nanoid) — all fixed via non-breaking lockfile bumps (`npm audit fix`, 20-line lock diff). CI's Frontend job now hard-gates **prod** deps against the canonical registry (the local mirror lacks the audit endpoint, so registry override is explicit); dev-dep findings surface as a warning until triaged.
- **Dropped the duplicate bare `playwright` devDependency** (`@playwright/test` brings its own matching copy).
- **codemirror meta-package kept**: audit follow-up showed it is *not* redundant — `TomlEditor.tsx` imports `basicSetup` from it, which has no granular-package equivalent. Removing it would mean hand-assembling an extension set; recorded as the known deviation from the issue text rather than a rushed rewrite.

## Verification
- `npm audit` → 0 vulnerabilities · `npm run build` green · tsc/eslint untouched by dep removal

🤖 Generated with [ZCode](https://zcode.ai)