### PR TITLE
perf(web): move synchronous file I/O off the async runtime (#268 item 4, web minor)

### DIFF
--- a/crates/oxo-flow-web/src/domains/ai/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/ai/handlers.rs
@@ -186,21 +186,26 @@ pub async fn explain(
             .unwrap_or(None);
 
         if let Some(run) = run {
-            // Node status comes from the engine's checkpoint state.
-            let node_items = crate::domains::execution::checkpoint_status::load_node_statuses(
-                std::path::Path::new(run.workdir.as_deref().unwrap_or("")),
-                run.status == "running",
-            );
-
-            let log = run
-                .workdir
-                .as_ref()
-                .and_then(|wd| std::fs::read_to_string(format!("{wd}/execution.log")).ok())
-                .unwrap_or_default();
-
-            let benchmarks = crate::domains::execution::checkpoint_status::load_benchmarks(
-                std::path::Path::new(run.workdir.as_deref().unwrap_or("")),
-            );
+            // Node status comes from the engine's checkpoint state. The
+            // checkpoint/log reads are synchronous file I/O — run the
+            // combined block on the blocking pool (#268 item 4, web minor).
+            let workdir = run.workdir.clone();
+            let running = run.status == "running";
+            let (node_items, log, benchmarks) = tokio::task::spawn_blocking(move || {
+                let wd = workdir.as_deref().unwrap_or("");
+                let node_items = crate::domains::execution::checkpoint_status::load_node_statuses(
+                    std::path::Path::new(wd),
+                    running,
+                );
+                let log =
+                    std::fs::read_to_string(format!("{wd}/execution.log")).unwrap_or_default();
+                let benchmarks = crate::domains::execution::checkpoint_status::load_benchmarks(
+                    std::path::Path::new(wd),
+                );
+                (node_items, log, benchmarks)
+            })
+            .await
+            .unwrap_or_default();
             let diagnostics =
                 crate::domains::execution::service::diagnose_run(&node_items, &log, &benchmarks);
             (diagnostics, log)
@@ -265,21 +270,27 @@ pub async fn interpret(
 
         run.and_then(|r| {
             r.workdir.as_ref().and_then(|wd| {
-                // Read result files for summary
-                let mut summary = String::new();
-                if let Ok(entries) = std::fs::read_dir(wd) {
-                    for entry in entries.filter_map(|e| e.ok()) {
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        if let Ok(meta) = entry.metadata() {
-                            summary.push_str(&format!("{} ({} bytes)\n", name, meta.len()));
+                // Read result files for summary — synchronous directory
+                // walk, kept off the async runtime (#268 item 4, web
+                // minor). The blocking-pool hop is only worth it when a
+                // workdir exists; otherwise stay on the cheap path.
+                let wd = wd.to_string();
+                tokio::task::block_in_place(|| {
+                    let mut summary = String::new();
+                    if let Ok(entries) = std::fs::read_dir(&wd) {
+                        for entry in entries.filter_map(|e| e.ok()) {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            if let Ok(meta) = entry.metadata() {
+                                summary.push_str(&format!("{} ({} bytes)\n", name, meta.len()));
+                            }
                         }
                     }
-                }
-                if summary.is_empty() {
-                    None
-                } else {
-                    Some(summary)
-                }
+                    if summary.is_empty() {
+                        None
+                    } else {
+                        Some(summary)
+                    }
+                })
             })
         })
         .unwrap_or_default()

--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -346,9 +346,10 @@ pub async fn create_run(
         }
 
         // Save pipeline TOML to the working directory so the executor (CLI
-        // subprocess) can read it.
+        // subprocess) can read it. `tokio::fs` keeps the small write off
+        // the async runtime's blocking threads (#268 item 4, web minor).
         let workflow_path = run_dir.join("workflow.oxoflow");
-        if let Err(e) = std::fs::write(&workflow_path, toml) {
+        if let Err(e) = tokio::fs::write(&workflow_path, toml).await {
             tracing::error!("Failed to write workflow to {:?}: {e}", workflow_path);
         } else {
             tracing::info!("Saved workflow to {:?}", workflow_path);
@@ -1040,24 +1041,30 @@ pub async fn get_run_results(
     let run = load_owned_run(pool, &user, &id).await?;
 
     // List files in the workdir recursively so nested products (e.g.
-    // results/sample1/peaks.bed) are visible (issue #79 P1-08).
-    let results: Vec<serde_json::Value> = run
-        .workdir
-        .as_ref()
-        .map(|wd| {
-            service::list_files_recursive(std::path::Path::new(wd))
-                .into_iter()
-                .map(|f| {
-                    serde_json::json!({
-                        "name": f.name,
-                        "path": f.path,
-                        "size_bytes": f.size_bytes,
-                        "is_dir": f.is_dir,
-                    })
+    // results/sample1/peaks.bed) are visible (issue #79 P1-08). The walk
+    // is bounded (500 entries / depth 4) but still synchronous — run it
+    // on the blocking pool (#268 item 4, web minor).
+    let results: Vec<serde_json::Value> = match run.workdir.as_ref() {
+        Some(wd) => {
+            let wd = wd.clone();
+            tokio::task::spawn_blocking(move || {
+                service::list_files_recursive(std::path::Path::new(&wd))
+            })
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|f| {
+                serde_json::json!({
+                    "name": f.name,
+                    "path": f.path,
+                    "size_bytes": f.size_bytes,
+                    "is_dir": f.is_dir,
                 })
-                .collect()
-        })
-        .unwrap_or_default();
+            })
+            .collect()
+        }
+        None => Vec::new(),
+    };
 
     Ok(Json(results))
 }
@@ -1657,22 +1664,27 @@ async fn build_report_for_run(
 
     // Recursive listing: nested products must reach the report page and the
     // AI narrative (issue #79 P1-08 — the narrative claimed "4 output files"
-    // while the real products lived in subdirectories).
-    let files: Vec<ReportFile> = run
-        .workdir
-        .as_ref()
-        .map(|wd| {
-            service::list_files_recursive(std::path::Path::new(wd))
-                .into_iter()
-                .map(|f| ReportFile {
-                    path: f.path,
-                    name: f.name,
-                    size_bytes: f.size_bytes,
-                    is_dir: f.is_dir,
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    // while the real products lived in subdirectories). Synchronous but
+    // bounded walk → blocking pool (#268 item 4, web minor).
+    let files: Vec<ReportFile> = match run.workdir.as_ref() {
+        Some(wd) => {
+            let wd = wd.clone();
+            tokio::task::spawn_blocking(move || {
+                service::list_files_recursive(std::path::Path::new(&wd))
+            })
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|f| ReportFile {
+                path: f.path,
+                name: f.name,
+                size_bytes: f.size_bytes,
+                is_dir: f.is_dir,
+            })
+            .collect()
+        }
+        None => Vec::new(),
+    };
 
     let log_summary = match run.workdir.as_ref() {
         Some(wd) => tokio::fs::read_to_string(format!("{wd}/execution.log"))


### PR DESCRIPTION
## Summary

Final #268 item 4 finding: bounded-but-synchronous `std::fs` calls inside async handlers. All were documented 'acceptable, but `spawn_blocking` would be the idiomatic guard' — this PR applies exactly that.

- `execution/handlers.rs`: both `list_files_recursive` sites (run files listing, report builder) → `spawn_blocking`; workflow TOML save → `tokio::fs::write`.
- `ai/handlers.rs`: diagnostics block (node statuses + execution.log + benchmarks) → one `spawn_blocking` unit; output-summary dir walk → `block_in_place`.

No behavior change: same responses, same defaults on absent workdirs.

## Test plan

- `cargo test -p oxo-flow-web --lib` → 293 passed, 0 failed
- `cargo test -p oxo-flow-web --test phase3_collaboration_integration` → 15 passed
- `cargo clippy -p oxo-flow-web --all-targets` → clean; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)