### PR TITLE
perf(core): shared subtree walk in rss sampler; view-based freshness checksums (#268 item 4)

### DIFF
--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1310,8 +1310,32 @@ impl LocalExecutor {
         // cached upload stage is not proof the cloud still has the file.
         // Recorded provenance checksums tighten the gate (issue #194 B2):
         // content identity wins over mtime when digests are available.
-        let freshness_checksums = match &self.config.checkpoint {
-            Some(ck) => Some(ck.lock().await.checksums.clone()),
+        // The map is only ever queried (`contains_key`/`get` on the few
+        // expanded outputs), so we clone just those lookups' worth of data
+        // instead of deep-copying every recorded checksum per rule (#268
+        // item 4). Consistency across the handful of queries below is all
+        // that matters, and the small view is enough.
+        let freshness_checksums: Option<HashMap<String, String>> = match &self.config.checkpoint {
+            Some(ck) => {
+                let guard = ck.lock().await;
+                let expanded: Vec<String> = rule
+                    .output
+                    .iter()
+                    .map(|o| super::checkpoint::expand_config_in_path(o, wildcard_values))
+                    .collect();
+                if expanded.iter().all(|o| guard.checksums.contains_key(o)) {
+                    Some(
+                        expanded
+                            .iter()
+                            .filter_map(|o| guard.checksums.get(o).map(|v| (o.clone(), v.clone())))
+                            .collect(),
+                    )
+                } else {
+                    // Not every output has a recorded hash — the gate
+                    // degrades to the mtime path either way.
+                    None
+                }
+            }
             None => None,
         };
         if !self.config.force_rerun

--- a/crates/oxo-flow-core/src/executor/rss.rs
+++ b/crates/oxo-flow-core/src/executor/rss.rs
@@ -115,6 +115,21 @@ impl RssSampler {
                                 guard.iter().map(|(pid, tp)| (*pid, tp.clone())).collect()
                             };
                             system.refresh_processes(ProcessesToUpdate::All, true);
+                            // One shared parent→children map per tick (built
+                            // once, O(P)), plus one shared subtree walk per
+                            // root. The old shape called `subtree_rss_bytes`
+                            // per tracked child, each re-scanning the whole
+                            // process table in a fixpoint loop —
+                            // O(ticks × rules × passes × P) (#268 item 4).
+                            let mut children_of: HashMap<u32, Vec<u32>> = HashMap::new();
+                            for (pid, proc) in system.processes() {
+                                if let Some(parent) = proc.parent() {
+                                    children_of
+                                        .entry(parent.as_u32())
+                                        .or_default()
+                                        .push(pid.as_u32());
+                                }
+                            }
                             for (pid, tp) in &snapshot {
                                 // CPU accumulates only while the process is
                                 // alive: a dead-but-retained entry or a
@@ -143,8 +158,10 @@ impl RssSampler {
                                     tp.cpu_micros.fetch_add(micros, Ordering::SeqCst);
                                     tp.seen.store(true, Ordering::SeqCst);
                                 }
-                                tp.peak
-                                    .fetch_max(subtree_rss_bytes(&system, *pid), Ordering::Relaxed);
+                                tp.peak.fetch_max(
+                                    subtree_rss_bytes(&children_of, &system, *pid),
+                                    Ordering::Relaxed,
+                                );
                             }
                         }
                     });
@@ -237,32 +254,32 @@ impl Drop for RssHandle {
 }
 
 /// Summed RSS (bytes) of `root` and all its live descendants.
-fn subtree_rss_bytes(system: &sysinfo::System, root: u32) -> u64 {
-    let mut targets = vec![root];
-    // Expand outward: anything whose parent is already in the set.
-    loop {
-        let mut found = false;
-        for (child_pid, proc) in system.processes() {
-            let child = child_pid.as_u32();
-            if targets.contains(&child) {
-                continue;
-            }
-            if let Some(parent) = proc.parent()
-                && targets.contains(&parent.as_u32())
-            {
-                targets.push(child);
-                found = true;
-            }
+///
+/// `children_of` is the parent→children map over the CURRENT process table,
+/// built once per tick by the caller and shared by every tracked root: the
+/// walk is then O(subtree) instead of a full-table fixpoint per rule.
+fn subtree_rss_bytes(
+    children_of: &HashMap<u32, Vec<u32>>,
+    system: &sysinfo::System,
+    root: u32,
+) -> u64 {
+    // Iterate the descendant closure over an explicit stack (a recursive
+    // visit would need the same map anyway).
+    let mut total = 0u64;
+    let mut stack = vec![root];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(pid) = stack.pop() {
+        if !visited.insert(pid) {
+            continue;
         }
-        if !found {
-            break;
+        if let Some(proc) = system.process(sysinfo::Pid::from_u32(pid)) {
+            total += proc.memory();
+        }
+        if let Some(children) = children_of.get(&pid) {
+            stack.extend_from_slice(children);
         }
     }
-    targets
-        .iter()
-        .filter_map(|pid| system.process(sysinfo::Pid::from_u32(*pid)))
-        .map(|p| p.memory())
-        .sum()
+    total
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes the two remaining #268 item 4 (PERF) findings after #272's config_values hoist.

### 1. rss.rs — subtree rescan per tracked pid per tick

The sampler called `subtree_rss_bytes` **per tracked child, per tick**; each call ran a parent-closure fixpoint over the **whole process table** with O(P) `Vec::contains` scans per pass → O(ticks × rules × passes × P). With 8 concurrent rules on a busy box (hundreds of processes) this was the engine's main background CPU consumer.

Now: one parent→children `HashMap` is built per tick (single O(P) pass) and shared by every tracked root; each walk is a visited-set-bounded stack descent — O(subtree).

### 2. process.rs — freshness gate clones the whole checksum map per rule

`ck.lock().await.checksums.clone()` deep-copied every recorded output checksum for every executed rule, but the gate only does `contains_key`/`get` on that rule's few expanded outputs. It now extracts a small view (only the expanded outputs' entries) under the same lock hold. When any output lacks a recorded hash, `None` short-circuits to the mtime path exactly as before — same verdicts.

## Test plan

- `cargo test -p oxo-flow-core --lib` → 1301 passed, 0 failed (includes `sampler_tracks_child_subtree_peak` and the checksum-freshness tests)
- `cargo clippy -p oxo-flow-core --all-targets` → clean
- `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)