### PR TITLE
feat(core): workflow-level on_complete / on_error terminal hooks

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -705,7 +705,7 @@ pub async fn run_command(
     let e005 = undefined_config_findings(&config);
     if !e005.is_empty() {
         if json {
-            emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0, vec![]);
+            emit_run_json_summary(json, "failed", &workflow, &RunCounts::default(), vec![]);
         }
         return Err(anyhow::anyhow!(
             "workflow references undefined config variable(s) — fix before running:\n  {}",
@@ -730,7 +730,7 @@ pub async fn run_command(
             None => {
                 // Pre-execution abort: nothing ran, but the summary
                 // contract still holds for --json (issue #142 H6).
-                emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0, vec![]);
+                emit_run_json_summary(json, "failed", &workflow, &RunCounts::default(), vec![]);
                 return Err(anyhow::anyhow!(
                     "unknown module '{m}' — known modules: {}",
                     known_modules_hint(&config.module_rules)
@@ -1180,11 +1180,13 @@ pub async fn run_command(
                 "failed"
             },
             &workflow,
-            summary.succeeded,
-            summary.skipped,
-            summary.failed,
-            summary.non_required_failed,
-            0,
+            &RunCounts {
+                succeeded: summary.succeeded,
+                skipped: summary.skipped,
+                failed: summary.failed,
+                non_required_failed: summary.non_required_failed,
+                blocked: 0,
+            },
             // Cluster per-rule resources come from sacct accounting at
             // report time, not the live checkpoint — empty here.
             vec![],
@@ -1273,7 +1275,7 @@ pub async fn run_command(
             .join("\n");
         // Pre-execution abort: nothing ran — the summary still reports
         // the failed run for --json consumers (issue #142 H6).
-        emit_run_json_summary(json, "failed", &workflow, 0, 0, 0, 0, 0, vec![]);
+        emit_run_json_summary(json, "failed", &workflow, &RunCounts::default(), vec![]);
         return Err(anyhow::anyhow!(
             "resource budget too small for {} rule(s); no rules were run:\n{}",
             breaches.len(),
@@ -1603,11 +1605,7 @@ pub async fn run_command(
                                     json,
                                     "failed",
                                     &workflow,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
+                                    &RunCounts::default(),
                                     vec![],
                                 );
                                 return Err(anyhow::anyhow!(
@@ -1621,11 +1619,7 @@ pub async fn run_command(
                                     json,
                                     "failed",
                                     &workflow,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
+                                    &RunCounts::default(),
                                     vec![],
                                 );
                                 return Err(anyhow::anyhow!(
@@ -2382,11 +2376,14 @@ pub async fn run_command(
                         json,
                         "failed",
                         &workflow,
-                        success_count.load(std::sync::atomic::Ordering::Relaxed),
-                        skipped_count.load(std::sync::atomic::Ordering::Relaxed),
-                        fail_count.load(std::sync::atomic::Ordering::Relaxed),
-                        non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed),
-                        blocked.lock().await.len(),
+                        &RunCounts {
+                            succeeded: success_count.load(std::sync::atomic::Ordering::Relaxed),
+                            skipped: skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+                            failed: fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                            non_required_failed: non_required_fail_count
+                                .load(std::sync::atomic::Ordering::Relaxed),
+                            blocked: blocked.lock().await.len(),
+                        },
                         vec![],
                     );
                     return Err(anyhow::anyhow!(
@@ -2586,13 +2583,25 @@ pub async fn run_command(
                 json,
                 "failed",
                 &workflow,
-                success_count.load(std::sync::atomic::Ordering::Relaxed),
-                skipped_count.load(std::sync::atomic::Ordering::Relaxed),
-                fail_count.load(std::sync::atomic::Ordering::Relaxed),
-                non_required_fail_count.load(std::sync::atomic::Ordering::Relaxed),
-                blocked.lock().await.len(),
+                &RunCounts {
+                    succeeded: success_count.load(std::sync::atomic::Ordering::Relaxed),
+                    skipped: skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+                    failed: fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                    non_required_failed: non_required_fail_count
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                    blocked: blocked.lock().await.len(),
+                },
                 rule_resource_rows(&ck),
             );
+            // on_error fires on the plain-failure abort too (issue #227).
+            run_terminal_hook(
+                &config,
+                &workdir_actual,
+                success_count.load(std::sync::atomic::Ordering::Relaxed),
+                fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+            )
+            .await;
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
 
@@ -2756,6 +2765,17 @@ pub async fn run_command(
     {
         eprintln!("  {} Report snapshot failed: {e}", "⚠".yellow());
     }
+
+    // Workflow-level terminal hooks (issue #227 item 1): on_complete /
+    // on_error fire on every terminal path of the run loop.
+    run_terminal_hook(
+        &config,
+        &workdir_actual,
+        success_count,
+        fail_count,
+        skipped_count,
+    )
+    .await;
 
     // With --keep-going, execution continues past failures, so list every failed
     // rule (and why) in one place rather than making the user hunt for them.
@@ -2994,11 +3014,13 @@ pub async fn run_command(
             "completed"
         },
         &workflow,
-        success_count,
-        skipped_count,
-        fail_count,
-        non_required_fail_count,
-        blocked.len(),
+        &RunCounts {
+            succeeded: success_count,
+            skipped: skipped_count,
+            failed: fail_count,
+            non_required_failed: non_required_fail_count,
+            blocked: blocked.len(),
+        },
         // `checkpoint` here is the MutexGuard locked above (line ~2415);
         // Deref coercion hands rule_resource_rows the underlying state.
         rule_resource_rows(&checkpoint),
@@ -3025,15 +3047,61 @@ pub async fn run_command(
 /// document (issue #142 H6). Only emits when `--json` was requested;
 /// stdout carries nothing else, so the document is always the sole output.
 #[allow(clippy::too_many_arguments)] // matching the crate's established convention
-fn emit_run_json_summary(
-    json: bool,
-    status: &str,
-    workflow: &Path,
+/// Run the workflow-level terminal hook (`on_complete` after a fully
+/// successful run, `on_error` after any failure) on every terminal path of
+/// the run loop. Rendered with `{config.*}` plus the run counters and
+/// `{workdir}`; best-effort by design — a failing hook warns, never
+/// changes the run status (issue #227 item 1).
+async fn run_terminal_hook(
+    config: &WorkflowConfig,
+    workdir: &std::path::Path,
+    succeeded: usize,
+    failed: usize,
+    skipped: usize,
+) {
+    let hook_cmd = if failed > 0 {
+        config.workflow.on_error.as_deref()
+    } else {
+        config.workflow.on_complete.as_deref()
+    };
+    let Some(hook_cmd) = hook_cmd else {
+        return;
+    };
+    let mut values: std::collections::HashMap<String, String> = config
+        .config
+        .iter()
+        .map(|(k, v)| (format!("config.{k}"), config_value_string(v)))
+        .collect();
+    values.insert("succeeded".to_string(), succeeded.to_string());
+    values.insert("failed".to_string(), failed.to_string());
+    values.insert("skipped".to_string(), skipped.to_string());
+    values.insert("workdir".to_string(), workdir.display().to_string());
+    let rendered = oxo_flow_core::executor::process::expand_placeholders(hook_cmd, &values);
+    oxo_flow_core::executor::process::run_workflow_hook(
+        &rendered,
+        workdir,
+        config.defaults.shell_prelude.as_deref(),
+    )
+    .await;
+}
+
+/// Terminal run counters shared by the `--json` summary and the workflow
+/// terminal hooks. Grouped so the summary emitter stays under clippy's
+/// argument-count lint.
+#[derive(Default)]
+struct RunCounts {
     succeeded: usize,
     skipped: usize,
     failed: usize,
     non_required_failed: usize,
     blocked: usize,
+}
+
+fn emit_run_json_summary(
+    json: bool,
+    status: &str,
+    workflow: &Path,
+    counts: &RunCounts,
     resources: Vec<serde_json::Value>,
 ) {
     if !json {
@@ -3044,11 +3112,11 @@ fn emit_run_json_summary(
         "status": status,
         "workflow": workflow.to_string_lossy(),
         "results": serde_json::json!({
-            "succeeded": succeeded,
-            "skipped": skipped,
-            "failed": failed,
-            "non_required_failed": non_required_failed,
-            "blocked": blocked,
+            "succeeded": counts.succeeded,
+            "skipped": counts.skipped,
+            "failed": counts.failed,
+            "non_required_failed": counts.non_required_failed,
+            "blocked": counts.blocked,
         }),
         "resources": resources,
     });

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -130,6 +130,22 @@ pub struct WorkflowMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format_version: Option<String>,
 
+    /// Shell command to run once after the whole workflow completes
+    /// successfully (no failed rules). Rendered with `{config.*}` and the
+    /// run counters `{succeeded}`/`{failed}`/`{skipped}`/`{workdir}`.
+    ///
+    /// Best-effort like rule hooks: a failing hook warns, never changes
+    /// the run status.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_complete: Option<String>,
+
+    /// Shell command to run once after the workflow reaches a terminal
+    /// state with at least one failed rule. Same rendering as `on_complete`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_error: Option<String>,
+
     /// Genome build (e.g., "GRCh38", "hg38", "GRCh37").
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -1550,6 +1550,32 @@ fn filter_samples_invalid_spec() {
 }
 
 #[test]
+fn workflow_meta_hooks_parse() {
+    // Workflow-level terminal hooks (issue #227 item 1): on_complete
+    // fires after a fully successful run, on_error after any failure.
+    let toml = r#"
+        [workflow]
+        name = "test"
+        version = "1.0.0"
+        on_complete = "touch done.marker"
+        on_error = "touch error.marker"
+
+        [[rules]]
+        name = "step1"
+        shell = "echo hi"
+    "#;
+    let config = WorkflowConfig::parse(toml).unwrap();
+    assert_eq!(
+        config.workflow.on_complete.as_deref(),
+        Some("touch done.marker")
+    );
+    assert_eq!(
+        config.workflow.on_error.as_deref(),
+        Some("touch error.marker")
+    );
+}
+
+#[test]
 fn override_samples_replaces_inline_samples() {
     // `--samples` explicit names replace inline [[sample_groups]] fixture
     // names instead of filtering them — the fix for "inline samples can't

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -2511,6 +2511,42 @@ async fn run_hook(cmd: &str, rule: &Rule, workdir: &std::path::Path, shell_prelu
     }
 }
 
+/// Expand `{key}` placeholders in a workflow-level hook command from an
+/// arbitrary value map (`{config.*}`, run counters, `{workdir}`). Unknown
+/// keys stay literal so a typo is visible in the executed command.
+pub fn expand_placeholders(cmd: &str, values: &HashMap<String, String>) -> String {
+    super::expand_to_fixed_point(cmd, values, render_wildcard_value)
+}
+
+/// Execute a workflow-level terminal hook (`on_complete` / `on_error`) in
+/// the workflow root. Best-effort like rule hooks: a failing hook is a
+/// warning, never a run-status change.
+pub async fn run_workflow_hook(cmd: &str, workdir: &std::path::Path, shell_prelude: Option<&str>) {
+    // Hooks take the same prelude as rule commands (issue #92).
+    let cmd = crate::config::prepend_shell_prelude(cmd, shell_prelude);
+    let child = match spawn_rule_shell(&cmd, workdir, &HashMap::new()) {
+        Ok(child) => child,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to spawn workflow hook");
+            return;
+        }
+    };
+    let result = child.wait_with_output().await;
+    match result {
+        Ok(output) if !output.status.success() => {
+            tracing::warn!(
+                code = %output.status.code().unwrap_or(-1),
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "workflow hook failed (best-effort)"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to spawn workflow hook");
+        }
+        _ => {}
+    }
+}
+
 pub fn render_shell_command(
     cmd: &str,
     rule: &Rule,
@@ -3142,6 +3178,29 @@ mod tests {
         block_on(move_path(&src, &dest)).expect("move");
         assert_eq!(std::fs::read(&dest).expect("read dest"), b"content");
         assert!(!src.exists(), "source removed after rename");
+    }
+
+    #[test]
+    fn expand_placeholders_renders_workflow_keys() {
+        // Workflow-hook placeholders (issue #227 item 1): config.* values
+        // and the run counters the CLI injects.
+        let mut values = HashMap::new();
+        values.insert("config.email".to_string(), "a@b.c".to_string());
+        values.insert("succeeded".to_string(), "3".to_string());
+        values.insert("failed".to_string(), "0".to_string());
+        let cmd = "mail -s '{succeeded}/{failed}' {config.email}";
+        let rendered = expand_placeholders(cmd, &values);
+        assert_eq!(rendered, "mail -s '3/0' a@b.c");
+    }
+
+    #[tokio::test]
+    async fn run_workflow_hook_executes_in_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        run_workflow_hook("touch hooked.marker", dir.path(), None).await;
+        assert!(
+            dir.path().join("hooked.marker").exists(),
+            "workflow hook ran in the workflow root"
+        );
     }
 
     #[test]

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -186,6 +186,29 @@ author = "Your Name"
 | `sample_groups_file` | String | No | — | External TSV/JSON file defining sample groups |
 | `pairs_pattern` | String | No | — | File glob pattern for auto-discovering pairs (e.g., `"aligned/{pair_id}/{exp}_vs_{ctrl}.bam"`) |
 | `sample_pattern` | String | No | — | File glob pattern for auto-discovering samples (e.g., `"raw/{sample}_R1.fastq.gz"`) |
+| `on_complete` | String | No | — | Shell command run once after the whole workflow completes successfully (no failed rules). Rendered with `{config.*}` and the counters `{succeeded}`/`{failed}`/`{skipped}` plus `{workdir}`; runs in the workflow root with the workflow `shell_prelude`. Best-effort: a failing hook warns, never changes the run status. |
+| `on_error` | String | No | — | Shell command run once after the workflow reaches a terminal state with at least one failed rule. Same rendering and best-effort semantics as `on_complete`. |
+
+### Workflow-Level Terminal Hooks
+
+`on_complete` / `on_error` mirror the rule-level `on_success` / `on_failure`
+hooks at the whole-workflow level — the nf-core `workflow.onComplete` /
+snakemake `onerror` pattern (completion emails, cleanup, notifications):
+
+```toml
+[workflow]
+name = "my-pipeline"
+version = "1.0.0"
+on_complete = "notify 'run done: {succeeded} succeeded, {failed} failed' --tag {config.project}"
+on_error = "notify 'run FAILED: {failed} failed' --tag {config.project} && tar czf failed-run.tar.gz {workdir}/logs"
+```
+
+Both hooks run exactly once per `oxo-flow run` (the CLI) that reaches a
+terminal state (including `--keep-going` runs); `on_complete` fires only
+when no rule failed, `on_error` otherwise. The web UI executor has its
+own run loop and does not fire these hooks yet. Placeholders: every
+`[config]` key is available as `{config.<key>}`, plus `{succeeded}`,
+`{failed}`, `{skipped}`, and `{workdir}`. Unknown keys stay literal.
 
 ### Custom Interpreters (`interpreter_map`)
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -8958,3 +8958,75 @@ fn cli_reference_path_migration_with_identical_content_skips_rebuild() {
         "identical content at a new path must not rebuild: {stderr}"
     );
 }
+
+// ─── Workflow-level terminal hooks (issue #227 item 1) ─────────────────────
+
+/// `on_complete` fires once after a fully successful run, `on_error` after
+/// any terminal failure — with `{config.*}`, the run counters and
+/// `{workdir}` rendered. Both paths run through the real CLI binary.
+#[test]
+fn cli_run_workflow_terminal_hooks_fire_on_both_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("hooks.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "hooks"
+version = "1.0.0"
+on_complete = "echo '{succeeded}/{failed}/{skipped}' > {workdir}/complete.marker"
+on_error = "echo '{succeeded}/{failed}/{skipped}' > {workdir}/error.marker"
+
+[config]
+explode = false
+
+[[rules]]
+name = "ok"
+output = ["hello.txt"]
+shell = "echo hi > {output}"
+
+[[rules]]
+name = "boom"
+when = "config.explode"
+output = ["boom.txt"]
+shell = "exit 7"
+"#,
+    )
+    .unwrap();
+
+    // Success path: on_complete with 1/0/1 counters.
+    let ok = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(ok.status.success(), "success-path run must exit 0");
+    let marker = dir.path().join("complete.marker");
+    assert!(marker.exists(), "on_complete must create complete.marker");
+    assert_eq!(fs::read_to_string(&marker).unwrap().trim(), "1/0/1");
+
+    // Failure path: on_error with 0/1/0 (ok is blocked by the failure).
+    fs::remove_file(dir.path().join("complete.marker")).unwrap();
+    let fail = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--arg", "explode=true"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !fail.status.success(),
+        "failure-path run must exit non-zero"
+    );
+    let marker = dir.path().join("error.marker");
+    assert!(marker.exists(), "on_error must create error.marker");
+    // The `ok` rule either ran before the failure (1/1/0) or was blocked
+    // by it (0/1/1) — scheduling order is not deterministic; the hook's
+    // failed=1 and succeeded=0 verdict is.
+    let content = fs::read_to_string(&marker).unwrap();
+    assert!(
+        content.trim().starts_with("0/1/"),
+        "on_error counters must report 0 succeeded / 1 failed, got: {content}"
+    );
+    assert!(
+        !dir.path().join("complete.marker").exists(),
+        "on_complete must not fire on a failed run"
+    );
+}


### PR DESCRIPTION
Implements issue #227 item 1 — the engine gap keeping the PIPELINE_COMPLETION / onerror-email class of catalog exclusions open (scrnaseq, fetchngs, auto-sra).

- `[workflow] on_complete` / `on_error` shell commands, rendered with `{config.*}` + `{succeeded}`/`{failed}`/`{skipped}`/`{workdir}`, executed in the workflow root with the workflow shell_prelude.
- Fire on EVERY terminal path (incl. the plain-failure abort, which previously bypassed the summary block).
- Best-effort like rule hooks: a failing hook warns, never changes run status.
- Tests: config parse, placeholder rendering, hook execution; E2E both paths (success → complete.marker, failure → error.marker).
- Docs: reference/workflow-format.md workflow-metadata table + a new section.

Follow-up for the catalog repos (separate PRs once this lands): scrnaseq PIPELINE_COMPLETION, fetchngs PIPELINE_COMPLETION, auto-sra onerror email.