### PR TITLE
fix(core,cli): targeted run (-t) closes over the instantiated DAG (#247)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/cluster.rs
@@ -280,12 +280,49 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
                 }
             }
 
+            // Targeted cluster runs close over the INSTANTIATED DAG
+            // (issue #247): when-gated instances never enter the set.
+            let when_false_rules: std::collections::HashSet<String> = if target.is_empty() {
+                std::collections::HashSet::new()
+            } else {
+                let wildcard_values: std::collections::HashMap<String, String> = config
+                    .config
+                    .iter()
+                    .map(|(key, value)| {
+                        let string_val = match value {
+                            toml::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        (format!("config.{key}"), string_val)
+                    })
+                    .collect();
+                config
+                    .rules
+                    .iter()
+                    .filter(|rule| {
+                        crate::commands::run_preview::when_condition_false(
+                            rule,
+                            &config,
+                            &wildcard_values,
+                        )
+                    })
+                    .map(|rule| rule.name.clone())
+                    .collect()
+            };
             let order = if target.is_empty() {
                 dag.execution_order()?
             } else {
                 let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-                dag.execution_order_for_targets(&target_refs)
-                    .with_context(|| "failed to resolve target rules")?
+                let (filtered, skipped_targets) = dag
+                    .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+                    .with_context(|| "failed to resolve target rules")?;
+                for skipped in &skipped_targets {
+                    eprintln!(
+                        "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
+                        "Note:".yellow()
+                    );
+                }
+                filtered
             };
 
             let cluster_config = oxo_flow_core::cluster::ClusterJobConfig {

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -979,12 +979,44 @@ pub async fn run_command(
         run_log_path.display()
     );
 
+    // Targeted runs (-t) close over the INSTANTIATED DAG (issue #247):
+    // instances whose `when` evaluates false under the effective config
+    // never enter the execution set, and the closure does not expand
+    // through them. Prefix matching still resolves the entries.
+    let when_false_rules: std::collections::HashSet<String> = if target.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        let wildcard_values: HashMap<String, String> = config_placeholder_values(&config.config);
+        config
+            .rules
+            .iter()
+            .filter(|rule| {
+                crate::commands::run_preview::when_condition_false(rule, &config, &wildcard_values)
+            })
+            .map(|rule| rule.name.clone())
+            .collect()
+    };
+
     let mut order = if target.is_empty() {
         dag.execution_order()?
     } else {
         let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-        dag.execution_order_for_targets(&target_refs)
-            .with_context(|| "failed to resolve target rules")?
+        let (filtered_order, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+            .with_context(|| "failed to resolve target rules")?;
+        for skipped in &skipped_targets {
+            eprintln!(
+                "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
+                "Note:".yellow()
+            );
+        }
+        if filtered_order.is_empty() {
+            emit_run_json_summary(json, "failed", &workflow, &RunCounts::default(), vec![]);
+            return Err(anyhow::anyhow!(
+                "all requested targets are when-gated false — nothing to run"
+            ));
+        }
+        filtered_order
     };
     emit_execution_event(oxo_flow_core::executor::ExecutionEvent::WorkflowStarted {
         workflow_name: config.workflow.name.clone(),
@@ -2058,8 +2090,16 @@ pub async fn run_command(
                 dag.execution_order()?
             } else {
                 let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-                dag.execution_order_for_targets(&target_refs)
-                    .with_context(|| "failed to resolve target rules")?
+                let (filtered, skipped_targets) = dag
+                    .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+                    .with_context(|| "failed to resolve target rules")?;
+                for skipped in &skipped_targets {
+                    eprintln!(
+                        "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
+                        "Note:".yellow()
+                    );
+                }
+                filtered
             };
         }
     }
@@ -2090,8 +2130,16 @@ pub async fn run_command(
                     dag.execution_order()?
                 } else {
                     let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-                    dag.execution_order_for_targets(&target_refs)
-                        .with_context(|| "failed to resolve target rules")?
+                    let (filtered, skipped_targets) = dag
+                        .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+                        .with_context(|| "failed to resolve target rules")?;
+                    for skipped in &skipped_targets {
+                        eprintln!(
+                            "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
+                            "Note:".yellow()
+                        );
+                    }
+                    filtered
                 };
             }
         }
@@ -3784,6 +3832,27 @@ pub async fn dry_run_command(
             }
         }
     }
+    // Targeted dry-runs close over the INSTANTIATED DAG (issue #247) —
+    // the same when-gate filter `run` applies, so the preview cannot list
+    // instances that would never execute.
+    let dry_wildcard_values: HashMap<String, String> = config_placeholder_values(&config.config);
+    let when_false_rules: std::collections::HashSet<String> = if target.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        config
+            .rules
+            .iter()
+            .filter(|rule| {
+                crate::commands::run_preview::when_condition_false(
+                    rule,
+                    &config,
+                    &dry_wildcard_values,
+                )
+            })
+            .map(|rule| rule.name.clone())
+            .collect()
+    };
+
     // Compute the execution set (respects --target), then display it in
     // parallel-group order — the same grouping `run` uses for scheduling.
     // Independent rules at the same level appear adjacent, so the listing
@@ -3803,8 +3872,16 @@ pub async fn dry_run_command(
         ordered
     } else {
         let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-        dag.execution_order_for_targets(&target_refs)
-            .with_context(|| "failed to resolve target rules")?
+        let (filtered, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+            .with_context(|| "failed to resolve target rules")?;
+        for skipped in &skipped_targets {
+            eprintln!(
+                "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
+                "Note:".yellow()
+            );
+        }
+        filtered
     };
 
     eprintln!(
@@ -3912,8 +3989,10 @@ pub async fn dry_run_command(
                 ordered
             } else {
                 let target_refs: Vec<&str> = target.iter().map(String::as_str).collect();
-                dag.execution_order_for_targets(&target_refs)
-                    .with_context(|| "failed to resolve target rules")?
+                let (filtered, _) = dag
+                    .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
+                    .with_context(|| "failed to resolve target rules")?;
+                filtered
             };
             let old_order_len = order.len();
             order = new_order;

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -438,6 +438,135 @@ impl WorkflowDag {
             .collect())
     }
 
+    /// [`Self::execution_order_for_targets`] with a `skip` set: the
+    /// closure traverses the INSTANTIATED DAG (issue #247) — nodes whose
+    /// `when` evaluated false never enter the execution set, and the
+    /// closure does not expand through them (their upstream exists only
+    /// to feed them).
+    ///
+    /// Dead-node propagation: a surviving node with a pruned DAG parent is
+    /// un-runnable (its input comes from a variant that never executes —
+    /// the executor would fail it on the missing file), so it is pruned
+    /// too, transitively to a fixpoint.
+    ///
+    /// - A when-false node that is also an explicit target is REPORTED via
+    ///   the returned `Vec` of skipped target names (the caller warns) and
+    ///   excluded from the order: `-t <name>` on a never-executing variant
+    ///   must say so, not silently plan a run that cannot produce output.
+    /// - A when-false non-target producer is silently pruned together with
+    ///   its upstream — the mutual-exclusion variant that did not match
+    ///   contributes nothing.
+    ///
+    /// Prefix matching resolves entries exactly like the unfiltered method;
+    /// the filter applies AFTER resolution, so an entry that matches only
+    /// pruned variants reports every pruned match by instance name.
+    pub fn execution_order_for_targets_skipping(
+        &self,
+        targets: &[&str],
+        skip: &HashSet<String>,
+    ) -> Result<(Vec<String>, Vec<String>)> {
+        if targets.is_empty() {
+            return Ok((self.execution_order()?, Vec::new()));
+        }
+
+        // Resolve targets (same validation + prefix matching as the
+        // unfiltered method).
+        let mut resolved_targets: Vec<String> = Vec::new();
+        for &target in targets {
+            if self.name_to_node.contains_key(target) {
+                resolved_targets.push(target.to_string());
+            } else {
+                let matches: Vec<&String> = self
+                    .name_to_node
+                    .keys()
+                    .filter(|name| name.starts_with(target))
+                    .collect();
+                if matches.is_empty() {
+                    let base_names: Vec<&str> =
+                        self.name_to_node.keys().map(|s| s.as_str()).collect();
+                    return Err(OxoFlowError::RuleNotFound {
+                        name: target.to_string(),
+                        available_rules: base_names.into_iter().map(String::from).collect(),
+                    });
+                }
+                for m in matches {
+                    resolved_targets.push(m.clone());
+                }
+            }
+        }
+
+        // Dead-node propagation to a fixpoint: a node whose parent is
+        // pruned cannot receive its input, so it is pruned as well (the
+        // executor fails such a rule on the missing file — surfacing that
+        // at plan time is the point of the instantiated-DAG closure).
+        let mut pruned: HashSet<String> = skip.clone();
+        loop {
+            let mut grew = false;
+            for idx in self.graph.node_indices() {
+                let name = &self.graph[idx].name;
+                if pruned.contains(name) {
+                    continue;
+                }
+                let has_pruned_parent = self
+                    .graph
+                    .neighbors_directed(idx, petgraph::Direction::Incoming)
+                    .any(|dep| pruned.contains(&self.graph[dep].name));
+                if has_pruned_parent && pruned.insert(name.clone()) {
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+
+        let skipped_targets: Vec<String> = resolved_targets
+            .iter()
+            .filter(|t| pruned.contains(*t))
+            .cloned()
+            .collect();
+
+        // Closure over SURVIVING nodes only: start from the non-pruned
+        // targets, expand incoming edges but do not include or traverse
+        // through pruned nodes.
+        let mut included: HashSet<NodeIndex> = HashSet::new();
+        let mut stack: Vec<NodeIndex> = resolved_targets
+            .iter()
+            .filter(|t| !pruned.contains(*t))
+            .map(|t| self.name_to_node.get(t.as_str()).copied().unwrap())
+            .collect();
+
+        while let Some(node) = stack.pop() {
+            let name = self.graph[node].name.clone();
+            if pruned.contains(&name) {
+                continue;
+            }
+            if included.insert(node) {
+                for dep in self
+                    .graph
+                    .neighbors_directed(node, petgraph::Direction::Incoming)
+                {
+                    if !included.contains(&dep) {
+                        stack.push(dep);
+                    }
+                }
+            }
+        }
+
+        let full_order = self.topological_order()?;
+        let order = full_order
+            .into_iter()
+            .filter(|n| {
+                self.name_to_node
+                    .get(&n.name)
+                    .map(|&idx| included.contains(&idx))
+                    .unwrap_or(false)
+            })
+            .map(|n| n.name.clone())
+            .collect();
+        Ok((order, skipped_targets))
+    }
+
     /// Returns the direct dependencies (upstream rules) for a given rule.
     #[must_use = "querying dependencies returns a Result that must be used"]
     pub fn dependencies(&self, rule_name: &str) -> Result<Vec<String>> {
@@ -1609,6 +1738,78 @@ mod tests {
         let dag = WorkflowDag::from_rules(&rules).unwrap();
         let result = dag.execution_order_for_targets(&["nonexistent"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn execution_order_for_targets_skipping_prunes_when_false_producers() {
+        // Issue #247: the closure traverses the INSTANTIATED DAG — a
+        // when-false producer is pruned, its upstream (which only feeds
+        // it) is not pulled in, and consumers of the pruned variant's
+        // output are dead too (their input can never exist).
+        //
+        // raw -> source -> a.txt -> trim_star (when-false) -.
+        //                \-> b.txt -> trim_hisat (when-true) --> merge
+        let rules = vec![
+            make_rule("raw", vec!["in.txt"], vec!["src.txt"]),
+            make_rule("source", vec!["src.txt"], vec!["a.txt", "b.txt"]),
+            make_rule("trim_star", vec!["a.txt"], vec!["ts.txt"]),
+            make_rule("trim_hisat", vec!["b.txt"], vec!["th.txt"]),
+            make_rule("merge", vec!["ts.txt", "th.txt"], vec!["final.txt"]),
+        ];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mut skip = std::collections::HashSet::new();
+        skip.insert("trim_star".to_string());
+
+        // Targeting the surviving variant's chain: raw -> source ->
+        // trim_hisat, nothing from the dead branch.
+        let (order, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&["trim_hisat"], &skip)
+            .unwrap();
+        assert!(skipped_targets.is_empty());
+        assert!(!order.contains(&"trim_star".to_string()), "{order:?}");
+        assert!(order.contains(&"trim_hisat".to_string()), "{order:?}");
+        assert!(order.contains(&"source".to_string()), "{order:?}");
+        assert!(order.contains(&"raw".to_string()), "{order:?}");
+
+        // Targeting merge (reads BOTH variants' outputs): the star branch
+        // is dead, so merge can never receive its ts.txt input — it is
+        // dead-propagated and reported as a skipped target.
+        let (order, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&["merge"], &skip)
+            .unwrap();
+        assert_eq!(skipped_targets, vec!["merge".to_string()]);
+        assert!(order.is_empty(), "merge cannot run without ts.txt");
+    }
+
+    #[test]
+    fn execution_order_for_targets_skipping_reports_when_false_target() {
+        // A target that names a never-executing variant is reported (not
+        // silently planned) and excluded together with its upstream.
+        let rules = vec![
+            make_rule("raw", vec!["in.txt"], vec!["src.txt"]),
+            make_rule("trim_star", vec!["src.txt"], vec!["ts.txt"]),
+            make_rule("trim_hisat", vec!["src.txt"], vec!["th.txt"]),
+        ];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mut skip = std::collections::HashSet::new();
+        skip.insert("trim_star".to_string());
+
+        let (order, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&["trim_star"], &skip)
+            .unwrap();
+        assert_eq!(skipped_targets, vec!["trim_star".to_string()]);
+        assert!(order.is_empty(), "only the skipped target was requested");
+
+        // A prefix that matches both variants keeps only the survivor.
+        let (order, skipped_targets) = dag
+            .execution_order_for_targets_skipping(&["trim"], &skip)
+            .unwrap();
+        assert_eq!(skipped_targets, vec!["trim_star".to_string()]);
+        assert!(order.contains(&"trim_hisat".to_string()));
+        assert!(order.contains(&"raw".to_string()));
+        assert!(!order.contains(&"trim_star".to_string()));
     }
 
     #[test]

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -148,6 +148,17 @@ oxo-flow run pipeline.oxoflow -j 8 -r 2
 oxo-flow run pipeline.oxoflow -t align -t sort
 ```
 
+Target names may be prefixes: `-t align` matches every rule whose name
+starts with `align` (including expanded instance names like
+`align_cohort_S1`). The closure walks the **instantiated DAG** — it
+includes each target plus every upstream rule that survives the plan-time
+`when` gating, and skips when-gated variants entirely: a variant whose
+`when` is false under the effective config never enters the execution set,
+its upstream is not pulled in, and consumers of its (never-produced)
+outputs are pruned too. Naming a when-gated-false target explicitly
+reports it and aborts with "nothing to run" instead of planning a run
+that cannot produce output.
+
 ### Set a per-job timeout
 
 ```bash

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -9410,3 +9410,92 @@ shell = "cat {input} > {output}"
     let s2 = fs::read_to_string(dir.path().join("merged/S2_R1.txt")).unwrap();
     assert_eq!(s2, "S2-L001\n");
 }
+
+// ─── Targeted run closes over the instantiated DAG (issue #247) ─────────────
+
+/// `--target` on a workflow with mutually-exclusive `when` variants must
+/// close over the INSTANTIATED DAG: the when-false variant is pruned with
+/// its upstream, a when-false target is reported and excluded, and the
+/// surviving variant runs.
+#[test]
+fn cli_target_prunes_when_gated_variants() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("t.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "t"
+version = "1.0.0"
+
+[config]
+aligner = "hisat2"
+
+[[rules]]
+name = "index"
+input = ["ref.fa"]
+output = ["ref.idx"]
+shell = "echo idx > {output}"
+
+[[rules]]
+name = "trim_hisat2"
+input = ["ref.idx"]
+output = ["trim_hisat2.fq"]
+when = "config.aligner == 'hisat2'"
+shell = "cat {input} > {output}"
+
+[[rules]]
+name = "trim_star"
+input = ["ref.idx"]
+output = ["trim_star.fq"]
+when = "config.aligner == 'star'"
+shell = "cat {input} > {output}"
+
+[[rules]]
+name = "map"
+input = ["trim_hisat2.fq"]
+output = ["map.bam"]
+shell = "cat {input} > {output}"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("ref.fa"), b"ref").unwrap();
+
+    // Target `map` with aligner=hisat2: closure pulls trim_hisat2 (when-
+    // true) + its producer index. The when-false trim_star variant must
+    // not appear even though the prefix names overlap.
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap(), "--target", "map"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "targeted run must succeed: {stderr}");
+    assert!(dir.path().join("map.bam").exists(), "{stderr}");
+    assert!(dir.path().join("trim_hisat2.fq").exists(), "{stderr}");
+    assert!(dir.path().join("ref.idx").exists(), "{stderr}");
+    assert!(
+        !dir.path().join("trim_star.fq").exists(),
+        "when-false variant must not run"
+    );
+
+    // Targeting the when-false variant directly: reported, excluded, and
+    // the run aborts with nothing to run.
+    let dir2 = tempfile::tempdir().unwrap();
+    let wf2 = dir2.path().join("t.oxoflow");
+    fs::write(&wf2, fs::read_to_string(&wf).unwrap()).unwrap();
+    fs::write(dir2.path().join("ref.fa"), b"ref").unwrap();
+    let out = oxo_flow_cmd()
+        .args(["run", wf2.to_str().unwrap(), "--target", "trim_star"])
+        .current_dir(dir2.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "all-when-false targets must fail the run, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("when-gated false"),
+        "must report the skipped target, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

targeted run 的前缀闭包按**规则名**拉取，但互斥 when 变体（trim_se/trim_pe 式）实例化后带后缀——名字前缀闭包会漏掉真实生产者，或点名到永不执行的变体（rnaseq port triage ④）。

## Solution — 闭包沿实例化后的 DAG 走

新 `WorkflowDag::execution_order_for_targets_skipping(targets, skip)`：

- 名字前缀解析不变（仅作入口）
- 闭包只走**存活实例**：when=false 的节点被排除且不穿过（其上游只为它存在）
- **死节点传播**（fixpoint）：存活节点的 DAG 父节点被剪 → 它收不到输入（执行器会因缺文件失败）→ 一并剪除
- when=false 且**同时是显式 target** 的节点：报告（调用方警告）并排除 —— `-t <永不执行的变体>` 明说并中止 "nothing to run"，不再规划注定失败的 run

接入全部 `-t` 站点：run（初始 + re-entry replay + output_pattern replay）、dry-run（初始 + replay）、cluster。when=false 集合用与执行器相同的求值器（`when_condition_false`：typed config、base_dir 感知）。

## Tests

- dag 单元测试：剪枝链、when-false target 报告、前缀保留存活变体
- 集成测试：config 门控互斥变体 —— 存活链运行、when-false 变体不执行、点名它则报告并中止
- `make ci` 全绿

## Docs

- `run.md` 的 target 小节：实例化 DAG 闭包语义

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)