### PR TITLE
test(ci): flaky-test governance — signal-grace window + capped retry (#249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,32 @@ jobs:
       - name: Test
         run: |
           export PATH="$PWD/target/debug:$PATH"
-          cargo test --workspace
+
+          # Issue #249 flaky governance: first attempt runs the full suite.
+          # On failure, the FAILED test list is extracted from that run's
+          # output and ONLY those tests re-run once — a load-timing flake
+          # (signal-grace races, first-run resource contention) passes and
+          # the job stays green; a genuine regression fails again and the
+          # job goes red. The retry is capped at exactly one re-run so
+          # persistent breakage is never masked.
+          if OUT=$(cargo test --workspace 2>&1); then
+            echo "$OUT"
+            exit 0
+          fi
+          echo "$OUT"
+
+          echo "::warning::test suite failed — re-running FAILED tests once (flake gate, issue #249)"
+          FAILED=$(echo "$OUT" | grep -E "^test .* FAILED" | sed -E 's/^test ([^ ]+) \.\.\. FAILED$/\1/' | sort -u || true)
+          if [ -z "$FAILED" ]; then
+            echo "could not extract failed test names (compile error or format change) — failing the job"
+            exit 1
+          fi
+          echo "Re-running: $FAILED"
+          if cargo test --workspace -- --exact $FAILED; then
+            echo "::warning::FAILED tests passed on re-run — classified as load-timing flakes (issue #249)"
+            exit 0
+          fi
+          exit 1
         env:
           RUST_BACKTRACE: "1"
 

--- a/crates/oxo-flow-core/src/executor/timeout.rs
+++ b/crates/oxo-flow-core/src/executor/timeout.rs
@@ -225,7 +225,15 @@ mod tests {
         }
         assert!(pidfile.exists(), "child pid file never appeared");
 
-        kill_process_tree(sh_pid).expect("tree kill");
+        // Explicit LONG grace (issue #249): under CI load the TERM'd shell
+        // can sit descheduled well past the 10 s production grace before it
+        // gets to run its trap — the escalation then SIGKILLs it and the
+        // marker never appears, reading as an engine bug that is not. The
+        // assertion's intent is "TERM arrives first, escalation only after
+        // the grace", so the test grants a much wider window; a healthy
+        // shell exits in milliseconds and pays nothing, a starved one gets
+        // its cleanup chance instead of failing the run.
+        kill_process_tree_with_grace(sh_pid, Duration::from_secs(30)).expect("tree kill");
         let _ = sh.wait();
 
         assert!(

--- a/docs/guide/src/development/contributing.md
+++ b/docs/guide/src/development/contributing.md
@@ -34,6 +34,21 @@ cargo test --test web_role_matrix   # deployment + 3-role simulation matrix (aut
 cargo test --test web_integration   # web API integration tests
 ```
 
+#### Flaky-test policy (issue #249)
+
+CI runs the full suite once; if it fails, ONLY the failed tests are
+re-run a single time — passing then classifies the failure as a
+load-timing flake (the job stays green with a warning annotation),
+failing again is a genuine regression (the job goes red). The cap is
+exactly one re-run: persistent breakage is never masked.
+
+When writing time-sensitive tests, do not assert on wall-clock margins
+that only hold on an idle machine — grant the generous window in the
+test itself (e.g. an explicit long grace for signal handling) so the
+assertion measures the property under test, not machine load. A first
+run that flakes under CI load is a test bug, not an engine bug; fix
+the window before adding retries.
+
 ### Run All CI Checks Locally
 
 ```bash


### PR DESCRIPTION
## Problem

三次进 flake 家族（issue #249 表格）：

| Flake | 类别 |
|---|---|
| `kill_process_tree_delivers_sigterm_before_escalating`（"TERM trap never ran"） | 时序类（CI 负载下宽限窗口过短）—— **#255 合入后在 main 又实锤一次** |
| `character_device_output_is_never_fresh` | mtime 粒度类（已在 #255 以显式 filetime 修复） |
| `background_run` 60s / `cli_integration` 首跑 | 首跑资源类 |

## Solution（按 issue 治理方案）

1. **时序类**：`kill_process_tree_delivers_sigterm_before_escalating` 改用显式 30s 宽限。被测属性不变（"TERM 先到、宽限后才升级"）；健康 shell 毫秒级退出零开销，被 CI 负载饿死的 shell 获得清理机会而不是把 run 判红。
2. **CI 侧重试加上限**（item 3）：Test 步骤改为全量一次 → 失败时**仅重跑 FAILED 测试一次** → 通过则标注 warning 保持绿（归类负载时序 flake），再失败判红。单次重跑上限确保持续回归永不被掩盖。首跑资源类（background_run / cli_integration）由该门覆盖。
3. **文档**：contributing.md 新增 Flaky-test policy —— 宽限窗口写进测试本身而不是靠重试次数。

## Tests

- `cargo test -p oxo-flow-core --lib timeout::` 全绿（0.19s —— 显式长宽限零常态开销）
- YAML 校验通过；sed 模式对照 cargo 真实输出格式（`test NAME ... FAILED`）验证

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)