### PR TITLE
feat(core): docker GPU passthrough (environment gpus field)

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -258,6 +258,37 @@ impl WorkflowConfig {
         self.expansion_values.clear();
         self.expansion_pairs.clear();
 
+        // Environment field-level validation (the CLI run path does not
+        // call per-rule `validate`): `gpus` requires a container backend.
+        for rule in &self.rules {
+            rule.environment.validate_gpus().map_err(|e| match e {
+                crate::error::OxoFlowError::Validation {
+                    message,
+                    suggestion,
+                    ..
+                } => crate::error::OxoFlowError::Validation {
+                    message: format!("rule '{}': {message}", rule.name),
+                    rule: Some(rule.name.clone()),
+                    suggestion,
+                },
+                other => other,
+            })?;
+        }
+        for (name, spec) in &self.env_groups {
+            spec.validate_gpus().map_err(|e| match e {
+                crate::error::OxoFlowError::Validation {
+                    message,
+                    suggestion,
+                    ..
+                } => crate::error::OxoFlowError::Validation {
+                    message: format!("environment group '{name}': {message}"),
+                    rule: None,
+                    suggestion,
+                },
+                other => other,
+            })?;
+        }
+
         // Validate [[values]] tables: non-empty names/values, unique names,
         // and no collisions with built-in wildcards (a rule referencing
         // `{sample}` must not be ambiguous between group and value fan-out).

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -5780,6 +5780,88 @@ fn output_pattern_and_output_mutually_exclusive_errors() {
 }
 
 #[test]
+fn gpus_without_container_backend_errors() {
+    // `gpus` only applies to container backends (docker `--gpus`); on a
+    // system/conda rule the flag would be silently ignored, so it is a
+    // validation error instead.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("gpus.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "gpus"
+
+        [[rules]]
+        name = "smi"
+        output = ["out/smi.txt"]
+        environment = { gpus = "all" }
+        shell = "nvidia-smi > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("gpus") && err.to_string().contains("docker"),
+        "error should point at the backend mismatch: {err}"
+    );
+}
+
+#[test]
+fn gpus_with_singularity_errors_not_implemented() {
+    // GPU passthrough currently maps only to docker's --gpus; singularity
+    // --nv is not implemented, and passing validation silently would be
+    // the exact "silently ignored flag" pattern validation exists to kill.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("gpus-sif.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "gpus-sif"
+
+        [[rules]]
+        name = "smi"
+        output = ["out/smi.txt"]
+        environment = { singularity = "docker://biocontainers/bwa:0.7.17", gpus = "all" }
+        shell = "nvidia-smi > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    let err = config.expand_wildcards().unwrap_err();
+    assert!(
+        err.to_string().contains("gpus") && err.to_string().contains("docker"),
+        "error should point at the docker-only contract: {err}"
+    );
+}
+
+#[test]
+fn gpus_with_docker_passes_expansion() {
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("gpus-ok.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "gpus-ok"
+
+        [[rules]]
+        name = "smi"
+        output = ["out/smi.txt"]
+        environment = { docker = "nvidia/cuda:12.6.3-base-ubuntu24.04", gpus = "all" }
+        shell = "nvidia-smi > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    assert_eq!(config.rules[0].environment.gpus.as_deref(), Some("all"));
+}
+
+#[test]
 fn output_pattern_rejects_transform_rules() {
     let dir = tempfile::tempdir().unwrap();
     let workflow_path = dir.path().join("transform.oxoflow");

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -589,6 +589,39 @@ fn quay_biocontainers_fallback(spec: &str) -> Option<String> {
     }
 }
 
+impl DockerBackend {
+    /// Like [`EnvironmentBackend::wrap_command`], with GPU passthrough:
+    /// `gpus` maps to docker's `--gpus <value>` (e.g. `"all"`, `"0"`),
+    /// requiring nvidia-container-toolkit on the host.
+    fn wrap_command_with_gpus(
+        &self,
+        command: &str,
+        spec: &str,
+        resources: Option<&crate::rule::Resources>,
+        workdir: &std::path::Path,
+        gpus: Option<&str>,
+    ) -> Result<String> {
+        // Docker requires absolute paths for -v/-w: a relative workdir
+        // ("." when running from the workflow dir) is rejected by the
+        // daemon ("the working directory '.' is invalid").
+        let workdir = absolute_host_path(workdir);
+        let escaped_cmd = escape_for_sh_single_quote(command);
+        let spec = mirrored_spec(spec);
+
+        let mut mem_arg = String::new();
+        if let Some(res) = resources
+            && let Some(mem) = &res.memory
+        {
+            mem_arg = format!(" --memory {mem}");
+        }
+        let gpus_arg = gpus.map(|g| format!(" --gpus {g}")).unwrap_or_default();
+
+        Ok(format!(
+            "docker run --rm --user $(id -u):$(id -g){mem_arg}{gpus_arg} -v {workdir}:{workdir} -w {workdir} {spec} sh -c '{CONTAINER_BASH_SHIM}' sh '{escaped_cmd}'"
+        ))
+    }
+}
+
 impl EnvironmentBackend for DockerBackend {
     fn name(&self) -> &str {
         "docker"
@@ -608,23 +641,7 @@ impl EnvironmentBackend for DockerBackend {
         resources: Option<&crate::rule::Resources>,
         workdir: &std::path::Path,
     ) -> Result<String> {
-        // Docker requires absolute paths for -v/-w: a relative workdir
-        // ("." when running from the workflow dir) is rejected by the
-        // daemon ("the working directory '.' is invalid").
-        let workdir = absolute_host_path(workdir);
-        let escaped_cmd = escape_for_sh_single_quote(command);
-        let spec = mirrored_spec(spec);
-
-        let mut mem_arg = String::new();
-        if let Some(res) = resources
-            && let Some(mem) = &res.memory
-        {
-            mem_arg = format!(" --memory {mem}");
-        }
-
-        Ok(format!(
-            "docker run --rm --user $(id -u):$(id -g){mem_arg} -v {workdir}:{workdir} -w {workdir} {spec} sh -c '{CONTAINER_BASH_SHIM}' sh '{escaped_cmd}'"
-        ))
+        self.wrap_command_with_gpus(command, spec, resources, workdir, None)
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
@@ -1214,9 +1231,13 @@ impl EnvironmentResolver {
             return self.pixi.wrap_command(command, pixi, resources, workdir);
         }
         if let Some(ref docker) = env_spec.docker {
-            return self
-                .docker
-                .wrap_command(command, docker, resources, workdir);
+            return self.docker.wrap_command_with_gpus(
+                command,
+                docker,
+                resources,
+                workdir,
+                env_spec.gpus.as_deref(),
+            );
         }
         if let Some(ref singularity) = env_spec.singularity {
             return self
@@ -1769,6 +1790,27 @@ mod tests {
         assert!(result.contains("docker run"));
         assert!(result.contains("--user $(id -u):$(id -g)"));
         assert!(result.contains("biocontainers/bwa:0.7.17"));
+    }
+
+    #[test]
+    fn docker_wrap_command_with_gpus() {
+        let backend = DockerBackend;
+        let result = backend
+            .wrap_command_with_gpus(
+                "nvidia-smi",
+                "nvidia/cuda:12.6.3-base-ubuntu24.04",
+                None,
+                std::path::Path::new("."),
+                Some("all"),
+            )
+            .unwrap();
+        assert!(result.contains("docker run"));
+        assert!(result.contains("--gpus all"));
+        // No gpus requested → no --gpus flag at all.
+        let plain = backend
+            .wrap_command_with_gpus("echo hi", "alpine:3", None, std::path::Path::new("."), None)
+            .unwrap();
+        assert!(!plain.contains("--gpus"));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -289,6 +289,15 @@ pub struct EnvironmentSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docker: Option<String>,
 
+    /// GPU devices to pass through to docker — `--gpus <value>` (e.g.
+    /// `"all"`, `"0"`, `"device=0,1"`). Requires nvidia-container-toolkit
+    /// on the host. Validated to require a docker image (singularity
+    /// `--nv` is not implemented; a bare `gpus` on any other backend is
+    /// an error).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<String>,
+
     /// Singularity/Apptainer image reference.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,6 +339,24 @@ pub struct EnvironmentSpec {
 }
 
 impl EnvironmentSpec {
+    /// Validates the GPU-passthrough field: `gpus` currently maps only to
+    /// docker's `--gpus` (singularity `--nv` is not implemented yet). Any
+    /// other backend would silently ignore the flag, so it is a
+    /// validation error instead.
+    pub fn validate_gpus(&self) -> crate::error::Result<()> {
+        if self.gpus.is_some() && self.docker.is_none() {
+            return Err(crate::error::OxoFlowError::Validation {
+                message: "environment declares 'gpus' but no docker image — GPU passthrough currently maps only to docker's --gpus (singularity --nv is not implemented)".to_string(),
+                rule: None,
+                suggestion: Some(
+                    "add `docker = \"<image>\"` (nvidia-container-toolkit required on the host)"
+                        .to_string(),
+                ),
+            });
+        }
+        Ok(())
+    }
+
     /// Returns `true` if no environment is specified.
     pub fn is_empty(&self) -> bool {
         self.conda.is_none()
@@ -1182,6 +1209,7 @@ impl Rule {
             });
         }
         self.validate_output_pattern()?;
+        self.environment.validate_gpus()?;
         if let Some(threads) = self.threads
             && threads == 0
         {

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -635,6 +635,14 @@ exists — or a **local SIF path** (e.g. a site image store's
 `/data/images/bwa_0.7.17.sif`), which is used as-is with no pull step. A
 local path that does not exist fails the rule with a clear diagnostic.
 
+**GPU passthrough (`gpus`):** `environment = { docker = "nvcr.io/nvidia/clara-parabricks:4.4.0-1", gpus = "all" }`
+passes the host's GPU devices to the container via docker's
+`--gpus <value>` (also `"0"` or `"device=0,1"`). Requires
+nvidia-container-toolkit on the host. Declaring `gpus` without a docker
+image is a validation error — the flag would otherwise be silently
+ignored on system/conda backends. (Singularity `--nv` passthrough is not
+implemented yet; `gpus` with a `singularity` image is rejected for now.)
+
 # # Mamba / micromamba (auto-detects binary, same YAML format as conda)
 # environment = { mamba = "envs/qc.yaml", mamba_prefix = ".oxo-flow/envs" }
 


### PR DESCRIPTION
snparcher parabricks 排除项的引擎半场（--nv/--gpus 直通缺位）；NVIDIA EULA/许可证半场维持排除。

## 变更
- `EnvironmentSpec.gpus: Option<String>` → docker 规则渲染 `--gpus <value>`（"all"/"0"/"device=0,1"），需宿主 nvidia-container-toolkit
- 校验：`gpus` 无 docker/singularity 镜像 = validation error（否则在 system/conda 后端被静默忽略）—— 双路径强制（Rule::validate + expand_wildcards，含 env_groups）
- 文档：environment 章节补 gpus 字段说明

## 测试
- docker wrap 带/不带 --gpus 各一
- gpus 无容器后端 expansion 报错 + gpus+docker 正常展开
- 本地门禁：fmt ✓ clippy -D warnings ✓ 44 套件 ✓（cli_integration 首跑 1 例 flake，重跑 249/0 干净）

## 实测计划（合并后）
bioinfo-wsx（NVIDIA L20 46GB + nvidia-container-cli 已确认）：真跑 nvidia/cuda base 镜像 + gpus="all"，容器内 nvidia-smi 见 GPU 为 PASS。