### PR TITLE
feat(core,cli): wire [webhook] to the run path — workflow events (#227 item 1)

### DIFF
--- a/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
+++ b/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
@@ -878,6 +878,51 @@
           "null"
         ],
         "description": "Schema synced from config whitelist (see known_keys.rs)"
+      },
+      "webhook": {
+        "type": [
+          "string",
+          "array",
+          "object",
+          "boolean",
+          "number",
+          "integer",
+          "null"
+        ],
+        "description": "Schema synced from config whitelist (see known_keys.rs)"
+      }
+    },
+    "webhook": {
+      "type": "object",
+      "description": "Workflow-level webhook notifications (issue #227)",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "headers": {
+          "type": "object"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "signature_scheme": {
+          "type": "string"
+        },
+        "timeout_secs": {
+          "type": "integer"
+        },
+        "max_retries": {
+          "type": "integer"
+        }
       }
     }
   },

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1022,6 +1022,12 @@ pub async fn run_command(
         workflow_name: config.workflow.name.clone(),
         total_rules: order.len(),
     });
+    notify_webhook(
+        &config,
+        oxo_flow_core::webhook::WebhookEvent::WorkflowStarted,
+        None,
+    )
+    .await;
     eprintln!(
         "{} {} rules in execution order",
         "DAG:".bold().green(),
@@ -1464,6 +1470,16 @@ pub async fn run_command(
             // report time, not the live checkpoint — empty here.
             vec![],
         );
+        notify_webhook(
+            &config,
+            if summary.is_success() {
+                oxo_flow_core::webhook::WebhookEvent::WorkflowCompleted
+            } else {
+                oxo_flow_core::webhook::WebhookEvent::WorkflowFailed
+            },
+            Some((summary.succeeded, summary.failed, summary.skipped)),
+        )
+        .await;
         if !summary.is_success() {
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
@@ -3079,6 +3095,16 @@ pub async fn run_command(
                 skipped_count.load(std::sync::atomic::Ordering::Relaxed),
             )
             .await;
+            notify_webhook(
+                &config,
+                oxo_flow_core::webhook::WebhookEvent::WorkflowFailed,
+                Some((
+                    success_count.load(std::sync::atomic::Ordering::Relaxed),
+                    fail_count.load(std::sync::atomic::Ordering::Relaxed),
+                    skipped_count.load(std::sync::atomic::Ordering::Relaxed),
+                )),
+            )
+            .await;
             return Err(anyhow::anyhow!("workflow execution failed"));
         }
 
@@ -3250,13 +3276,24 @@ pub async fn run_command(
     }
 
     // Workflow-level terminal hooks (issue #227 item 1): on_complete /
-    // on_error fire on every terminal path of the run loop.
+    // on_error fire on every terminal path of the run loop, and the
+    // configured `[webhook]` endpoint receives the matching event.
     run_terminal_hook(
         &config,
         &workdir_actual,
         success_count,
         fail_count,
         skipped_count,
+    )
+    .await;
+    notify_webhook(
+        &config,
+        if fail_count > 0 {
+            oxo_flow_core::webhook::WebhookEvent::WorkflowFailed
+        } else {
+            oxo_flow_core::webhook::WebhookEvent::WorkflowCompleted
+        },
+        Some((success_count, fail_count, skipped_count)),
     )
     .await;
 
@@ -3566,6 +3603,47 @@ async fn run_terminal_hook(
         config.defaults.shell_prelude.as_deref(),
     )
     .await;
+}
+
+/// Workflow-level webhook notification (issue #227 item 1): posts the
+/// `workflow_started` / `workflow_completed` / `workflow_failed` event to
+/// the `[webhook]` endpoint. Best-effort by design — a failing endpoint
+/// logs a warning and never changes the run status. Awaited (not spawned)
+/// so the process cannot exit before the request lands; the client's own
+/// timeout bounds the wait.
+async fn notify_webhook(
+    config: &WorkflowConfig,
+    event: oxo_flow_core::webhook::WebhookEvent,
+    counts: Option<(usize, usize, usize)>,
+) {
+    let Some(ref webhook) = config.webhook else {
+        return;
+    };
+    let (succeeded, failed, skipped) = counts.unwrap_or_default();
+    let payload = oxo_flow_core::webhook::WebhookPayload {
+        event,
+        workflow_name: config.workflow.name.clone(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        data: oxo_flow_core::webhook::WebhookData {
+            total_rules: None,
+            succeeded: Some(succeeded),
+            failed: Some(failed),
+            skipped: Some(skipped),
+            duration_ms: None,
+            rule: None,
+            exit_code: None,
+            error: if failed > 0 {
+                Some(format!("{failed} rule(s) failed"))
+            } else {
+                None
+            },
+        },
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let client = oxo_flow_core::webhook::WebhookClient::new(webhook.clone());
+    if let Err(e) = client.send(&payload).await {
+        tracing::warn!(error = %e, event = %event, "webhook notification failed (run continues)");
+    }
 }
 
 /// Terminal run counters shared by the `--json` summary and the workflow

--- a/crates/oxo-flow-core/src/config/known_keys.rs
+++ b/crates/oxo-flow-core/src/config/known_keys.rs
@@ -40,6 +40,7 @@ const TOP_LEVEL_KEYS: &[&str] = &[
     "rules",
     "sample_groups",
     "values",
+    "webhook",
     "wildcard_constraints",
     "workflow",
 ];
@@ -129,6 +130,19 @@ const EXECUTION_GROUP_KEYS: &[&str] = &["mode", "name", "rules"];
 
 /// Keys of the `[citation]` table.
 const CITATION_KEYS: &[&str] = &["authors", "doi", "title", "url"];
+
+/// Keys of the `[webhook]` table (issue #227 item 1) — mirrors
+/// `crate::webhook::WebhookConfig`.
+const WEBHOOK_KEYS: &[&str] = &[
+    "events",
+    "headers",
+    "max_retries",
+    "method",
+    "secret",
+    "signature_scheme",
+    "timeout_secs",
+    "url",
+];
 
 /// Keys of the `[cluster]` table.
 const CLUSTER_KEYS: &[&str] = &[
@@ -398,6 +412,7 @@ fn nested_table(key: &str) -> Option<&'static [&'static str]> {
         "scatter" => Some(SCATTER_KEYS),
         "split" => Some(SPLIT_KEYS),
         "transform" => Some(TRANSFORM_KEYS),
+        "webhook" => Some(WEBHOOK_KEYS),
         "workflow" => Some(WORKFLOW_KEYS),
         _ => None,
     }

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -1676,6 +1676,14 @@ pub struct WorkflowConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub citation: Option<CitationInfo>,
 
+    /// Workflow-level webhook notifications (issue #227 item 1): the run
+    /// path posts `workflow_started` / `workflow_completed` /
+    /// `workflow_failed` events to the configured endpoint. Best-effort —
+    /// a failing endpoint never fails the run.
+    #[serde(default, rename = "webhook")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook: Option<crate::webhook::WebhookConfig>,
+
     /// Cluster execution profile.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -1576,6 +1576,51 @@ fn workflow_meta_hooks_parse() {
 }
 
 #[test]
+fn webhook_section_parses_and_defaults() {
+    // Issue #227 item 1: the `[webhook]` section reaches WorkflowConfig —
+    // the previously dead surface. Partial sections take the serde
+    // defaults (POST, [workflow_completed], 30s timeout, 3 retries).
+    let toml = r#"
+        [workflow]
+        name = "test"
+        version = "1.0.0"
+
+        [webhook]
+        url = "https://hooks.example.com/oxo"
+
+        [[rules]]
+        name = "step1"
+        shell = "echo hi"
+    "#;
+    let config = WorkflowConfig::parse(toml).unwrap();
+    let webhook = config.webhook.as_ref().expect("[webhook] parses");
+    assert_eq!(webhook.url, "https://hooks.example.com/oxo");
+    assert_eq!(
+        webhook.events,
+        vec![crate::webhook::WebhookEvent::WorkflowCompleted]
+    );
+    assert_eq!(webhook.max_retries, 3);
+    assert_eq!(webhook.timeout_secs, 30);
+
+    // Event selection parses.
+    let full = toml.replace(
+        "url = \"https://hooks.example.com/oxo\"",
+        "url = \"https://hooks.example.com/oxo\"\n        events = [\"workflow_started\", \"workflow_completed\", \"workflow_failed\"]\n        secret = \"hunter2\"",
+    );
+    let config = WorkflowConfig::parse(&full).unwrap();
+    let webhook = config.webhook.as_ref().unwrap();
+    assert_eq!(webhook.events.len(), 3);
+    assert_eq!(webhook.secret.as_deref(), Some("hunter2"));
+
+    // A workflow without [webhook] stays None.
+    let plain = WorkflowConfig::parse(
+        "[workflow]\nname = \"t\"\n\n[[rules]]\nname = \"s\"\nshell = \"echo hi\"\n",
+    )
+    .unwrap();
+    assert!(plain.webhook.is_none());
+}
+
+#[test]
 fn override_samples_replaces_inline_samples() {
     // `--samples` explicit names replace inline [[sample_groups]] fixture
     // names instead of filtering them — the fix for "inline samples can't

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -54,6 +54,7 @@ Workflow files must use the `.oxoflow` extension (e.g., `qc_pipeline.oxoflow`).
 [[reference_db]]    # Optional: tracked reference database versions
 [citation]          # Optional: citation metadata (DOI, authors, etc.)
 [plugins]           # Optional: plugin configuration
+[webhook]           # Optional: workflow-level webhook notifications (issue #227)
 ```
 
 ---
@@ -2397,6 +2398,41 @@ Semantics:
 - Checkpoints persist the discovered domain (`output_pattern_domains`), so
   a `resume` re-instantiates the consumers **without re-running the
   producer**; re-instantiation is idempotent (same names, same plan).
+
+## `[webhook]` — Workflow-Level Notifications
+
+Post `workflow_started` / `workflow_completed` / `workflow_failed` events
+to an HTTP endpoint when a run starts and finishes (issue #227 item 1) —
+the transport counterpart of the `on_complete` / `on_error` shell hooks.
+
+```toml
+[webhook]
+url = "https://hooks.example.com/oxo"
+# method = "POST"                  # POST (default) | PUT | GET
+# events = ["workflow_completed", "workflow_failed"]  # default: workflow_completed
+# headers = { Authorization = "Bearer …" }
+# secret = "…HMAC key…"            # X-OxoFlow-Signature header (HMAC-SHA256)
+# signature_scheme = "hmac-sha256"
+# timeout_secs = 30
+# max_retries = 3
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `url` | String | **Yes** | Webhook endpoint URL |
+| `method` | String | `POST` | HTTP method (`POST`/`PUT`/`GET`) |
+| `events` | Array of String | `["workflow_completed"]` | Which events fire: `workflow_started`, `workflow_completed`, `workflow_failed`, `rule_completed`, `rule_failed` |
+| `headers` | Table | `{}` | Custom request headers |
+| `secret` | String | — | HMAC key for the `X-OxoFlow-Signature` header |
+| `signature_scheme` | String | `hmac-sha256` | `hmac-sha256` (RFC 2104) or the legacy `sha256-keyed` |
+| `timeout_secs` | Integer | `30` | Per-request timeout |
+| `max_retries` | Integer | `3` | Retries with exponential backoff |
+
+The payload is JSON: `{event, workflow_name, timestamp, data, version}`
+where `data` carries the run counters (`succeeded`, `failed`, `skipped`)
+and, on failure, an `error` summary. Notifications are **best-effort** —
+an unreachable or erroring endpoint logs a warning and never changes the
+run status or its exit code.
 
 ## See Also
 

--- a/docs/schema/oxoflow-v1.schema.json
+++ b/docs/schema/oxoflow-v1.schema.json
@@ -878,6 +878,51 @@
           "null"
         ],
         "description": "Schema synced from config whitelist (see known_keys.rs)"
+      },
+      "webhook": {
+        "type": [
+          "string",
+          "array",
+          "object",
+          "boolean",
+          "number",
+          "integer",
+          "null"
+        ],
+        "description": "Schema synced from config whitelist (see known_keys.rs)"
+      }
+    },
+    "webhook": {
+      "type": "object",
+      "description": "Workflow-level webhook notifications (issue #227)",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "headers": {
+          "type": "object"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "signature_scheme": {
+          "type": "string"
+        },
+        "timeout_secs": {
+          "type": "integer"
+        },
+        "max_retries": {
+          "type": "integer"
+        }
       }
     }
   },

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -9499,3 +9499,74 @@ shell = "cat {input} > {output}"
         "must report the skipped target, got: {stderr}"
     );
 }
+
+// ─── Workflow webhook notifications (issue #227 item 1) ─────────────────────
+
+/// A `[webhook]` endpoint receives workflow events — and an unreachable
+/// endpoint must never fail the run (best-effort by design).
+#[test]
+fn cli_webhook_is_best_effort_on_run_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = dir.path().join("hook.oxoflow");
+    fs::write(
+        &wf,
+        r#"[workflow]
+name = "hook"
+version = "1.0.0"
+
+[webhook]
+url = "http://127.0.0.1:9/no-such-endpoint"
+timeout_secs = 1
+max_retries = 0
+
+[[rules]]
+name = "gen"
+output = ["out.txt"]
+shell = "echo hi > {output}"
+"#,
+    )
+    .unwrap();
+
+    // Success path: the run completes even though every webhook call dies.
+    let out = oxo_flow_cmd()
+        .args(["run", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "an unreachable webhook must never fail the run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(dir.path().join("out.txt").exists());
+
+    // Failure path: same contract.
+    let wf2 = dir.path().join("fail.oxoflow");
+    fs::write(
+        &wf2,
+        r#"[workflow]
+name = "hook2"
+version = "1.0.0"
+
+[webhook]
+url = "http://127.0.0.1:9/no-such-endpoint"
+timeout_secs = 1
+max_retries = 0
+
+[[rules]]
+name = "boom"
+output = ["never.txt"]
+shell = "exit 3"
+"#,
+    )
+    .unwrap();
+    let out = oxo_flow_cmd()
+        .args(["run", wf2.to_str().unwrap()])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "the failing rule must still fail the run"
+    );
+}


### PR DESCRIPTION
## Problem（#227 item 1 的残留）

`WebhookClient`（HMAC 签名、重试、退避 —— #67 §4 已建成）存在于引擎，但 **CLI run 路径从未调用它** —— #227 明确指出这是 dead surface。引擎侧其余部分（`on_complete`/`on_error` shell hooks、metadata 绑定、input_groups、`group_by = meta.*`、output_pattern）均已落地；缺的就是通知传输。

## Solution — [webhook] 接入 run 路径

- `WorkflowConfig.webhook: Option<WebhookConfig>`（`[webhook]` 节；known_keys 白名单 + schema 双份登记，E017 与 drift 门同步）
- run 路径发布事件：`workflow_started`（DAG 计算后）、`workflow_completed` / `workflow_failed`（run loop 两条终态路径 + cluster 路径），载荷带 run 计数
- **尽力而为**：不可达端点仅记 warning，绝不改变 run 状态或退出码 —— 集成测试在成功/失败两条路径用死端点钉死该契约

## Tests

- config 解析测试：section + serde 默认值 + events 选择 + 无 section 为 None
- 尽力而为集成测试：不可达端点下成功 run 与失败 run 状态均正确
- `make ci` 全绿（schema drift 门同步通过）

## Docs

- workflow-format 新增 `[webhook]` 小节（字段表、载荷形态、best-effort 契约）

Part of #227（item 1 的 transport 部分；items 2-5 的引擎支持此前已落地）

🤖 Generated with [Claude Code](https://claude.com/claude-code)