### PR TITLE
fix(cli): warn on config drift between checkpoint snapshot and current run (#243)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1032,6 +1032,75 @@ pub async fn run_command(
     adopt_checkpoint_for_workflow(&mut loaded_checkpoint, &workflow_abs);
     let checkpoint: Arc<Mutex<CheckpointState>> = Arc::new(Mutex::new(loaded_checkpoint));
 
+    // Sensitive keys are needed by the snapshot-drift warning below and by
+    // config-change detection.
+    let sensitive_keys: std::collections::HashSet<String> = config
+        .config_meta
+        .iter()
+        .filter(|(_, def)| def.sensitive)
+        .map(|(key, _)| key.clone())
+        .collect();
+
+    // ── Snapshot drift warning (issue #243) ──────────────────────────────
+    // The checkpoint records the EFFECTIVE config of the original run
+    // (workflow defaults + its CLI overrides). This invocation re-parsed
+    // the workflow with THIS invocation's overrides — `resume` passes none,
+    // so plan-time gates (pair/instance `when`, `{meta.*}` baking) re-judge
+    // on defaults and the instance set can drift from the original run
+    // before any invalidation machinery sees it. Invalidation (below)
+    // covers shell interpolation and gate flips; it cannot resurrect
+    // instances expansion already dropped. Warn loudly, naming every key
+    // that differs — the operator decides whether to re-pass the overrides.
+    {
+        let ck = checkpoint.lock().await;
+        let drifted: Vec<String> = ck
+            .config_snapshot
+            .keys()
+            .filter(|key| {
+                !oxo_flow_core::config_impact::is_engine_injected_key(key)
+                    && match config.config.get(key.as_str()) {
+                        Some(value) => {
+                            let new = oxo_flow_core::config_impact::snapshot_value(
+                                value,
+                                sensitive_keys.contains(key.as_str()),
+                            );
+                            &new != ck.config_snapshot.get(*key).unwrap()
+                        }
+                        None => true,
+                    }
+            })
+            .cloned()
+            .collect();
+        if !drifted.is_empty() && !ck.completed_rules.is_empty() {
+            eprintln!(
+                "{} effective config differs from the original run's snapshot — \
+                 plan-time gated instances (pair/sample `when`, `{{meta.*}}`) may \
+                 drift from the recorded run. Re-pass the original overrides to \
+                 resume the same instance set:",
+                "Config drift:".bold().yellow()
+            );
+            for key in &drifted {
+                match config.config.get(key.as_str()) {
+                    Some(value) => {
+                        let new = oxo_flow_core::config_impact::snapshot_value(
+                            value,
+                            sensitive_keys.contains(key.as_str()),
+                        );
+                        let old = ck.config_snapshot.get(key.as_str()).unwrap();
+                        let (old, new) = if old.starts_with("sha256:") || new.starts_with("sha256:")
+                        {
+                            ("****".to_string(), "****".to_string())
+                        } else {
+                            (old.clone(), new)
+                        };
+                        eprintln!("  {key}: {old} → {new}");
+                    }
+                    None => eprintln!("  {key}: (removed from this invocation)"),
+                }
+            }
+        }
+    }
+
     // Store workflow path and working directory in the checkpoint so
     // `resume` re-runs from the same place (issue #68). Both are made
     // absolute — a raw relative path would only resolve from the original
@@ -1051,12 +1120,6 @@ pub async fn run_command(
     // are invalidated; edited rule definitions are caught by fingerprints.
     // Engine-injected keys (samples_list, samples_<group>) are excluded:
     // their --samples churn must not invalidate everything.
-    let sensitive_keys: std::collections::HashSet<String> = config
-        .config_meta
-        .iter()
-        .filter(|(_, def)| def.sensitive)
-        .map(|(key, _)| key.clone())
-        .collect();
     let old_snapshot = {
         let ck = checkpoint.lock().await;
         ck.config_snapshot.clone()

--- a/docs/guide/src/commands/resume.md
+++ b/docs/guide/src/commands/resume.md
@@ -35,6 +35,15 @@ inputs are compared against the recorded manifests, and changed inputs
 re-execute the affected rules (see
 [Input changes and manifest invalidation](run.md#input-changes-and-manifest-invalidation)).
 
+`resume` passes no CLI config overrides, so the effective config is the
+workflow's defaults. When the original run carried overrides (its recorded
+config snapshot differs), the resumed run prints a **Config drift** warning
+naming every key that changed and its old → new values — plan-time gated
+instances (pair/sample `when`, `{meta.*}` baking) re-judge on the defaults
+and may drift from the recorded instance set. Re-pass the original
+overrides with `oxo-flow run` (which auto-resumes) to reproduce the
+recorded instance set exactly.
+
 ## Options
 
 | Option | Description |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -779,9 +779,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,9 +796,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,9 +813,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,9 +830,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -859,9 +847,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -879,9 +864,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2565,9 +2547,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2589,9 +2568,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2613,9 +2589,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2637,9 +2610,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -9268,3 +9268,87 @@ shell = "cat {input} > {output}"
         "no consumer output may exist when the producer failed"
     );
 }
+
+// ─── Resume config-drift warning (issue #243) ───────────────────────────────
+
+/// The checkpoint records the original run's EFFECTIVE config (workflow
+/// defaults + CLI overrides). Re-running the workflow without re-passing
+/// the overrides re-judges plan-time gates on defaults — the instance set
+/// can drift from the recorded run. The run must warn loudly, naming the
+/// drifted keys and their old → new values.
+#[test]
+fn cli_resume_without_overrides_warns_config_drift() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("drift.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "drift"
+version = "1.0.0"
+
+[config]
+threshold = "low"
+
+[[rules]]
+name = "step"
+output = ["out.txt"]
+shell = "echo {config.threshold} > {output}"
+"#,
+    )
+    .unwrap();
+
+    // Original run carries an override: snapshot records threshold=high.
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--arg", "threshold=high"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Re-run with the DEFAULT (no override) — the effective config drifts
+    // from the snapshot. The run must warn, naming the key and values.
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Config drift"),
+        "re-run without the original override must warn, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("threshold") && stderr.contains("high") && stderr.contains("low"),
+        "warning must name the drifted key and both values, got:\n{stderr}"
+    );
+
+    // Re-running WITH the original override right after the recorded run:
+    // snapshot still holds threshold=high → no drift, no warning.
+    let dir2 = tempfile::tempdir().unwrap();
+    let wf2 = dir2.path().join("drift2.oxoflow");
+    fs::write(&wf2, fs::read_to_string(&wf).unwrap()).unwrap();
+    let out = oxo_flow_cmd()
+        .args(["run", wf2.to_str().unwrap(), "--arg", "threshold=high"])
+        .current_dir(dir2.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let out = oxo_flow_cmd()
+        .args(["run", wf2.to_str().unwrap(), "--arg", "threshold=high"])
+        .current_dir(dir2.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Config drift"),
+        "matching override must not warn, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

checkpoint 记录了 `config_snapshot`（原 run 的**生效**配置 = workflow 默认值 + 其 CLI 覆盖），但 resume/重跑只按本次调用的配置重计划 —— `resume` 不传 CLI 覆盖，`when` 门按默认值重判，**实例集与原 run 漂移**。现有的 config-change invalidation 覆盖 shell 插值与门翻转，但无法复活已被 expansion 丢弃的实例（snparcher CSI port 实测）。

## Solution — loud drift warning（issue 的保守选项）

checkpoint 加载后、失效分析前：将生效配置与记录的 snapshot 逐键对比（排除 engine-injected 键；sensitive 值两侧掩码），不一致则打印 **Config drift** 大字警告，逐键列出 `old → new`，并提示重传覆盖可复现原实例集。一致则完全静默。

不采用激进的重放 snapshot 覆盖：类型与敏感值回放有风险，且 invalidation 机制已正确处理值变化的影响面。

## Tests

- 集成测试：`--arg threshold=high` 跑一遍 → 不带覆盖重跑 → 警告点名键与两个值；带相同覆盖重跑 → 静默
- `make ci` 全绿

## Docs

- `docs/guide/src/commands/resume.md`：新增 Config drift 段落（机制、后果、`run` + 覆盖重传的恢复姿势）

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)