### PR TITLE
fix(core): SLURM settlement survives clusters without slurmdbd (#244)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -394,6 +394,7 @@ pub(crate) async fn run_on_cluster(
         // No wall-clock budget: cluster jobs legitimately sit in the queue
         // for hours. Cancellation is the user's call (phase 2 follow-up).
         poll_timeout: None,
+        unknown_settle_grace: std::time::Duration::from_secs(90),
     };
 
     eprintln!(

--- a/crates/oxo-flow-core/src/backend/cluster.rs
+++ b/crates/oxo-flow-core/src/backend/cluster.rs
@@ -490,9 +490,28 @@ impl super::ExecutorBackend for ClusterExecutor {
 
     /// Terminal record for a job that has left the live queue, read from the
     /// scheduler's accounting store (sacct / qstat -x / qacct / bacct).
+    ///
+    /// SLURM fallback (issue #244): on clusters WITHOUT slurmdbd, sacct
+    /// errors ("accounting storage is disabled") and returns nothing —
+    /// settlement would then poll forever. `scontrol show job <id>` reads
+    /// the controller's in-memory record, which survives briefly after a
+    /// job completes even without accounting; its JobState/ExitCode parse
+    /// into the same TerminalRecord (Elapsed/MaxRSS/TotalCPU unavailable —
+    /// the controller does not report them).
     async fn terminal_status(&self, job_id: &str) -> Option<TerminalRecord> {
-        let text = self.logs(job_id).await.ok()?;
-        parse_accounting(&self.backend, &text)
+        if let Ok(text) = self.logs(job_id).await
+            && let Some(rec) = parse_accounting(&self.backend, &text)
+        {
+            return Some(rec);
+        }
+        if self.backend == ClusterBackend::Slurm {
+            let out = self
+                .run_cmd("scontrol", &["show", "job", job_id])
+                .await
+                .ok()?;
+            return parse_scontrol(&String::from_utf8_lossy(&out.stdout));
+        }
+        None
     }
 
     fn polls_elements_directly(&self) -> bool {
@@ -701,6 +720,46 @@ fn parse_sacct(text: &str) -> Option<TerminalRecord> {
         elapsed_secs: allocation.get(3).copied().and_then(parse_duration_secs),
         max_rss_mb,
         cpu_seconds,
+    })
+}
+
+/// Parse `scontrol show job <id>` output (issue #244): the controller's
+/// in-memory record, available on clusters WITHOUT slurmdbd while the job
+/// stays in the controller's cache after completion. Only state and exit
+/// code are recoverable — the controller does not report Elapsed/MaxRSS/
+/// TotalCPU.
+fn parse_scontrol(text: &str) -> Option<TerminalRecord> {
+    let mut job_state = None;
+    let mut exit_code = None;
+    for token in text.split_whitespace() {
+        if let Some(state) = token.strip_prefix("JobState=") {
+            job_state = Some(state.trim_end_matches(['(', '+']).to_string());
+        }
+        if let Some(code) = token.strip_prefix("ExitCode=") {
+            exit_code = Some(code.to_string());
+        }
+    }
+    // A pending/running record from the controller is not terminal — the
+    // live poller owns those states; only settle on terminal vocabulary.
+    // "CANCELLED by <uid>"/"CANCELLED+(Reason)" — sacct/scontrol append
+    // reasons; the alphabetic head is the state word.
+    let state_word: String = job_state
+        .as_deref()?
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect();
+    let status = match state_word.as_str() {
+        "COMPLETED" => BackendJobStatus::Completed,
+        "FAILED" | "TIMEOUT" | "OUT_OF_MEMORY" | "NODE_FAIL" | "BOOT_FAIL" => {
+            BackendJobStatus::Failed
+        }
+        "CANCELLED" | "PREEMPTED" => BackendJobStatus::Cancelled,
+        _ => return None,
+    };
+    Some(TerminalRecord {
+        status,
+        exit_code: exit_code.as_deref().and_then(parse_exit_code),
+        ..TerminalRecord::default()
     })
 }
 
@@ -1021,6 +1080,51 @@ mod tests {
 #[cfg(test)]
 mod accounting_tests {
     use super::*;
+
+    #[test]
+    fn parses_scontrol_completed_record() {
+        // Issue #244: the no-slurmdbd fallback. Real `scontrol show job`
+        // output (whitespace-separated key=value pairs).
+        let text = "JobId=12345 JobName=align\n\
+   UserId=ops(1000) GroupId=ops(1000) MCS_label=N/A\n\
+   Priority=4294901759 Nice=0 Account=(null) QOS=normal\n\
+   JobState=COMPLETED Reason=(None) Dependency=(null)\n\
+   ExitCode=0:0 RunTime=00:01:22 TimeLimit=02:00:00\n";
+        assert_eq!(
+            parse_scontrol(text),
+            Some(TerminalRecord {
+                status: BackendJobStatus::Completed,
+                exit_code: Some(0),
+                ..TerminalRecord::default()
+            })
+        );
+
+        // A failed job reports the signal-aware exit code.
+        let failed = "JobId=12346 JobName=align\n   JobState=FAILED Reason=NonZeroExitCode\n   ExitCode=1:0\n";
+        assert_eq!(
+            parse_scontrol(failed),
+            Some(TerminalRecord {
+                status: BackendJobStatus::Failed,
+                exit_code: Some(1),
+                ..TerminalRecord::default()
+            })
+        );
+
+        // A CANCELLED job (state may carry the reason in parentheses).
+        let cancelled = "JobId=12347 JobName=x\n   JobState=CANCELLED+(Reason)\n   ExitCode=0:15\n";
+        assert_eq!(
+            parse_scontrol(cancelled),
+            Some(TerminalRecord {
+                status: BackendJobStatus::Cancelled,
+                exit_code: Some(143),
+                ..TerminalRecord::default()
+            })
+        );
+
+        // A RUNNING record is NOT terminal — the live poller owns those.
+        let running = "JobId=12348 JobName=x\n   JobState=RUNNING\n   ExitCode=0:0\n";
+        assert_eq!(parse_scontrol(running), None);
+    }
 
     #[test]
     fn parses_sacct_terminal_lines() {

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -33,6 +33,13 @@ pub struct DriverConfig {
     pub poll_interval: Duration,
     /// Overall wall-clock budget; `None` = run until terminal states.
     pub poll_timeout: Option<Duration>,
+    /// How long a job must be in flight before the blind-settlement guard
+    /// starts counting (issue #244): accounting stores legitimately lag —
+    /// slurmdbd can take tens of seconds to surface a record — so the
+    /// guard must never race a slow-but-alive store. `UNKNOWN_SETTLE_
+    /// ROUNDS` consecutive blind rounds AFTER this grace settle the job
+    /// as Failed with an unknown exit code.
+    pub unknown_settle_grace: Duration,
 }
 
 impl Default for DriverConfig {
@@ -43,6 +50,7 @@ impl Default for DriverConfig {
             no_arrays: false,
             poll_interval: Duration::from_secs(5),
             poll_timeout: None,
+            unknown_settle_grace: Duration::from_secs(90),
         }
     }
 }
@@ -143,6 +151,14 @@ fn same_dependencies(a: &[String], b: &[String]) -> bool {
 /// to tell a full partition from a hung driver without drowning the log.
 const PENDING_HEARTBEAT_ROUNDS: u32 = 12;
 
+/// How many consecutive blind rounds (invisible to the live queue AND the
+/// accounting/terminal probes) a job may sit in before the driver settles
+/// it as Failed with an unknown exit code (issue #244). At the default 5s
+/// poll interval this is 3 minutes — long enough for a slow accounting
+/// store to catch up, short enough that a slurmdbd-less cluster cannot
+/// poll forever.
+const UNKNOWN_SETTLE_ROUNDS: u32 = 36;
+
 impl BackendDriver {
     pub fn new(backend: Arc<dyn ExecutorBackend>, config: DriverConfig) -> Self {
         Self { backend, config }
@@ -232,6 +248,9 @@ impl BackendDriver {
         // Consecutive polls each job has been seen waiting (PENDING, or not
         // yet reported by the scheduler) — drives the queue-wait heartbeat.
         let mut pending_rounds: HashMap<String, u32> = HashMap::new();
+        // Consecutive polls a job has been invisible to BOTH the live
+        // queue and the accounting/terminal probes (issue #244 guard).
+        let mut unknown_rounds: HashMap<String, u32> = HashMap::new();
 
         loop {
             // 1. Failure propagation: pending rules blocked by a failed dep.
@@ -729,6 +748,55 @@ impl BackendDriver {
                         Some(id),
                         Some(&format!("pending for {waited}s")),
                     );
+                }
+                // Terminal-unknown settlement guard (issue #244): a job
+                // gone from the live queue whose accounting store (and the
+                // scontrol fallback) yields NOTHING is otherwise polled
+                // forever — on a slurmdbd-less cluster the engine hung
+                // indefinitely (queue empty, sacct empty, zero progress).
+                // After UNKNOWN_SETTLE_ROUNDS consecutive blind rounds the
+                // job settles as Failed with exit code unavailable and a
+                // loud warning telling the operator to verify via output
+                // files. Never an infinite poll.
+                for (id, f) in inflight.iter() {
+                    let age = (now - f.submitted_at).to_std().unwrap_or_default();
+                    match statuses.get(id) {
+                        None | Some(BackendJobStatus::Unknown)
+                            if age >= self.config.unknown_settle_grace =>
+                        {
+                            *unknown_rounds.entry(id.clone()).or_insert(0) += 1;
+                        }
+                        _ => {
+                            unknown_rounds.remove(id);
+                        }
+                    }
+                }
+                let mut blind: Vec<String> = unknown_rounds
+                    .iter()
+                    .filter(|(_, r)| **r >= UNKNOWN_SETTLE_ROUNDS)
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                blind.sort();
+                for id in &blind {
+                    if let Some(f) = inflight.get(id) {
+                        tracing::warn!(
+                            rule = %f.rule,
+                            job = %id,
+                            blind_rounds = unknown_rounds.get(id).copied().unwrap_or(0),
+                            "job left the queue but no terminal state is available from the scheduler or accounting store — settling as FAILED with exit code unknown; verify via the rule's output files"
+                        );
+                        emit(
+                            &mut events,
+                            "FAILED",
+                            &f.rule,
+                            Some(id),
+                            Some(
+                                "terminal state unavailable (no accounting store?) — verify via output files",
+                            ),
+                        );
+                        statuses.insert(id.clone(), BackendJobStatus::Failed);
+                    }
+                    unknown_rounds.remove(id);
                 }
                 let settled: Vec<(String, InFlight, BackendJobStatus)> = inflight
                     .iter()
@@ -1263,6 +1331,7 @@ mod tests {
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(50),
                 poll_timeout: Some(std::time::Duration::from_secs(30)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         (d, executor)
@@ -1514,6 +1583,7 @@ mod tests {
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(50),
                 poll_timeout: None,
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let mut plan = chain_plan(fx.workdir.path(), &[("a", "true", "a.txt")]);
@@ -1911,6 +1981,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(20),
                 poll_timeout: Some(std::time::Duration::from_secs(30)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let records = tokio::runtime::Runtime::new()
@@ -1959,6 +2030,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(10),
                 poll_timeout: Some(std::time::Duration::from_secs(10)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let records = tokio::runtime::Runtime::new()
@@ -1987,6 +2059,46 @@ shell = "echo asm > out/{assembler}.txt"
                 );
             }
         }
+    }
+
+    #[test]
+    fn blind_unknown_jobs_settle_as_failed_instead_of_polling_forever() {
+        // Issue #244: on a cluster without slurmdbd the live queue empties,
+        // the accounting store knows nothing, and settlement polled
+        // forever. After UNKNOWN_SETTLE_ROUNDS blind rounds the driver
+        // settles the job as Failed with exit code unavailable.
+        let fx = setup();
+        let mut plan = priority_plan(fx.workdir.path(), &[("solo", 0)]);
+        let to_run: HashSet<String> = plan.order.iter().cloned().collect();
+        let backend = Arc::new(MockBackend::new(true, BackendJobStatus::Unknown));
+        let d = BackendDriver::new(
+            backend,
+            DriverConfig {
+                max_submitted: 1,
+                max_array_size: 0,
+                no_arrays: true,
+                poll_interval: std::time::Duration::from_millis(10),
+                poll_timeout: None, // NO timeout: only the guard ends this
+                unknown_settle_grace: std::time::Duration::from_millis(0),
+            },
+        );
+        let records = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(d.run(
+                &mut plan,
+                &to_run,
+                DriverOptions {
+                    run_dir: fx.run_dir.path(),
+                    on_checkpoint: None,
+                    merge: None,
+                    sensitive_values: &[],
+                    on_submit: None,
+                },
+            ))
+            .expect("the blind-settlement guard must end the run");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, JobStatus::Failed);
+        assert_eq!(records[0].exit_code, None, "exit code is unknown, not 0");
     }
 
     #[test]
@@ -2030,6 +2142,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(10),
                 poll_timeout: Some(std::time::Duration::from_millis(300)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let err = tokio::runtime::Runtime::new()
@@ -2084,6 +2197,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(20),
                 poll_timeout: Some(std::time::Duration::from_secs(30)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         tokio::runtime::Runtime::new()
@@ -2142,6 +2256,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(5),
                 poll_timeout: Some(std::time::Duration::from_millis(300)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let err = tokio::runtime::Runtime::new()
@@ -2195,6 +2310,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(5),
                 poll_timeout: Some(std::time::Duration::from_millis(200)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         tokio::runtime::Runtime::new()
@@ -2232,6 +2348,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(2),
                 poll_timeout: Some(std::time::Duration::from_millis(200)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         let err = tokio::runtime::Runtime::new()
@@ -2276,6 +2393,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(2),
                 poll_timeout: Some(std::time::Duration::from_millis(120)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         tokio::runtime::Runtime::new()
@@ -2346,6 +2464,7 @@ shell = "echo asm > out/{assembler}.txt"
                 no_arrays: false,
                 poll_interval: std::time::Duration::from_millis(10),
                 poll_timeout: Some(std::time::Duration::from_secs(30)),
+                unknown_settle_grace: std::time::Duration::from_secs(90),
             },
         );
         tokio::runtime::Runtime::new()

--- a/docs/guide/src/commands/cluster.md
+++ b/docs/guide/src/commands/cluster.md
@@ -175,6 +175,14 @@ SLURM prints the job's `sacct` record (`JobID|State|ExitCode|Elapsed|MaxRSS`);
 PBS/SGE/LSF are best-effort (`qstat -f` / `qacct` / `bacct`). Requires the
 scheduler's client commands on `PATH`.
 
+On SLURM clusters **without slurmdbd** (accounting storage disabled), `sacct`
+returns nothing — settlement falls back to `scontrol show job <id>`, which
+reads the controller's in-memory record (state + exit code; no Elapsed/RSS/
+CPU). A job that has left both the live queue and every probe for longer
+than the blind-settlement window settles as **failed with an unknown exit
+code** and a warning naming the rule — the run ends instead of polling
+forever, and the operator verifies via the rule's output files.
+
 ---
 
 ## Output

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -94,6 +94,7 @@ fn fast_driver_config() -> DriverConfig {
         no_arrays: false,
         poll_interval: std::time::Duration::from_millis(50),
         poll_timeout: Some(std::time::Duration::from_secs(30)),
+        unknown_settle_grace: std::time::Duration::from_secs(90),
     }
 }
 
@@ -257,6 +258,7 @@ fn local_run_and_backend_run_produce_same_checkpoint_semantics() {
             no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
+            unknown_settle_grace: std::time::Duration::from_secs(90),
         },
     )
     .unwrap();
@@ -370,6 +372,7 @@ fn dry_run_will_run_set_equals_driver_submitted_set() {
             no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
+            unknown_settle_grace: std::time::Duration::from_secs(90),
         },
     )
     .unwrap();
@@ -420,6 +423,7 @@ output = ["fail.done"]
             no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(1)),
+            unknown_settle_grace: std::time::Duration::from_secs(90),
         },
     )
     .unwrap_err();
@@ -606,6 +610,7 @@ fn driver_settles_jobs_that_vanish_from_the_live_queue_via_accounting() {
             no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
+            unknown_settle_grace: std::time::Duration::from_secs(90),
         },
         &[("MOCK_SQUEUE_HIDE_TERMINAL", "1")],
     )

--- a/tests/reentry_integration.rs
+++ b/tests/reentry_integration.rs
@@ -300,6 +300,7 @@ fn backend_driver_executes_reentry_rounds() {
             no_arrays: false,
             poll_interval: std::time::Duration::from_millis(50),
             poll_timeout: Some(std::time::Duration::from_secs(30)),
+            unknown_settle_grace: std::time::Duration::from_secs(90),
         },
     );
 


### PR DESCRIPTION
## Problem

SLURM 的 `terminal_status()` 只走 sacct（`logs()` 对 Slurm 硬编码 sacct；`parse_accounting` 解析不到就 None）。**无 slurmdbd 的集群**（`sacct: Slurm accounting storage is disabled`）上：作业消失后队列空 + sacct 空 → 结算永远不完成 → 引擎无限轮询（实测：队列空 00:56:59Z，01:10Z 仍在轮询，checkpoint 零写入）。

## Solution — 按 issue 的双层设计

1. **scontrol 回退**（cluster.rs）：sacct 落空后回退 `scontrol show job <id>` —— 无记账时控制器内存中仍短暂保留完成记录。新 `parse_scontrol` 把 JobState/ExitCode（含 `CANCELLED+(Reason)` 类后缀状态）映射为同一 TerminalRecord；Elapsed/RSS/CPU 按设计不可得。
2. **盲结算守卫**（driver.rs，四后端一致 —— PBS/SGE/LSF 同样覆盖）：作业对活动队列**和**所有终态探针都不可见，连续 `UNKNOWN_SETTLE_ROUNDS`（36 轮）且超过 `unknown_settle_grace`（默认 90s —— 记账库合法滞后，守卫绝不与慢而活的存储竞争）后，结算为 **FAILED + 退出码不可得** + 大字警告点名规则。绝不允许无限轮询。

## Tests

- `parse_scontrol` 单元测试：completed / failed / cancelled+reason / running-非终态
- driver 守卫测试：Unknown verdict + 空记账 → 结算 Failed + None 退出码，**未设 poll_timeout**（只有守卫能结束 run）
- mock 调度器回归（`driver_settles_jobs_that_vanish_from_the_live_queue_via_accounting`）在 grace 窗口下照常通过 —— 慢记账不会被守卫抢跑
- `make ci` 全绿

## Docs

- `cluster.md` 记账小节：scontrol 回退 + 盲结算语义

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)