### PR TITLE
feat(core): [defaults] time_limit — default wall-time for every rule

### DIFF
--- a/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
+++ b/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
@@ -241,6 +241,10 @@
             "null"
           ],
           "description": "Schema synced from config whitelist (see known_keys.rs)"
+        },
+        "time_limit": {
+          "type": "string",
+          "description": "Default wall-time limit (e.g. 48h) applied to every rule whose resources.time_limit is unset"
         }
       }
     },

--- a/crates/oxo-flow-core/src/config/known_keys.rs
+++ b/crates/oxo-flow-core/src/config/known_keys.rs
@@ -108,7 +108,13 @@ const WORKFLOW_KEYS: &[&str] = &[
 ];
 
 /// Keys of the `[defaults]` table.
-const DEFAULTS_KEYS: &[&str] = &["environment", "memory", "shell_prelude", "threads"];
+const DEFAULTS_KEYS: &[&str] = &[
+    "environment",
+    "memory",
+    "shell_prelude",
+    "threads",
+    "time_limit",
+];
 
 /// Keys of the `[report]` table.
 const REPORT_KEYS: &[&str] = &["format", "sections", "template"];

--- a/crates/oxo-flow-core/src/config/model.rs
+++ b/crates/oxo-flow-core/src/config/model.rs
@@ -70,7 +70,7 @@ pub(crate) fn pair_when_unknown_config_keys<'a>(
 }
 
 pub(crate) fn is_defaults_empty(d: &Defaults) -> bool {
-    d.threads.is_none() && d.memory.is_none() && d.environment.is_none()
+    d.threads.is_none() && d.memory.is_none() && d.environment.is_none() && d.time_limit.is_none()
 }
 
 /// Maximum depth for nested include directives to prevent infinite recursion.
@@ -356,6 +356,15 @@ pub struct Defaults {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_prelude: Option<String>,
+
+    /// Default wall-time limit (e.g. `"48h"`) applied to every rule whose
+    /// `resources.time_limit` is unset — the cluster-pathSBATCH `-t` value.
+    /// Catalog repos declared it here historically (eager, auto-sra); the
+    /// E017 whitelist previously rejected the key, so this makes the
+    /// documented intent real (catalog sweep 2026-08-29).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_limit: Option<String>,
 }
 
 /// Prepend a shell prelude to a command on its own line (issue #92).

--- a/crates/oxo-flow-core/src/config/parse.rs
+++ b/crates/oxo-flow-core/src/config/parse.rs
@@ -699,6 +699,14 @@ impl WorkflowConfig {
             {
                 rule.environment = env.clone();
             }
+            // Apply default wall-time limit when the rule's resources don't
+            // declare one (catalog sweep 2026-08-29: eager/auto-sra declared
+            // defaults.time_limit historically; the key now actually works).
+            if rule.resources.time_limit.is_none()
+                && let Some(ref tl) = self.defaults.time_limit
+            {
+                rule.resources.time_limit = Some(tl.clone());
+            }
         }
     }
 

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -156,6 +156,43 @@ fn apply_defaults_propagates() {
 }
 
 #[test]
+fn apply_defaults_time_limit_flows_into_resources() {
+    // defaults.time_limit fills every rule's resources.time_limit when the
+    // rule doesn't declare one (catalog sweep 2026-08-29: eager/auto-sra
+    // declared this key historically; the E017 whitelist used to reject it).
+    let toml_str = r#"
+        [workflow]
+        name = "test"
+
+        [defaults]
+        time_limit = "48h"
+
+        [[rules]]
+        name = "step1"
+        shell = "echo hello"
+
+        [[rules]]
+        name = "step2"
+        shell = "echo world"
+
+        [rules.resources]
+        time_limit = "4h"
+    "#;
+
+    let mut config = WorkflowConfig::parse(toml_str).unwrap();
+    config.apply_defaults();
+
+    let step1 = config.get_rule("step1").unwrap();
+    assert_eq!(step1.resources.time_limit.as_deref(), Some("48h"));
+    let step2 = config.get_rule("step2").unwrap();
+    assert_eq!(
+        step2.resources.time_limit.as_deref(),
+        Some("4h"),
+        "rule-level resources.time_limit wins over the default"
+    );
+}
+
+#[test]
 fn apply_defaults_respects_resources_field() {
     // resources.threads / resources.memory (non-deprecated style) must
     // take precedence over [defaults]. A rule that declares only

--- a/docs/schema/oxoflow-v1.schema.json
+++ b/docs/schema/oxoflow-v1.schema.json
@@ -241,6 +241,10 @@
             "null"
           ],
           "description": "Schema synced from config whitelist (see known_keys.rs)"
+        },
+        "time_limit": {
+          "type": "string",
+          "description": "Default wall-time limit (e.g. 48h) applied to every rule whose resources.time_limit is unset"
         }
       }
     },


### PR DESCRIPTION
## Summary

24-workflow catalog sweep（对照当前引擎逐仓 validate）发现：eager 与 auto-sra-rnaseq-pipeline 历史上声明了 `defaults.time_limit`，但 E017 白名单拒绝该键 —— 文档意图静默失效。本 PR 使其生效：

- `Defaults` 新增 `time_limit`；`apply_defaults` 在规则未声明时填充 `resources.time_limit`（规则级优先）
- known_keys + schema 同步
- 测试：流入未声明规则、规则级覆盖优先

## Test

- 单测 3 项（apply_defaults 组）全绿
- `make ci` 全绿（含 schema drift 门）

Catalog sweep 后续修复（sample_group_name 清理、E005 面等）另行推进。