### PR TITLE
docs(agents): describe pagination schemes as they are, not one imaginary envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The web crate (`oxo-flow-web`) is designed as an AI-native API surface:
 - **API discovery**: `GET /api/openapi.json` returns full OpenAPI 3.1 schema
 - **Intent-driven authoring**: `POST /api/workflows/generate` maps natural language to pipelines
 - **SSE streaming**: `GET /api/events` provides real-time execution events
-- **Pagination**: List endpoints use `{data, meta: {page, per_page, total_items, total_pages}}` envelope
+- **Pagination**: `GET /api/runs` uses cursor pagination `{items, next_cursor, total}`; most other list endpoints return bare capped arrays (≤ 100); the storage layer exposes an offset-style `Paginated<T> {items, page, per_page, total_items, total_pages}` internally. There is deliberately no single uniform envelope — document per endpoint (see web-api.md)
 
 ## 🖥️ Frontend SPA
 The frontend is a React/TypeScript SPA built with Vite, located in `frontend/`:


### PR DESCRIPTION
## Summary

Fixes #212 via its recommended **option B** (honesty over uniformity).

The web-api.md reference already documents each scheme accurately (cursor envelope for /api/runs, bare capped arrays elsewhere, audit's own {entries, days, page, …} shape) — the only source of the fictional uniform `{data, meta}` envelope was **AGENTS.md line 63**. Replaced with a precise description naming all three schemes including the internal `Paginated<T>` offset struct, explicitly noting there is deliberately no single envelope.

Deliberately not attempted here (per issue discussion): OpenAPI gate assertions binding each list route to its declared scheme — worthwhile follow-up once endpoints consolidate.

Docs-only diff. 🤖 Generated with [ZCode](https://zcode.ai)