### PR TITLE
fix(core): input_groups prunes group keys outside the declared sample set (#246)

### DIFF
--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -1838,6 +1838,51 @@ impl WorkflowConfig {
             return Ok(Vec::new());
         }
 
+        // Declared-sample-set intersection (#246): when the workflow
+        // declares a sample domain — sample_groups (explicit or
+        // sample_pattern auto-discovered) or pairs — group keys for the
+        // SAMPLE dimension must live in that domain. Filesystem
+        // discovery alone instantiates orphan rules for stale files of
+        // undeclared samples (prior-run leftovers), which then execute
+        // with zero DAG consumers. Keys outside the domain are pruned at
+        // plan time with a warning naming them. The intersection applies
+        // ONLY to `group_by = "sample"` — other key dimensions
+        // (`meta.antibody` etc.) are orthogonal to the sample set, and
+        // workflows with no declared domain keep the filesystem as the
+        // source of truth.
+        if decl.group_by == "sample" {
+            let declared: std::collections::HashSet<&str> = self
+                .sample_groups
+                .iter()
+                .flat_map(|g| g.samples.iter().map(String::as_str))
+                .chain(
+                    self.pairs
+                        .iter()
+                        .flat_map(|p| std::iter::once(p.experiment.as_str()))
+                        .chain(self.pairs.iter().filter_map(|p| p.control.as_deref())),
+                )
+                .collect();
+            if !declared.is_empty() {
+                let stale: Vec<String> = grouped
+                    .keys()
+                    .filter(|key| !declared.contains(key.as_str()))
+                    .cloned()
+                    .collect();
+                for key in &stale {
+                    tracing::warn!(
+                        rule = %rule.name,
+                        key,
+                        "input_groups discovered files for '{}' but no declared sample set (sample_groups/pairs/sample_pattern) names it — the instance is pruned (declare the sample to include it)",
+                        key
+                    );
+                    grouped.remove(key);
+                }
+                if grouped.is_empty() {
+                    return Ok(Vec::new());
+                }
+            }
+        }
+
         let mut out = Vec::with_capacity(grouped.len());
         for (key, mut entries) in grouped {
             entries.sort_by(|a, b| a.0.cmp(&b.0));

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -3169,6 +3169,96 @@ fn input_groups_fans_rule_into_one_instance_per_group_key() {
 }
 
 #[test]
+fn input_groups_intersects_declared_sample_set() {
+    // #246: the discovery domain of an input_groups rule is the
+    // FILESYSTEM, not the declared sample set — stale files for
+    // undeclared samples (a prior run's leftovers) instantiated orphan
+    // rules that executed with zero DAG consumers. When the workflow
+    // declares a sample domain (sample_groups/pairs/sample_pattern),
+    // group keys outside it are pruned at plan time with a warning.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("merge.oxoflow");
+    for sample in ["S1", "S2", "S3"] {
+        let path = dir.path().join(format!("raw/{sample}_R1.fastq.gz"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+    }
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "merge"
+
+        [[sample_groups]]
+        name = "grp"
+        samples = ["S1", "S2"]
+
+        [[rules]]
+        name = "merge"
+        input_groups = [
+            { pattern = "raw/{sample}_R1.fastq.gz", group_by = "sample" }
+        ]
+        output = ["merged/{sample}.fq"]
+        shell = "cat {input} > {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    // S3 exists on disk but is not a declared sample — pruned.
+    assert_eq!(names, vec!["merge_S1", "merge_S2"]);
+}
+
+#[test]
+fn input_groups_non_sample_group_key_keeps_filesystem_domain() {
+    // The declared-set intersection applies ONLY when the group key is
+    // the sample dimension (`group_by = "sample"`). Other keys
+    // (chipseq-style `group_by = "meta.antibody"`) are orthogonal to the
+    // sample set and must keep their filesystem domain.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("ab.oxoflow");
+    std::fs::write(
+        dir.path().join("samples.tsv"),
+        "sample\tantibody\nS1\tA1\nS2\tA2\n",
+    )
+    .unwrap();
+    for sample in ["S1", "S2"] {
+        let path = dir.path().join(format!("bams/{sample}.bam"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+    }
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "ab"
+        metadata_file = "samples.tsv"
+
+        [[sample_groups]]
+        name = "grp"
+        samples = ["S1", "S2"]
+
+        [[rules]]
+        name = "concat"
+        input_groups = [
+            { pattern = "bams/{sample}.bam", group_by = "meta.antibody" }
+        ]
+        output = ["consensus/{antibody}.peaks.bed"]
+        shell = "touch {output[0]}"
+        "#,
+    )
+    .unwrap();
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    // Keys are antibody values (A1/A2), not sample names — no pruning.
+    assert_eq!(names, vec!["concat_A1", "concat_A2"]);
+}
+
+#[test]
 fn input_groups_matches_zero_files_drops_rule_with_warning() {
     // A group key that matches zero files is not instantiated — no
     // instance means nothing to run (issue #227 item 3 skip semantics).


### PR DESCRIPTION
#246 MEDIUM（9c 审定的交集语义）：

- 声明域存在（sample_groups ∪ pairs ∪ sample_pattern 非空）时，`group_by = "sample"` 的组键与声明集求交，域外键计划期剪枝 + warn 点名（"files exist but no declared sample"）
- 无声明域（纯文件驱动工作流）→ 保留文件系统域现状
- 交集**仅**作用于 sample 维（meta.antibody 等正交键不受影响 —— chipseq 多抗体 port 不受扰）
- --samples 随之自然生效（作用于声明集）

测试：声明 2 + 磁盘 3 → 2 实例（修复前 RED 3 实例）；非 sample 键不受剪枝；既有无声明集扇出测试保持（fallback 域）。live 复现证据在 issue comment（rnaseq cat_reads S3-S6 孤儿执行 8 次/日志）。

本地门禁：fmt ✓ clippy -D warnings ✓ 全 workspace ✓。