### PR TITLE
fix(core): bake {meta.*} before plan-time when evaluation

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -678,11 +678,12 @@ impl WorkflowConfig {
 
                         // Per-instance `when` filtering (snakemake-style DAG
                         // morphing): conditions referencing `wildcard.<key>`
-                        // resolve against this combo and non-matching
-                        // instances never enter the DAG. Conditions without
-                        // wildcard references keep the execution-time flow.
+                        // or `{meta.<col>}` resolve against this combo and
+                        // non-matching instances never enter the DAG.
+                        // Conditions without per-instance references keep
+                        // the execution-time flow.
                         if let Some(ref when) = rule.when
-                            && when.contains("wildcard.")
+                            && (when.contains("wildcard.") || when.contains("{meta."))
                         {
                             let config_values: HashMap<String, toml::Value> = self
                                 .config
@@ -690,8 +691,16 @@ impl WorkflowConfig {
                                 .map(|(k, v)| (k.clone(), v.clone()))
                                 .collect();
                             let combo_values = Self::expansion_when_context(&combo);
+                            // Bake BOTH per-instance namespaces before
+                            // evaluation: a raw `{meta.<col>}` token hits
+                            // the evaluator's default-true fallback and
+                            // phantom instances survive planning. Baking
+                            // makes the plan-time instance set match the
+                            // execution-time verdict exactly.
+                            let baked = Self::bake_wildcard_when(when, &combo);
+                            let baked = Self::bake_meta_when(&baked, &self.metadata, &combo);
                             if !crate::executor::process::evaluate_condition_with_wildcards(
-                                when,
+                                &baked,
                                 &config_values,
                                 &combo_values,
                             ) {
@@ -717,14 +726,17 @@ impl WorkflowConfig {
                         let mut expanded = rule.clone();
                         expanded.name = new_name;
 
-                        // Bake the per-instance wildcard bindings into the
-                        // `when` (the instance survived filtering above), so
-                        // the execution-time re-check re-evaluates this same
-                        // verdict with no wildcard context.
+                        // Bake the per-instance bindings into the `when`
+                        // (the instance survived filtering above), so the
+                        // execution-time re-check re-evaluates this same
+                        // verdict with no wildcard/meta context — both
+                        // namespaces, mirroring the input_groups path.
                         if let Some(ref when) = rule.when
-                            && when.contains("wildcard.")
+                            && (when.contains("wildcard.") || when.contains("{meta."))
                         {
-                            expanded.when = Some(Self::bake_wildcard_when(when, &combo));
+                            let baked = Self::bake_wildcard_when(when, &combo);
+                            expanded.when =
+                                Some(Self::bake_meta_when(&baked, &self.metadata, &combo));
                         }
 
                         // Expand input/output/shell/log patterns
@@ -801,9 +813,12 @@ impl WorkflowConfig {
                         }
 
                         // Per-instance `when` filtering (snakemake-style DAG
-                        // morphing) — see the pair branch above.
+                        // morphing) — see the pair branch above: both
+                        // namespaces baked before evaluation so the
+                        // plan-time instance set matches the execution-time
+                        // verdict.
                         if let Some(ref when) = rule.when
-                            && when.contains("wildcard.")
+                            && (when.contains("wildcard.") || when.contains("{meta."))
                         {
                             let config_values: HashMap<String, toml::Value> = self
                                 .config
@@ -811,8 +826,10 @@ impl WorkflowConfig {
                                 .map(|(k, v)| (k.clone(), v.clone()))
                                 .collect();
                             let combo_values = Self::expansion_when_context(&merged);
+                            let baked = Self::bake_wildcard_when(when, &merged);
+                            let baked = Self::bake_meta_when(&baked, &self.metadata, &merged);
                             if !crate::executor::process::evaluate_condition_with_wildcards(
-                                when,
+                                &baked,
                                 &config_values,
                                 &combo_values,
                             ) {
@@ -838,13 +855,15 @@ impl WorkflowConfig {
                         let mut expanded = rule.clone();
                         expanded.name = new_name;
 
-                        // Bake the per-instance wildcard bindings into the
-                        // `when` (the instance survived filtering above) —
-                        // see the pair branch for the rationale.
+                        // Bake the per-instance bindings into the `when`
+                        // (the instance survived filtering above) — both
+                        // namespaces, see the pair branch for the rationale.
                         if let Some(ref when) = rule.when
-                            && when.contains("wildcard.")
+                            && (when.contains("wildcard.") || when.contains("{meta."))
                         {
-                            expanded.when = Some(Self::bake_wildcard_when(when, &merged));
+                            let baked = Self::bake_wildcard_when(when, &merged);
+                            expanded.when =
+                                Some(Self::bake_meta_when(&baked, &self.metadata, &merged));
                         }
 
                         expanded.input = rule

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -5231,6 +5231,75 @@ fn metadata_file_missing_errors() {
 }
 
 #[test]
+fn plan_time_when_meta_only_gate_filters_instances() {
+    // A `when` referencing ONLY `{meta.<col>}` must be decided at plan
+    // time. The raw token would otherwise hit the evaluator's default-true
+    // fallback and phantom instances survive planning (rnaseq-star's
+    // `{meta.sra} != ''` gate). Empty and missing values close the gate;
+    // a non-empty value opens it — plan-time instance set must equal the
+    // runtime verdict.
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\trun_qc\nS1\tyes\nS2\t\n",
+        r#"
+        [[sample_groups]]
+        name = "grp"
+        samples = ["S1", "S2", "S3"]
+        "#,
+        r#"
+        [[rules]]
+        name = "qc"
+        input = ["raw/{sample}.fq"]
+        output = ["qc/{sample}.txt"]
+        shell = "touch {output[0]}"
+        when = "{meta.run_qc} != ''"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    let names: Vec<_> = config
+        .rules
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect::<Vec<_>>();
+    // S2 has an empty run_qc value and S3 has no row — both gates close.
+    assert_eq!(names, vec!["qc_grp_S1"]);
+}
+
+#[test]
+fn plan_time_when_mixed_wildcard_and_meta_gate_bakes_both() {
+    // A `when` mixing `wildcard.<key>` and `{meta.<col>}` must bake BOTH
+    // namespaces before plan-time evaluation: the wildcard binding comes
+    // from group metadata, the {meta.} value from the metadata_file row.
+    let (_dir, workflow_path) = metadata_workflow(
+        "sample\trun_qc\nS1\tyes\nS2\t\n",
+        r#"
+        [[sample_groups]]
+        name = "grp"
+        samples = ["S1", "S2"]
+        metadata = { input_type = "fastq" }
+        "#,
+        r#"
+        [[rules]]
+        name = "qc"
+        input = ["raw/{sample}.fq"]
+        output = ["qc/{sample}.txt"]
+        shell = "touch {output[0]}"
+        when = "wildcard.input_type == 'fastq' && {meta.run_qc} != ''"
+        "#,
+    );
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    let names: Vec<_> = config
+        .rules
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["qc_grp_S1"]);
+}
+
+#[test]
 fn meta_namespace_expands_in_shells_per_sample() {
     // rnaseq-star-style per-unit lookup: a metadata column feeds a shell
     // flag, resolved per instance from the instance's `{sample}` binding.
@@ -5369,24 +5438,15 @@ fn meta_namespace_in_when_renders_per_instance() {
         se1.when.as_deref(),
         Some("config.single_end_mode || 'SE' == 'SE'")
     );
-    let pe1 = config
-        .rules
-        .iter()
-        .find(|r| r.name == "trim_control_PE1")
-        .expect("PE1 instance");
-    assert_eq!(
-        pe1.when.as_deref(),
-        Some("config.single_end_mode || 'PE' == 'SE'")
-    );
-    // No row for X1: the placeholder renders empty → the gate is closed.
-    let x1 = config
-        .rules
-        .iter()
-        .find(|r| r.name == "trim_control_X1")
-        .expect("X1 instance");
-    assert_eq!(
-        x1.when.as_deref(),
-        Some("config.single_end_mode || '' == 'SE'")
+    // PE1 and X1 are pruned at PLAN time (the baked gate evaluates false),
+    // so the plan-time instance set matches the runtime verdict — no
+    // phantom instances in dry-run/validate output.
+    assert!(
+        config
+            .rules
+            .iter()
+            .all(|r| r.name != "trim_control_PE1" && r.name != "trim_control_X1"),
+        "gated instances must not survive planning"
     );
 }
 

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -2104,31 +2104,15 @@ async fn meta_when_gate_runs_se_and_skips_pe_instances() {
     assert_eq!(record.status, JobStatus::Success);
     assert!(dir.path().join("trimmed/SE1.fq").exists());
 
-    let pe1 = config
-        .rules
-        .iter()
-        .find(|r| r.name == "trim_control_PE1")
-        .expect("PE1 instance");
-    let record = executor
-        .execute_rule_with_config(pe1, &wildcard_values, &typed_config)
-        .await
-        .unwrap();
-    assert_eq!(record.status, JobStatus::Skipped);
-    assert_eq!(
-        record.skip_reason.as_deref(),
-        Some("condition evaluated to false")
+    // PE1 and X1 are pruned at PLAN time (gate false / missing row), so
+    // the expansion matches the runtime verdict exactly — the executor
+    // never sees phantom instances. The kept instance's baked `when` is
+    // still re-checked at execution time (SE1 ran above).
+    assert!(
+        config
+            .rules
+            .iter()
+            .all(|r| r.name != "trim_control_PE1" && r.name != "trim_control_X1"),
+        "gated instances must not survive planning"
     );
-    assert!(!dir.path().join("trimmed/PE1.fq").exists());
-
-    let x1 = config
-        .rules
-        .iter()
-        .find(|r| r.name == "trim_control_X1")
-        .expect("X1 instance");
-    let record = executor
-        .execute_rule_with_config(x1, &wildcard_values, &typed_config)
-        .await
-        .unwrap();
-    assert_eq!(record.status, JobStatus::Skipped);
-    assert!(!dir.path().join("trimmed/X1.fq").exists());
 }

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1894,7 +1894,7 @@ Supported multi-omics pair patterns:
 
 ## `when` — Conditional Rule Execution (WF-01)
 
-The optional `when` field on a rule contains an expression evaluated against `[config]` values. When the expression evaluates to **false** the rule is skipped at execution time (`JobStatus::Skipped`, "condition evaluated to false") — it remains in the DAG but does not run.
+The optional `when` field on a rule contains an expression evaluated against `[config]` values. When the expression evaluates to **false** the rule is skipped at execution time (`JobStatus::Skipped`, "condition evaluated to false") — it remains in the DAG but does not run. Predicates over per-instance bindings (`wildcard.<key>`, `{meta.<column>}`) are decided earlier, at plan time: non-matching instances never enter the DAG, so dry-run and `validate` counts reflect exactly what a real run would execute.
 
 ```toml
 [[rules]]
@@ -1916,6 +1916,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
+| `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |
 | `<expr> && <expr>` | `config.run_qc && config.min_cov >= 20` | Logical AND |
 | `<expr> \|\| <expr>` | `config.wgs \|\| config.wes` | Logical OR |
@@ -1937,10 +1938,28 @@ other cohorts omit the key entirely.
 > incident). `oxo-flow lint` flags `when` references to keys no pair/group
 > can ever bind as a **W027** warning — such rules never run.
 
-Per-instance wildcard bindings (including metadata keys) are baked into a
-kept rule's `when` at expansion time, so the execution-time re-check
+Per-instance wildcard and `{meta.<column>}` bindings are baked into a kept
+rule's `when` at expansion time, so the execution-time re-check
 re-evaluates the exact same per-instance verdict; config-only predicates
 continue to gate at execution as before.
+
+### `{meta.<column>}` truthiness and boolean columns
+
+In a bare truthiness position (`when = "{meta.do_qc}"`) a metadata value
+bakes to `true`/`false` with shell-style truthiness: **non-empty and not
+`false` and not `0` is true** — so `"0"`, `""`, and `"false"` close the
+gate and everything else (including `"foo"`) opens it. For a strict
+boolean column, use the comparison form instead so any unexpected value
+falls through to *no override* rather than opening both branches of a
+markdup/nomarkdup pair:
+
+```toml
+# strict per-sample boolean (recommended for true/false columns)
+when = "config.mark_duplicates || {meta.mark_duplicates} == 'true'"
+```
+
+A missing row or column renders `false` in a truthiness position and `''`
+in a comparison — always a closed gate, never an unbound token.
 
 ### Example
 


### PR DESCRIPTION
snparcher port 的引擎发现 ①（9c 判定真 bug，直接修）。

## 症状
when 引用 `{meta.<col>}` 时计划期按**原文** evaluate —— token 命中 evaluator 的 default-true fallback（process.rs 2848），门控实例在 dry-run/validate 中存活为幻影规则（rnaseq-star `{meta.sra} != ''` 同病）。运行期正确、计划面污染（与 #199 同家族）。

## 修复
- 两个 fan-out 路径（pairs 循环 + groups 循环）的过滤器：evaluate 前先 `bake_wildcard_when` + `bake_meta_when`（双命名空间，顺序无关，9c 提示）
- 门控条件从 `when.contains("wildcard.")` 拓宽为 `|| when.contains("{meta.")`
- 存活实例的存储 when 同样双重 bake（与 input_groups 路径 1549-1552 既有模式一致）——执行期重查与计划期判定逐字节一致
- 文档：when 章节新增 `{meta.<column>}` 谓词行 + 计划期剪枝语义 + truthiness 语义（非空且≠false且≠0 为真；严格布尔列推荐 `== 'true'` 比较型，垃圾值回落不覆盖——snparcher PR #16 实践上升为约定，9c ②）

## 测试
- 2 个新测试：meta-only 门控 + wildcard+meta 混合门控，均断言计划期剪枝（修复前 RED：幻影实例 3 个/1 个）
- 2 个既有 methylseq 式测试按新契约更新（门控实例不再计划期存活，断言扩展结果）
- 本地门禁：fmt ✓ clippy -D warnings ✓ 全 workspace 测试 ✓（44 套件含 cli_integration）

行为变化说明：含 `{meta.}`/`wildcard.` 谓词的 when 从「计划期全保留+运行期跳过」变为「计划期剪枝」——dry-run/validate 计数与真实 run 一致；规则执行集合不变（被剪枝实例此前运行期必跳过）。