### PR TITLE
test(web): PG runs-boundary contract + startup capability matrix (#207 phase-1 completion)

### DIFF
--- a/crates/oxo-flow-web/Cargo.toml
+++ b/crates/oxo-flow-web/Cargo.toml
@@ -19,7 +19,7 @@ oxo-flow-ai = { workspace = true }
 oxo-license = "0.1.1"
 axum = { workspace = true, features = ["multipart"] }
 async_zip = { version = "0.0.17", default-features = false }
-tower = { workspace = true }
+tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/oxo-flow-web/src/audit.rs
+++ b/crates/oxo-flow-web/src/audit.rs
@@ -173,7 +173,14 @@ pub async fn audit_middleware(
     // Awaited, not fire-and-forget: an audit trail that can silently lose
     // rows is not an audit trail. One indexed INSERT per mutation is cheap
     // and the response is already computed.
-    if let Err(e) = crate::db::insert_audit_row(&user, &action, &path, result, &metadata).await {
+    // PostgreSQL deployments never initialize the legacy audit store. A
+    // missing audit backend must degrade explicitly, not panic the request
+    // path — the structured log event below remains the machine trail.
+    if crate::db::try_pool().is_none() {
+        tracing::warn!("audit store unavailable (PostgreSQL backend?): {action} not audited");
+    } else if let Err(e) =
+        crate::db::insert_audit_row(&user, &action, &path, result, &metadata).await
+    {
         tracing::error!("audit insert failed for {action}: {e}");
     }
     // Structured event stream for machine consumers (issue #81).

--- a/crates/oxo-flow-web/src/main.rs
+++ b/crates/oxo-flow-web/src/main.rs
@@ -150,9 +150,14 @@ async fn main() -> Result<()> {
         {
             tracing::info!("Initializing PostgreSQL backend");
             oxo_flow_web::infra::db::postgres::init_pool(&database_url).await;
+            // Issue #207 acceptance: an explicit capability matrix at startup,
+            // so operators see the served/gated split before the first 503.
             tracing::warn!(
-                "Capability boundary: workflow RUN EXECUTION is SQLite-only — \
-                 POST /api/runs will respond 503 RUNS_REQUIRE_SQLITE"
+                "PostgreSQL deployment capability matrix:\n  \
+                 available: pipeline library · templates · auth · AI · observability\n  \
+                 degraded: audit trail (SQLite-only, logged-not-persisted)\n  \
+                 gated 503 RUNS_REQUIRE_SQLITE: every /api/runs* endpoint \
+                 (run execution is SQLite-only)"
             );
         }
         #[cfg(not(feature = "postgres"))]

--- a/crates/oxo-flow-web/tests/pg_boundary_contract.rs
+++ b/crates/oxo-flow-web/tests/pg_boundary_contract.rs
@@ -1,0 +1,86 @@
+//! Issue #207 phase-1 contract test.
+//!
+//! On a deployment where the embedded SQLite pool is never initialized
+//! (PostgreSQL mode), EVERY `/api/runs*` endpoint must answer the same
+//! structured 503 envelope, and non-run routes must stay outside the gate.
+//! This process never calls `init_pool`, so `try_pool()` is absent — the
+//! exact condition the router-layer gate keys on.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use oxo_flow_web::server::build_router;
+use tower::ServiceExt;
+
+/// The full `/api/runs*` route contract (mirrors the `run_routes` table in
+/// `server.rs`; update both together).
+const RUN_ROUTES: &[(&str, &str)] = &[
+    ("POST", "/api/runs"),
+    ("GET", "/api/runs"),
+    ("GET", "/api/runs/r1"),
+    ("GET", "/api/runs/r1/status"),
+    ("GET", "/api/runs/r1/dag-status"),
+    ("GET", "/api/runs/r1/diagnostics"),
+    ("GET", "/api/runs/r1/instances"),
+    ("POST", "/api/runs/r1/clean"),
+    ("POST", "/api/runs/r1/resume-checkpoint"),
+    ("GET", "/api/runs/r1/logs"),
+    ("GET", "/api/runs/r1/results"),
+    ("POST", "/api/runs/r1/retry"),
+    ("POST", "/api/runs/r1/cancel"),
+    ("POST", "/api/runs/r1/pause"),
+    ("POST", "/api/runs/r1/resume"),
+    ("GET", "/api/runs/r1/preview"),
+    ("GET", "/api/runs/r1/ai-status"),
+    ("GET", "/api/runs/r1/report"),
+    ("POST", "/api/runs/r1/report/ask"),
+    ("POST", "/api/runs/r1/report/visualize"),
+    ("GET", "/api/runs/r1/files"),
+];
+
+#[tokio::test]
+async fn every_runs_route_answers_the_structured_sqlite_boundary() {
+    let app = build_router("personal");
+    for (method, path) in RUN_ROUTES {
+        let req = Request::builder()
+            .method(*method)
+            .uri(*path)
+            .body(Body::empty())
+            .expect("request builds");
+        let resp = app.clone().oneshot(req).await.expect("infallible service");
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{method} {path} must answer the structured runs boundary"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body reads");
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!("{method} {path}: envelope is not the ApiError JSON: {e} — {bytes:?}")
+        });
+        assert_eq!(
+            envelope["code"], "RUNS_REQUIRE_SQLITE",
+            "{method} {path}: wrong code in {envelope}"
+        );
+        assert!(
+            envelope["message"].is_string() && envelope["suggestion"].is_string(),
+            "{method} {path}: envelope must carry message + suggestion, got {envelope}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn non_run_routes_are_not_gated() {
+    let app = build_router("personal");
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/health")
+        .body(Body::empty())
+        .expect("request builds");
+    let resp = app.oneshot(req).await.expect("infallible service");
+    assert_ne!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "health must stay outside the runs gate"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the remaining Phase-1 acceptance criteria of #207 (boundary itself shipped via #222 + #228):

1. **Contract test** (`tests/pg_boundary_contract.rs`): the issue demanded *"Structured 503s measured by a contract test"* — none existed. New in-process router test walks the **full 21-route `/api/runs*` table** with `tower::oneshot` on a router built in a pool-less process (exactly the PG-mode condition the gate keys on) and asserts per route: `503` + JSON envelope `code == "RUNS_REQUIRE_SQLITE"` + `message`/`suggestion` present. Negative control: `/api/health` stays ungated.

2. **Capability matrix at startup**: the acceptance line *"PG startup logs explicit capability matrix"* was a single sentence. Now a structured served/degraded/gated matrix, grep-able by `capability matrix`.

3. **Real bug the new contract test caught immediately**: on a pool-less (PG) deployment, `audit_middleware` **panicked** via the legacy `db.rs` pool getter on every mutating request — not just runs, but login and any write. Fixed with explicit degradation (`try_pool().is_none()` → warn + structured log event persists; no panic). The matrix gains a `degraded: audit trail` row so the trade-off is visible at boot.

4. `tower` gains the `util` feature (test-only ergonomics for `oneshot`).

## Acceptance-criteria mapping for #207 (Phase 1)

- [x] PG startup logs explicit capability matrix — `main.rs` warn, three-row matrix
- [x] Structured 503s measured by a contract test — 21-route envelope assertion + ungated control
- [x] Docs updated — landed in #228 (AGENTS.md · deploy-modes · web-api.md)

Phase 2 of the issue is a product decision point; the shipped docs record the current stance (run execution = SQLite, PG = team library/AI/auth). Phase 3 (full parity) remains specified in the #207 body for whenever demand appears.

## Test plan

- [x] `cargo test -p oxo-flow-web --test pg_boundary_contract` → 2/2
- [x] full workspace tests single-threaded → 0 failures
- [x] `make audit` clean
