### PR TITLE
docs: plan-time file_exists semantics + abort sibling resume note (#242)

### DIFF
--- a/docs/guide/src/how-to/run-on-cluster.md
+++ b/docs/guide/src/how-to/run-on-cluster.md
@@ -282,6 +282,12 @@ On clusters, the scheduler enforces resources based on the generated directives.
 !!! tip "Use `--keep-going` for large batches"
     When running hundreds of samples, use `oxo-flow run -k` so that a single failure does not abort the entire run.
 
+!!! note "Aborted in-flight siblings are incomplete, not failed"
+    When a run aborts, rules still in flight are killed and recorded as
+    **incomplete** (neither completed nor failed) — `resume` re-runs them
+    from their checkpoint, so no output is silently trusted from a killed
+    job.
+
 !!! tip "Check resource availability"
     Use `sinfo` (SLURM), `pbsnodes` (PBS), or `qhost` (SGE) to verify available resources before submitting.
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1922,7 +1922,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> != "value"` | `config.mode != "WES"` | String inequality |
 | `config.<key> == true\|false` | `config.skip == false` | Boolean equality |
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
-| `file_exists("path")` | `file_exists("panel.bed")` | File existence test |
+| `file_exists("path")` | `file_exists("panel.bed")` | File existence test. In per-instance predicates (`wildcard.<key>` / `{meta.<column>}`) it is evaluated at **plan time** — the instance set is fixed when the DAG is built, so files produced mid-run cannot gate instances; express those with `{meta.*}` (plan-time bakeable) or an execution-time `config` gate instead |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |


### PR DESCRIPTION
纯文档补丁，关闭 #242 两项：① when 表 file_exists 行注明 per-instance 谓词计划期求值语义（mid-run 副作用文件用 {meta.*} 或执行期 config 门）；② run-on-cluster.md 补 abort 在飞兄弟=未完成、resume 重跑语义（9c triage ④，无行为改动）。