### PR TITLE
feat(web): encrypt AI provider keys at rest under OXO_FLOW_MASTER_KEY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OXO_FLOW_AI_API_KEY` | No | — | Generic API key fallback |
 | `OXO_FLOW_AI_API_URL` | No | (provider default) | Custom API endpoint URL |
 | `OXO_FLOW_AI_MODEL` | No | (provider default) | Model name override |
+| `OXO_FLOW_MASTER_KEY` | No | — | AES-256-GCM seed encrypting AI provider keys at rest (`v1:`-prefixed rows in the local DB). Unset = plaintext legacy mode |
 | `ANTHROPIC_AUTH_TOKEN` | No | — | Claude/Anthropic API key (overrides OXO_FLOW_AI_API_KEY) |
 | `ANTHROPIC_BASE_URL` | No | `https://api.anthropic.com` | Anthropic-compatible API base URL |
 | `ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Claude model name |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1111,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,6 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1315,6 +1351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1860,6 +1905,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2818,6 +2873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,11 +3011,13 @@ dependencies = [
 name = "oxo-flow-web"
 version = "0.16.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-stream",
  "async-trait",
  "async_zip",
  "axum",
+ "base64",
  "bcrypt",
  "chrono",
  "clap",
@@ -3252,6 +3315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4371,7 +4446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4857,6 +4932,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,7 +5214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ fs2 = "0.4"
 
 # Crypto
 sha2 = "0.10"
+aes-gcm = "0.10"
 sha1 = "0.10"
 hmac = "0.12"
 base64 = "0.22"

--- a/crates/oxo-flow-web/Cargo.toml
+++ b/crates/oxo-flow-web/Cargo.toml
@@ -33,6 +33,8 @@ tokio-stream = { workspace = true }
 tokio-util = { version = "0.7", features = ["io"] }
 crc32fast = "1.4"
 sha2 = "0.10"
+aes-gcm = { workspace = true }
+base64 = { workspace = true }
 async-stream = "0.3.6"
 dashmap = "6.1"
 bcrypt = "0.17"

--- a/crates/oxo-flow-web/src/ai_provider.rs
+++ b/crates/oxo-flow-web/src/ai_provider.rs
@@ -66,7 +66,10 @@ pub async fn provider_for(user_id: &str) -> AiProvider {
         if let Some((provider_kind, api_url, model, api_key)) = row
             && provider_kind != "disabled"
         {
-            let key = api_key.unwrap_or_default();
+            // Rows are written through infra::crypto::seal (issue #205), so
+            // the stored value may be a `v1:` ciphertext — decrypt here too,
+            // never hand the encoded form to a provider.
+            let key = crate::infra::crypto::open(&api_key.unwrap_or_default());
             // A per-user row without a key is not a usable configuration.
             // Fall back to the shared runtime so the user gets the global
             // provider (or Noop if none is configured) instead of a provider

--- a/crates/oxo-flow-web/src/domains/ai/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/ai/handlers.rs
@@ -475,7 +475,7 @@ pub async fn restore_ai_config_from_db() {
     {
         let _ = crate::ai_provider::AiProviderRegistry::global().reconfigure(
             &provider,
-            Some(api_key),
+            Some(crate::infra::crypto::open(&api_key)),
             Some(api_url),
             Some(model),
         );
@@ -615,6 +615,9 @@ pub async fn update_server_ai_config(
     let api_url = req.get("api_url").and_then(|v| v.as_str()).unwrap_or("");
     let model = req.get("model").and_then(|v| v.as_str()).unwrap_or("");
     let api_key = req.get("api_key").and_then(|v| v.as_str()).unwrap_or("");
+    // Issue #205: encrypt third-party credentials at rest when a master
+    // key is configured; plaintext passthrough keeps legacy behavior.
+    let stored_api_key = crate::infra::crypto::seal(api_key);
 
     // Upsert server config (user_id IS NULL)
     sqlx::query(
@@ -624,7 +627,7 @@ pub async fn update_server_ai_config(
     .bind(provider)
     .bind(api_url)
     .bind(model)
-    .bind(api_key)
+    .bind(&stored_api_key)
     .bind(chrono::Utc::now().to_rfc3339())
     .bind(chrono::Utc::now().to_rfc3339())
     .execute(pool)
@@ -697,6 +700,9 @@ pub async fn update_user_ai_config(
     let api_url = req.get("api_url").and_then(|v| v.as_str()).unwrap_or("");
     let model = req.get("model").and_then(|v| v.as_str()).unwrap_or("");
     let api_key = req.get("api_key").and_then(|v| v.as_str()).unwrap_or("");
+    // Issue #205: encrypt third-party credentials at rest when a master
+    // key is configured; plaintext passthrough keeps legacy behavior.
+    let stored_api_key = crate::infra::crypto::seal(api_key);
     let search_enabled = req
         .get("search_enabled")
         .and_then(|v| v.as_bool())
@@ -724,7 +730,7 @@ pub async fn update_user_ai_config(
     .bind(provider)
     .bind(api_url)
     .bind(model)
-    .bind(api_key)
+    .bind(&stored_api_key)
     .bind(search_enabled as i64)
     .bind(monitor_enabled as i64)
     .bind(auto_retry_enabled as i64)

--- a/crates/oxo-flow-web/src/infra/crypto.rs
+++ b/crates/oxo-flow-web/src/infra/crypto.rs
@@ -1,0 +1,116 @@
+//! At-rest protection for secrets stored in the local database
+//! (issue #205): third-party AI provider API keys.
+//!
+//! `OXO_FLOW_MASTER_KEY` seeds an AES-256-GCM key (SHA-256 of the secret).
+//! With the var unset, writes stay plaintext (previous behavior) and reads
+//! accept both forms, so enabling or rotating is transparent and nothing
+//! bricks when the secret is missing.
+
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use sha2::{Digest, Sha256};
+
+const PREFIX: &str = "v1:";
+
+fn master_key() -> Option<[u8; 32]> {
+    let raw = std::env::var("OXO_FLOW_MASTER_KEY").ok()?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(Sha256::digest(raw.as_bytes()).into())
+}
+
+fn encrypt_with(key: &[u8; 32], plain: &str) -> String {
+    let cipher = Aes256Gcm::new(key.into());
+    let mut nonce_bytes = [0u8; 12];
+    OsRng.fill_bytes(&mut nonce_bytes);
+    let ct = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plain.as_bytes())
+        .expect("AES-GCM encryption cannot fail for valid inputs");
+    format!("{PREFIX}{}:{}", B64.encode(nonce_bytes), B64.encode(ct))
+}
+
+fn decrypt_with(key: &[u8; 32], stored: &str) -> Option<String> {
+    let body = stored.strip_prefix(PREFIX)?;
+    let (nonce_b64, ct_b64) = body.split_once(':')?;
+    let nonce = B64.decode(nonce_b64).ok()?;
+    let ct = B64.decode(ct_b64).ok()?;
+    let cipher = Aes256Gcm::new(key.into());
+    cipher
+        .decrypt(Nonce::from_slice(&nonce), ct.as_ref())
+        .ok()
+        .and_then(|plain| String::from_utf8(plain).ok())
+}
+
+/// Encrypt to the stored format, or return plaintext unchanged when no
+/// master key is configured (legacy mode).
+pub fn seal(plain: &str) -> String {
+    match master_key() {
+        Some(key) => encrypt_with(&key, plain),
+        None => plain.to_string(),
+    }
+}
+
+/// Decrypt anything previously written: transparently passes legacy
+/// plaintext through; `v1:` payloads require the same master key.
+pub fn open(stored: &str) -> String {
+    if !stored.starts_with(PREFIX) {
+        return stored.to_string();
+    }
+    let Some(key) = master_key() else {
+        tracing::error!("Encrypted AI credential present but OXO_FLOW_MASTER_KEY unset");
+        return String::new();
+    };
+    match decrypt_with(&key, stored) {
+        Some(plain) => plain,
+        None => {
+            tracing::error!(
+                "AI credential decryption failed (wrong OXO_FLOW_MASTER_KEY or corrupt row)"
+            );
+            String::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const K1: [u8; 32] = [7u8; 32];
+    const K2: [u8; 32] = [9u8; 32];
+
+    #[test]
+    fn sealed_form_is_prefixed_and_roundtrips_only_with_right_key() {
+        let sealed = encrypt_with(&K1, "sk-live-abc123");
+        assert!(sealed.starts_with(PREFIX));
+        assert!(!sealed.contains("sk-live"));
+        assert_eq!(
+            decrypt_with(&K1, &sealed).as_deref(),
+            Some("sk-live-abc123")
+        );
+        assert_eq!(decrypt_with(&K2, &sealed), None);
+        // Fresh random nonce per write: identical plaintext must differ.
+        assert_ne!(encrypt_with(&K1, "x"), encrypt_with(&K1, "x"));
+    }
+
+    #[test]
+    fn legacy_plaintext_passes_through_when_no_master_key() {
+        // This test binary never sets OXO_FLOW_MASTER_KEY; if that ever
+        // changes, seal() here would emit a v1: row and this catches it.
+        assert_eq!(open("plaintext-key"), "plaintext-key");
+        assert_eq!(seal("plaintext-key"), "plaintext-key");
+    }
+
+    #[test]
+    fn pair_semantics_match_wrapper_contract() {
+        // The wrappers add only key lookup + passthrough on top of these
+        // primitives — pin that contract down without mutating process env.
+        let sealed = encrypt_with(&K1, "row-key");
+        assert_eq!(decrypt_with(&K2, &sealed), None);
+        assert_eq!(decrypt_with(&K1, &sealed).as_deref(), Some("row-key"));
+        assert!(seal("whatever") == "whatever" || seal("whatever").starts_with(PREFIX));
+    }
+}

--- a/crates/oxo-flow-web/src/infra/mod.rs
+++ b/crates/oxo-flow-web/src/infra/mod.rs
@@ -1,3 +1,4 @@
+pub mod crypto;
 pub mod db;
 pub mod hpc;
 pub mod license;

--- a/crates/oxo-flow-web/src/main.rs
+++ b/crates/oxo-flow-web/src/main.rs
@@ -180,6 +180,19 @@ async fn main() -> Result<()> {
 
     // Initialize AI provider from environment variables
     oxo_flow_web::ai_provider::AiProviderRegistry::global().init_from_env();
+    // Issue #205: at-rest encryption is opt-in. Loudly surface the plaintext
+    // trade-off so operators make the choice consciously; legacy rows keep
+    // working and enabling the key later only affects new writes.
+    if std::env::var("OXO_FLOW_MASTER_KEY")
+        .map(|v| v.is_empty())
+        .unwrap_or(true)
+    {
+        tracing::warn!(
+            "OXO_FLOW_MASTER_KEY is not set: AI provider keys are stored as \
+             plaintext in the local database. Set it to encrypt new writes \
+             (existing rows remain readable)."
+        );
+    }
     // Restore the DB-persisted tier (settings UI) when env did not configure
     // a provider — otherwise a saved key would be lost on restart.
     oxo_flow_web::domains::ai::handlers::restore_ai_config_from_db().await;


### PR DESCRIPTION
## Summary

Fixes #205.

- New `infra/crypto.rs`: AES-256-GCM (key = SHA-256 of `OXO_FLOW_MASTER_KEY`), random nonce per write, stored format `v1:<b64 nonce>:<b64 ct>`
- **Transparent lifecycle**: master key unset ⇒ writes stay plaintext (previous behavior) and reads accept both forms; set later ⇒ new writes seal while legacy rows still load; wrong/missing key on a `v1:` row yields empty credential with an explicit error log — never a panic or partial key
- Both AI-config upserts (`POST /api/ai/config/user`, server-tier variant) now persist via `seal()`; the DB→registry restore path decrypts via `open()`; runtime injection and API echoes untouched (keys never leave the server)
- `OXO_FLOW_MASTER_KEY` documented in AGENTS.md env table
- Unit tests: prefix + roundtrip-only-with-right-key, wrong-key rejection, per-write nonce uniqueness, legacy passthrough semantics

Deps: adds `aes-gcm` (workspace) and wires existing workspace `base64` into the web crate.

🤖 Generated with [ZCode](https://zcode.ai)