### PR TITLE
feat(core): per-sample metadata_file, {meta.*} placeholders, and input_groups group_by = "meta.<column>" (issue #227)

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -135,6 +135,68 @@ impl WorkflowConfig {
         result
     }
 
+    /// Per-instance `{meta.<column>}` substitution for `when` expressions,
+    /// mirroring [`Self::bake_wildcard_when`] so the execution-time re-check
+    /// re-evaluates the same per-instance verdict:
+    ///
+    /// - comparison operand → the metadata value as a quoted literal
+    ///   (`'SE' == 'SE'` — the evaluator's literal comparison requires
+    ///   quotes on both sides),
+    /// - bare truthiness position → `true`/`false` for the value,
+    /// - missing row OR column → `''` in a comparison (a closed gate) and
+    ///   `false` in a truthiness position — never a bare token, which the
+    ///   evaluator's default-true fallback would run.
+    fn bake_meta_when(
+        when: &str,
+        table: &crate::wildcard::MetadataTable,
+        combo: &crate::wildcard::WildcardValues,
+    ) -> String {
+        const OPS: &[&str] = &[">=", "<=", "==", "!=", ">", "<"];
+
+        let row = crate::wildcard::metadata_row_for(combo, table);
+        let mut result = String::with_capacity(when.len());
+        let mut cursor = 0usize;
+        for cap in crate::config::META_NS_RE.captures_iter(when) {
+            let m = cap.get(0).expect("full match");
+            let column = cap.get(1).expect("column group").as_str();
+            let (start, end) = (m.start(), m.end());
+            result.push_str(&when[cursor..start]);
+
+            // Non-space context around the token decides its position.
+            let after = when[end..]
+                .find(|c: char| !c.is_whitespace())
+                .map(|i| &when[end + i..])
+                .unwrap_or_default();
+            let before = when[..start].trim_end();
+            let in_comparison = OPS
+                .iter()
+                .any(|op| after.starts_with(op) || before.ends_with(op));
+
+            match row.and_then(|r| r.get(column)) {
+                // Comparison operand → quoted literal of the metadata value.
+                Some(value) if in_comparison => {
+                    let rendered = crate::executor::process::render_wildcard_value(value);
+                    if rendered.contains('\'') {
+                        result.push_str(&format!("\"{rendered}\""));
+                    } else {
+                        result.push_str(&format!("'{rendered}'"));
+                    }
+                }
+                // Bare truthiness position → literal true/false.
+                Some(value) => {
+                    let truthy = !value.is_empty() && value != "false" && value != "0";
+                    result.push_str(if truthy { "true" } else { "false" });
+                }
+                // Missing row or column: a closed gate, never a bare token.
+                None if in_comparison => result.push_str("''"),
+                None => result.push_str("false"),
+            }
+            cursor = end;
+        }
+        result.push_str(&when[cursor..]);
+        result
+    }
+
     pub fn expand_wildcards(&mut self) -> Result<()> {
         // Preserve the unexpanded templates on first expansion — checkpoint
         // re-entry (issue #78 P3) re-expands from them with merged values.
@@ -249,6 +311,12 @@ impl WorkflowConfig {
         // Wildcards that trigger group expansion
         const GROUP_WILDCARDS: &[&str] = &["group", "sample"];
 
+        // The known `{meta.<column>}` vocabulary (issue #227 item 2): the
+        // union of columns any metadata row defines. Used for the
+        // plan-time typo warning below.
+        let metadata_columns: std::collections::HashSet<String> =
+            crate::wildcard::metadata_columns(&self.metadata);
+
         let mut expanded_rules: Vec<Rule> = Vec::new();
         let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         // Track original → expanded name mapping for depends_on resolution
@@ -289,6 +357,45 @@ impl WorkflowConfig {
             }
             if let Some(ref when) = rule.when {
                 all_text.push(when);
+            }
+
+            // `{meta.<column>}` plan-time typo check (issue #227 item 2): a
+            // column no row defines renders empty on every instance — warn
+            // once per rule+column so the author notices at plan time,
+            // matching the `{values.name}` stance (warn, never error).
+            // Free-text fields (log, script, hooks) are scanned too.
+            if !metadata_columns.is_empty() || all_text.iter().any(|t| t.contains("{meta.")) {
+                let mut meta_texts: Vec<&str> = all_text.clone();
+                if let Some(ref log) = rule.log {
+                    meta_texts.push(log);
+                }
+                for text in [
+                    &rule.script,
+                    &rule.pre_exec,
+                    &rule.on_success,
+                    &rule.on_failure,
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    meta_texts.push(text);
+                }
+                let mut warned_columns: Vec<String> = Vec::new();
+                for text in meta_texts {
+                    for cap in META_NS_RE.captures_iter(text) {
+                        let column = &cap[1];
+                        if !metadata_columns.contains(column)
+                            && !warned_columns.iter().any(|w| w == column)
+                        {
+                            tracing::warn!(
+                                rule = %rule.name,
+                                column,
+                                "rule references '{{meta.{column}}}' but no metadata row defines a column named '{column}' — the placeholder will render empty"
+                            );
+                            warned_columns.push(column.to_string());
+                        }
+                    }
+                }
             }
 
             let uses_pair_wildcard = !pair_combos.is_empty()
@@ -452,6 +559,9 @@ impl WorkflowConfig {
                         expand_command_text_fields(&mut expanded, rule, |s| {
                             expand_rule_shell(s, &combo)
                         });
+                        // Per-instance `{meta.<column>}` substitution from
+                        // the sample-like bindings (issue #227 item 2).
+                        self.apply_instance_meta(&mut expanded, &combo);
 
                         // Record which sample names this expansion belongs to
                         // (issue #63 readiness attribution).
@@ -611,6 +721,10 @@ impl WorkflowConfig {
                         expand_command_text_fields(&mut expanded, rule, |s| {
                             expand_rule_shell(s, &merged)
                         });
+                        // Per-instance `{meta.<column>}` substitution from
+                        // the instance's `{sample}` binding (issue #227
+                        // item 2).
+                        self.apply_instance_meta(&mut expanded, &merged);
 
                         // Record which sample this expansion belongs to
                         // (issue #63 readiness attribution).
@@ -707,6 +821,9 @@ impl WorkflowConfig {
                     expand_command_text_fields(&mut expanded, rule, |s| {
                         expand_rule_shell(s, combo)
                     });
+                    // Per-instance `{meta.<column>}` substitution (issue
+                    // #227 item 2) — see the pair branch.
+                    self.apply_instance_meta(&mut expanded, combo);
 
                     self.expansion_values
                         .insert(new_name.clone(), combo.clone());
@@ -1156,6 +1273,83 @@ impl WorkflowConfig {
         Ok(())
     }
 
+    /// Apply the per-instance `{meta.<column>}` substitution (issue #227
+    /// item 2) to every text field of an expanded rule — inputs, outputs,
+    /// shell, log, `when`, script, and the hooks — the same field set that
+    /// already carries per-instance substitutions.
+    ///
+    /// The instance's sample-like binding (from `combo`) selects the
+    /// metadata row; a missing row OR column renders empty, so
+    /// `when = "config.single_end_mode || {meta.endedness} == 'SE'"`-style
+    /// predicates evaluate false for samples without the data (the gate is
+    /// closed, never a literal token). Rules without any `{meta.`
+    /// reference are untouched.
+    fn apply_instance_meta(&self, expanded: &mut Rule, combo: &crate::wildcard::WildcardValues) {
+        let refers = expanded.input.iter().any(|p| p.contains("{meta."))
+            || expanded.output.iter().any(|p| p.contains("{meta."))
+            || expanded
+                .shell
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .log
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .when
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .script
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .pre_exec
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .on_success
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."))
+            || expanded
+                .on_failure
+                .as_deref()
+                .is_some_and(|s| s.contains("{meta."));
+        if !refers {
+            return;
+        }
+        let expand =
+            |text: &str| crate::wildcard::expand_meta_namespace(text, &self.metadata, combo);
+        let meta_expand_patterns = |patterns: &FilePatterns| -> FilePatterns {
+            match patterns {
+                FilePatterns::List(v) => FilePatterns::List(v.iter().map(|p| expand(p)).collect()),
+                FilePatterns::Map(m) => {
+                    FilePatterns::Map(m.iter().map(|(k, v)| (k.clone(), expand(v))).collect())
+                }
+                FilePatterns::Dir { path, pattern } => FilePatterns::Dir {
+                    path: expand(path),
+                    pattern: pattern.clone(),
+                },
+            }
+        };
+        expanded.input = meta_expand_patterns(&expanded.input);
+        expanded.output = meta_expand_patterns(&expanded.output);
+        expanded.shell = expanded.shell.as_deref().map(expand);
+        expanded.log = expanded.log.as_deref().map(expand);
+        // `when` gets the bake treatment (quoted literals in comparisons,
+        // true/false in truthiness positions) so the execution-time re-check
+        // re-evaluates this same verdict — plain substitution would leave
+        // unquoted values that the evaluator's default-true fallback runs.
+        expanded.when = expanded
+            .when
+            .as_deref()
+            .map(|w| Self::bake_meta_when(w, &self.metadata, combo));
+        expanded.script = expanded.script.as_deref().map(expand);
+        expanded.pre_exec = expanded.pre_exec.as_deref().map(expand);
+        expanded.on_success = expanded.on_success.as_deref().map(expand);
+        expanded.on_failure = expanded.on_failure.as_deref().map(expand);
+    }
+
     /// Expand one `input_groups` rule into its per-group instances (issue
     /// #227 item 3).
     ///
@@ -1203,7 +1397,46 @@ impl WorkflowConfig {
                 ),
             });
         }
-        if !pattern_wildcards.contains(&decl.group_by) {
+        // `group_by = "meta.<column>"` (issue #227 item 4): the group key
+        // comes from the per-sample metadata table instead of a pattern
+        // wildcard. The instance map binds the COLUMN name (e.g.
+        // `{antibody}`); pattern wildcards are never bound — the group's
+        // value lists are reachable as `{input_group.<wildcard>}` — so
+        // `keep` is meaningless for metadata grouping and rejected.
+        let meta_group_by: Option<&str> = decl
+            .group_by
+            .strip_prefix("meta.")
+            .filter(|column| !column.is_empty());
+        if let Some(column) = meta_group_by {
+            let known = crate::wildcard::metadata_columns(&self.metadata);
+            if !known.contains(column) {
+                return Err(OxoFlowError::Validation {
+                    message: format!(
+                        "input_groups group_by '{}' of rule '{}' references metadata column '{}' that no metadata row defines",
+                        decl.group_by, rule.name, column
+                    ),
+                    rule: Some(rule.name.clone()),
+                    suggestion: Some(
+                        "check the metadata_file columns, or use a pattern wildcard as group_by"
+                            .to_string(),
+                    ),
+                });
+            }
+            if decl.keep.is_some() {
+                return Err(OxoFlowError::Validation {
+                    message: format!(
+                        "input_groups keep of rule '{}' is not supported with group_by = '{}': \
+                         metadata-grouped instances bind only the group key ('{{{column}}}')",
+                        rule.name, decl.group_by
+                    ),
+                    rule: Some(rule.name.clone()),
+                    suggestion: Some(
+                        "use {input_group.<wildcard>} to reference the group's value lists"
+                            .to_string(),
+                    ),
+                });
+            }
+        } else if !pattern_wildcards.contains(&decl.group_by) {
             return Err(OxoFlowError::Validation {
                 message: format!(
                     "input_groups group_by '{}' of rule '{}' is not a wildcard in pattern '{}'",
@@ -1221,24 +1454,33 @@ impl WorkflowConfig {
             .filter(|w| w.as_str() != decl.group_by)
             .cloned()
             .collect();
-        let keep: Vec<String> = match &decl.keep {
-            Some(names) => {
-                for name in names {
-                    if !others.contains(name) {
-                        return Err(OxoFlowError::Validation {
-                            message: format!(
-                                "input_groups keep of rule '{}' names '{}' which is not a \
-                                 pattern wildcard (other than group_by '{}')",
-                                rule.name, name, decl.group_by
-                            ),
-                            rule: Some(rule.name.clone()),
-                            suggestion: Some(format!("keep may only list: {}", others.join(", "))),
-                        });
+        let keep: Vec<String> = if meta_group_by.is_some() {
+            // Metadata grouping binds only the column name; no pattern
+            // wildcard is bound (validation above rejects `keep`).
+            Vec::new()
+        } else {
+            match &decl.keep {
+                Some(names) => {
+                    for name in names {
+                        if !others.contains(name) {
+                            return Err(OxoFlowError::Validation {
+                                message: format!(
+                                    "input_groups keep of rule '{}' names '{}' which is not a \
+                                     pattern wildcard (other than group_by '{}')",
+                                    rule.name, name, decl.group_by
+                                ),
+                                rule: Some(rule.name.clone()),
+                                suggestion: Some(format!(
+                                    "keep may only list: {}",
+                                    others.join(", ")
+                                )),
+                            });
+                        }
                     }
+                    names.clone()
                 }
-                names.clone()
+                None => others.clone(),
             }
-            None => others.clone(),
         };
 
         // `{config.x}` placeholders resolve against the workflow config
@@ -1253,12 +1495,6 @@ impl WorkflowConfig {
         // Source 1: files already on disk under the workflow root.
         let mut candidates: Vec<(String, crate::wildcard::WildcardValues)> = Vec::new();
         for combo in crate::wildcard::discover_wildcards_from_pattern_tree(&base, &pattern)? {
-            let Some(key) = combo.get(&decl.group_by).cloned() else {
-                continue;
-            };
-            if key.is_empty() {
-                continue;
-            }
             let path = crate::wildcard::expand_pattern(&pattern, &combo)
                 .unwrap_or_else(|_| pattern.clone());
             candidates.push((path, combo));
@@ -1283,12 +1519,6 @@ impl WorkflowConfig {
             if !any {
                 continue;
             }
-            let Some(key) = combo.get(&decl.group_by) else {
-                continue;
-            };
-            if key.is_empty() {
-                continue;
-            }
             candidates.push((output.clone(), combo));
         }
 
@@ -1301,7 +1531,22 @@ impl WorkflowConfig {
             return Ok(Vec::new());
         }
 
-        // Group the (file, combo) pairs by the group_by value. Determinism
+        // The group key of a candidate: the `group_by` wildcard value, or —
+        // for `group_by = "meta.<column>"` — the metadata row's column
+        // value resolved from the combo's sample-like binding. A missing
+        // metadata row or an empty cell yields no key: the file is skipped
+        // (empty-column rows are never grouped).
+        let group_key_of = |combo: &crate::wildcard::WildcardValues| -> Option<String> {
+            match meta_group_by {
+                Some(column) => crate::wildcard::metadata_row_for(combo, &self.metadata)
+                    .and_then(|row| row.get(column))
+                    .filter(|value| !value.is_empty())
+                    .cloned(),
+                None => combo.get(&decl.group_by).cloned(),
+            }
+        };
+
+        // Group the (file, combo) pairs by the group key. Determinism
         // matters: keys sort by BTreeMap, files sort within a group, and
         // the "first occurrence" wildcard bindings come from the FIRST
         // SORTED file — never from readdir order.
@@ -1310,8 +1555,21 @@ impl WorkflowConfig {
             Vec<(String, crate::wildcard::WildcardValues)>,
         > = std::collections::BTreeMap::new();
         for (path, combo) in candidates {
-            let key = combo[&decl.group_by].clone();
+            let Some(key) = group_key_of(&combo) else {
+                continue;
+            };
+            if key.is_empty() {
+                continue;
+            }
             grouped.entry(key).or_default().push((path, combo));
+        }
+        if grouped.is_empty() {
+            tracing::warn!(
+                rule = %rule.name,
+                group_by = %decl.group_by,
+                "input_groups pattern matched files but none had a group key — the rule is not instantiated (nothing to run)"
+            );
+            return Ok(Vec::new());
         }
 
         let mut out = Vec::with_capacity(grouped.len());
@@ -1334,16 +1592,25 @@ impl WorkflowConfig {
             }
             // The instance wildcard map: the group key + the first
             // occurrence of every kept wildcard (for `{output}` etc.).
+            // Metadata grouping binds the group key under the COLUMN name
+            // (`group_by = "meta.antibody"` → `{antibody}`) and never
+            // binds pattern wildcards (`keep` is rejected above).
             let mut instance_map = crate::wildcard::WildcardValues::new();
-            instance_map.insert(decl.group_by.clone(), key.clone());
+            let key_name = meta_group_by.unwrap_or(decl.group_by.as_str());
+            instance_map.insert(key_name.to_string(), key.clone());
             for name in &keep {
                 if let Some(v) = entries[0].1.get(name) {
                     instance_map.insert(name.clone(), v.clone());
                 }
             }
             // Space-joined per-group value lists for `{input_group.<name>}`.
+            // The distinct sample values are kept for readiness attribution.
             let mut group_lists = HashMap::new();
+            let mut group_samples: Vec<String> = Vec::new();
             for (name, values) in value_lists {
+                if name == "sample" {
+                    group_samples = values.clone();
+                }
                 group_lists.insert(name, values.join(" "));
             }
 
@@ -1412,6 +1679,41 @@ impl WorkflowConfig {
                 };
                 expanded.when = Some(expand_group_text(&baked, &instance_map, &group_lists));
             }
+            // Per-instance `{meta.<column>}` substitution (issue #227 item
+            // 2): a plain group binds `{sample}` so the row lookup works;
+            // a metadata-grouped instance binds only the column name, so no
+            // row resolves and `{meta.*}` renders empty (the instance has
+            // no single sample — an ambiguous lookup must not pick one).
+            self.apply_instance_meta(&mut expanded, &instance_map);
+
+            // Metadata-grouped instances have no single pattern-wildcard
+            // binding — `{sample}` in an output is an authoring error (the
+            // instance's one binding is the column name, e.g. `{antibody}`).
+            // Fail the plan instead of running a literal token. The column
+            // name itself is exempt (a pattern may legitimately carry the
+            // same wildcard as the metadata column).
+            if let Some(column) = meta_group_by
+                && let Some(wild) = pattern_wildcards.iter().find(|w| {
+                    w.as_str() != column
+                        && expanded
+                            .output
+                            .iter()
+                            .any(|out| out.contains(&format!("{{{w}}}")))
+                })
+            {
+                return Err(OxoFlowError::Validation {
+                    message: format!(
+                        "outputs of input_groups rule '{}' use '{{{wild}}}' but metadata-grouped \
+                         instances have no single '{{{wild}}}' binding — the group key \
+                         ('{{{column}}}') is the instance's only binding",
+                        expanded.name
+                    ),
+                    rule: Some(rule.name.clone()),
+                    suggestion: Some(format!(
+                        "use '{{{column}}}' for the group key or '{{{{input_group.{wild}}}}}' for the group's values"
+                    )),
+                });
+            }
 
             // A leftover `{input_group.<name>}` means the author referenced
             // a wildcard this pattern never captures — fail the plan
@@ -1453,9 +1755,15 @@ impl WorkflowConfig {
             }
 
             // Readiness attribution (issue #63): the group key is the
-            // sample in the common case.
-            self.expansion_samples
-                .insert(expanded.name.clone(), vec![key]);
+            // sample in the common case; metadata-grouped instances
+            // attribute their group's sample values instead.
+            if meta_group_by.is_some() {
+                self.expansion_samples
+                    .insert(expanded.name.clone(), group_samples);
+            } else {
+                self.expansion_samples
+                    .insert(expanded.name.clone(), vec![key]);
+            }
             // Per-instance bindings so expand_inputs patterns referencing
             // `{sample}` / kept wildcards resolve per instance (same
             // contract as the pair/group branches).

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -26,6 +26,13 @@ use std::sync::LazyLock;
 pub(crate) static VALUES_NS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\{values\.(\w+)\}").expect("valid values-namespace regex"));
 
+/// Matches the namespaced `{meta.<column>}` wildcard form — the per-sample
+/// metadata vocabulary (issue #227 item 2). Like `{values.name}`, the
+/// engine's placeholder regex (`\w+` only) cannot match dotted names, so
+/// this namespace is detected and substituted textually.
+pub(crate) static META_NS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{meta\.(\w+)\}").expect("valid meta-namespace regex"));
+
 /// Matches a `wildcard.<key>` reference inside a `when` expression (the
 /// per-instance pair/group binding vocabulary, including metadata keys).
 pub(crate) static WHEN_WILDCARD_REF_RE: LazyLock<Regex> =
@@ -228,6 +235,36 @@ pub struct WorkflowMeta {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pairs_pattern: Option<String>,
+
+    /// Path to an external per-sample metadata table (a samplesheet).
+    ///
+    /// Supports TSV, CSV, and JSON formats, like `pairs_file` /
+    /// `sample_groups_file`. The first column holds the sample id (matching
+    /// the `{sample}` wildcard values; pair workflows may also key rows by
+    /// `pair_id` / experiment); every other column is an arbitrary key
+    /// addressed as `{meta.<column>}` in rule shells, inputs, outputs,
+    /// `when` expressions, scripts, and hooks. Rows do NOT define the
+    /// sample set — samples come from the normal sources (sample groups,
+    /// pairs, `sample_pattern`); the table is a per-sample lookup.
+    ///
+    /// # File format
+    ///
+    /// **TSV/CSV** (tab or comma separated):
+    /// ```text
+    /// sample    endedness    adapters
+    /// SE1    SE    AGATCGGAAG
+    /// PE1    PE    CTGTCTCTTA
+    /// ```
+    ///
+    /// **JSON** (array of objects; the `sample` key is the id):
+    /// ```json
+    /// [
+    ///   {"sample": "SE1", "endedness": "SE", "adapters": "AGATCGGAAG"}
+    /// ]
+    /// ```
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_file: Option<String>,
 
     /// Wildcard pattern for auto-discovering samples from the filesystem.
     ///
@@ -1319,6 +1356,167 @@ impl SampleGroup {
     }
 }
 
+/// One row of the per-sample metadata table (`[workflow] metadata_file`).
+///
+/// The row's id must match the sample wildcard values (or a pair id /
+/// experiment name in pair workflows); every other column is an arbitrary
+/// key addressed as `{meta.<column>}`. The table is a LOOKUP — rows do not
+/// define the sample set.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SampleMetadata {
+    /// Sample id (first column of the table).
+    pub sample: String,
+
+    /// Arbitrary column → value pairs.
+    pub values: HashMap<String, String>,
+}
+
+impl SampleMetadata {
+    /// Load the metadata table from a TSV, CSV, or JSON file.
+    ///
+    /// # File format
+    ///
+    /// **TSV/CSV** (first column = sample id, header required):
+    /// ```text
+    /// sample    endedness    adapters
+    /// SE1    SE    AGATCGGAAG
+    /// PE1    PE    CTGTCTCTTA
+    /// ```
+    ///
+    /// **JSON** (array of objects; the `sample` key is the id):
+    /// ```json
+    /// [
+    ///   {"sample": "SE1", "endedness": "SE", "adapters": "AGATCGGAAG"}
+    /// ]
+    /// ```
+    pub fn load_from_file(path: &Path) -> Result<Vec<Self>> {
+        let metadata = std::fs::metadata(path).map_err(|e| OxoFlowError::Parse {
+            path: path.to_path_buf(),
+            message: format!("failed to read metadata for metadata_file: {}", e),
+        })?;
+
+        // 50MB limit to prevent OOM on accidental binary file input
+        if metadata.len() > 50 * 1024 * 1024 {
+            return Err(OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: format!(
+                    "metadata file is too large ({} bytes). Maximum allowed size is 50MB.",
+                    metadata.len()
+                ),
+            });
+        }
+
+        let content = std::fs::read_to_string(path).map_err(|e| OxoFlowError::Parse {
+            path: path.to_path_buf(),
+            message: format!("failed to read metadata_file: {}", e),
+        })?;
+
+        let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+        match extension {
+            "json" => Self::parse_json(&content, path),
+            "csv" => Self::parse_csv(&content, path),
+            "tsv" | "txt" | "" => Self::parse_tsv(&content, path),
+            _ => Err(OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: format!("unsupported metadata file format: {}", extension),
+            }),
+        }
+    }
+
+    fn parse_json(content: &str, path: &Path) -> Result<Vec<Self>> {
+        let rows: Vec<toml::Value> =
+            serde_json::from_str(content).map_err(|e| OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: format!("invalid JSON metadata file: {}", e),
+            })?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let toml::Value::Table(table) = row else {
+                return Err(OxoFlowError::Parse {
+                    path: path.to_path_buf(),
+                    message: "metadata JSON rows must be objects".to_string(),
+                });
+            };
+            let sample = table
+                .get("sample")
+                .and_then(toml::Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if sample.is_empty() {
+                return Err(OxoFlowError::Parse {
+                    path: path.to_path_buf(),
+                    message: "metadata JSON rows must have a non-empty 'sample' key".to_string(),
+                });
+            }
+            let values = table
+                .into_iter()
+                .filter(|(k, _)| k != "sample")
+                .map(|(k, v)| {
+                    let v = match v {
+                        toml::Value::String(s) => s,
+                        other => other.to_string(),
+                    };
+                    (k, v)
+                })
+                .collect();
+            out.push(Self { sample, values });
+        }
+        Ok(out)
+    }
+
+    fn parse_csv(content: &str, path: &Path) -> Result<Vec<Self>> {
+        Self::parse_delimited(content, ',', path)
+    }
+
+    fn parse_tsv(content: &str, path: &Path) -> Result<Vec<Self>> {
+        Self::parse_delimited(content, '\t', path)
+    }
+
+    fn parse_delimited(content: &str, delimiter: char, path: &Path) -> Result<Vec<Self>> {
+        let mut reader = csv::ReaderBuilder::new()
+            .delimiter(delimiter as u8)
+            .has_headers(true)
+            .trim(csv::Trim::All)
+            .comment(Some(b'#'))
+            .from_reader(content.as_bytes());
+
+        let headers = reader
+            .headers()
+            .map_err(|e| OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: format!("metadata file is empty or has invalid headers: {}", e),
+            })?
+            .clone();
+        if headers.is_empty() {
+            return Err(OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: "metadata file has no columns".to_string(),
+            });
+        }
+
+        let mut out = Vec::new();
+        for (row_idx, result) in reader.records().enumerate() {
+            let record = result.map_err(|e| OxoFlowError::Parse {
+                path: path.to_path_buf(),
+                message: format!("error parsing row {}: {}", row_idx + 2, e),
+            })?;
+            let sample = record.get(0).unwrap_or("").to_string();
+            if sample.is_empty() {
+                continue;
+            }
+            let values = headers
+                .iter()
+                .enumerate()
+                .skip(1)
+                .map(|(i, header)| (header.to_string(), record.get(i).unwrap_or("").to_string()))
+                .collect();
+            out.push(Self { sample, values });
+        }
+        Ok(out)
+    }
+}
+
 /// Resource group configuration for limiting shared resources like API rate
 /// limits or database connections.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -1478,6 +1676,17 @@ pub struct WorkflowConfig {
     #[serde(default, rename = "sample_groups")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sample_groups: Vec<SampleGroup>,
+
+    /// Per-sample metadata table (issue #227 item 2): sample id → column →
+    /// value, loaded from `[workflow] metadata_file` at plan time. Rules
+    /// address columns as `{meta.<column>}`, resolved per instance from
+    /// the instance's sample-like binding (`{sample}`, or `{pair_id}` /
+    /// experiment / control in pair workflows). A missing row or column
+    /// renders as an empty string. Never set by user TOML — the table only
+    /// comes from `metadata_file`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, HashMap<String, String>>,
 
     /// Named value lists for arbitrary parameter wildcards (`[[values]]`).
     ///

--- a/crates/oxo-flow-core/src/config/parse.rs
+++ b/crates/oxo-flow-core/src/config/parse.rs
@@ -125,6 +125,19 @@ impl WorkflowConfig {
             tracing::info!("Loaded {} sample groups from {}", count, groups_file);
         }
 
+        // Load the per-sample metadata table from external file if
+        // specified (issue #227 item 2): the `{meta.<column>}` lookup
+        // vocabulary, keyed by sample id.
+        if let Some(ref metadata_file) = config.workflow.metadata_file {
+            let meta_path = parent.join(metadata_file);
+            let rows = SampleMetadata::load_from_file(&meta_path)?;
+            let count = rows.len();
+            for row in rows {
+                config.metadata.insert(row.sample, row.values);
+            }
+            tracing::info!("Loaded {} metadata rows from {}", count, metadata_file);
+        }
+
         // Auto-discover samples from filesystem pattern
         if let Some(ref sample_pattern) = config.workflow.sample_pattern {
             // Expand config variables in the pattern (e.g. {config.data_dir}/.../{sample}_R1.fq.gz)

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -5013,3 +5013,520 @@ fn unbound_values_namespace_keeps_rule_unchanged() {
         vec!["reads/{values.assembler}/in.fq"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// Sample metadata table + {meta.<column>} namespace (issue #227 item 2)
+// ---------------------------------------------------------------------------
+
+/// Write a `metadata_file` (samples.tsv) plus the given sample groups and
+/// rules into a tempdir; returns the tempdir and the workflow path.
+fn metadata_workflow(
+    metadata_tsv: &str,
+    sample_groups: &str,
+    rules: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("samples.tsv"), metadata_tsv).unwrap();
+    let workflow_path = dir.path().join("meta.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        format!(
+            r#"
+        [workflow]
+        name = "meta"
+        metadata_file = "samples.tsv"
+
+        {sample_groups}
+        {rules}
+        "#
+        ),
+    )
+    .unwrap();
+    (dir, workflow_path)
+}
+
+#[test]
+fn metadata_file_loads_tsv_rows_into_config() {
+    // `[workflow] metadata_file` loads a per-sample table: the first column
+    // is the sample id (matching `{sample}` values), the remaining columns
+    // are arbitrary keys addressed as `{meta.<column>}`.
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\tendedness\tadapters\nS1\tSE\tAGATCGGAAG\nS2\tPE\t\n",
+        r#"
+        [[sample_groups]]
+        name = "control"
+        samples = ["S1", "S2"]
+        "#,
+        r#"
+        [[rules]]
+        name = "trim"
+        input = ["raw/{sample}_R1.fastq.gz"]
+        output = ["trimmed/{sample}.fq"]
+        shell = "cutadapt -a {meta.adapters}"
+        "#,
+    );
+    let config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let s1 = config.metadata.get("S1").expect("S1 row");
+    assert_eq!(s1.get("endedness").map(String::as_str), Some("SE"));
+    assert_eq!(s1.get("adapters").map(String::as_str), Some("AGATCGGAAG"));
+    let s2 = config.metadata.get("S2").expect("S2 row");
+    assert_eq!(s2.get("endedness").map(String::as_str), Some("PE"));
+    assert_eq!(s2.get("adapters"), Some(&String::new()));
+}
+
+#[test]
+fn metadata_file_accepts_csv_and_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("samples.csv"),
+        "sample,endedness\nS1,SE\nS2,PE\n",
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("csv.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "meta-csv"
+        metadata_file = "samples.csv"
+        "#,
+    )
+    .unwrap();
+    let config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    assert_eq!(config.metadata["S1"]["endedness"], "SE");
+
+    std::fs::write(
+        dir.path().join("samples.json"),
+        r#"[{"sample": "S1", "endedness": "SE"}, {"sample": "S2", "endedness": "PE"}]"#,
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("json.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "meta-json"
+        metadata_file = "samples.json"
+        "#,
+    )
+    .unwrap();
+    let config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    assert_eq!(config.metadata["S2"]["endedness"], "PE");
+}
+
+#[test]
+fn metadata_file_missing_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("missing.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "meta"
+        metadata_file = "nope.tsv"
+        "#,
+    )
+    .unwrap();
+    let err = WorkflowConfig::from_file(&workflow_path).unwrap_err();
+    assert!(err.to_string().contains("nope.tsv"));
+}
+
+#[test]
+fn meta_namespace_expands_in_shells_per_sample() {
+    // rnaseq-star-style per-unit lookup: a metadata column feeds a shell
+    // flag, resolved per instance from the instance's `{sample}` binding.
+    // A column that exists but is empty on a row renders ""; a column no
+    // row defines renders "" too.
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\tadapters\textra\nS1\tAGATCGGAAG\t--clip-r1 5\nS2\tCTGTCTCTTA\t\n",
+        r#"
+        [[sample_groups]]
+        name = "control"
+        samples = ["S1", "S2"]
+        "#,
+        r#"
+        [[rules]]
+        name = "trim"
+        input = ["raw/{sample}_R1.fastq.gz"]
+        output = ["trimmed/{sample}.fq"]
+        shell = "cutadapt -a {meta.adapters} {meta.extra}"
+
+        [[rules]]
+        name = "qc"
+        input = ["trimmed/{sample}.fq"]
+        output = ["qc/{sample}.txt"]
+        shell = "check {meta.unknown_column}"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+
+    let s1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_S1")
+        .expect("S1 instance");
+    assert_eq!(
+        s1.shell.as_deref(),
+        Some("cutadapt -a AGATCGGAAG --clip-r1 5")
+    );
+    let s2 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_S2")
+        .expect("S2 instance");
+    // Empty cell on the row renders empty.
+    assert_eq!(s2.shell.as_deref(), Some("cutadapt -a CTGTCTCTTA "));
+
+    // Column that no row defines renders empty on every instance.
+    for name in ["qc_control_S1", "qc_control_S2"] {
+        let rule = config.rules.iter().find(|r| r.name == name).expect(name);
+        assert_eq!(rule.shell.as_deref(), Some("check "));
+    }
+}
+
+#[test]
+fn meta_namespace_resolves_input_paths_and_dag_edges() {
+    // A rule-level `input` entry can be `{meta.<column>}` — the path is a
+    // plan-time literal after expansion, so exact-match DAG edge inference
+    // connects it to the producer.
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\tbam_path\nS1\taligned/S1.bam\nS2\taligned/S2.bam\n",
+        r#"
+        [[sample_groups]]
+        name = "control"
+        samples = ["S1", "S2"]
+        "#,
+        r#"
+        [[rules]]
+        name = "map"
+        output = ["aligned/{sample}.bam"]
+        shell = "echo hi > {output[0]}"
+
+        [[rules]]
+        name = "call"
+        input = ["{meta.bam_path}"]
+        output = ["calls/{sample}.vcf"]
+        shell = "bcftools call {input[0]} -o {output[0]}"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+
+    let call_s1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "call_control_S1")
+        .expect("call S1 instance");
+    assert_eq!(call_s1.input.to_vec(), vec!["aligned/S1.bam"]);
+    let call_s2 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "call_control_S2")
+        .expect("call S2 instance");
+    assert_eq!(call_s2.input.to_vec(), vec!["aligned/S2.bam"]);
+
+    let dag = crate::dag::WorkflowDag::from_rules(&config.rules).unwrap();
+    assert_eq!(
+        dag.dependencies("call_control_S1").unwrap(),
+        vec!["map_control_S1"]
+    );
+    assert_eq!(
+        dag.dependencies("call_control_S2").unwrap(),
+        vec!["map_control_S2"]
+    );
+}
+
+#[test]
+fn meta_namespace_in_when_renders_per_instance() {
+    // methylseq-style endedness gate: the per-sample column is substituted
+    // into `when` so `'SE' == 'SE'`-style predicates evaluate per instance;
+    // a sample with no metadata row renders empty (gate closed).
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\tendedness\nSE1\tSE\nPE1\tPE\n",
+        r#"
+        [[sample_groups]]
+        name = "control"
+        samples = ["SE1", "PE1", "X1"]
+        "#,
+        r#"
+        [[rules]]
+        name = "trim"
+        input = ["raw/{sample}_R1.fastq.gz"]
+        output = ["trimmed/{sample}.fq"]
+        when = "config.single_end_mode || {meta.endedness} == 'SE'"
+        shell = "cp {input[0]} {output[0]}"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+
+    let se1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_SE1")
+        .expect("SE1 instance");
+    assert_eq!(
+        se1.when.as_deref(),
+        Some("config.single_end_mode || 'SE' == 'SE'")
+    );
+    let pe1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_PE1")
+        .expect("PE1 instance");
+    assert_eq!(
+        pe1.when.as_deref(),
+        Some("config.single_end_mode || 'PE' == 'SE'")
+    );
+    // No row for X1: the placeholder renders empty → the gate is closed.
+    let x1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_X1")
+        .expect("X1 instance");
+    assert_eq!(
+        x1.when.as_deref(),
+        Some("config.single_end_mode || '' == 'SE'")
+    );
+}
+
+#[test]
+fn meta_namespace_lookup_falls_back_to_pair_id() {
+    // Pair workflows: metadata rows keyed by pair_id (or experiment) still
+    // resolve — the instance's sample-like bindings are tried in order.
+    let (_dir, workflow_path) = metadata_workflow(
+        "pair_id\tstudy\nP1\tcase\nP2\tcontrol\n",
+        "",
+        r#"
+        [[pairs]]
+        pair_id = "P1"
+        experiment = "T1"
+        control = "N1"
+
+        [[pairs]]
+        pair_id = "P2"
+        experiment = "T2"
+        control = "N2"
+
+        [[rules]]
+        name = "cmp"
+        input = ["reads/{pair_id}/in.txt"]
+        output = ["cmp/{pair_id}.txt"]
+        shell = "echo {meta.study} {pair_id}"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+
+    let p1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "cmp_P1")
+        .expect("P1 instance");
+    assert_eq!(p1.shell.as_deref(), Some("echo case P1"));
+    let p2 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "cmp_P2")
+        .expect("P2 instance");
+    assert_eq!(p2.shell.as_deref(), Some("echo control P2"));
+}
+
+#[test]
+fn input_groups_group_by_meta_fans_out_one_instance_per_value() {
+    // chipseq multi-antibody (issue #227 item 4): group files by a metadata
+    // column value instead of a pattern wildcard. 3 samples × 2 antibody
+    // values → 2 instances; `{input}` is the group's files space-joined
+    // (sorted), `{input_group.sample}` the sample names, and the group key
+    // binds under the COLUMN name (`{antibody}`). Rows with an empty column
+    // value are skipped.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("results/mapping")).unwrap();
+    for sample in ["S1", "S2", "S3", "S4"] {
+        std::fs::write(
+            dir.path().join(format!("results/mapping/{sample}.bam")),
+            "bam",
+        )
+        .unwrap();
+    }
+    let (_dir, workflow_path) = {
+        std::fs::write(
+            dir.path().join("samples.tsv"),
+            "sample\tantibody\nS1\tH3K27ac\nS2\tH3K27ac\nS3\tInput\nS4\t\n",
+        )
+        .unwrap();
+        let workflow_path = dir.path().join("chipseq.oxoflow");
+        std::fs::write(
+            &workflow_path,
+            r#"
+            [workflow]
+            name = "chipseq"
+            metadata_file = "samples.tsv"
+
+            [[rules]]
+            name = "peaks"
+            input_groups = [
+                { pattern = "results/mapping/{sample}.bam", group_by = "meta.antibody" }
+            ]
+            output = ["peaks/{antibody}.bed"]
+            shell = "macs2 callpeak -t {input} -n {antibody} --outdir peaks && echo {input_group.sample}"
+            "#,
+        )
+        .unwrap();
+        (dir, workflow_path)
+    };
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+
+    let h3 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "peaks_H3K27ac")
+        .expect("H3K27ac instance");
+    assert_eq!(
+        h3.input.to_vec(),
+        vec![
+            "results/mapping/S1.bam".to_string(),
+            "results/mapping/S2.bam".to_string(),
+        ]
+    );
+    // `{input}` stays literal at expansion (execution-time rendering); the
+    // group key binds under the COLUMN name (`{antibody}`) and
+    // `{input_group.sample}` is the group's space-joined sample names.
+    assert_eq!(
+        h3.shell.as_deref(),
+        Some("macs2 callpeak -t {input} -n H3K27ac --outdir peaks && echo S1 S2")
+    );
+    let input = config
+        .rules
+        .iter()
+        .find(|r| r.name == "peaks_Input")
+        .expect("Input instance");
+    assert_eq!(input.input.to_vec(), vec!["results/mapping/S3.bam"]);
+    assert_eq!(
+        input.shell.as_deref(),
+        Some("macs2 callpeak -t {input} -n Input --outdir peaks && echo S3")
+    );
+    // The empty-antibody row (S4) and its bam are skipped entirely.
+    assert!(!config.rules.iter().any(|r| r.name == "peaks_S4"));
+    assert!(!config.rules.iter().any(|r| {
+        r.input
+            .to_vec()
+            .contains(&"results/mapping/S4.bam".to_string())
+    }));
+}
+
+#[test]
+fn input_groups_group_by_meta_rejects_sample_in_outputs() {
+    // Metadata-grouped instances have no single {sample} binding — the
+    // group key (column name) is the only binding. Outputs referencing a
+    // pattern wildcard are a plan-time validation error.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("results/mapping")).unwrap();
+    std::fs::write(dir.path().join("results/mapping/S1.bam"), "bam").unwrap();
+    std::fs::write(
+        dir.path().join("samples.tsv"),
+        "sample\tantibody\nS1\tH3K27ac\n",
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("chipseq.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "chipseq"
+        metadata_file = "samples.tsv"
+
+        [[rules]]
+        name = "peaks"
+        input_groups = [
+            { pattern = "results/mapping/{sample}.bam", group_by = "meta.antibody" }
+        ]
+        output = ["peaks/{sample}.bed"]
+        shell = "echo {input} > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("{sample}"),
+        "error should name the forbidden wildcard: {err}"
+    );
+}
+
+#[test]
+fn input_groups_group_by_meta_rejects_keep() {
+    // `keep` selects pattern wildcards to bind into the instance map —
+    // meaningless when the group key comes from metadata, where the spec
+    // says the instance map binds only the column name.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("results/mapping")).unwrap();
+    std::fs::write(dir.path().join("results/mapping/S1.bam"), "bam").unwrap();
+    std::fs::write(
+        dir.path().join("samples.tsv"),
+        "sample\tantibody\nS1\tH3K27ac\n",
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("chipseq.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "chipseq"
+        metadata_file = "samples.tsv"
+
+        [[rules]]
+        name = "peaks"
+        input_groups = [
+            { pattern = "results/mapping/{sample}.bam", group_by = "meta.antibody", keep = "sample" }
+        ]
+        output = ["peaks/{antibody}.bed"]
+        shell = "echo {input} > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("keep"),
+        "error should mention keep: {err}"
+    );
+}
+
+#[test]
+fn input_groups_group_by_meta_unknown_column_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("results/mapping")).unwrap();
+    std::fs::write(dir.path().join("results/mapping/S1.bam"), "bam").unwrap();
+    std::fs::write(
+        dir.path().join("samples.tsv"),
+        "sample\tantibody\nS1\tH3K27ac\n",
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("chipseq.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "chipseq"
+        metadata_file = "samples.tsv"
+
+        [[rules]]
+        name = "peaks"
+        input_groups = [
+            { pattern = "results/mapping/{sample}.bam", group_by = "meta.notacolumn" }
+        ]
+        output = ["peaks/{antibody}.bed"]
+        shell = "echo {input} > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("notacolumn"),
+        "error should name the unknown column: {err}"
+    );
+}

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -2693,12 +2693,15 @@ fn render_shell_command_inner(
             );
         }
     }
-    if expanded.contains("{config.") || expanded.contains("{input") || expanded.contains("{output")
+    if expanded.contains("{config.")
+        || expanded.contains("{meta.")
+        || expanded.contains("{input")
+        || expanded.contains("{output")
     {
         tracing::warn!(
             rule = %rule.name,
             command = %expanded,
-            "unresolved config/input/output placeholder remained in the rendered command"
+            "unresolved config/meta/input/output placeholder remained in the rendered command"
         );
     }
     expanded

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -2035,3 +2035,100 @@ async fn scratch_rule_pre_exec_runs_in_scratch_with_absolute_inputs() {
     assert!(workdir.path().join("data.txt").exists());
     assert!(scratch_entries(workdir.path()).is_empty());
 }
+
+#[tokio::test]
+async fn meta_when_gate_runs_se_and_skips_pe_instances() {
+    // methylseq-style endedness gate driven by the sample metadata table
+    // (issue #227 item 2): `single_end_mode = false` and a per-sample
+    // `endedness` column — SE instances execute, PE instances skip, and a
+    // sample with NO metadata row also skips (its placeholder rendered
+    // empty, so the `== 'SE'` predicate evaluated false).
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("raw")).unwrap();
+    for sample in ["SE1", "PE1", "X1"] {
+        std::fs::write(
+            dir.path().join(format!("raw/{sample}_R1.fastq.gz")),
+            "reads",
+        )
+        .unwrap();
+    }
+    std::fs::write(
+        dir.path().join("samples.tsv"),
+        "sample\tendedness\nSE1\tSE\nPE1\tPE\n",
+    )
+    .unwrap();
+    let workflow_path = dir.path().join("methyl.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "methyl"
+        metadata_file = "samples.tsv"
+
+        [config]
+        single_end_mode = false
+
+        [[sample_groups]]
+        name = "control"
+        samples = ["SE1", "PE1", "X1"]
+
+        [[rules]]
+        name = "trim"
+        input = ["raw/{sample}_R1.fastq.gz"]
+        output = ["trimmed/{sample}.fq"]
+        when = "config.single_end_mode || {meta.endedness} == 'SE'"
+        shell = "cp {input[0]} {output[0]}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = crate::config::WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+    let executor = LocalExecutor::new(ExecutorConfig {
+        workdir: dir.path().to_path_buf(),
+        ..Default::default()
+    });
+    let mut typed_config = HashMap::new();
+    typed_config.insert("single_end_mode".to_string(), toml::Value::Boolean(false));
+    let wildcard_values = HashMap::new();
+
+    let se1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_SE1")
+        .expect("SE1 instance");
+    let record = executor
+        .execute_rule_with_config(se1, &wildcard_values, &typed_config)
+        .await
+        .unwrap();
+    assert_eq!(record.status, JobStatus::Success);
+    assert!(dir.path().join("trimmed/SE1.fq").exists());
+
+    let pe1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_PE1")
+        .expect("PE1 instance");
+    let record = executor
+        .execute_rule_with_config(pe1, &wildcard_values, &typed_config)
+        .await
+        .unwrap();
+    assert_eq!(record.status, JobStatus::Skipped);
+    assert_eq!(
+        record.skip_reason.as_deref(),
+        Some("condition evaluated to false")
+    );
+    assert!(!dir.path().join("trimmed/PE1.fq").exists());
+
+    let x1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "trim_control_X1")
+        .expect("X1 instance");
+    let record = executor
+        .execute_rule_with_config(x1, &wildcard_values, &typed_config)
+        .await
+        .unwrap();
+    assert_eq!(record.status, JobStatus::Skipped);
+    assert!(!dir.path().join("trimmed/X1.fq").exists());
+}

--- a/crates/oxo-flow-core/src/wildcard.rs
+++ b/crates/oxo-flow-core/src/wildcard.rs
@@ -488,6 +488,69 @@ pub fn expand_values_namespace(pattern: &str, bindings: &WildcardValues) -> Stri
     out
 }
 
+/// The per-sample metadata table: sample id → column → value
+/// (issue #227 item 2).
+pub type MetadataTable =
+    std::collections::HashMap<String, std::collections::HashMap<String, String>>;
+
+/// The sample-like instance bindings tried, in order, when resolving
+/// `{meta.<column>}` for an instance: the `{sample}` binding first (the
+/// common group/sample fan-out), then the pair vocabulary for pair
+/// workflows (rows keyed by pair_id or by experiment/control names).
+pub const METADATA_LOOKUP_KEYS: &[&str] = &["sample", "pair_id", "experiment", "control"];
+
+/// Resolve an instance's metadata row: the first non-empty sample-like
+/// binding that has a row in the table. `None` when no binding matches —
+/// the instance renders every `{meta.<column>}` reference empty.
+#[must_use]
+pub fn metadata_row_for<'a>(
+    bindings: &WildcardValues,
+    table: &'a MetadataTable,
+) -> Option<&'a std::collections::HashMap<String, String>> {
+    METADATA_LOOKUP_KEYS.iter().find_map(|key| {
+        let id = bindings.get(*key)?;
+        if id.is_empty() {
+            return None;
+        }
+        table.get(id)
+    })
+}
+
+/// The union of column names defined by any metadata row — the known
+/// `{meta.<column>}` vocabulary for plan-time typo warnings.
+#[must_use]
+pub fn metadata_columns(table: &MetadataTable) -> std::collections::HashSet<String> {
+    table.values().flat_map(|row| row.keys().cloned()).collect()
+}
+
+/// Expand `{meta.<column>}` namespace placeholders for one instance.
+///
+/// The metadata row is resolved from the instance's sample-like binding
+/// ([`metadata_row_for`]); a column present on the row substitutes its
+/// value, and a missing row OR column substitutes an empty string (the
+/// `when = "config.single_end_mode || {meta.endedness} == 'SE'"` gate
+/// therefore evaluates false for samples without the data — the gate is
+/// closed, never a literal token). Unresolvable references in rules that
+/// never fan out (no sample-like binding at all) stay untouched; the
+/// execution-time residual-placeholder guard warns about those.
+#[must_use = "expanding returns a new String"]
+pub fn expand_meta_namespace(
+    text: &str,
+    table: &MetadataTable,
+    bindings: &WildcardValues,
+) -> String {
+    if !text.contains("{meta.") {
+        return text.to_string();
+    }
+    let row = metadata_row_for(bindings, table);
+    crate::config::META_NS_RE
+        .replace_all(text, |caps: &regex::Captures| {
+            let column = &caps[1];
+            row.and_then(|r| r.get(column)).cloned().unwrap_or_default()
+        })
+        .into_owned()
+}
+
 /// Generates the Cartesian product of all wildcard value lists.
 ///
 /// Given `{"sample": ["A", "B"], "read": ["1", "2"]}`, produces:

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -184,6 +184,7 @@ author = "Your Name"
 | `format_version` | String | No | — | Format specification version for compatibility |
 | `pairs_file` | String | No | — | External TSV/CSV/JSON file defining experiment-control pairs |
 | `sample_groups_file` | String | No | — | External TSV/JSON file defining sample groups |
+| `metadata_file` | String | No | — | External TSV/CSV/JSON file of per-sample metadata columns, addressed as `{meta.<column>}` (see [Sample Metadata](#sample-metadata-metadata_file)) |
 | `pairs_pattern` | String | No | — | File glob pattern for auto-discovering pairs (e.g., `"aligned/{pair_id}/{exp}_vs_{ctrl}.bam"`) |
 | `sample_pattern` | String | No | — | File glob pattern for auto-discovering samples (e.g., `"raw/{sample}_R1.fastq.gz"`) |
 | `on_complete` | String | No | — | Shell command run once after the whole workflow completes successfully (no failed rules). Rendered with `{config.*}` and the counters `{succeeded}`/`{failed}`/`{skipped}` plus `{workdir}`; runs in the workflow root with the workflow `shell_prelude`. Best-effort: a failing hook warns, never changes the run status. |
@@ -1030,11 +1031,14 @@ shell = "cat {input} > {output}"
 - `pattern` — path glob with `{wildcard}` placeholders, relative to the
   workflow file's directory (the same root `sample_pattern` scans).
 - `group_by` — the wildcard that names each group. One instance is
-  created per discovered group value.
+  created per discovered group value. May also be a metadata column,
+  `group_by = "meta.<column>"` — see below.
 - `keep` — optional restriction: which *other* pattern wildcards are
   bound to the group's **first** (sorted) file and become available as
   `{wildcard}` placeholders in `output`/`shell`. Omitted = all other
-  wildcards. A string or an array of strings is accepted.
+  wildcards. A string or an array of strings is accepted. Not allowed
+  with `group_by = "meta.<column>"` (metadata-grouped instances bind only
+  the column name).
 - `{input}` — all matched files of the group, space-joined in stable
   sorted order (files sort by path; the first sorted file supplies the
   `keep` bindings, so results never depend on readdir order).
@@ -1074,6 +1078,42 @@ input_groups = [
 output = ["qc/multiqc_{sample}.html"]
 shell = "multiqc {input} -o qc -n {output}"
 ```
+
+#### Grouping by metadata column
+
+`group_by = "meta.<column>"` groups the matched files by a
+[`metadata_file`](#sample-metadata-metadata_file) column value instead of
+a pattern wildcard — the chipseq multi-antibody pattern, where the BAMs of
+several samples carry the same antibody and one peak-calling instance per
+antibody is wanted:
+
+```toml
+[workflow]
+metadata_file = "samples.tsv"   # sample  antibody
+#                                S1       H3K27ac
+#                                S2       H3K27ac
+#                                S3       Input
+
+[[rules]]
+name = "peaks"
+input_groups = [
+    { pattern = "results/mapping/{sample}.bam", group_by = "meta.antibody" }
+]
+output = ["peaks/{antibody}.bed"]
+shell = "macs2 callpeak -t {input} -n {antibody} --outdir peaks && echo {input_group.sample}"
+```
+
+- One instance per distinct column value: `peaks_H3K27ac` receives
+  `results/mapping/S1.bam results/mapping/S2.bam` and
+  `peaks_Input` receives `results/mapping/S3.bam`.
+- The group key binds under the **column name** (`{antibody}`), not
+  `{sample}` — a metadata-grouped instance has no single sample. Files
+  whose row has an empty column value are skipped.
+- Outputs must not reference pattern wildcards (`{sample}` in an output
+  is a plan-time error); the per-group sample names stay available as
+  `{input_group.sample}`.
+- `keep` is rejected with `group_by = "meta.<column>"` — the column name
+  is the instance's only binding.
 
 ### Retry Configuration
 
@@ -1697,6 +1737,82 @@ These injected values are **comma-joined strings** (e.g. `"S001,S002"`):
   [Expand Inputs](#expand-inputs).
 - In shell templates, `{config.samples_list}` renders as the comma-joined
   text, e.g. `for s in $(echo {config.samples_list} | tr ',' ' ')`.
+
+### Sample Metadata (`metadata_file`)
+
+Per-sample metadata is loaded at plan time from an external TSV/CSV/JSON
+table and addressed as `{meta.<column>}` in any rule's `input`, `output`,
+`shell`, `log`, `script`, hooks, and `when`. This is the
+[`metadata`](#sample_groups-multi-sample-cohorts-wc-02) group/pair-key
+mechanism generalized to an arbitrary per-sample column vocabulary — the
+methylseq `when = "config.single_end_mode || {meta.endedness} == 'SE'"`
+pattern, chipseq antibody fan-out (see
+[Input Groups](#input-groups-input_groups)), and rnaseq-style per-sample
+parameter lookups:
+
+```toml
+[workflow]
+name = "methylseq"
+metadata_file = "metadata/samples.tsv"  # or .csv, .json
+```
+
+**TSV/CSV format** — the first column is the sample id (must match the
+values your `{sample}` wildcards resolve to); every other header becomes a
+column:
+
+```text
+sample    endedness    adapters
+SE1       SE           AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+PE1       PE           AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+```
+
+**JSON format** — a list of objects; the `sample` key identifies the row
+(all other keys become columns):
+
+```json
+[
+  {"sample": "SE1", "endedness": "SE", "adapters": "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA"},
+  {"sample": "PE1", "endedness": "PE", "adapters": "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"}
+]
+```
+
+**Semantics:**
+
+- The table is a **lookup only** — it does not define the sample set. Use
+  `sample_groups` / `sample_groups_file` / `sample_pattern` for that.
+- At expansion, each rule instance resolves its metadata row from its
+  `{sample}` binding, falling back to `{pair_id}`, then `{experiment}`,
+  then `{control}` (first binding that has a row wins).
+- A missing row or column renders **empty** in shells/inputs/outputs, with
+  a plan-time **warning** for a column that no row defines (the same
+  stance as `{values.name}`).
+- In `when`, metadata values are baked as quoted literals in comparisons
+  (`{meta.endedness} == 'SE'` → `'SE' == 'SE'`) and `true`/`false` in
+  truthiness positions; a missing row or column renders `''` / `false` —
+  the gate is closed, so samples without the data evaluate false instead
+  of running.
+- A `{meta.<column>}` reference in a rule that never fans out (no
+  sample-like binding) is an error at execution time (residual
+  placeholder).
+
+```toml
+[[rules]]
+name   = "trim"
+input  = ["raw/{sample}_R1.fastq.gz"]
+output = ["trimmed/{sample}.fq"]
+when   = "config.single_end_mode || {meta.endedness} == 'SE'"
+shell  = "cutadapt -a {meta.adapters} {input[0]} -o {output[0]}"
+```
+
+Metadata paths can also feed inputs directly (DAG edges still infer by
+exact path match, since the paths are plan-time literals):
+
+```toml
+[[rules]]
+name  = "mapping_qc"
+input = ["{meta.bam_path}"]
+shell = "samtools stats {input[0]} > {output[0]}"
+```
 
 ### Partial Pair Tolerance & Tumor-Only Mode
 


### PR DESCRIPTION
Closes the shared root cause behind issue #227 items 2 and 4: the engine has no per-sample column vocabulary. This PR adds one.

## What was there before

A `{gvcf_path}`-style metadata-input mechanism does **not** exist in this engine. The closest existing mechanism: pair/group `metadata` keys bind as **top-level bare wildcards** via `wildcard_combinations_from_pairs` / `wildcard_combinations_from_groups` (e.g. a pair with `metadata = { bam_path = "..." }` makes `{bam_path}` resolve). That mechanism is untouched and still works.

## What this PR adds

**1. `[workflow] metadata_file = "samples.tsv"`** — an external per-sample metadata table (TSV/CSV/JSON, same parsing family as `pairs_file` / `sample_groups_file`; 50MB limit; JSON rows need a non-empty `sample` key). First column = sample id; remaining columns are arbitrary keys. Loaded at plan time into `WorkflowConfig.metadata`. **Rows are a lookup only — they never define the sample set.**

**2. `{meta.<column>}` placeholders** in every rule `input` / `output` / `shell` / `log` / `script` / hooks / `when`, substituted per instance at expansion from the instance's `{sample}` binding, falling back to `{pair_id}` → `{experiment}` → `{control}`. Missing row or column renders **empty** in shells/inputs/outputs, with a plan-time warning for columns no row defines (the `{values.name}` stance). Metadata-derived input paths are plan-time literals, so exact-match DAG edge inference works.

**3. `when` gates** — the methylseq pattern `when = "config.single_end_mode || {meta.endedness} == 'SE'"` works per instance: values bake as quoted literals in comparison positions and `true`/`false` in truthiness positions (mirroring `bake_wildcard_when`), and a missing row/column closes the gate (`'' == 'SE'` → false). Without the quoting, a bare unquoted value falls through the evaluator to its default-true fallback and the rule **runs** when it should skip — the executor test locks this in.

**4. `input_groups` `group_by = "meta.<column>"`** — the chipseq multi-antibody pattern: one instance per distinct column value, group key bound under the **column name** (`{antibody}`, never `{sample}`), `{input}` = the group's files, `{input_group.sample}` = sample names. `keep` is rejected (validation error), pattern wildcards in outputs are validated (error naming the wildcard), and rows with an empty column value are skipped.

## Design decisions (deviations from a literal reading)

- `{meta.}` is a **textual namespace** (`\{meta\.(\w+)\}` regex + textual substitution) exactly like the existing `{values.name}` — the engine's placeholder regex (`\w+` only) cannot match dotted names. The old bare-key pair/group metadata mechanism is left as-is.
- Metadata-grouped instances render `{meta.*}` **empty** (their only binding is the column name; the row is ambiguous across the group's samples — picking one would be wrong).
- `when` values are quoted via `render_wildcard_value` (double-quotes when the value contains a single quote).
- A `{meta.<column>}` reference in a rule that never fans out (no sample-like binding) errors loudly at execution via the residual-placeholder guard (now naming `{meta.`).

## Tests (12 new, all green)

- `metadata_file_loads_tsv_rows_into_config` / `metadata_file_accepts_csv_and_json` / `metadata_file_missing_errors`
- `meta_namespace_expands_in_shells_per_sample` (cutadapt adapters/extra per sample)
- `meta_namespace_resolves_input_paths_and_dag_edges` (input = `["{meta.bam_path}"]`, DAG edges inferred)
- `meta_namespace_in_when_renders_per_instance` (`'SE' == 'SE'` / `'PE' == 'SE'` / `'' == 'SE'`)
- `meta_namespace_lookup_falls_back_to_pair_id`
- `input_groups_group_by_meta_fans_out_one_instance_per_value` (3 samples × 2 antibody values → 2 instances)
- `input_groups_group_by_meta_rejects_keep` / `input_groups_group_by_meta_rejects_sample_in_outputs` / `input_groups_group_by_meta_unknown_column_errors`
- `executor::tests::meta_when_gate_runs_se_and_skips_pe_instances` (SE runs, PE skips, no-row skips)

**Gates:** fmt clean; clippy (core + cli, all targets) 0 warnings; core lib 1230 passed; cli 160 passed; cli_integration 247 passed.

Docs: `workflow-format.md` — `metadata_file` table row, "Sample Metadata (`metadata_file`)" section, and "Grouping by metadata column" under Input Groups.