### PR TITLE
feat(core): per-sample multi-file grouping primitive (input_groups)

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -253,8 +253,26 @@ impl WorkflowConfig {
         let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         // Track original → expanded name mapping for depends_on resolution
         let mut name_map: HashMap<String, Vec<String>> = HashMap::new();
+        // input_groups rules (issue #227 item 3): fanned out in the
+        // post-loop pass below, where producer outputs are known.
+        let mut pending_input_groups: Vec<Rule> = Vec::new();
 
         for rule in &self.rules {
+            if !rule.input_groups.is_empty() {
+                // Per-sample multi-file grouping (issue #227 item 3 — the
+                // groupTuple pattern). The fan-out runs in a post-loop pass
+                // once every producer's expanded literal outputs are known:
+                // group enumeration must see the files the workflow ITSELF
+                // will produce, not only files that pre-exist on disk. Rules
+                // declaring input_groups never fan out on pair/group/value
+                // wildcards — the discovered group key IS the instance's
+                // binding source; any wildcard the instance map does not
+                // bind stays literal and hits the execution-time
+                // residual-placeholder guard (loud, attributable).
+                pending_input_groups.push(rule.clone());
+                continue;
+            }
+
             // Collect all text fields that might contain wildcards. The fan-out
             // TRIGGER set is input/output/shell only — script and the hooks
             // substitute per instance when the rule fans out, but never start
@@ -997,6 +1015,77 @@ impl WorkflowConfig {
             }
         }
 
+        // ── input_groups fan-out (issue #227 item 3, the groupTuple
+        // pattern) ────────────────────────────────────────────────────────
+        // Runs AFTER scatter/transform expansion so group enumeration sees
+        // every materialized producer's literal outputs — the
+        // plan-time-known paths that make exact-match DAG edges work even
+        // for files that only come into existence mid-run. The producer
+        // pool grows as instances materialize, so input_groups chains
+        // (lanemerge → library_merge → seqtype_merge) resolve in
+        // declaration order. Producers declared AFTER their input_groups
+        // consumer are not yet in the pool when the consumer processes
+        // (v1: declare in topological order; a zero-match consumer then
+        // warns and instantiates nothing, per the skip semantics).
+        // Generated instances append after the regular rules — DAG edges,
+        // not list order, drive scheduling.
+        if !pending_input_groups.is_empty() {
+            // Literal (wildcard-free, `{config.x}`-expanded) outputs of
+            // every rule materialized so far — the enumeration source for
+            // files the workflow itself will produce.
+            let mut producer_outputs: Vec<String> = Vec::new();
+            for rule in &final_rules {
+                producer_outputs.extend(
+                    rule.output
+                        .to_vec()
+                        .into_iter()
+                        .map(|o| expand_config_vars_in_path(&o, &self.config)),
+                );
+            }
+            for rule in pending_input_groups {
+                let instances = self.expand_input_groups_rule(&rule, &producer_outputs)?;
+                let mut expanded_names = Vec::new();
+                for instance in instances {
+                    if !seen_names.insert(instance.name.clone()) {
+                        return Err(OxoFlowError::DuplicateRule {
+                            name: instance.name.clone(),
+                        });
+                    }
+                    expanded_names.push(instance.name.clone());
+                    producer_outputs.extend(
+                        instance
+                            .output
+                            .to_vec()
+                            .into_iter()
+                            .map(|o| expand_config_vars_in_path(&o, &self.config)),
+                    );
+                    final_rules.push(instance);
+                }
+                name_map.insert(rule.name.clone(), expanded_names);
+            }
+
+            // The input_groups instances joined the rule set after the
+            // depends_on pass above ran on expanded_rules — re-resolve on
+            // the final set so `depends_on = ["lanemerge"]` reaches every
+            // instance (idempotent: already-expanded names are not keys).
+            if !name_map.is_empty() {
+                for rule in &mut final_rules {
+                    if rule.depends_on.is_empty() {
+                        continue;
+                    }
+                    let mut resolved_deps = Vec::new();
+                    for dep in &rule.depends_on {
+                        if let Some(expanded_names) = name_map.get(dep.as_str()) {
+                            resolved_deps.extend(expanded_names.clone());
+                        } else {
+                            resolved_deps.push(dep.clone());
+                        }
+                    }
+                    rule.depends_on = resolved_deps;
+                }
+            }
+        }
+
         // Apply gather injections and expand_inputs
         for rule in &mut final_rules {
             if let Some(injected) = gather_injections.get(&rule.name) {
@@ -1065,6 +1154,319 @@ impl WorkflowConfig {
 
         self.rules = final_rules;
         Ok(())
+    }
+
+    /// Expand one `input_groups` rule into its per-group instances (issue
+    /// #227 item 3).
+    ///
+    /// Group candidates come from TWO plan-time-known sources, deduplicated
+    /// by path:
+    /// 1. files already on disk under the workflow root (the same
+    ///    filesystem walk as `sample_pattern` discovery), and
+    /// 2. literal outputs already materialized by producers (the files the
+    ///    workflow itself will produce — matching a producer's expanded
+    ///    output against the pattern extracts the same wildcard values, so
+    ///    exact-match DAG edges to those producers work).
+    ///
+    /// Files are grouped by the `group_by` wildcard: one instance per key
+    /// with `{input}` = the group's files (sorted), the instance wildcard
+    /// map = group key + first occurrence of every `keep`-listed wildcard,
+    /// and `{input_group.<wildcard>}` = space-joined per-group value lists.
+    fn expand_input_groups_rule(
+        &mut self,
+        rule: &Rule,
+        producer_outputs: &[String],
+    ) -> Result<Vec<Rule>> {
+        if rule.input_groups.len() > 1 {
+            return Err(OxoFlowError::Validation {
+                message: format!(
+                    "rule '{}' declares {} input_groups entries — v1 supports at most one",
+                    rule.name,
+                    rule.input_groups.len()
+                ),
+                rule: Some(rule.name.clone()),
+                suggestion: Some("split the rule into one rule per pattern".to_string()),
+            });
+        }
+        let decl = &rule.input_groups[0];
+        let pattern_wildcards = crate::wildcard::extract_wildcards(&decl.pattern);
+        if pattern_wildcards.is_empty() {
+            return Err(OxoFlowError::Validation {
+                message: format!(
+                    "input_groups pattern '{}' of rule '{}' has no {{wildcard}} placeholders",
+                    decl.pattern, rule.name
+                ),
+                rule: Some(rule.name.clone()),
+                suggestion: Some(
+                    "add a {wildcard} (e.g. {sample}) to the pattern so files can be grouped"
+                        .to_string(),
+                ),
+            });
+        }
+        if !pattern_wildcards.contains(&decl.group_by) {
+            return Err(OxoFlowError::Validation {
+                message: format!(
+                    "input_groups group_by '{}' of rule '{}' is not a wildcard in pattern '{}'",
+                    decl.group_by, rule.name, decl.pattern
+                ),
+                rule: Some(rule.name.clone()),
+                suggestion: Some(format!(
+                    "use one of the pattern wildcards: {}",
+                    pattern_wildcards.join(", ")
+                )),
+            });
+        }
+        let others: Vec<String> = pattern_wildcards
+            .iter()
+            .filter(|w| w.as_str() != decl.group_by)
+            .cloned()
+            .collect();
+        let keep: Vec<String> = match &decl.keep {
+            Some(names) => {
+                for name in names {
+                    if !others.contains(name) {
+                        return Err(OxoFlowError::Validation {
+                            message: format!(
+                                "input_groups keep of rule '{}' names '{}' which is not a \
+                                 pattern wildcard (other than group_by '{}')",
+                                rule.name, name, decl.group_by
+                            ),
+                            rule: Some(rule.name.clone()),
+                            suggestion: Some(format!("keep may only list: {}", others.join(", "))),
+                        });
+                    }
+                }
+                names.clone()
+            }
+            None => others.clone(),
+        };
+
+        // `{config.x}` placeholders resolve against the workflow config
+        // before matching, exactly like every other path in the engine.
+        let base = self
+            .base_dir
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let pattern = expand_config_vars_in_path(&decl.pattern, &self.config);
+        let pattern_re = crate::wildcard::pattern_to_regex(&pattern)?;
+
+        // Source 1: files already on disk under the workflow root.
+        let mut candidates: Vec<(String, crate::wildcard::WildcardValues)> = Vec::new();
+        for combo in crate::wildcard::discover_wildcards_from_pattern_tree(&base, &pattern)? {
+            let Some(key) = combo.get(&decl.group_by).cloned() else {
+                continue;
+            };
+            if key.is_empty() {
+                continue;
+            }
+            let path = crate::wildcard::expand_pattern(&pattern, &combo)
+                .unwrap_or_else(|_| pattern.clone());
+            candidates.push((path, combo));
+        }
+
+        // Source 2: literal outputs of producers already materialized —
+        // the files this workflow itself will create. Matching the
+        // config-expanded output string against the pattern regex
+        // extracts the same wildcard values a disk scan would.
+        for output in producer_outputs {
+            let Some(captures) = pattern_re.captures(output) else {
+                continue;
+            };
+            let mut combo = crate::wildcard::WildcardValues::new();
+            let mut any = false;
+            for name in &pattern_wildcards {
+                if let Some(m) = captures.name(name) {
+                    combo.insert(name.clone(), m.as_str().to_string());
+                    any = true;
+                }
+            }
+            if !any {
+                continue;
+            }
+            let Some(key) = combo.get(&decl.group_by) else {
+                continue;
+            };
+            if key.is_empty() {
+                continue;
+            }
+            candidates.push((output.clone(), combo));
+        }
+
+        if candidates.is_empty() {
+            tracing::warn!(
+                rule = %rule.name,
+                "input_groups pattern '{}' matched no files (disk or producer outputs) — the rule is not instantiated (nothing to run)",
+                decl.pattern
+            );
+            return Ok(Vec::new());
+        }
+
+        // Group the (file, combo) pairs by the group_by value. Determinism
+        // matters: keys sort by BTreeMap, files sort within a group, and
+        // the "first occurrence" wildcard bindings come from the FIRST
+        // SORTED file — never from readdir order.
+        let mut grouped: std::collections::BTreeMap<
+            String,
+            Vec<(String, crate::wildcard::WildcardValues)>,
+        > = std::collections::BTreeMap::new();
+        for (path, combo) in candidates {
+            let key = combo[&decl.group_by].clone();
+            grouped.entry(key).or_default().push((path, combo));
+        }
+
+        let mut out = Vec::with_capacity(grouped.len());
+        for (key, mut entries) in grouped {
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            entries.dedup_by(|a, b| a.0 == b.0);
+            let mut files = Vec::with_capacity(entries.len());
+            let mut value_lists: HashMap<String, Vec<String>> = HashMap::new();
+            for (path, combo) in &entries {
+                files.push(path.clone());
+                for name in &pattern_wildcards {
+                    if let Some(v) = combo.get(name)
+                        && !value_lists
+                            .get(name)
+                            .is_some_and(|list: &Vec<String>| list.contains(v))
+                    {
+                        value_lists.entry(name.clone()).or_default().push(v.clone());
+                    }
+                }
+            }
+            // The instance wildcard map: the group key + the first
+            // occurrence of every kept wildcard (for `{output}` etc.).
+            let mut instance_map = crate::wildcard::WildcardValues::new();
+            instance_map.insert(decl.group_by.clone(), key.clone());
+            for name in &keep {
+                if let Some(v) = entries[0].1.get(name) {
+                    instance_map.insert(name.clone(), v.clone());
+                }
+            }
+            // Space-joined per-group value lists for `{input_group.<name>}`.
+            let mut group_lists = HashMap::new();
+            for (name, values) in value_lists {
+                group_lists.insert(name, values.join(" "));
+            }
+
+            // ── Build the instance ──────────────────────────────────────
+            let orig_name = rule.name.clone();
+            let new_name = format!(
+                "{}_{}",
+                rule.name,
+                crate::wildcard::sanitize_instance_value(&key)
+            );
+            let mut expanded = rule.clone();
+            expanded.name = new_name;
+            // Instances never re-expand: the declaration is consumed by
+            // this fan-out.
+            expanded.input_groups.clear();
+
+            // Group files come FIRST (sorted, stable order), the declared
+            // `input` entries append after — both resolved against the
+            // instance map and `{input_group.*}` lists.
+            let mut inputs = files;
+            inputs.extend(
+                rule.input
+                    .to_vec()
+                    .into_iter()
+                    .map(|p| expand_group_text(&p, &instance_map, &group_lists)),
+            );
+            expanded.input = FilePatterns::List(inputs);
+            expanded.output = match &rule.output {
+                FilePatterns::List(v) => FilePatterns::List(
+                    v.iter()
+                        .map(|p| expand_group_text(p, &instance_map, &group_lists))
+                        .collect(),
+                ),
+                FilePatterns::Map(m) => FilePatterns::Map(
+                    m.iter()
+                        .map(|(k, v)| {
+                            (k.clone(), expand_group_text(v, &instance_map, &group_lists))
+                        })
+                        .collect(),
+                ),
+                FilePatterns::Dir { path, pattern } => FilePatterns::Dir {
+                    path: expand_group_text(path, &instance_map, &group_lists),
+                    pattern: pattern.clone(),
+                },
+            };
+            if let Some(ref shell) = rule.shell {
+                expanded.shell = Some(expand_group_text(shell, &instance_map, &group_lists));
+            }
+            if let Some(ref log) = rule.log {
+                expanded.log = Some(expand_group_text(log, &instance_map, &group_lists));
+            }
+            // Script and hooks take the same per-instance substitution
+            // (issue #98) — same class as shell/log.
+            expand_command_text_fields(&mut expanded, rule, |s| {
+                expand_group_text(s, &instance_map, &group_lists)
+            });
+            // Per-instance `when` filtering (snakemake-style DAG morphing):
+            // wildcard references bake like the pair/group branches;
+            // `{input_group.*}` and bare `{sample}`-style placeholders
+            // resolve from the instance map.
+            if let Some(ref when) = rule.when {
+                let baked = if when.contains("wildcard.") {
+                    Self::bake_wildcard_when(when, &instance_map)
+                } else {
+                    when.clone()
+                };
+                expanded.when = Some(expand_group_text(&baked, &instance_map, &group_lists));
+            }
+
+            // A leftover `{input_group.<name>}` means the author referenced
+            // a wildcard this pattern never captures — fail the plan
+            // instead of running a literal token.
+            let mut known: Vec<&str> = group_lists.keys().map(String::as_str).collect();
+            known.sort_unstable();
+            let mut residual: Vec<&str> = expanded
+                .input
+                .iter()
+                .map(String::as_str)
+                .chain(expanded.output.iter().map(String::as_str))
+                .collect();
+            if let Some(ref shell) = expanded.shell {
+                residual.push(shell);
+            }
+            if let Some(ref log) = expanded.log {
+                residual.push(log);
+            }
+            if let Some(ref script) = expanded.script {
+                residual.push(script);
+            }
+            if let Some(ref w) = expanded.when {
+                residual.push(w);
+            }
+            if let Some(bad) = residual.iter().find(|t| t.contains("{input_group.")) {
+                return Err(OxoFlowError::Validation {
+                    message: format!(
+                        "rule '{}' references unknown `{{{{input_group.<wildcard>}}}}` \
+                         placeholder in '{}' — input_groups exposes: {}",
+                        expanded.name,
+                        bad,
+                        known.join(", ")
+                    ),
+                    rule: Some(rule.name.clone()),
+                    suggestion: Some(
+                        "fix the wildcard name, or add it to the input_groups pattern".to_string(),
+                    ),
+                });
+            }
+
+            // Readiness attribution (issue #63): the group key is the
+            // sample in the common case.
+            self.expansion_samples
+                .insert(expanded.name.clone(), vec![key]);
+            // Per-instance bindings so expand_inputs patterns referencing
+            // `{sample}` / kept wildcards resolve per instance (same
+            // contract as the pair/group branches).
+            self.expansion_values
+                .insert(expanded.name.clone(), instance_map);
+            self.expansion_templates
+                .insert(expanded.name.clone(), orig_name);
+
+            out.push(expanded);
+        }
+        Ok(out)
     }
 
     /// Resolve split values from SplitConfig.
@@ -1176,4 +1578,21 @@ impl WorkflowConfig {
         // Fall back to defaults
         self.defaults.environment.clone()
     }
+}
+
+/// Expand a rule text field with an input_groups instance: bake the bare
+/// wildcard bindings (`{sample}`, kept wildcards) and then the
+/// space-joined `{input_group.<wildcard>}` lists. `{input}` and the other
+/// execution-time placeholders never match the `\w+` placeholder regex
+/// and pass through untouched.
+fn expand_group_text(
+    text: &str,
+    combo: &crate::wildcard::WildcardValues,
+    lists: &HashMap<String, String>,
+) -> String {
+    let mut out = expand_rule_shell(text, combo);
+    for (name, joined) in lists {
+        out = out.replace(&format!("{{input_group.{name}}}"), joined);
+    }
+    out
 }

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -1536,6 +1536,14 @@ pub struct WorkflowConfig {
     /// call — the source for checkpoint re-entry re-expansion (issue #78 P3).
     #[serde(skip)]
     pub rule_templates: Vec<Rule>,
+
+    /// Engine-internal: the directory `input_groups` patterns resolve
+    /// against — the workflow file's parent, the same root
+    /// `sample_pattern` discovery scans (issue #227 item 3). Set by
+    /// [`WorkflowConfig::from_file`]; falls back to the current directory
+    /// when unset. Never serialized — user TOML cannot set it.
+    #[serde(skip)]
+    pub(crate) base_dir: Option<std::path::PathBuf>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/oxo-flow-core/src/config/parse.rs
+++ b/crates/oxo-flow-core/src/config/parse.rs
@@ -70,6 +70,10 @@ impl WorkflowConfig {
 
         config.extract_declarative_config()?;
 
+        // input_groups patterns resolve against the workflow root — the
+        // workflow file's parent, the same root sample_pattern scans.
+        config.base_dir = Some(crate::parent_dir(path).to_path_buf());
+
         // Format Versioning check (S5)
         const SUPPORTED_FORMAT_VERSION: &str = "1.0";
         if let Some(ref version) = config.workflow.format_version

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -3024,6 +3024,262 @@ fn expand_inputs_resolves_injected_samples_list_per_sample() {
 }
 
 #[test]
+fn input_groups_config_parses() {
+    // Issue #227 item 3 (groupTuple pattern): `input_groups` declares a
+    // filesystem pattern whose per-group-key files feed ONE instance.
+    // `keep` accepts both the single-string form (`keep = "lane"`) and an
+    // array form (`keep = ["lane", "read"]`).
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("groups.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "groups"
+
+        [[rules]]
+        name = "lanemerge"
+        input_groups = [
+            { pattern = "results/adapterremoval/{sample}_{lane}_R1.fastq.gz", group_by = "sample", keep = "lane" }
+        ]
+        output = ["results/merged/{sample}_R1.fastq.gz"]
+        shell = "cat {input} > {output}"
+
+        [[rules]]
+        name = "seqmerge"
+        input_groups = [
+            { pattern = "bams/{sample}_{replicate}_{seqtype}.bam", group_by = "sample", keep = ["replicate", "seqtype"] }
+        ]
+        output = ["merged/{sample}.bam"]
+        shell = "samtools merge {output} {input}"
+        "#,
+    )
+    .unwrap();
+
+    let config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let lanemerge = config
+        .rules
+        .iter()
+        .find(|r| r.name == "lanemerge")
+        .expect("lanemerge rule");
+    assert_eq!(lanemerge.input_groups.len(), 1);
+    let g = &lanemerge.input_groups[0];
+    assert_eq!(
+        g.pattern,
+        "results/adapterremoval/{sample}_{lane}_R1.fastq.gz"
+    );
+    assert_eq!(g.group_by, "sample");
+    // Single-string `keep` normalizes to a one-element list.
+    assert_eq!(g.keep.as_deref(), Some(&["lane".to_string()][..]));
+
+    let seqmerge = config
+        .rules
+        .iter()
+        .find(|r| r.name == "seqmerge")
+        .expect("seqmerge rule");
+    assert_eq!(
+        seqmerge.input_groups[0].keep.as_deref(),
+        Some(&["replicate".to_string(), "seqtype".to_string()][..])
+    );
+}
+
+#[test]
+fn input_groups_fans_rule_into_one_instance_per_group_key() {
+    // The groupTuple expansion: files on disk matching the pattern are
+    // grouped by the `group_by` wildcard; each group key becomes one rule
+    // instance whose `{input}` renders ALL of the group's files (sorted)
+    // and whose wildcard map binds the key plus the first occurrence of
+    // every other pattern wildcard. Per-group value lists are exposed as
+    // `{input_group.<wildcard>}`.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("merge.oxoflow");
+    for file in [
+        "raw/S1_L1_R1.fastq.gz",
+        "raw/S1_L2_R1.fastq.gz",
+        "raw/S2_L1_R1.fastq.gz",
+    ] {
+        let path = dir.path().join(file);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, file).unwrap();
+    }
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "merge"
+
+        [[rules]]
+        name = "lanemerge"
+        input_groups = [
+            { pattern = "raw/{sample}_{lane}_R1.fastq.gz", group_by = "sample" }
+        ]
+        output = ["merged/{sample}_R1.fastq.gz"]
+        shell = "cat {input} > merged/{sample}_R1.fastq.gz && echo lanes: {input_group.lane}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, vec!["lanemerge_S1", "lanemerge_S2"]);
+
+    let s1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "lanemerge_S1")
+        .expect("S1 instance");
+    assert_eq!(
+        s1.input.to_vec(),
+        vec![
+            "raw/S1_L1_R1.fastq.gz".to_string(),
+            "raw/S1_L2_R1.fastq.gz".to_string(),
+        ]
+    );
+    assert_eq!(s1.output.to_vec(), vec!["merged/S1_R1.fastq.gz"]);
+    assert!(
+        s1.input_groups.is_empty(),
+        "instances must not carry the input_groups declaration"
+    );
+    // The shell baked the instance map ({sample} = key, {lane} = first
+    // occurrence) and the space-joined {input_group.lane} list; {input}
+    // stays for execution-time rendering.
+    assert_eq!(
+        s1.shell.as_deref(),
+        Some("cat {input} > merged/S1_R1.fastq.gz && echo lanes: L1 L2")
+    );
+    // Readiness attribution (issue #63) records the group key.
+    assert_eq!(
+        config.expansion_samples.get("lanemerge_S1"),
+        Some(&vec!["S1".to_string()])
+    );
+    // Per-instance bindings for expand_inputs pattern resolution.
+    let s1_bindings = config.expansion_values.get("lanemerge_S1").unwrap();
+    assert_eq!(s1_bindings.get("sample").map(String::as_str), Some("S1"));
+    assert_eq!(s1_bindings.get("lane").map(String::as_str), Some("L1"));
+
+    let s2 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "lanemerge_S2")
+        .expect("S2 instance");
+    assert_eq!(s2.input.to_vec(), vec!["raw/S2_L1_R1.fastq.gz"]);
+}
+
+#[test]
+fn input_groups_matches_zero_files_drops_rule_with_warning() {
+    // A group key that matches zero files is not instantiated — no
+    // instance means nothing to run (issue #227 item 3 skip semantics).
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("empty.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "empty"
+
+        [[rules]]
+        name = "noop"
+        input_groups = [
+            { pattern = "missing/{sample}_{lane}_R1.fastq.gz", group_by = "sample" }
+        ]
+        output = ["merged/{sample}_R1.fastq.gz"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    assert!(
+        config.rules.iter().all(|r| r.name != "noop"),
+        "zero-match input_groups rule must not be instantiated"
+    );
+}
+
+#[test]
+fn input_groups_regular_input_appends_after_group_files() {
+    // `input` and `input_groups` coexist: the group files come first in
+    // the instance's input list, the declared inputs append after them.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("coexist.oxoflow");
+    for file in ["raw/S1_L1_R1.fastq.gz", "raw/S1_L2_R1.fastq.gz"] {
+        let path = dir.path().join(file);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, file).unwrap();
+    }
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "coexist"
+
+        [[rules]]
+        name = "merge"
+        input = ["meta/{sample}.txt"]
+        input_groups = [
+            { pattern = "raw/{sample}_{lane}_R1.fastq.gz", group_by = "sample" }
+        ]
+        output = ["merged/{sample}_R1.fastq.gz"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let s1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "merge_S1")
+        .expect("S1 instance");
+    assert_eq!(
+        s1.input.to_vec(),
+        vec![
+            "raw/S1_L1_R1.fastq.gz".to_string(),
+            "raw/S1_L2_R1.fastq.gz".to_string(),
+            // Regular inputs append AFTER the group files, expanded with
+            // the instance map ({sample} = group key).
+            "meta/S1.txt".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn input_groups_rejects_invalid_declarations() {
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("invalid.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "invalid"
+
+        [[rules]]
+        name = "bad_group_by"
+        input_groups = [
+            { pattern = "raw/{sample}_{lane}_R1.fastq.gz", group_by = "read" }
+        ]
+        shell = "echo hi"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("group_by"),
+        "group_by not in pattern must fail: {err}"
+    );
+}
+
+#[test]
 fn from_file_injects_pairs_list_from_pairs() {
     // [[pairs]] is the single source of truth: the engine injects
     // config.pairs_list (a sorted, comma-joined string) exactly like

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -475,6 +475,97 @@ pub struct ExpandConfig {
     pub variables: HashMap<String, String>,
 }
 
+/// Per-sample multi-file grouping (issue #227 item 3 — the groupTuple
+/// pattern): N files of one sample fan into ONE per-sample instance whose
+/// `{input}` renders all of them.
+///
+/// At plan time the engine walks the workflow root, matches `pattern`
+/// (a path glob with `{wildcard}` placeholders, `{config.x}`-expandable),
+/// and groups the matched files by the `group_by` wildcard's value. One
+/// instance is created per distinct group key; the instance's `{input}`
+/// is the group's files space-joined (sorted, stable order); its wildcard
+/// map binds the group key plus the first occurrence of every other
+/// pattern wildcard (so `{output}` etc. resolve); the full per-group
+/// value lists are exposed as `{input_group.<wildcard>}` (space-joined)
+/// for shells that need them. A key matching zero files is simply not
+/// instantiated — nothing to run.
+///
+/// The discovered files are plan-time-known literal paths, so exact-match
+/// DAG edge inference to producer outputs works (the win over the
+/// dir/glob convention). `input` and `input_groups` may coexist: the
+/// declared inputs append after the group files.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InputGroupConfig {
+    /// Path glob with `{wildcard}` placeholders, relative to the workflow
+    /// root. Every wildcard except `group_by` may vary within a group.
+    pub pattern: String,
+
+    /// Wildcard that keys instances: one instance per distinct value.
+    pub group_by: String,
+
+    /// Other pattern wildcards whose FIRST occurrence is bound into the
+    /// instance's wildcard map (usable in `{output}` and shells). When
+    /// omitted, every other pattern wildcard is bound; wildcards not
+    /// listed here are only reachable as `{input_group.<wildcard>}` lists.
+    /// Accepts a single wildcard name (`keep = "lane"`) or a list.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_keep_wildcards")]
+    pub keep: Option<Vec<String>>,
+}
+
+/// Deserialize `keep` from either a single wildcard name or a list.
+fn deserialize_keep_wildcards<'de, D>(de: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct KeepVisitor;
+    impl<'de> serde::de::Visitor<'de> for KeepVisitor {
+        type Value = Option<Vec<String>>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a wildcard name or a list of wildcard names")
+        }
+
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D2>(self, de: D2) -> Result<Self::Value, D2::Error>
+        where
+            D2: serde::Deserializer<'de>,
+        {
+            // The present value: unwrap the Option wrapper, then accept a
+            // single name or a list of names.
+            struct KeepInner;
+            impl<'de> serde::de::Visitor<'de> for KeepInner {
+                type Value = Vec<String>;
+
+                fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str("a wildcard name or a list of wildcard names")
+                }
+
+                fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                    Ok(vec![v.to_string()])
+                }
+
+                fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                    self,
+                    mut seq: A,
+                ) -> Result<Self::Value, A::Error> {
+                    let mut out = Vec::new();
+                    while let Some(v) = seq.next_element::<String>()? {
+                        out.push(v);
+                    }
+                    Ok(out)
+                }
+            }
+            Ok(Some(de.deserialize_any(KeepInner)?))
+        }
+    }
+    de.deserialize_option(KeepVisitor)
+}
+
 /// A collection of file patterns, which can be either a simple list or a named map.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -678,6 +769,16 @@ pub struct Rule {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub expand_inputs: Vec<ExpandConfig>,
+
+    /// Per-sample multi-file grouping (groupTuple pattern, issue #227
+    /// item 3): files discovered on disk are grouped by the `group_by`
+    /// wildcard and each group fans into ONE instance whose `{input}`
+    /// renders all of the group's files. Consumed by
+    /// [`WorkflowConfig::expand_wildcards`]; cleared on the generated
+    /// instances so they never re-expand.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub input_groups: Vec<InputGroupConfig>,
 
     /// Output file patterns (may contain wildcards).
     /// Supports either a list `["a.txt"]` or a map `{ bam = "a.bam" }`.

--- a/crates/oxo-flow-core/src/wildcard.rs
+++ b/crates/oxo-flow-core/src/wildcard.rs
@@ -294,6 +294,85 @@ pub fn discover_wildcards_from_pattern(
     Ok(results)
 }
 
+/// Discover wildcard combinations by walking a directory TREE, matching
+/// each file's path (relative to `dir`, `/`-separated) against `pattern`.
+///
+/// The single-directory [`discover_wildcards_from_pattern`] only ever
+/// sees bare file names, so patterns with literal directory components
+/// (`results/adapterremoval/{sample}_{lane}_R1.fastq.gz`) can never
+/// match. This walker resolves those — the filesystem source of the
+/// per-sample grouping primitive (`input_groups`, issue #227 item 3).
+///
+/// Patterns WITHOUT a directory component deliberately keep the
+/// single-directory semantics (no surprise matches in nested folders),
+/// so existing `sample_pattern`-style discovery is unchanged.
+pub fn discover_wildcards_from_pattern_tree(
+    dir: &std::path::Path,
+    pattern: &str,
+) -> Result<WildcardCombinations> {
+    if !pattern.contains('/') {
+        return discover_wildcards_from_pattern(dir, pattern);
+    }
+    let re = pattern_to_regex(pattern)?;
+    let wildcard_names = extract_wildcards(pattern);
+    let mut results = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Walk the tree; only files whose relative path matches the full
+    // pattern contribute. Symlinks are followed, unreadable subtrees are
+    // skipped (best-effort, matching the flat walker's stance).
+    fn walk(
+        dir: &std::path::Path,
+        base: &std::path::Path,
+        re: &Regex,
+        wildcard_names: &[String],
+        seen: &mut HashSet<String>,
+        results: &mut Vec<WildcardValues>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = entry.file_type().ok();
+            if file_type.is_some_and(|t| t.is_dir()) {
+                walk(&path, base, re, wildcard_names, seen, results);
+            } else if file_type.is_none_or(|t| t.is_file() || t.is_symlink()) {
+                let rel = match path.strip_prefix(base) {
+                    Ok(rel) => rel,
+                    Err(_) => continue,
+                };
+                let rel_str = rel
+                    .to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/");
+                if let Some(captures) = re.captures(&rel_str) {
+                    let mut values = WildcardValues::new();
+                    for name in wildcard_names {
+                        if let Some(m) = captures.name(name) {
+                            values.insert(name.clone(), m.as_str().to_string());
+                        }
+                    }
+                    if !values.is_empty() {
+                        let mut parts: Vec<(&str, &str)> = values
+                            .iter()
+                            .map(|(k, v)| (k.as_str(), v.as_str()))
+                            .collect();
+                        parts.sort_by_key(|(k, _)| *k);
+                        let dedup_key: String =
+                            parts.iter().flat_map(|(k, v)| [k, "=", v, ","]).collect();
+                        if seen.insert(dedup_key) {
+                            results.push(values);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    walk(dir, dir, &re, &wildcard_names, &mut seen, &mut results);
+
+    Ok(results)
+}
+
 /// Extracts wildcard names from a pattern string.
 ///
 /// # Examples
@@ -827,6 +906,51 @@ mod tests {
         let results =
             discover_wildcards_from_pattern(dir.path(), "{sample}_R{read}.fastq.gz").unwrap();
         assert!(results.len() >= 2);
+    }
+
+    #[test]
+    fn discover_wildcards_from_pattern_tree_matches_subdirectories() {
+        // The recursive walker resolves patterns with literal directory
+        // components (`results/adapterremoval/{sample}_{lane}_R1.fastq.gz`),
+        // which the single-directory walker cannot see — the engine-level
+        // input_groups primitive (issue #227 item 3) scans with this.
+        let dir = tempfile::tempdir().unwrap();
+        let raw = dir.path().join("results/adapterremoval");
+        std::fs::create_dir_all(&raw).unwrap();
+        std::fs::write(raw.join("S1_L1_R1.fastq.gz"), "").unwrap();
+        std::fs::write(raw.join("S1_L2_R1.fastq.gz"), "").unwrap();
+        std::fs::write(raw.join("S2_L1_R1.fastq.gz"), "").unwrap();
+        // A decoy outside the literal directory must not match.
+        std::fs::write(dir.path().join("S1_L9_R1.fastq.gz"), "").unwrap();
+
+        let results = discover_wildcards_from_pattern_tree(
+            dir.path(),
+            "results/adapterremoval/{sample}_{lane}_R1.fastq.gz",
+        )
+        .unwrap();
+        let mut combos: Vec<_> = results
+            .into_iter()
+            .map(|c| (c["sample"].clone(), c["lane"].clone()))
+            .collect();
+        combos.sort();
+        assert_eq!(
+            combos,
+            vec![
+                ("S1".to_string(), "L1".to_string()),
+                ("S1".to_string(), "L2".to_string()),
+                ("S2".to_string(), "L1".to_string()),
+            ]
+        );
+
+        // Patterns without a directory component keep the single-directory
+        // semantics — no surprise matches in nested folders.
+        let flat = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(flat.path().join("sub")).unwrap();
+        std::fs::write(flat.path().join("sub/S1_L1_R1.fastq.gz"), "").unwrap();
+        let results =
+            discover_wildcards_from_pattern_tree(flat.path(), "{sample}_{lane}_R1.fastq.gz")
+                .unwrap();
+        assert!(results.is_empty(), "flat pattern must not scan recursively");
     }
 
     // -----------------------------------------------------------------------

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -561,6 +561,7 @@ memory = "32G"
 | `checkpoint_manifest` | String | No | Path (relative to workdir, `{config.x}`-expanded) of the TOML manifest the checkpoint rule writes at runtime to declare new samples |
 | `scatter` | Table | No | Fan-out parallel execution over a variable with optional gather |
 | `expand_inputs` | Table | No | Cartesian product expansion of input patterns |
+| `input_groups` | Array of tables | No | Group files by a pattern wildcard into one per-group instance (the Nextflow `groupTuple` pattern) — see [Input Groups](#input-groups-input_groups) |
 | `priority` | Integer | No | Execution priority (higher = runs first; default: 0) |
 | `target` | Boolean | No | Mark as default target (built when no explicit `-t` given) |
 | `required` | Boolean | No | Pipeline fails if this rule fails, even without downstream deps |
@@ -1005,6 +1006,69 @@ depends_on = []  # Run first, before file-based dependencies
 name = "local_only"
 shell = "echo 'local task'"
 localrule = true  # Never submitted to HPC cluster
+```
+
+### Input Groups (`input_groups`)
+
+Group many files of one sample (or any pattern key) into a **single**
+per-key rule instance whose `{input}` renders all of them — the Nextflow
+`groupTuple` pattern. Unblocks lane-merging (`cat` a sample's lane files
+in one step), library merging, and multi-file per-sample catalog steps.
+
+```toml
+[[rules]]
+name = "lanemerge"
+input_groups = [
+    { pattern = "results/adapterremoval/{sample}_{lane}_R1.fastq.gz",
+      group_by = "sample",
+      keep = "lane" }
+]
+output = ["results/merged/{sample}_R1.fastq.gz"]
+shell = "cat {input} > {output}"
+```
+
+- `pattern` — path glob with `{wildcard}` placeholders, relative to the
+  workflow file's directory (the same root `sample_pattern` scans).
+- `group_by` — the wildcard that names each group. One instance is
+  created per discovered group value.
+- `keep` — optional restriction: which *other* pattern wildcards are
+  bound to the group's **first** (sorted) file and become available as
+  `{wildcard}` placeholders in `output`/`shell`. Omitted = all other
+  wildcards. A string or an array of strings is accepted.
+- `{input}` — all matched files of the group, space-joined in stable
+  sorted order (files sort by path; the first sorted file supplies the
+  `keep` bindings, so results never depend on readdir order).
+- `{input_group.<wildcard>}` — a captured per-group value as a list
+  (space-joined), e.g. `{input_group.lane}` renders `L1 L2`. These are
+  **lists**: use them in shell loops/commands, not as single paths.
+- Files are discovered at **plan time** from two sources: files already
+  on disk under the workflow root, and the literal outputs of upstream
+  rules — so a producer rule declared earlier in the file (e.g. a
+  per-`{sample}_{lane}` rule) flows straight into the group's `{input}`,
+  with DAG edges inferred from those plan-time-known paths.
+- Regular `input` entries coexist: group files render first, declared
+  inputs append after them in `{input}`.
+- A group key with zero files instantiates **nothing** — the rule is
+  skipped for that key with a warning (no instance = nothing to run).
+
+v1 constraints: at most **one** `input_groups` entry per rule;
+`**` recursion is not supported in `pattern` (single-level paths);
+producers must be declared **before** their `input_groups` consumer;
+the `keep` wildcard bindings come from the first sorted file only (the
+captured per-group values of every file stay available via
+`{input_group.*}`); `{config.x}` placeholders in `pattern` resolve
+against the workflow config.
+
+```toml
+# A multiqc-style aggregator over grouped files: one instance per
+# sample, receiving every fastQC zip of that sample.
+[[rules]]
+name = "multiqc"
+input_groups = [
+    { pattern = "qc/fastqc_{sample}_{replicate}.zip", group_by = "sample" }
+]
+output = ["qc/multiqc_{sample}.html"]
+shell = "multiqc {input} -o qc -n {output}"
 ```
 
 ### Retry Configuration

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -200,6 +200,64 @@ fn cli_samples_pilot_then_scale_up() {
     assert!(dir.path().join("out/S3.txt").exists());
 }
 
+/// input_groups (issue #227 item 3 — the groupTuple pattern): rule 1
+/// writes per-(sample, lane) files, rule 2 groups them per sample and
+/// merges. Each rule-2 instance receives ALL of the sample's files as
+/// `{input}`, with DAG edges inferred from the plan-time-discovered
+/// literal paths (the exact-match win over the dir/glob convention).
+#[test]
+fn cli_input_groups_merges_per_sample_lane_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("lanemerge.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "lanemerge"
+version = "1.0.0"
+
+[[sample_groups]]
+name = "cohort"
+samples = ["S1", "S2"]
+
+[[values]]
+name = "lane"
+values = ["L1", "L2"]
+
+[[rules]]
+name = "simulate"
+output = ["raw/{sample}_{lane}_R1.txt"]
+shell = "echo {sample}-{lane} > {output}"
+
+[[rules]]
+name = "lanemerge"
+input_groups = [
+    { pattern = "raw/{sample}_{lane}_R1.txt", group_by = "sample" }
+]
+output = ["merged/{sample}_R1.txt"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "-j", "2"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Each sample's merged file contains BOTH lanes, in stable (sorted)
+    // file order — {input} rendered the full group, not one file.
+    let s1 = fs::read_to_string(dir.path().join("merged/S1_R1.txt")).unwrap();
+    assert_eq!(s1, "S1-L1\nS1-L2\n");
+    let s2 = fs::read_to_string(dir.path().join("merged/S2_R1.txt")).unwrap();
+    assert_eq!(s2, "S2-L1\nS2-L2\n");
+}
+
 /// `--samples @sheet` REPLACES inline fixture samples with the sheet's —
 /// the invocation-side sample swap (workflow ships S1/S2, caller runs
 /// real identifiers without editing the file).


### PR DESCRIPTION
## What

Implements **issue #227 item 3** — the per-sample multi-file grouping primitive (the Nextflow `groupTuple` pattern): a rule fans N files of one sample into **ONE** per-sample instance whose `{input}` renders all of them. This unblocks methylseq `CAT_FASTQ`, eager `lanemerge`/`library_merge`/`seqtype_merge`, and atacseq merged-replicate catalog exclusions.

```toml
[[rules]]
name = "lanemerge"
input_groups = [
    { pattern = "results/adapterremoval/{sample}_{lane}_R1.fastq.gz",
      group_by = "sample",
      keep = "lane" }
]
output = ["results/merged/{sample}_R1.fastq.gz"]
shell = "cat {input} > {output}"
```

## Design

- **Plan-time enumeration from two sources**: (1) a recursive disk walk of the workflow root matching the pattern (new `discover_wildcards_from_pattern_tree` — the flat walker only sees bare file names, so patterns with literal directory components never matched); (2) **producer materialized literal outputs** regex-matched against the pattern. Source 2 is the key decision: files the workflow itself will produce don't exist at plan time, yet their paths are plan-time-known — so the fan-out sees them AND exact-match DAG edge inference to producers works, giving correct scheduling for mid-run files.
- One instance per distinct `group_by` value; `{input}` = group's files space-joined (sorted, stable — first sorted file supplies the `keep` bindings, never readdir order).
- Instance wildcard map = group key + first occurrence of every kept wildcard (usable in `{output}`/shell); full per-group value lists exposed as `{input_group.<wildcard>}` (space-joined).
- `input` and `input_groups` coexist: declared inputs append after the group files.
- Zero-file group key → not instantiated (warn + skip; no `optional` interaction in v1).
- v1 constraints validated loudly: at most one entry per rule, `group_by`/`keep` must be pattern wildcards, residual `{input_group.*}` placeholders fail the plan naming the known wildcards.

## Tests

- `config::tests::input_groups_config_parses` — `keep` as string and array
- `config::tests::input_groups_fans_rule_into_one_instance_per_group_key` — disk files → 2 instances, `{input}` = both lane files, shell baked, `expansion_samples`/`expansion_values` recorded
- `config::tests::input_groups_matches_zero_files_drops_rule_with_warning`
- `config::tests::input_groups_regular_input_appends_after_group_files`
- `config::tests::input_groups_rejects_invalid_declarations` — `group_by` not in pattern
- `wildcard::discover_wildcards_from_pattern_tree_matches_subdirectories`
- `cli_integration::cli_input_groups_merges_per_sample_lane_files` — E2E: per-(sample,lane) producer → per-sample lanemerge, asserts `merged/S1_R1.txt` contains `S1-L1\nS1-L2\n` (both lanes, sorted)

Gates: fmt, clippy `-p oxo-flow-core -p oxo-flow-cli --all-targets` (0 errors), 1218 core lib tests + 11 doctests, 247 cli_integration tests, full workspace build. Docs added to `docs/guide/src/reference/workflow-format.md` (field row + Input Groups section).

## Deviations from the design surface (documented)

- `keep` semantics: an optional restriction list (omitted = all other pattern wildcards bound to first occurrence); design said the same, confirmed in implementation
- At most **one** `input_groups` entry per rule (validation error) — v1 simplification
- Producer outputs added as a second enumeration source beyond disk (needed for DAG-correct mid-run grouping)
- `base_dir` = workflow file's parent (same root `sample_pattern` scans), not the `-d` workdir override — v1 limitation
- No `**` recursion in patterns (single-level literal directory components); producers must be declared before their input_groups consumer
- Map-typed `input` converts to List values when combined with input_groups (same as `expand_inputs` pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)