### PR TITLE
feat(core): pair-level `when` gating + input_groups E003 exemption

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -209,7 +209,31 @@ impl WorkflowConfig {
         };
         use regex::Regex;
 
-        let pair_combos = wildcard_combinations_from_pairs(&self.pairs);
+        // Pair-level `when` gating (snakemake-style DAG morphing at pair
+        // scope): pairs whose `when` evaluates false declare no rule
+        // instances. The static [[pairs]] table can therefore carry
+        // profile-switched sample sets — a toggle in `config` decides
+        // which pairs fan out.
+        let config_values: HashMap<String, toml::Value> = self
+            .config
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let active_pairs: Vec<crate::config::ExperimentControlPair> = self
+            .pairs
+            .iter()
+            .filter(|pair| {
+                pair.when.as_deref().is_none_or(|when| {
+                    crate::executor::process::evaluate_condition_with_wildcards(
+                        when,
+                        &config_values,
+                        &HashMap::new(),
+                    )
+                })
+            })
+            .cloned()
+            .collect();
+        let pair_combos = wildcard_combinations_from_pairs(&active_pairs);
         let group_combos = wildcard_combinations_from_groups(&self.sample_groups);
 
         // Rebuild expansion provenance from scratch — this method may run on a

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -783,6 +783,19 @@ impl std::fmt::Display for ReferenceDatabase {
 /// experiment = "SAMPLE_EXP_02"
 /// control    = "SAMPLE_CTRL_02"
 /// ```
+///
+/// Pairs can be gated with a `when` condition (the same expression
+/// language as rule `when`, evaluated against `config.*` and
+/// `file_exists(...)`): a pair whose condition is false is excluded from
+/// wildcard fan-out — it declares no rule instances. This lets one static
+/// `[[pairs]]` table serve profile-switched sample sets:
+///
+/// ```toml
+/// [[pairs]]
+/// pair_id = "EXTRA_001"
+/// experiment = "SAMPLE_EXP_03"
+/// when = "config.enable_extended_cohort"
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExperimentControlPair {
     /// Unique identifier for this pair (available as `{pair_id}`).
@@ -815,6 +828,13 @@ pub struct ExperimentControlPair {
     /// Arbitrary key-value metadata; each key is available as a wildcard.
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+
+    /// Optional gate condition (rule-`when` expression language, evaluated
+    /// against `config.*` / `file_exists(...)` at plan time). A pair whose
+    /// condition is false is excluded from wildcard fan-out. Default: no
+    /// gate — every pair expands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when: Option<String>,
 }
 
 /// Backward-compatible alias; prefer [`ExperimentControlPair`].
@@ -969,6 +989,7 @@ impl ExperimentControlPair {
                             control: Some(control.clone()),
                             experiment_type: wildcards.get("experiment_type").cloned(),
                             metadata: HashMap::new(),
+                            when: None,
                         };
                         pairs.push(pair);
                     }
@@ -1080,6 +1101,7 @@ impl ExperimentControlPair {
                 experiment_type: experiment_type_col
                     .and_then(|&i| record.get(i).map(|s| s.to_string())),
                 metadata,
+                when: None,
             };
             pairs.push(pair);
         }

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -3327,6 +3327,67 @@ fn from_file_injects_pairs_list_from_pairs() {
 }
 
 #[test]
+fn pair_when_gates_fan_out_per_config_toggle() {
+    // A pair with `when` declares no rule instances while the condition is
+    // false — one static [[pairs]] table serves profile-switched sample
+    // sets (multi-sample chipseq/scrna ports gate extra pairs on a config
+    // toggle flipped by `--profile` override).
+    let toml = r#"
+        [workflow]
+        name = "test"
+        version = "1.0.0"
+
+        [config]
+        extended = false
+
+        [[pairs]]
+        pair_id = "BASE_001"
+        experiment = "EXP_01"
+        control = "CTR_01"
+
+        [[pairs]]
+        pair_id = "EXTRA_001"
+        experiment = "EXP_02"
+        control = "CTR_02"
+        when = "config.extended"
+
+        [[rules]]
+        name = "step1"
+        input = ["raw/{pair_id}.fq"]
+        output = ["out/{pair_id}.fq"]
+        shell = "cp {input[0]} {output[0]}"
+    "#;
+    let mut config = WorkflowConfig::parse(toml).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    // Gated pair excluded: only BASE_001 fans out.
+    assert_eq!(
+        config
+            .rules
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["step1_BASE_001"]
+    );
+
+    // Flipping the toggle includes the gated pair (re-expand from the
+    // preserved templates, the checkpoint re-entry pattern).
+    config
+        .config
+        .insert("extended".to_string(), toml::Value::Boolean(true));
+    config.rules = config.rule_templates.clone();
+    config.expand_wildcards().unwrap();
+    assert_eq!(
+        config
+            .rules
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["step1_BASE_001", "step1_EXTRA_001"]
+    );
+}
+
+#[test]
 fn from_file_feeds_pair_members_into_samples_list() {
     // [[pairs]] members are samples too: a pairs-only workflow renders
     // {config.samples_list} as a literal before this (live: pair-driven

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -215,8 +215,24 @@ pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
         // Exception: scatter rules use scatter variables, not input wildcards
         // Exception: pairs rules use {pair_id}, {experiment}, {control} wildcards
         // Exception: sample_groups rules use {group}, {sample} wildcards
-        let input_wildcards =
+        // Exception: input_groups rules bind the pattern wildcards AND the
+        // `group_by` key — `group_by = "meta.<column>"` binds the column
+        // name like a scatter variable (issue #227 items 3-4).
+        let mut input_wildcards: Vec<String> =
             crate::wildcard::extract_wildcards_from_patterns(&rule.input.to_vec());
+        for ig in &rule.input_groups {
+            for wc in crate::wildcard::extract_wildcards(&ig.pattern) {
+                if !input_wildcards.contains(&wc) {
+                    input_wildcards.push(wc);
+                }
+            }
+            if let Some(column) = ig.group_by.strip_prefix("meta.")
+                && !column.is_empty()
+                && !input_wildcards.contains(&column.to_string())
+            {
+                input_wildcards.push(column.to_string());
+            }
+        }
         let output_wildcards =
             crate::wildcard::extract_wildcards_from_patterns(&rule.output.to_vec());
 
@@ -2057,6 +2073,41 @@ mod tests {
         assert!(
             result.errors().iter().all(|d| d.code != "E003"),
             "values-declared wildcards must be E003-exempt: {:?}",
+            result.errors()
+        );
+    }
+
+    #[test]
+    fn validate_wildcard_consistency_exempts_input_groups() {
+        // input_groups rules (issue #227 items 3-4): the pattern wildcards
+        // and the group key are bound at fan-out, so outputs may reference
+        // them without an `input` counterpart — group_by = "meta.antibody"
+        // binds the column name like a scatter variable.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "consensus"
+            input_groups = [
+                { pattern = "peaks/{sample}_peaks.broadPeak", group_by = "meta.antibody" }
+            ]
+            output = ["consensus/{antibody}/{antibody}.peaks.bed"]
+            shell = "echo {input} > {output}"
+
+            [[rules]]
+            name = "consensus_pattern_key"
+            input_groups = [
+                { pattern = "consensus/{antibody}/{antibody}.peaks.bed", group_by = "{antibody}" }
+            ]
+            output = ["counts/{antibody}.txt"]
+            shell = "wc -l {input[0]} > {output[0]}"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let result = validate_format(&config);
+        assert!(
+            result.errors().iter().all(|d| d.code != "E003"),
+            "input_groups-bound wildcards must be E003-exempt: {:?}",
             result.errors()
         );
     }

--- a/crates/oxo-flow-core/src/reentry.rs
+++ b/crates/oxo-flow-core/src/reentry.rs
@@ -93,6 +93,9 @@ pub fn parse_manifest(
                 control: p.control,
                 experiment_type: p.experiment_type,
                 metadata: p.metadata,
+                // Re-entry pairs come from a saved manifest — the gate was
+                // already applied when the manifest was written.
+                when: None,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -322,6 +325,7 @@ mod tests {
             control: Some(control.into()),
             experiment_type: None,
             metadata: Default::default(),
+            when: None,
         }
     }
 

--- a/crates/oxo-flow-core/src/wildcard.rs
+++ b/crates/oxo-flow-core/src/wildcard.rs
@@ -106,6 +106,11 @@ pub fn validate_wildcard_constraints(
 pub fn pattern_to_regex(pattern: &str) -> Result<Regex> {
     let mut regex_str = String::from("^");
     let mut last_end = 0;
+    // A pattern may repeat the same wildcard (e.g. "consensus/{antibody}/
+    // {antibody}.peaks.bed") — the regex crate forbids duplicate capture
+    // names, so the first occurrence captures and later ones match
+    // anonymously (same value by construction of the pattern).
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for mat in WILDCARD_RE.find_iter(pattern) {
         let literal = &pattern[last_end..mat.start()];
@@ -121,7 +126,11 @@ pub fn pattern_to_regex(pattern: &str) -> Result<Regex> {
                 ),
             })?;
         let name = &cap[1];
-        regex_str.push_str(&format!("(?P<{}>\\S+)", name));
+        if seen.insert(name.to_string()) {
+            regex_str.push_str(&format!("(?P<{}>\\S+)", name));
+        } else {
+            regex_str.push_str("(?:\\S+)");
+        }
 
         last_end = mat.end();
     }
@@ -687,6 +696,7 @@ pub fn paired_end_pattern(dir: &str, sample_pattern: &str, extension: &str) -> (
 ///         control: Some("CTRL_01".to_string()),
 ///         experiment_type: Some("lung".to_string()),
 ///         metadata: Default::default(),
+///         when: None,
 ///     },
 /// ];
 /// let combos = wildcard_combinations_from_pairs(&pairs);
@@ -972,6 +982,17 @@ mod tests {
     }
 
     #[test]
+    fn pattern_to_regex_repeated_wildcard() {
+        // "consensus/{antibody}/{antibody}.peaks.bed" repeats the wildcard
+        // — the first occurrence captures, later ones match anonymously
+        // (regex crate: no duplicate capture names).
+        let re = pattern_to_regex("consensus/{antibody}/{antibody}.peaks.bed").unwrap();
+        assert!(re.is_match("consensus/H3K4me3/H3K4me3.peaks.bed"));
+        let caps = re.captures("consensus/H3K4me3/H3K4me3.peaks.bed").unwrap();
+        assert_eq!(&caps["antibody"], "H3K4me3");
+    }
+
+    #[test]
     fn discover_wildcards_from_directory() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("SAMPLE_A_R1.fastq.gz"), "").unwrap();
@@ -1043,6 +1064,7 @@ mod tests {
                 control: Some("CTRL_01".to_string()),
                 experiment_type: Some("lung".to_string()),
                 metadata: Default::default(),
+                when: None,
             },
             ExperimentControlPair {
                 pair_id: "CASE_002".to_string(),
@@ -1050,6 +1072,7 @@ mod tests {
                 control: Some("CTRL_02".to_string()),
                 experiment_type: None,
                 metadata: Default::default(),
+                when: None,
             },
         ];
         let combos = wildcard_combinations_from_pairs(&pairs);
@@ -1081,6 +1104,7 @@ mod tests {
             control: Some("C1".to_string()),
             experiment_type: None,
             metadata: meta,
+            when: None,
         }];
         let combos = wildcard_combinations_from_pairs(&pairs);
         assert_eq!(combos[0]["patient_id"], "PT-001");


### PR DESCRIPTION
Three coordinated core changes that unblock the chipseq multi-antibody port (oxo-flow-community/oxo-flow-chipseq#6, built on #234 metadata binding + #231 input_groups):

## 1. Pair-level `when` gating (new)
`ExperimentControlPair` gains an optional `when` condition — the same expression language as rule `when`, evaluated against `config.*` / `file_exists(...)` at plan time in expand_wildcards. A pair whose condition is false is excluded from wildcard fan-out: it declares no rule instances.

Why: profiles cannot merge `[[pairs]]` (static table), and `pair_ids` is only consumed by expand_inputs variables. A profile-switched sample set (chipseq's second antibody replicate set) previously required duplicating the workflow. Now one static `[[pairs]]` table carries both modes:

```toml
[[pairs]]
pair_id = S2_REP1
experiment = S2_REP1
control = C2_REP1
when = config.multi_antibody
```

Default plan is byte-identical (gated pairs declare nothing); flipping the toggle via `--profile` override expands them.

## 2. E003: input_groups exemption
Rules declaring `input_groups` bind the pattern wildcards AND the group_by key (`group_by = "meta.<column>"` binds the column name like a scatter variable). Outputs may reference them without an `input` counterpart — previously a grouped rule with any plain input and an `{antibody}` output failed wildcard-consistency validation.

## 3. pattern_to_regex: repeated wildcards
`consensus/{antibody}/{antibody}.peaks.bed` repeats a wildcard — the regex crate forbids duplicate capture names, breaking input_groups producer-output matching on such patterns. The first occurrence now captures; later ones match anonymously.

## Tests (workspace: 2413 pass)
- pair_when_gates_fan_out_per_config_toggle (config toggle flips the fan-out both ways)
- validate_wildcard_consistency_exempts_input_groups
- pattern_to_regex_repeated_wildcard

## Live verification
- chipseq default dry-run: 153 run / 59 skip / 212 rules — byte-identical to pre-port
- chipseq multi dry-run: 303 run / 91 skip / 394 rules with per-antibody instances
- released v0.16.0 validate on the port: 0 errors (bridge entries; this PR is for the new engine)

Needed by the chipseq multi-antibody port; the format.rs and wildcard.rs fixes are correctness fixes for the #227 input_groups feature.