### PR TITLE
feat(release): dedicated Docker release channel — prebuilt binaries, multi-arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,12 +1022,18 @@ jobs:
           exit 1
 
   # ─── Docker: publish the image to ghcr.io (GitHub Packages) ───────────────
-  # Reuses the docker-build leg's build + smoke test, then pushes. Triggers:
-  #   - every release tag / dispatch release  → ghcr.io/traitome/oxo-flow:<version> + :latest
-  #   - pushes to main                        → ghcr.io/traitome/oxo-flow:main
-  # so users can `docker run ghcr.io/traitome/oxo-flow` without building.
+  # Two channels with distinct jobs:
+  #   docker-publish         — main pushes → :main, built from source
+  #                            (Dockerfile). This is the regression gate:
+  #                            the shipped Dockerfile must keep compiling.
+  #   docker-publish-release — release tags/dispatch → :<version> + :latest,
+  #                            multi-arch (amd64+arm64) from the prebuilt
+  #                            release binaries (Dockerfile.release,
+  #                            SHA256-verified), so the image is
+  #                            byte-identical with the release tarballs and
+  #                            arm64 hosts get a native image.
   docker-publish:
-    name: Docker (publish to ghcr.io)
+    name: Docker (publish :main to ghcr.io)
     runs-on: ubuntu-latest
     needs: [sync-version, test, docker-build]
     if: >-
@@ -1035,9 +1041,7 @@ jobs:
       needs.docker-build.result == 'success' &&
       (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
       needs.test.result == 'success' &&
-      (startsWith(github.ref, 'refs/tags/v') ||
-       (github.event_name == 'workflow_dispatch' && inputs.tag != '') ||
-       github.ref == 'refs/heads/main')
+      github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -1054,14 +1058,9 @@ jobs:
       - name: Compute image tags
         id: tags
         run: |
-          # Release legs use the synced version; main pushes get a moving
-          # :main tag instead of a misleading :latest.
-          if [[ "${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}" == "true" ]]; then
-            VERSION="${{ needs.sync-version.outputs.version }}"
-            TAGS="${IMAGE}:${VERSION}"$'\n'"${IMAGE}:latest"
-          else
-            TAGS="${IMAGE}:main"
-          fi
+          # Main pushes get a moving :main tag instead of a misleading
+          # :latest (release tags are published by docker-publish-release).
+          TAGS="${IMAGE}:main"
           {
             echo "tags<<EOF"
             echo "$TAGS"
@@ -1092,14 +1091,8 @@ jobs:
 
       - name: Smoke-test the pushed image (health endpoint)
         run: |
-          # Pick whichever tag this run published and verify it serves.
-          if [[ "${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.tag != '') }}" == "true" ]]; then
-            PUBLISHED_TAG="latest"
-          else
-            PUBLISHED_TAG="main"
-          fi
-          docker pull "${IMAGE}:${PUBLISHED_TAG}"
-          docker run -d --name oxo-flow-pub -p 3000:3000 "${IMAGE}:${PUBLISHED_TAG}"
+          docker pull "${IMAGE}:main"
+          docker run -d --name oxo-flow-pub -p 3000:3000 "${IMAGE}:main"
           for i in $(seq 1 20); do
             if curl -sf http://localhost:3000/api/health | grep -q '"status":"ok"'; then
               echo "published image healthy"
@@ -1109,6 +1102,84 @@ jobs:
             sleep 3
           done
           echo "::error::published image did not become healthy"
+          docker logs oxo-flow-pub || true
+          docker rm -f oxo-flow-pub > /dev/null || true
+          exit 1
+
+  # Release channel: assembles the image from the prebuilt release binaries
+  # (no cargo build) as a multi-arch manifest (amd64 + arm64), publishing
+  # ghcr.io/traitome/oxo-flow:<version> + :latest. Runs only on release
+  # tags / dispatch-with-tag, and only after the release job has actually
+  # uploaded the artifacts — the binaries it installs come from that
+  # release, verified against SHA256SUMS.txt inside Dockerfile.release.
+  docker-publish-release:
+    name: Docker (publish release to ghcr.io)
+    runs-on: ubuntu-latest
+    needs: [sync-version, test, release]
+    if: >-
+      always() &&
+      needs.release.result == 'success' &&
+      (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
+      needs.test.result == 'success' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       (github.event_name == 'workflow_dispatch' && inputs.tag != ''))
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && needs.sync-version.outputs.updated_sha) || github.ref }}
+
+      # repository_owner is "Traitome" (uppercase) but ghcr requires lowercase
+      # image paths — force it down (${VAR,,} bash lowercase).
+      - name: Compute image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/oxo-flow" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU (arm64 emulation for the non-native leg)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.release
+          # VERSION is the synced release version; the Dockerfile resolves
+          # the per-arch tarball triple from TARGETARCH at build time.
+          build-args: VERSION=${{ needs.sync-version.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ needs.sync-version.outputs.version }}
+            ${{ env.IMAGE }}:latest
+          labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          provenance: false
+
+      - name: Smoke-test the pushed image (health endpoint, native arch)
+        run: |
+          docker pull "${IMAGE}:${{ needs.sync-version.outputs.version }}"
+          docker run -d --name oxo-flow-pub -p 3000:3000 "${IMAGE}:${{ needs.sync-version.outputs.version }}"
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:3000/api/health | grep -q '"status":"ok"'; then
+              echo "published release image healthy"
+              docker rm -f oxo-flow-pub > /dev/null
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::published release image did not become healthy"
           docker logs oxo-flow-pub || true
           docker rm -f oxo-flow-pub > /dev/null || true
           exit 1

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,101 @@
+# Release-channel image: assembles the image from the prebuilt binaries
+# published on the GitHub Release for the build ARG VERSION — no cargo
+# compilation happens here. A companion to ./Dockerfile (which compiles from
+# source and gates every push to main).
+#
+# ARG VERSION selects the release (e.g. 0.16.0); the target triple follows
+# the build platform: amd64 → x86_64-unknown-linux-gnu, arm64 →
+# aarch64-unknown-linux-gnu. Binaries are verified against the release's
+# SHA256SUMS.txt before being installed.
+#
+# Build it yourself:
+#   docker build -f Dockerfile.release \
+#     --build-arg VERSION=0.16.0 -t oxo-flow:0.16.0 .
+
+# ===== Fetch + verify release binaries (per-TARGETARCH) =====
+FROM debian:trixie-slim AS binaries
+ARG VERSION
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Map Docker's TARGETARCH (amd64/arm64) to the release tarball triple.
+# Only gnu targets: the release binaries are glibc-linked (verified: max
+# GLIBC symbol requirement 2.18) and this runtime is trixie-slim (glibc 2.41).
+RUN case "${TARGETARCH}" in \
+      amd64) OXO_TARGET="x86_64-unknown-linux-gnu" ;; \
+      arm64) OXO_TARGET="aarch64-unknown-linux-gnu" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && RELEASE_URL="https://github.com/Traitome/oxo-flow/releases/download/v${VERSION}" \
+    && mkdir -p /out \
+    && curl -fsSL -o /out/SHA256SUMS.txt "${RELEASE_URL}/SHA256SUMS.txt" \
+    && for pkg in oxo-flow oxo-flow-web; do \
+         curl -fsSL -o "/out/${pkg}.tar.gz" \
+           "${RELEASE_URL}/${pkg}-v${VERSION}-${OXO_TARGET}.tar.gz" || exit 1; \
+       done \
+    # Verify against the release's checksums. grep must produce exactly the
+    # two expected lines (one per tarball) or sha256sum -c fails on the
+    # missing/renamed entry — a renamed asset cannot sneak through.
+    && cd /out \
+    && grep -F "oxo-flow-v${VERSION}-${OXO_TARGET}.tar.gz" SHA256SUMS.txt > wanted.txt \
+    && grep -F "oxo-flow-web-v${VERSION}-${OXO_TARGET}.tar.gz" SHA256SUMS.txt >> wanted.txt \
+    && [ "$(wc -l < wanted.txt)" -eq 2 ] \
+    && sha256sum -c wanted.txt \
+    && tar -xzf oxo-flow.tar.gz \
+    && tar -xzf oxo-flow-web.tar.gz \
+    && rm -f /out/*.tar.gz /out/wanted.txt /out/SHA256SUMS.txt
+
+# ===== Frontend builder (SPA assets are not in any release tarball) =====
+FROM node:22-alpine AS frontend-builder
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ===== Runtime =====
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# vite emits to ../crates/oxo-flow-web/static (vite.config.ts outDir),
+# NOT frontend/dist — copy from there.
+COPY --from=frontend-builder /app/crates/oxo-flow-web/static /app/frontend/dist
+COPY --from=binaries /out/oxo-flow /app/oxo-flow
+COPY --from=binaries /out/oxo-flow-web /app/oxo-flow-web
+
+RUN mkdir -p /app/data && \
+    chown -R 1000:1000 /app
+
+USER 1000:1000
+
+# Same state/layout contract as ./Dockerfile: both entrypoints default their
+# SQLite DB to ./oxo-flow.db in the CWD — run from /app/data so state lands
+# on the mounted volume and survives container restarts. Binary paths stay
+# absolute.
+WORKDIR /app/data
+
+ENV OXO_FLOW_FRONTEND_DIR=/app/frontend/dist \
+    OXO_FLOW_MODE=team
+
+EXPOSE 3000
+
+LABEL org.opencontainers.image.title="oxo-flow" \
+      org.opencontainers.image.description="Bioinformatics pipeline engine" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.licenses="Apache-2.0 AND LicenseRef-OxoFlow-Commercial" \
+      org.opencontainers.image.vendor="Traitome" \
+      org.opencontainers.image.authors="Shixiang Wang <w_shixiang@163.com>" \
+      org.opencontainers.image.source="https://github.com/Traitome/oxo-flow"
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -sf http://localhost:3000/api/health | grep -q '"status":"ok"' || exit 1
+
+CMD ["/app/oxo-flow-web", "--host", "0.0.0.0", "--port", "3000", "--mode", "team"]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ conda install -c bioconda oxo-flow-cli
 
 ### Run with Docker
 
-Pre-built images are published to GitHub Container Registry on every release (and every push to `main`):
+Pre-built images are published to GitHub Container Registry on every release (and every push to `main`). Release images are multi-arch (`linux/amd64` + `linux/arm64`, so Apple silicon and ARM servers pull a native image); `:main` is amd64-only and compiled from source:
 
 ```bash
 # Web UI at http://localhost:3000 (CLI is inside the same image)

--- a/docs/guide/src/tutorials/installation.md
+++ b/docs/guide/src/tutorials/installation.md
@@ -122,7 +122,9 @@ Desktop users may prefer the `.deb` / `.rpm` / `.AppImage` /
 
 ## Option 4 — Run with Docker
 
-Images are published to GitHub Container Registry automatically on every release and every push to `main`:
+Images are published to GitHub Container Registry automatically on every release and every push to `main`.
+Release images are multi-arch (`linux/amd64` + `linux/arm64`) and are assembled from the
+SHA256-verified release binaries; `:main` is amd64-only and compiled from source:
 
 ```bash
 # Web UI at http://localhost:3000


### PR DESCRIPTION
Follow-up to #276 (Docker work). Implements the two-channel split discussed after #277 landed the initial publishing job.

## What

| Channel | Trigger | Image | Built from | Arch |
|---|---|---|---|---|
| `docker-publish` | push to `main` | `:main` | source via `./Dockerfile` (regression gate — Dockerfile must keep compiling) | amd64 |
| `docker-publish-release` (new) | `v*` tag / dispatch-with-tag, gated on the `release` job | `:<version>` + `:latest` | prebuilt release binaries via new `Dockerfile.release` | **amd64 + arm64** |

## Why two channels

- On `main` there are no release artifacts (build-linux only uploads on tags), so a prebuilt-binary image is impossible there — the source build stays and doubles as the regression gate (it already caught the #276 MSRV and glibc incidents).
- On releases the tarballs already exist and are SHA256-summed; `Dockerfile.release` downloads them per-`TARGETARCH` (amd64 → `x86_64-unknown-linux-gnu`, arm64 → `aarch64-unknown-linux-gnu`), verifies against `SHA256SUMS.txt` inside the build, and installs. No cargo compilation — the arm64 leg under QEMU only downloads + runs npm, which is fast.
- Binaries are glibc-dynamic (max `GLIBC_2.18`), runtime is `debian:trixie-slim` (glibc 2.41) — verified compatible. SPA assets are not in any tarball, so a small `node:22-alpine` stage builds the frontend.

## Verification

- [x] YAML parses; job graph validated (needs: `[sync-version, test, release]`, release-only `if`)
- [x] Release assets for v0.16.0 inspected: tarball names, SHA256SUMS.txt format, ELF glibc requirements
- [x] `:main` smoke test unchanged; release smoke test pulls/ runs the pushed `:<version>` image
- [x] Docs updated (README + installation guide): release images multi-arch, `:main` amd64-only
- [ ] Full release-channel run will first execute on the next `v*` tag (needs real release artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)