### PR TITLE
fix(ci): validate release Docker image; verify tarballs under original asset names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,13 +1064,16 @@ jobs:
         run: |
           # Version comes straight from the tag input (sync-version is skipped
           # in publish_images_only mode and cannot run for an existing tag).
+          # No --load: a multi-platform build produces a manifest list, which
+          # the docker exporter cannot load; validation happens in the build
+          # itself (both platforms must assemble successfully).
           VERSION="${TAG#v}"
           docker buildx build \
             --file Dockerfile.release \
             --build-arg VERSION="$VERSION" \
             --platform linux/amd64,linux/arm64 \
             -t oxo-flow-release:ci \
-            --load .
+            .
         env:
           TAG: ${{ inputs.tag }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         required: false
         default: true
+      publish_images_only:
+        description: 'With tag set: skip the release pipeline (tag/version/crates) and only build the Docker release image from the existing release artifacts. Requires publish_images.'
+        type: boolean
+        required: false
+        default: false
 
 # Cancel in-progress runs for the same branch/PR; preserve tag releases.
 # A dispatch-driven release (tag input set) runs in its own concurrency
@@ -41,7 +46,10 @@ jobs:
   sync-version:
     name: Sync version from tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    if: >-
+      (startsWith(github.ref, 'refs/tags/v') ||
+       (github.event_name == 'workflow_dispatch' && inputs.tag != '')) &&
+      inputs.publish_images_only != true
     permissions:
       contents: write
     outputs:
@@ -67,7 +75,7 @@ jobs:
           echo "Release tag format OK: ${TAG}"
 
       - name: Ensure release tag does not already exist
-        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.publish_images_only != true
         shell: bash
         run: |
           set -euo pipefail
@@ -1033,7 +1041,7 @@ jobs:
   docker-build-release:
     name: Docker (build release, no publish)
     runs-on: ubuntu-latest
-    needs: [sync-version, test]
+    needs: [test]
     if: >-
       always() &&
       needs.test.result == 'success' &&
@@ -1054,11 +1062,16 @@ jobs:
 
       - name: Build the release image (both platforms, no push)
         run: |
+          # Version comes straight from the tag input (sync-version is skipped
+          # in publish_images_only mode and cannot run for an existing tag).
+          VERSION="${TAG#v}"
           docker buildx build \
             --file Dockerfile.release \
-            --build-arg VERSION="${{ needs.sync-version.outputs.version }}" \
+            --build-arg VERSION="$VERSION" \
             --platform linux/amd64,linux/arm64 \
             --load oxo-flow-release:ci .
+        env:
+          TAG: ${{ inputs.tag }}
 
   # ─── Docker: publish the image to ghcr.io (GitHub Packages) ───────────────
   # Two channels with distinct jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
         description: 'Release tag to build and publish (e.g. v0.1.0). Leave empty for a plain CI run.'
         required: false
         default: ''
+      publish_images:
+        description: 'With tag set: also publish Docker release images to ghcr.io (uncheck to only validate the image build against the existing release artifacts).'
+        type: boolean
+        required: false
+        default: true
 
 # Cancel in-progress runs for the same branch/PR; preserve tag releases.
 # A dispatch-driven release (tag input set) runs in its own concurrency
@@ -1021,6 +1026,40 @@ jobs:
           docker rm -f oxo-flow-ci > /dev/null || true
           exit 1
 
+  # Validation leg for the release channel: builds Dockerfile.release from an
+  # EXISTING release's artifacts (no tag push, no publish) so the channel's
+  # download → verify → assemble → serve path is exercised between releases.
+  # Skipped everywhere except manual dispatch with a tag input.
+  docker-build-release:
+    name: Docker (build release, no publish)
+    runs-on: ubuntu-latest
+    needs: [sync-version, test]
+    if: >-
+      always() &&
+      needs.test.result == 'success' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.tag != ''
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (arm64 emulation for the non-native leg)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the release image (both platforms, no push)
+        run: |
+          docker buildx build \
+            --file Dockerfile.release \
+            --build-arg VERSION="${{ needs.sync-version.outputs.version }}" \
+            --platform linux/amd64,linux/arm64 \
+            --load oxo-flow-release:ci .
+
   # ─── Docker: publish the image to ghcr.io (GitHub Packages) ───────────────
   # Two channels with distinct jobs:
   #   docker-publish         — main pushes → :main, built from source
@@ -1122,7 +1161,7 @@ jobs:
       (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
       needs.test.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/v') ||
-       (github.event_name == 'workflow_dispatch' && inputs.tag != ''))
+       (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.publish_images == true))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,11 @@ jobs:
     needs: [test]
     # Skip on pull_request events — the test job already validates compilation.
     # Build and package are only needed for releases and main-branch pushes.
-    if: always() && needs.test.result == 'success' && github.event_name != 'pull_request'
+    if: >-
+      always() &&
+      needs.test.result == 'success' &&
+      github.event_name != 'pull_request' &&
+      inputs.publish_images_only != true
     # Partial artifact sets are acceptable for feature branches only —
     # a broken release build must fail CI on main and tag pushes.
     continue-on-error: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
@@ -488,7 +492,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [test]
     # Skip on pull_request events — macOS runners are slow and expensive.
-    if: always() && needs.test.result == 'success' && github.event_name != 'pull_request'
+    if: >-
+      always() && needs.test.result == 'success' &&
+      github.event_name != 'pull_request' &&
+      inputs.publish_images_only != true
     # A cancelled/unavailable runner must not block feature-branch runs,
     # but a broken macOS release build must fail CI on main and tags.
     continue-on-error: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
@@ -655,6 +662,7 @@ jobs:
     if: >-
       always() &&
       (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.tag != '')) &&
+      inputs.publish_images_only != true &&
       (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
       needs.build-linux.result == 'success' &&
       needs.build-macos.result == 'success'
@@ -890,12 +898,15 @@ jobs:
     # Depend directly on sync-version + test so crates.io publishing is not
     # blocked by binary build failures or a skipped GitHub Release job.
     # Publishing source crates is independent of the binary release artifacts.
+    # publish_images_only validation runs skip this entirely — a dry-run must
+    # never touch the crates.io registry.
     needs: [sync-version, test]
     runs-on: ubuntu-latest
     if: >-
       always() &&
       (startsWith(github.ref, 'refs/tags/v') ||
        (github.event_name == 'workflow_dispatch' && inputs.tag != '')) &&
+      inputs.publish_images_only != true &&
       (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
       needs.test.result == 'success'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1069,7 +1069,8 @@ jobs:
             --file Dockerfile.release \
             --build-arg VERSION="$VERSION" \
             --platform linux/amd64,linux/arm64 \
-            --load oxo-flow-release:ci .
+            -t oxo-flow-release:ci \
+            --load .
         env:
           TAG: ${{ inputs.tag }}
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -33,20 +33,24 @@ RUN case "${TARGETARCH}" in \
     && RELEASE_URL="https://github.com/Traitome/oxo-flow/releases/download/v${VERSION}" \
     && mkdir -p /out \
     && curl -fsSL -o /out/SHA256SUMS.txt "${RELEASE_URL}/SHA256SUMS.txt" \
+    # Download under the ORIGINAL release-asset names: sha256sum -c below
+    # checks the entries exactly as SHA256SUMS.txt lists them, so a renamed
+    # local file would read as "FAILED open or read" even when the content
+    # (and its checksum) is correct.
     && for pkg in oxo-flow oxo-flow-web; do \
-         curl -fsSL -o "/out/${pkg}.tar.gz" \
-           "${RELEASE_URL}/${pkg}-v${VERSION}-${OXO_TARGET}.tar.gz" || exit 1; \
+         ASSET="${pkg}-v${VERSION}-${OXO_TARGET}.tar.gz" \
+         && curl -fsSL -o "/out/${ASSET}" "${RELEASE_URL}/${ASSET}" || exit 1; \
        done \
-    # Verify against the release's checksums. grep must produce exactly the
-    # two expected lines (one per tarball) or sha256sum -c fails on the
-    # missing/renamed entry — a renamed asset cannot sneak through.
     && cd /out \
+    # Verify against the release's checksums. grep must produce exactly the
+    # two expected lines (one per tarball) or sha256sum -c fails on a
+    # missing entry — a renamed/mismatched asset cannot sneak through.
     && grep -F "oxo-flow-v${VERSION}-${OXO_TARGET}.tar.gz" SHA256SUMS.txt > wanted.txt \
     && grep -F "oxo-flow-web-v${VERSION}-${OXO_TARGET}.tar.gz" SHA256SUMS.txt >> wanted.txt \
     && [ "$(wc -l < wanted.txt)" -eq 2 ] \
     && sha256sum -c wanted.txt \
-    && tar -xzf oxo-flow.tar.gz \
-    && tar -xzf oxo-flow-web.tar.gz \
+    && tar -xzf "oxo-flow-v${VERSION}-${OXO_TARGET}.tar.gz" \
+    && tar -xzf "oxo-flow-web-v${VERSION}-${OXO_TARGET}.tar.gz" \
     && rm -f /out/*.tar.gz /out/wanted.txt /out/SHA256SUMS.txt
 
 # ===== Frontend builder (SPA assets are not in any release tarball) =====


### PR DESCRIPTION
Follow-up to #284: manually dispatching the release Docker channel against an existing tag (v0.16.0) exposed real bugs, fixed here and covered by a new validation leg.

## What the dispatches found

1. **Dockerfile.release checksum verify always failed** — downloads were renamed (`oxo-flow.tar.gz`) but `sha256sum -c` checks names exactly as `SHA256SUMS.txt` lists them (`oxo-flow-v0.16.0-<triple>.tar.gz`) → "FAILED open or read" on intact downloads. Fixed: download/extract under the original asset names.
2. **Tag-immutability vs validation** — `sync-version` refuses to re-run for an existing tag ("Never move a released tag"), so validating an old release's image was impossible. Added `workflow_dispatch` inputs:
   - `publish_images` (default true): publish to ghcr.io
   - `publish_images_only` (default false): skip sync-version + all release jobs, just build the release image from the existing release's artifacts
3. **Validation runs did wasted/dangerous work** — build-linux/build-macos cross-compiled 8 targets, `publish-crates` failed (no version bump ran), and GitHub Release could fire for an existing tag. All four jobs now gate on `publish_images_only != true`.

## Validation leg

`docker-build-release` job (dispatch + tag set): buildx multi-platform amd64+arm64 via QEMU, no push, no `--load` (docker exporter cannot load manifest lists — validation is both platforms assembling successfully).

## Verification

Run 33467518983 (dispatch `tag=v0.16.0 publish_images=false publish_images_only=true`) — **green**:
- `sha256sum -c`: `oxo-flow-v0.16.0-x86_64-unknown-linux-gnu.tar.gz: OK`, `oxo-flow-web-...: OK`, both aarch64 siblings OK
- Both platforms assembled; sync-version/Build/Publish/Release/Docker-publish all correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)