### PR TITLE
fix(core): safe-char default for wildcard values reaching shells (#203)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OPENAI_BASE_URL` | No | `https://api.openai.com/v1` | OpenAI-compatible API base URL |
 | `OPENAI_MODEL` | No | `gpt-4o` | OpenAI-compatible model name |
 | `OXO_FLOW_FRONTEND_DIR` | No | — | Path to built frontend dist directory |
+| `OXO_FLOW_UNSAFE_WILDCARDS` | No | unset | Set to `"1"` to relax the wildcard safe-default charset check (#203); command-substitution values stay blocked and a warning is logged once |
 
 ### AI Provider Examples
 

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1241,6 +1241,9 @@ pub async fn run_command(
         skip_env_setup,
         cache_dir: cache_dir.clone(),
         interpreter_map: config.workflow.interpreter_map.clone(),
+        // Unconstrained wildcards fall back to the safe default charset
+        // inside validate_wildcard_injection (issue #203).
+        wildcard_constraints: config.wildcard_constraints.clone(),
         // Shared with the manifest snapshot resolver so staging and
         // invalidation always see the same backends (issue #80 item 2).
         storage_resolver: crate::commands::run_preview::storage_resolver(),

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -297,6 +297,11 @@ pub struct ExecutorConfig {
     /// identity instead of mtime. `None` (tests, cluster paths) keeps the
     /// mtime-only gate.
     pub checkpoint: Option<Arc<Mutex<super::checkpoint::CheckpointState>>>,
+    /// Workflow-level `wildcard_constraints` (name -> regex) copied from the
+    /// parsed config (issue #203): unconstrained wildcards fall back to the
+    /// safe default charset inside `validate_wildcard_injection`, while a
+    /// declared constraint here governs that wildcard instead.
+    pub wildcard_constraints: HashMap<String, String>,
 }
 
 impl Default for ExecutorConfig {
@@ -320,6 +325,7 @@ impl Default for ExecutorConfig {
             sensitive_values: Vec::new(),
             shell_prelude: None,
             checkpoint: None,
+            wildcard_constraints: HashMap::new(),
         }
     }
 }
@@ -1340,7 +1346,7 @@ impl LocalExecutor {
             .cloned()
             .map(|c| mask_sensitive(&c, &self.config.sensitive_values));
 
-        validate_wildcard_injection(wildcard_values)?;
+        validate_wildcard_injection(wildcard_values, &self.config.wildcard_constraints)?;
         for cmd in &resolved_commands {
             validate_shell_safety(cmd)?;
             for warning in sanitize_shell_command(cmd) {

--- a/crates/oxo-flow-core/src/executor/security.rs
+++ b/crates/oxo-flow-core/src/executor/security.rs
@@ -3,6 +3,11 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Logs the `OXO_FLOW_UNSAFE_WILDCARDS` relaxation exactly once per process
+/// instead of once per rule execution.
+static UNSAFE_WILDCARDS_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Validate that an interpreter path is safe to use.
 ///
@@ -212,26 +217,56 @@ pub fn validate_shell_safety(cmd: &str) -> Result<()> {
     Ok(())
 }
 
-/// Validate wildcard VALUES for shell injection patterns.
+/// Character class accepted for wildcard values when the workflow declares
+/// no explicit `wildcard_constraints` entry (issue #203): letters, digits,
+/// dot, underscore, dash, and path separator — the superset observed across
+/// every shipped example. Anything else needs an explicit constraint.
+pub const DEFAULT_WILDCARD_PATTERN: &str = r"^[A-Za-z0-9._/-]+$";
+
+static DEFAULT_WILDCARD_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(DEFAULT_WILDCARD_PATTERN).expect("static regex"));
+
+/// Validate wildcard VALUES before they are substituted into shell commands.
 ///
-/// Unlike [`validate_shell_safety`] which operates on the full rendered
-/// command (and therefore trusts the shell template), this function checks
-/// only the values that will be *substituted* into the template via
-/// wildcard expansion (e.g., sample names from a CSV file, file paths).
+/// Two independent layers:
 ///
-/// Returns `Ok(())` if all values are safe, or an error if any value
-/// contains a pattern that would execute arbitrary shell code.
+/// 1. **Hard floor (always enforced)** — no `$(`, no backticks. This blocks
+///    direct command substitution regardless of configuration.
+/// 2. **Default charset (issue #203)** — values for wildcards WITHOUT an
+///    explicit `wildcard_constraints` entry must match
+///    [`DEFAULT_WILDCARD_PATTERN`]. Pipelines that legitimately need other
+///    characters declare a constraint for that wildcard (the pre-existing
+///    mechanism), or set `OXO_FLOW_UNSAFE_WILDCARDS=1` to relax the charset
+///    layer for the process — a one-time warning is logged and the
+///    `$(`/backtick floor still applies.
+///
+/// Values from `config.*` keys come from the trusted .oxoflow file itself
+/// and skip both layers, as before.
 #[must_use = "wildcard injection validation returns a Result that must be checked"]
-pub fn validate_wildcard_injection(wildcard_values: &HashMap<String, String>) -> Result<()> {
-    // Patterns that indicate injection attempts in externally supplied values.
-    // Config values from the .oxoflow file itself (prefixed with "config.")
-    // are trusted and skipped.
+pub fn validate_wildcard_injection(
+    wildcard_values: &HashMap<String, String>,
+    declared_constraints: &HashMap<String, String>,
+) -> Result<()> {
+    let unsafe_mode = std::env::var("OXO_FLOW_UNSAFE_WILDCARDS").as_deref() == Ok("1");
+    if unsafe_mode && !UNSAFE_WILDCARDS_WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            "OXO_FLOW_UNSAFE_WILDCARDS=1: wildcard value charset checks are relaxed \
+             for this process; command-substitution values are still rejected"
+        );
+    }
+    validate_wildcard_injection_inner(wildcard_values, declared_constraints, unsafe_mode)
+}
+
+fn validate_wildcard_injection_inner(
+    wildcard_values: &HashMap<String, String>,
+    declared_constraints: &HashMap<String, String>,
+    unsafe_mode: bool,
+) -> Result<()> {
     let injection_patterns = [
         ("$(", "command substitution"),
         ("`", "backtick substitution"),
     ];
     for (key, value) in wildcard_values {
-        // Skip config.* keys — these come from the trusted .oxoflow file.
         if key.starts_with("config.") {
             continue;
         }
@@ -249,6 +284,25 @@ pub fn validate_wildcard_injection(wildcard_values: &HashMap<String, String>) ->
                     ),
                 });
             }
+        }
+        // Charset layer only applies to unconstrained wildcards.
+        if declared_constraints.contains_key(key) || unsafe_mode {
+            continue;
+        }
+        if !DEFAULT_WILDCARD_RE.is_match(value) {
+            return Err(OxoFlowError::Validation {
+                message: format!(
+                    "Wildcard '{key}' has value '{}' outside the safe default \
+                     character set ({DEFAULT_WILDCARD_PATTERN})",
+                    value
+                ),
+                rule: None,
+                suggestion: Some(format!(
+                    "Declare a constraint for this wildcard in `wildcard_constraints` \
+                     (e.g. {key} = '^.+$' to allow anything), or set \
+                     OXO_FLOW_UNSAFE_WILDCARDS=1 to accept any characters with a logged warning."
+                )),
+            });
         }
     }
     Ok(())
@@ -299,4 +353,60 @@ pub fn validate_path_safety(workdir: &Path, path: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+#[cfg(test)]
+mod wildcard_default_tests {
+    use super::*;
+
+    fn v(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, val)| (k.to_string(), val.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn default_charset_accepts_realistic_samples() {
+        let vals = v(&[
+            ("sample", "SRR1039508"),
+            ("chr", "chr21"),
+            ("path", "data/subdir/genome.fa"),
+        ]);
+        assert!(validate_wildcard_injection_inner(&vals, &HashMap::new(), false).is_ok());
+    }
+
+    #[test]
+    fn default_charset_rejects_metacharacters_and_spaces() {
+        for bad in ["a; b", "x&&y", "a|b", "$(id)", "`id`", "two words", "a>b"] {
+            let vals = v(&[("sample", bad)]);
+            let err = validate_wildcard_injection_inner(&vals, &HashMap::new(), false)
+                .err()
+                .unwrap_or_else(|| panic!("'{bad}' must be rejected"));
+            let msg = err.to_string();
+            if bad.contains("$(") || bad.contains('`') {
+                assert!(msg.contains("injection"), "{msg}");
+            } else {
+                assert!(msg.contains("safe default"), "{msg}");
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_constraint_overrides_default_charset() {
+        let vals = v(&[("sample", "tumor / normal")]);
+        let mut constraints = HashMap::new();
+        constraints.insert("sample".to_string(), "^.+$".to_string());
+        assert!(
+            validate_wildcard_injection_inner(&vals, &constraints, false).is_ok(),
+            "declared constraint governs"
+        );
+    }
+
+    #[test]
+    fn unsafe_mode_relaxes_charset_but_not_substitution_floor() {
+        let relaxed = v(&[("sample", "two words")]);
+        assert!(validate_wildcard_injection_inner(&relaxed, &HashMap::new(), true).is_ok());
+        let hostile = v(&[("sample", "$(id)")]);
+        assert!(validate_wildcard_injection_inner(&hostile, &HashMap::new(), true).is_err());
+    }
 }

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -933,7 +933,7 @@ fn validate_shell_safety_blocks_dangerous_deletion() {
 fn validate_wildcard_injection_blocks_command_substitution() {
     let mut values = HashMap::new();
     values.insert("sample".to_string(), "$(whoami)".to_string());
-    assert!(validate_wildcard_injection(&values).is_err());
+    assert!(validate_wildcard_injection(&values, &HashMap::new()).is_err());
 }
 
 // ---------------------------------------------------------------------------
@@ -1345,24 +1345,24 @@ fn validate_wildcard_injection_allows_config_keys() {
     values.insert("config.sample_name".to_string(), "$(whoami)".to_string());
     values.insert("sample".to_string(), "SAMPLE_01".to_string());
     // Config-prefixed keys should be skipped (trusted from .oxoflow file)
-    validate_wildcard_injection(&values).unwrap();
+    validate_wildcard_injection(&values, &HashMap::new()).unwrap();
 }
 
 #[test]
 fn validate_wildcard_injection_blocks_pipe_in_value() {
     let mut values = HashMap::<String, String>::new();
     values.insert("sample".to_string(), "SAMPLE_01 | echo hacked".to_string());
-    // Pipes are not currently blocked by wildcard injection (only $() and backticks)
-    // This test verifies the current behavior
-    // The pipe would be caught by validate_shell_safety on the rendered command
-    validate_wildcard_injection(&values).unwrap();
+    // Issue #203 default charset: unconstrained wildcards reject shell
+    // metacharacters outright (previously deferred to the rendered-command
+    // scan; now fail fast at the value layer).
+    assert!(validate_wildcard_injection(&values, &HashMap::new()).is_err());
 }
 
 #[test]
 fn validate_wildcard_injection_blocks_backtick_in_value() {
     let mut values = HashMap::<String, String>::new();
     values.insert("sample".to_string(), "`evil`".to_string());
-    let result = validate_wildcard_injection(&values);
+    let result = validate_wildcard_injection(&values, &HashMap::new());
     assert!(result.is_err(), "should block backtick in wildcard values");
 }
 
@@ -1370,7 +1370,7 @@ fn validate_wildcard_injection_blocks_backtick_in_value() {
 fn validate_wildcard_injection_blocks_subshell_in_value() {
     let mut values = HashMap::<String, String>::new();
     values.insert("sample".to_string(), "$(echo hacked)".to_string());
-    let result = validate_wildcard_injection(&values);
+    let result = validate_wildcard_injection(&values, &HashMap::new());
     assert!(result.is_err(), "should block $() in wildcard values");
 }
 

--- a/docs/guide/src/reference/wildcards.md
+++ b/docs/guide/src/reference/wildcards.md
@@ -206,6 +206,12 @@ read = "[12]"
 
 If a value discovered from the filesystem does not match its constraint, it is ignored.
 
+### Safe Default Character Set
+
+Because wildcard values are substituted into shell command strings, wildcards **without** a declared constraint may only carry values matching `[A-Za-z0-9._/-]+` (letters, digits, dot, underscore, dash, path separator). Values outside this set fail validation before any shell runs. Direct command substitution (`$(` and backticks) is rejected unconditionally — including for constrained wildcards.
+
+If your data legitimately needs other characters, declare an explicit `[wildcard_constraints]` entry for that wildcard, or export `OXO_FLOW_UNSAFE_WILDCARDS=1` to relax the character-set layer for the process (a one-time warning is logged; the substitution floor remains enforced).
+
 ---
 
 ## Rule Name Expansion


### PR DESCRIPTION
## Summary

Fixes #203 — adopts the RFC's option-A/A-hybrid: wildcard values are validated against a conservative charset **by default** instead of passing unchecked into `sh -c`.

- Hard floor unchanged: `\$(` / backticks always rejected, config.* keys trusted
- Unconstrained wildcards must now match `^[A-Za-z0-9._/-]+$`; violations fail fast with an actionable message naming the offending value and three remedies
- Escape hatches: per-wildcard `[wildcard_constraints]` entry (still enforced at expansion time by the existing compiled-constraint check) or `OXO_FLOW_UNSAFE_WILDCARDS=1` — logs exactly one warning per process, floor stays enforced
- Constraints plumbed into `ExecutorConfig` (in-literal init); gallery sample inventory confirmed compatible with the default charset

## Review additions beyond the draft

- Draft left `crates/oxo-flow-cli/src/commands/run.rs` not compiling (missing field E0063 + post-construction mutation) — fixed with in-literal init
- Unsafe mode actually logs now (doc comment promised a warning; code was silent)

## Docs

- AGENTS.md env-var table gains `OXO_FLOW_UNSAFE_WILDCARDS`
- guide/reference/wildcards.md documents the safe-default layer and both escape hatches

## Test plan

- [x] fmt + clippy `-D warnings` + full workspace tests green locally
- [x] New unit tests: realistic samples accepted; metacharacters/spaces rejected with correct error class; explicit constraint overrides; unsafe mode relaxes charset but not substitution floor
- [x] Existing tests updated honestly (pipe-in-value now rejected by design)