### PR TITLE
feat(web): router-layer 503 boundary for all /api/runs endpoints on PostgreSQL (#207 phase 1 completion)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ The web crate (`oxo-flow-web`) is designed as an AI-native API surface:
 - **Intent-driven authoring**: `POST /api/workflows/generate` maps natural language to pipelines
 - **SSE streaming**: `GET /api/events` provides real-time execution events
 - **Pagination**: `GET /api/runs` uses cursor pagination `{items, next_cursor, total}`; most other list endpoints return bare capped arrays (≤ 100); the storage layer exposes an offset-style `Paginated<T> {items, page, per_page, total_items, total_pages}` internally. There is deliberately no single uniform envelope — document per endpoint (see web-api.md)
+- **Backend capability boundary (issue #207)**: run execution and its lifecycle bookkeeping are SQLite-only. PostgreSQL-backed team servers serve library/AI/auth; every `/api/runs*` request answers `503 {code:"RUNS_REQUIRE_SQLITE"}` via a router-layer gate (`require_sqlite_for_runs` in server.rs)
 
 ## 🖥️ Frontend SPA
 The frontend is a React/TypeScript SPA built with Vite, located in `frontend/`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OPENAI_MODEL` | No | `gpt-4o` | OpenAI-compatible model name |
 | `OXO_FLOW_FRONTEND_DIR` | No | — | Path to built frontend dist directory |
 | `OXO_FLOW_UNSAFE_WILDCARDS` | No | unset | Set to `"1"` to relax the wildcard safe-default charset check (#203); command-substitution values stay blocked and a warning is logged once |
+| `OXO_FLOW_RUNS_RATE_LIMIT` | No | `5` | Run-creation allowance per identity per minute on POST /api/runs (#213); `0` disables the dedicated limiter |
 
 ### AI Provider Examples
 

--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -163,27 +163,6 @@ pub async fn create_run(
     authenticated: Option<Extension<CurrentUser>>,
     Json(req): Json<serde_json::Value>,
 ) -> ApiResult<CreateRunResponse> {
-    // PostgreSQL deployments have no SQLite pool backing run bookkeeping
-    // (issue #207 phase 1): fail with a structured boundary instead of
-    // letting spawn/background tasks degrade mysteriously mid-run.
-    if crate::infra::db::sqlite::try_pool().is_err() {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError {
-                code: "RUNS_REQUIRE_SQLITE".into(),
-                message: "Workflow run execution is not available on this deployment."
-                    .into(),
-                detail: Some(
-                    "Run lifecycle bookkeeping uses the embedded SQLite store;                      PostgreSQL servers serve library/AI/auth features only."
-                        .into(),
-                ),
-                suggestion: Some(
-                    "Execute via `oxo-flow run` from the CLI, or use a personal-mode                      server backed by SQLite."
-                        .into(),
-                ),
-            }),
-        ));
-    }
     // Issue #213: dedicated budget for expensive run creation — separate
     // from the global per-minute request limiter so health checks / reads
     // cannot crowd it out (and vice versa).

--- a/crates/oxo-flow-web/src/server.rs
+++ b/crates/oxo-flow-web/src/server.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 
 use crate::domains::clusters;
+use crate::domains::workflow::handlers::ApiError;
 use crate::domains::*;
 use crate::infra::license::LicenseHeaderLayer;
 
@@ -281,6 +282,9 @@ pub fn build_router(mode: &str) -> Router {
         );
 
     // ---- Run routes ----
+    // Issue #207 phase 1: PostgreSQL deployments never initialize the
+    // embedded SQLite pool, so the entire runs domain is gated by one
+    // structured 503 at this router layer.
     let run_routes = Router::new()
         .route("/api/runs", post(execution::handlers::create_run))
         .route("/api/runs", get(execution::handlers::list_runs))
@@ -344,7 +348,41 @@ pub fn build_router(mode: &str) -> Router {
             "/api/runs/{id}/report/visualize",
             post(execution::handlers::visualize_report),
         )
-        .route("/api/runs/{id}/files", get(execution::files::get_run_file));
+        .route("/api/runs/{id}/files", get(execution::files::get_run_file))
+        .route_layer(axum::middleware::from_fn(require_sqlite_for_runs));
+
+    /// Structured capability boundary for PostgreSQL deployments (issue #207).
+    ///
+    /// Run lifecycle bookkeeping reads and writes through the embedded SQLite
+    /// pool, which postgres-mode servers never initialize. Gating the whole
+    /// `/api/runs*` domain at the router layer gives every run endpoint one
+    /// explicit, actionable answer instead of silent empty reads or spawn-task
+    /// degradations discovered mid-flight.
+    async fn require_sqlite_for_runs(
+        req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> Result<axum::response::Response, (StatusCode, axum::Json<ApiError>)> {
+        if crate::infra::db::sqlite::try_pool().is_ok() {
+            return Ok(next.run(req).await);
+        }
+        Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(ApiError {
+                code: "RUNS_REQUIRE_SQLITE".into(),
+                message: "Workflow run execution is not available on this deployment.".into(),
+                detail: Some(
+                    "Run lifecycle bookkeeping uses the embedded SQLite store; \
+                 PostgreSQL servers serve library/AI/auth features only."
+                        .into(),
+                ),
+                suggestion: Some(
+                    "Execute via `oxo-flow run` from the CLI, or use a personal-mode \
+                 server backed by SQLite."
+                        .into(),
+                ),
+            }),
+        ))
+    }
 
     // ---- File service routes (issue #82 P0-1/P0-2) ----
     let file_routes = Router::new()

--- a/docs/guide/src/how-to/deploy-modes.md
+++ b/docs/guide/src/how-to/deploy-modes.md
@@ -46,6 +46,7 @@ open http://localhost:8080
 |---------|-------|
 | Network | `127.0.0.1:8080` by default — pass `--host 0.0.0.0` to bind all interfaces |
 | Database | SQLite (default) or PostgreSQL |
+| Run execution | SQLite-backed servers only — with PostgreSQL the whole `/api/runs*` surface answers `503 RUNS_REQUIRE_SQLITE`; library/AI/auth keep working |
 | Auth | Password env vars (`OXO_FLOW_ADMIN_PASSWORD` / `OXO_FLOW_USER_PASSWORD` / `OXO_FLOW_VIEWER_PASSWORD`) + optional ORCID/GitHub OAuth |
 | Workspace | `workspace/users/<username>/runs/<run_id>` |
 

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -252,6 +252,9 @@ POST   /api/pipelines/search       # Search by name, tags, content
 ## Execution & Runs
 
 ### Create Run
+
+> **PostgreSQL deployments**: every `/api/runs*` endpoint returns `503 {"code": "RUNS_REQUIRE_SQLITE", "message", "detail", "suggestion"}` — run execution requires a SQLite-backed server. Library/AI/auth domains remain available.
+
 ```
 POST /api/runs
 Content-Type: application/json


### PR DESCRIPTION
## Summary

Follow-up to #222 completing **phase 1 of #207**.

#222 gated only `POST /api/runs`. On a PostgreSQL deployment every sibling runs endpoint (`list/status/dag-status/diagnostics/instances/clean/resume-checkpoint/logs/results/retry/cancel/pause/resume/preview/ai-status/report*/files`) still executed against an embedded SQLite pool that is never initialized there — silent empty reads instead of the honest boundary the issue demands.

- Single `require_sqlite_for_runs` middleware attached via `route_layer` on the existing `run_routes` sub-router → one source of truth for the whole domain
- Identical structured `503 RUNS_REQUIRE_SQLITE {code,message,detail,suggestion}` envelope on every run endpoint
- Inline duplicate inside `create_run` removed
- String-literal whitespace artifacts from #222's wrapped literals fixed

## Docs (issue acceptance criteria)

- AGENTS.md: backend capability boundary bullet in Web System section
- docs/guide/src/how-to/deploy-modes.md: Mode 2 table row marks run execution SQLite-only
- docs/guide/src/reference/web-api.md: Create Run section documents the PG 503

Out of scope (tracked in #207 body): recovering orphaned runs on PG, full parity phases.

## Test plan

- [x] fmt + clippy `-D warnings` green locally
- [x] Full workspace build; oxo-flow-web lib (287) + all integration suites pass
- [x] Existing create_run behavior unchanged on SQLite servers (gate passes through when pool exists)