### PR TITLE
feat(core): [[values]] values_from — config-driven fan-out dimensions

### DIFF
--- a/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
+++ b/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
@@ -379,6 +379,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "values_from": {
+            "type": "string",
+            "description": "Config-driven value list (comma string or array key) — resolves the fan-out at expansion time, CLI --arg / profile driven"
           }
         }
       }

--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -321,11 +321,23 @@ impl WorkflowConfig {
                     suggestion: None,
                 });
             }
-            if table.values.is_empty() {
+            let effective_len = match &table.values_from {
+                Some(from) => self.resolve_config_list(from).map(|v| v.len()).unwrap_or(0),
+                None => table.values.len(),
+            };
+            if effective_len == 0 {
+                let hint = if table.values_from.is_some() {
+                    format!(
+                        "values_from '{}' resolved to no values — check the config key exists and is non-empty",
+                        table.values_from.as_deref().unwrap_or("")
+                    )
+                } else {
+                    "add at least one value, or remove the table".to_string()
+                };
                 return Err(OxoFlowError::Validation {
-                    message: format!("[[values]] table '{}' has no values", table.name),
+                    message: format!("[[values]] table '{}' has no values: {hint}", table.name),
                     rule: None,
-                    suggestion: Some("add at least one value, or remove the table".to_string()),
+                    suggestion: Some(hint),
                 });
             }
             if RESERVED_VALUE_NAMES.contains(&table.name.as_str()) {
@@ -677,9 +689,28 @@ impl WorkflowConfig {
             let mut value_combos: Vec<crate::wildcard::WildcardValues> =
                 vec![crate::wildcard::WildcardValues::new()];
             for table in &active_value_tables {
-                let mut next = Vec::with_capacity(value_combos.len() * table.values.len());
+                // values_from resolves the fan-out from a config key at
+                // expansion time (issue #18 wave) — CLI --arg / profile
+                // driven dimensions. Falls back to the static `values`.
+                let effective: Vec<String> = match &table.values_from {
+                    Some(from) => {
+                        self.resolve_config_list(from)
+                            .ok_or_else(|| OxoFlowError::Validation {
+                                message: format!(
+                                    "[[values]] table '{}' values_from '{}' cannot be resolved",
+                                    table.name, from
+                                ),
+                                rule: None,
+                                suggestion: Some(format!(
+                                    "define '{from}' in [config] as a comma string or array"
+                                )),
+                            })?
+                    }
+                    None => table.values.clone(),
+                };
+                let mut next = Vec::with_capacity(value_combos.len() * effective.len());
                 for combo in &value_combos {
-                    for value in &table.values {
+                    for value in &effective {
                         let mut c = combo.clone();
                         c.insert(table.name.clone(), value.clone());
                         next.push(c);

--- a/crates/oxo-flow-core/src/config/known_keys.rs
+++ b/crates/oxo-flow-core/src/config/known_keys.rs
@@ -207,7 +207,7 @@ const PAIR_KEYS: &[&str] = &[
 const SAMPLE_GROUP_KEYS: &[&str] = &["metadata", "name", "samples"];
 
 /// Keys of one `[[values]]` entry.
-const VALUE_KEYS: &[&str] = &["name", "values"];
+const VALUE_KEYS: &[&str] = &["name", "values", "values_from"];
 
 /// Keys of the `[plugins]` table.
 const PLUGINS_KEYS: &[&str] = &["executor", "reports", "rules", "trusted_keys_file"];

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -1186,6 +1186,17 @@ pub struct ValueGroup {
     /// The values to fan out, e.g. `["spades", "megahit"]`.
     #[serde(default)]
     pub values: Vec<String>,
+
+    /// Config-driven value list (issue #18 wave): `values_from = "config.x"`
+    /// resolves the fan-out from a config key at expansion time — a string
+    /// splits on commas (`"u1,u2"` → `["u1", "u2"]`), an array is used
+    /// verbatim (the same semantics as `transform.split.values_from` and
+    /// `expand_inputs.variables` config references). CLI `--arg x=u1,u2`
+    /// or a profile then drives the fan-out without editing the workflow.
+    /// Takes precedence over `values` when both are set; a missing key is a
+    /// validation error naming the key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub values_from: Option<String>,
 }
 
 /// Instance-name suffix for a `[[values]]` combo: one `_name_value` segment

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -4544,6 +4544,64 @@ fn values_workflow(tables: &str, rules: &str) -> String {
 }
 
 #[test]
+fn values_from_resolves_fan_out_from_config() {
+    // values_from resolves the fan-out from a config key at expansion time
+    // (issue #18 wave) — CLI --arg / profile driven dimensions.
+    let toml = values_workflow(
+        r#"
+        [config]
+        library_ids = "u1,u2"
+
+        [[values]]
+        name = "assembler"
+        values_from = "config.library_ids"
+        "#,
+        r#"
+        [[rules]]
+        name = "assemble"
+        input = ["reads/{assembler}/in.fq"]
+        output = ["contigs/{assembler}/out.fa"]
+        shell = "{assembler} -o {output[0]} {input[0]}"
+        "#,
+    );
+    let mut config = WorkflowConfig::parse(&toml).unwrap();
+    config.expand_wildcards().unwrap();
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["assemble_assembler_u1", "assemble_assembler_u2"]
+    );
+
+    // Static values take a back seat to values_from.
+    let toml = toml.replace(
+        "values_from = \"config.library_ids\"",
+        "values_from = \"config.library_ids\"\n        values = [\"ignored\"]",
+    );
+    let mut config = WorkflowConfig::parse(&toml).unwrap();
+    config.expand_wildcards().unwrap();
+    assert_eq!(config.rules.len(), 2);
+
+    // A missing/unresolvable key fails validation with the key named.
+    let bad = values_workflow(
+        r#"
+        [[values]]
+        name = "assembler"
+        values_from = "config.missing_key"
+        "#,
+        r#"
+        [[rules]]
+        name = "assemble"
+        input = ["reads/{assembler}/in.fq"]
+        output = ["contigs/{assembler}/out.fa"]
+        shell = "{assembler} -o {output[0]} {input[0]}"
+        "#,
+    );
+    let mut config = WorkflowConfig::parse(&bad).unwrap();
+    let err = config.expand_wildcards().unwrap_err().to_string();
+    assert!(err.contains("missing_key"), "{err}");
+}
+
+#[test]
 fn values_single_table_fans_out_rule() {
     let toml = values_workflow(
         r#"

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1510,6 +1510,11 @@ shell = "{assembler} -o {output} {input}"
 
 - Every rule referencing `{assembler}` (bare form) or `{values.assembler}`
   (namespaced form) expands into one instance per value.
+- `values_from = "config.x"` resolves the value list from a config key at
+  expansion time — a comma string (`"u1,u2"`) or array, the same semantics
+  as `expand_inputs` config references. CLI `--arg x=u1,u2` or a profile
+  then drives the fan-out without editing the workflow; takes precedence
+  over a static `values` when both are set.
 - Multiple `[[values]]` tables form a cartesian product with each other
   and with sample groups / pairs (deterministic order: the first table
   varies slowest).

--- a/docs/schema/oxoflow-v1.schema.json
+++ b/docs/schema/oxoflow-v1.schema.json
@@ -379,6 +379,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "values_from": {
+            "type": "string",
+            "description": "Config-driven value list (comma string or array key) — resolves the fan-out at expansion time, CLI --arg / profile driven"
           }
         }
       }


### PR DESCRIPTION
## Summary

`[[values]]` 表新增 `values_from = "config.x"`：扇出值列表在展开期从 config 键解析（逗号串或数组 —— 与 expand_inputs variables / transform.split.values_from 相同的 resolve_config_list 语义）。CLI `--arg x=u1,u2` 或 profile 即可驱动扇出，无需改 workflow；与静态 `values` 并存时优先；键不可解析时验证失败并点名键。

## Motivation

snparcher #18 / chipseq #7 多文库移植（audit 方案 B）：`{library}` 扇出维需跟随 `config.library_ids`。默认 `"u1"` 字节级零变化（dry-run 对比：75/31/44 实例完全一致），多文库 cohort 只改配置。

## Test

- 单测：扇出跟随 config 列表、优先于静态 values、missing-key 报错点名
- snparcher live：默认 dry-run 75/31/44 一致；`library_ids=u1,u2` → 87/43/44，bwa_mem_library_u{1,2}_cohort_sample{1,2,3} 实例化 ✓；默认真跑 exit 0 / 40 outputs verified
- schema + known_keys 同步（drift 门全绿）；`make ci` 全绿

## Docs

workflow-format `[[values]]` 小节新增 values_from 说明。

Part of the multi-library wave.