### PR TITLE
feat(web): structured 503 boundary for run execution on PostgreSQL deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ oxo-flow serve
 # → Open http://127.0.0.1:3000 in your browser
 
 # Mode 2: Team server — SQLite/PG, 0.0.0.0, ORCID/GitHub OAuth2
+#   (note: workflow run EXECUTION requires the SQLite backend; PG servers serve library/AI/auth — POST /api/runs returns 503)
 oxo-flow serve --mode team --db postgres://...
 
 # Mode 3: HPC submit panel — Web UI for cluster job submission

--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -103,6 +103,28 @@ pub async fn create_run(
     authenticated: Option<Extension<CurrentUser>>,
     Json(req): Json<serde_json::Value>,
 ) -> ApiResult<CreateRunResponse> {
+    // PostgreSQL deployments have no SQLite pool backing run bookkeeping
+    // (issue #207 phase 1): fail with a structured boundary instead of
+    // letting spawn/background tasks degrade mysteriously mid-run.
+    if crate::infra::db::sqlite::try_pool().is_err() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiError {
+                code: "RUNS_REQUIRE_SQLITE".into(),
+                message: "Workflow run execution is not available on this deployment."
+                    .into(),
+                detail: Some(
+                    "Run lifecycle bookkeeping uses the embedded SQLite store;                      PostgreSQL servers serve library/AI/auth features only."
+                        .into(),
+                ),
+                suggestion: Some(
+                    "Execute via `oxo-flow run` from the CLI, or use a personal-mode                      server backed by SQLite."
+                        .into(),
+                ),
+            }),
+        ));
+    }
+
     let user = current_user::resolve(authenticated.as_ref());
     let toml = req
         .get("toml_content")

--- a/crates/oxo-flow-web/src/main.rs
+++ b/crates/oxo-flow-web/src/main.rs
@@ -150,6 +150,10 @@ async fn main() -> Result<()> {
         {
             tracing::info!("Initializing PostgreSQL backend");
             oxo_flow_web::infra::db::postgres::init_pool(&database_url).await;
+            tracing::warn!(
+                "Capability boundary: workflow RUN EXECUTION is SQLite-only — \
+                 POST /api/runs will respond 503 RUNS_REQUIRE_SQLITE"
+            );
         }
         #[cfg(not(feature = "postgres"))]
         {


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #207 (does NOT close it — parity survey remains).

- `POST /api/runs` responds `503 {code:"RUNS_REQUIRE_SQLITE"}` with detail+suggestion whenever the SQLite pool is absent (PostgreSQL builds) instead of accepting a request that would then degrade mysteriously in background tasks
- PostgreSQL startup logs an explicit capability warning
- README mode-2 example gains the boundary note so nobody deploys expecting PG runs

Intentionally out of scope here: OpenAPI annotation touch-up and the Phase-3 pool-unification epic tracked in #207.

Note on testing: the guard depends on process-global pool state that existing tests initialize; covered by compile + CI contract tests rather than a new unit case (documented).

🤖 Generated with [ZCode](https://zcode.ai)