### PR TITLE
fix(core): repeated-wildcard phantom-instance guard + pair-when typo warning

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -214,6 +214,22 @@ impl WorkflowConfig {
         // instances. The static [[pairs]] table can therefore carry
         // profile-switched sample sets — a toggle in `config` decides
         // which pairs fan out.
+        //
+        // Plan-time typo guard: a `config.<key>` reference absent from
+        // [config] evaluates false (unbound→false, #199) — at pair scope
+        // that silently drops the pair's whole rule set, so warn once per
+        // pair+key, matching the {meta.<column>} typo-warning style.
+        for pair in &self.pairs {
+            if let Some(when) = pair.when.as_deref() {
+                for key in crate::config::pair_when_unknown_config_keys(when, &self.config) {
+                    tracing::warn!(
+                        pair_id = %pair.pair_id,
+                        key,
+                        "pair `when` references 'config.{key}' but [config] defines no such key — the condition evaluates false and the pair fans out no rules"
+                    );
+                }
+            }
+        }
         let config_values: HashMap<String, toml::Value> = self
             .config
             .iter()
@@ -1707,6 +1723,16 @@ impl WorkflowConfig {
                 }
             }
             if !any {
+                continue;
+            }
+            // Round-trip guard against phantom combos, mirroring the
+            // disk-scan walkers: with a repeated wildcard the anonymous
+            // regex groups may capture a value different from the named
+            // one, so a combo that re-expands to a path other than the
+            // matched output can only come from such a mismatch.
+            if crate::wildcard::expand_pattern(&pattern, &combo)
+                .is_ok_and(|expanded| expanded.as_str() != output.as_str())
+            {
                 continue;
             }
             candidates.push((output.clone(), combo));

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -38,6 +38,37 @@ pub(crate) static META_NS_RE: LazyLock<Regex> =
 pub(crate) static WHEN_WILDCARD_REF_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"wildcard\.(\w+)").expect("valid when-wildcard regex"));
 
+/// Matches a `config.<key>` reference inside a pair-level `when`
+/// expression — the plan-time typo guard for pair gating. TOML keys may be
+/// dotted (`config.seq.type`), so the captured name spans word chars,
+/// dots, and hyphens.
+pub(crate) static PAIR_WHEN_CONFIG_REF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"config\.([A-Za-z_][A-Za-z0-9_.\-]*)").expect("valid pair-when config regex")
+});
+
+/// Collect the `config.<key>` references in a pair-level `when` that are
+/// NOT defined in `[config]`, deduplicated in order of first appearance.
+///
+/// The unbound→false stance (#199) is correct for rule gates, but at pair
+/// scope a false condition silently drops the pair's WHOLE rule set — so a
+/// typo (`config.extened`) deletes instances with no error. The caller
+/// warns once per pair+key at plan time, matching the `{meta.<column>}`
+/// typo-warning style (warn, never error).
+pub(crate) fn pair_when_unknown_config_keys<'a>(
+    when: &'a str,
+    config: &HashMap<String, toml::Value>,
+) -> Vec<&'a str> {
+    let mut unknown = Vec::new();
+    for cap in PAIR_WHEN_CONFIG_REF_RE.captures_iter(when) {
+        let Some(m) = cap.get(1) else { continue };
+        let key = &when[m.start()..m.end()];
+        if !config.contains_key(key) && !unknown.contains(&key) {
+            unknown.push(key);
+        }
+    }
+    unknown
+}
+
 pub(crate) fn is_defaults_empty(d: &Defaults) -> bool {
     d.threads.is_none() && d.memory.is_none() && d.environment.is_none()
 }

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -3388,6 +3388,44 @@ fn pair_when_gates_fan_out_per_config_toggle() {
 }
 
 #[test]
+fn pair_when_unknown_config_keys_reports_typos() {
+    // A pair `when` referencing a config key absent from [config]
+    // evaluates false — at pair scope that silently drops the pair's
+    // whole rule set, so the plan-time typo guard must surface the
+    // offending key (warn, never error — the #199 unbound→false stance).
+    use crate::config::pair_when_unknown_config_keys;
+    let mut config: std::collections::HashMap<String, toml::Value> =
+        std::collections::HashMap::new();
+    config.insert("extended".to_string(), toml::Value::Boolean(false));
+
+    assert_eq!(
+        pair_when_unknown_config_keys("config.extened", &config),
+        vec!["extened"]
+    );
+    assert_eq!(
+        pair_when_unknown_config_keys("config.extended", &config),
+        Vec::<&str>::new()
+    );
+    assert_eq!(
+        pair_when_unknown_config_keys("true", &config),
+        Vec::<&str>::new()
+    );
+    // Comparison form, nesting, negation — all reference positions count.
+    assert_eq!(
+        pair_when_unknown_config_keys(
+            "(config.extended && !config.missing) || config.other == \"yes\"",
+            &config
+        ),
+        vec!["missing", "other"]
+    );
+    // One warning per key, in order of first appearance.
+    assert_eq!(
+        pair_when_unknown_config_keys("config.typo || config.typo", &config),
+        vec!["typo"]
+    );
+}
+
+#[test]
 fn from_file_feeds_pair_members_into_samples_list() {
     // [[pairs]] members are samples too: a pairs-only workflow renders
     // {config.samples_list} as a literal before this (live: pair-driven

--- a/crates/oxo-flow-core/src/wildcard.rs
+++ b/crates/oxo-flow-core/src/wildcard.rs
@@ -109,7 +109,9 @@ pub fn pattern_to_regex(pattern: &str) -> Result<Regex> {
     // A pattern may repeat the same wildcard (e.g. "consensus/{antibody}/
     // {antibody}.peaks.bed") — the regex crate forbids duplicate capture
     // names, so the first occurrence captures and later ones match
-    // anonymously (same value by construction of the pattern).
+    // anonymously. Anonymous groups alone cannot enforce that both
+    // positions hold the SAME value; the discovery walkers add a
+    // round-trip check (expand back and compare) for that guarantee.
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for mat in WILDCARD_RE.find_iter(pattern) {
@@ -283,18 +285,16 @@ pub fn discover_wildcards_from_pattern(
                         values.insert(name.clone(), m.as_str().to_string());
                     }
                 }
-                if !values.is_empty() {
-                    // Build a compact dedup key from sorted key=value pairs
-                    let mut parts: Vec<(&str, &str)> = values
-                        .iter()
-                        .map(|(k, v)| (k.as_str(), v.as_str()))
-                        .collect();
-                    parts.sort_by_key(|(k, _)| *k);
-                    let dedup_key: String =
-                        parts.iter().flat_map(|(k, v)| [k, "=", v, ","]).collect();
-                    if seen.insert(dedup_key) {
-                        results.push(values);
-                    }
+                // Round-trip guard against phantom instances: with a
+                // repeated wildcard the regex's anonymous groups may
+                // capture a DIFFERENT value than the named one (e.g.
+                // "{s}.{s}.bam" regex-matches "B.A.bam" with s="B"). A
+                // combo whose expansion differs from the matched file
+                // name can only come from such a mismatch — skip it.
+                let is_real =
+                    expand_pattern(pattern, &values).is_ok_and(|expanded| expanded == filename);
+                if !values.is_empty() && is_real && seen.insert(wildcard_combo_key(&values)) {
+                    results.push(values);
                 }
             }
         }
@@ -333,6 +333,7 @@ pub fn discover_wildcards_from_pattern_tree(
     fn walk(
         dir: &std::path::Path,
         base: &std::path::Path,
+        pattern: &str,
         re: &Regex,
         wildcard_names: &[String],
         seen: &mut HashSet<String>,
@@ -345,7 +346,7 @@ pub fn discover_wildcards_from_pattern_tree(
             let path = entry.path();
             let file_type = entry.file_type().ok();
             if file_type.is_some_and(|t| t.is_dir()) {
-                walk(&path, base, re, wildcard_names, seen, results);
+                walk(&path, base, pattern, re, wildcard_names, seen, results);
             } else if file_type.is_none_or(|t| t.is_file() || t.is_symlink()) {
                 let rel = match path.strip_prefix(base) {
                     Ok(rel) => rel,
@@ -361,23 +362,29 @@ pub fn discover_wildcards_from_pattern_tree(
                             values.insert(name.clone(), m.as_str().to_string());
                         }
                     }
-                    if !values.is_empty() {
-                        let mut parts: Vec<(&str, &str)> = values
-                            .iter()
-                            .map(|(k, v)| (k.as_str(), v.as_str()))
-                            .collect();
-                        parts.sort_by_key(|(k, _)| *k);
-                        let dedup_key: String =
-                            parts.iter().flat_map(|(k, v)| [k, "=", v, ","]).collect();
-                        if seen.insert(dedup_key) {
-                            results.push(values);
-                        }
+                    // Round-trip guard against phantom instances — same
+                    // as the flat walker: a repeated wildcard's anonymous
+                    // regex groups may capture a value different from the
+                    // named one, so only accept combos that re-expand to
+                    // the matched relative path.
+                    let is_real =
+                        expand_pattern(pattern, &values).is_ok_and(|expanded| expanded == rel_str);
+                    if !values.is_empty() && is_real && seen.insert(wildcard_combo_key(&values)) {
+                        results.push(values);
                     }
                 }
             }
         }
     }
-    walk(dir, dir, &re, &wildcard_names, &mut seen, &mut results);
+    walk(
+        dir,
+        dir,
+        pattern,
+        &re,
+        &wildcard_names,
+        &mut seen,
+        &mut results,
+    );
 
     Ok(results)
 }
@@ -1048,6 +1055,46 @@ mod tests {
             discover_wildcards_from_pattern_tree(flat.path(), "{sample}_{lane}_R1.fastq.gz")
                 .unwrap();
         assert!(results.is_empty(), "flat pattern must not scan recursively");
+    }
+
+    #[test]
+    fn discover_wildcards_from_pattern_tree_rejects_mismatched_repeated_wildcard() {
+        // A repeated wildcard must hold the SAME value at every position:
+        // "consensus/{antibody}/{antibody}.peaks.bed" may regex-match
+        // "consensus/H3K4me3/H3K27ac.peaks.bed" (the second position is an
+        // anonymous group), but that combo re-expands to a path that does
+        // not exist — it must not surface as a phantom instance. The
+        // H3K27ac phantom has NO consistent counterpart file, so dedup
+        // alone cannot hide it.
+        let dir = tempfile::tempdir().unwrap();
+        let consensus = dir.path().join("consensus");
+        std::fs::create_dir_all(consensus.join("H3K4me3")).unwrap();
+        std::fs::create_dir_all(consensus.join("H3K27ac")).unwrap();
+        std::fs::write(consensus.join("H3K4me3/H3K4me3.peaks.bed"), "").unwrap();
+        // Mixed names: the two positions disagree — must be rejected.
+        std::fs::write(consensus.join("H3K27ac/H3K4me3.peaks.bed"), "").unwrap();
+
+        let results = discover_wildcards_from_pattern_tree(
+            dir.path(),
+            "consensus/{antibody}/{antibody}.peaks.bed",
+        )
+        .unwrap();
+        let combos: Vec<_> = results.into_iter().map(|c| c["antibody"].clone()).collect();
+        assert_eq!(combos, vec!["H3K4me3".to_string()]);
+    }
+
+    #[test]
+    fn discover_wildcards_from_pattern_rejects_mismatched_repeated_wildcard() {
+        // Same guarantee for the flat walker: "{s}.{s}.bam" must not yield
+        // a combo from "B.A.bam" (captured value "B" has no consistent
+        // counterpart file, so dedup alone cannot hide the phantom).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("A.A.bam"), "").unwrap();
+        std::fs::write(dir.path().join("B.A.bam"), "").unwrap();
+
+        let results = discover_wildcards_from_pattern(dir.path(), "{s}.{s}.bam").unwrap();
+        let combos: Vec<_> = results.into_iter().map(|c| c["s"].clone()).collect();
+        assert_eq!(combos, vec!["A".to_string()]);
     }
 
     // -----------------------------------------------------------------------

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1523,10 +1523,33 @@ control    = "CTRL_02"
 | `control` | String | **Yes** | Matched control sample name (alias: `normal`) |
 | `experiment_type` | String | No | Optional cohort label (alias: `tumor_type`) |
 | `metadata` | Table | No | Arbitrary key-value pairs (each key becomes a wildcard) |
+| `when` | String | No | Pair-level gate evaluated at plan time: while it evaluates `false`, the pair declares **no** rule instances. Uses the same condition vocabulary as rule `when` (`config.<key>` truthiness/comparisons, `&&`/`\|\|`/`!`, parentheses, `file_exists(...)`). A `config.<key>` reference with no matching `[config]` key evaluates `false` (the unbound→false stance) — a plan-time warning flags the referenced key so a typo does not silently drop the pair's whole rule set |
 
 Any rule that references `{experiment}`, `{control}`, or `{pair_id}` in its `input`, `output`, or `shell` fields is **automatically expanded** into one concrete rule instance per pair.  Rules that do not reference any pair wildcard are kept as-is.
 
 **Expanded rule naming:** `{rule_name}_{pair_id}` (e.g., `mutect2_CASE_001`).
+
+### Pair-level gating with `when`
+
+One static `[[pairs]]` table can carry profile-switched sample sets — a
+toggle in `[config]` decides which pairs fan out:
+
+```toml
+[config]
+extended = false   # flip via --profile or CLI override
+
+[[pairs]]
+pair_id = "EXTRA_001"
+experiment = "EXP_02"
+control = "CTRL_02"
+when = "config.extended"
+```
+
+While `extended` is `false`, `EXTRA_001` fans out no rules; flipping it and
+re-running restores the pair's instances (re-expansion from the preserved
+templates, the checkpoint re-entry pattern). Unknown keys evaluate `false`,
+so a misspelled key (`when = "config.extened"`) gates the pair out with a
+plan-time warning naming the offending key.
 
 ### Loading pairs from external file
 


### PR DESCRIPTION
#237 的两项 follow-up（9c review 标记）：

## 1. 重复通配符幻影实例（真缝隙）

`consensus/{antibody}/{antibody}.peaks.bed` 经 `pattern_to_regex` 编译后，第二个 `{antibody}` 是匿名组——会匹配 `consensus/H3K4me3/H3K27ac.peaks.bed`（两处值不同），发现时 combo 取第一个值、expand 重建出的路径与实际文件不一致 → 下游 input 指向不存在的文件，静默幻影实例。

**修复**：三个发现位点全部加 round-trip 校验——用捕获的 combo 重展开 pattern，与匹配到的实际相对路径不相等即跳过：
- `discover_wildcards_from_pattern`（平面 walker）
- `discover_wildcards_from_pattern_tree`（树 walker，input_groups 磁盘扫描）
- input_groups 的 producer-output 枚举（Source 2，同形洞）

顺带把两处 walker 里重复的 inline dedup-key 构建换成现成的 `wildcard_combo_key`（同文件 pub(crate) helper）。

## 2. pair-when 缺失 config 键 → 计划期警告

`when = "config.extened"`（拼错）求值为 false（#199 unbound→false 对规则门正确，但对 pair 门 = 整对规则集**静默消失**）。新增 `pair_when_unknown_config_keys()` 纯函数（model.rs，配套 `PAIR_WHEN_CONFIG_REF_RE`），expand 时 warn 一次 per pair+key，与 #234 `{meta.}` typo 警告同款风格（warn, never error）。文档补了 pair `when` 字段行 + "Pair-level gating" 小节（含"未知键求值为 false"说明）。

## 测试

- 2 个 walker 幻影拒绝测试（幻影值刻意无一致对应文件，dedup 无法掩盖，修复前 RED）
- `pair_when_unknown_config_keys` 单测：truthiness/比较/嵌套/去重四形态

本地门禁：fmt ✓ clippy -D warnings ✓ 全 workspace 测试 ✓（真实失败检测）