### PR TITLE
feat(report): rule-attached captions + MultiQC-style aggregate collector (#281)

### DIFF
--- a/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
+++ b/crates/oxo-flow-cli/schema/oxoflow-v1.schema.json
@@ -1876,6 +1876,18 @@
             "null"
           ],
           "description": "Rule-level output pattern override"
+        },
+        "report": {
+          "type": [
+            "string",
+            "array",
+            "object",
+            "boolean",
+            "number",
+            "integer",
+            "null"
+          ],
+          "description": "Schema synced from config whitelist (see known_keys.rs)"
         }
       }
     },

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -187,6 +187,7 @@ async fn terminate_on_signal(
             skip_reason: Some(format!("interrupted by {}", signal.name)),
             max_rss_mb: None,
             cpu_seconds: None,
+            caption: None,
         };
         ck.record_run(&record);
         ck.mark_failed(rule);
@@ -2216,6 +2217,12 @@ pub async fn run_command(
                         skip_reason: None,
                         max_rss_mb: None,
                         cpu_seconds: None,
+                        caption: config.get_rule(&rule_name).and_then(|r| {
+                            oxo_flow_core::executor::process::rule_report_caption(
+                                r,
+                                workdir_actual.as_ref(),
+                            )
+                        }),
                     });
                     skipped_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     if !is_tty {
@@ -2345,6 +2352,12 @@ pub async fn run_command(
                     ),
                     max_rss_mb: None,
                     cpu_seconds: None,
+                    caption: config.get_rule(&rule_name).and_then(|r| {
+                        oxo_flow_core::executor::process::rule_report_caption(
+                            r,
+                            workdir_actual.as_ref(),
+                        )
+                    }),
                 });
                 if !is_tty {
                     eprintln!(
@@ -2402,6 +2415,12 @@ pub async fn run_command(
             });
 
             let typed_config = config.config.clone();
+            // Resolve the rule's report caption BEFORE the spawn: the closure
+            // must not capture `config` (owned by this loop), only the already
+            // resolved value (issue #281).
+            let rule_caption = config.get_rule(&rule_name).and_then(|r| {
+                oxo_flow_core::executor::process::rule_report_caption(r, workdir_actual.as_ref())
+            });
             let instance_bindings = instance_bindings.clone();
             // Register the task name BEFORE the spawn: the closure moves
             // `rule_name` in, so the id→name map needs its own clone.
@@ -2698,6 +2717,7 @@ pub async fn run_command(
                             skip_reason: None,
                             max_rss_mb: None,
                             cpu_seconds: None,
+                            caption: rule_caption,
                         };
                         emit_execution_event(oxo_flow_core::executor::ExecutionEvent::RuleCompleted {
                             rule: rule_name.clone(),
@@ -2847,6 +2867,12 @@ pub async fn run_command(
                     skip_reason: None,
                     max_rss_mb: None,
                     cpu_seconds: None,
+                    caption: config.get_rule(&rule_name).and_then(|r| {
+                        oxo_flow_core::executor::process::rule_report_caption(
+                            r,
+                            workdir_actual.as_ref(),
+                        )
+                    }),
                 };
                 let mut ck = checkpoint.lock().await;
                 ck.record_run(&record);
@@ -2904,6 +2930,12 @@ pub async fn run_command(
                 skip_reason: Some(format!("re-entry manifest: {e}")),
                 max_rss_mb: None,
                 cpu_seconds: None,
+                caption: config.get_rule(&completed_rule).and_then(|r| {
+                    oxo_flow_core::executor::process::rule_report_caption(
+                        r,
+                        workdir_actual.as_ref(),
+                    )
+                }),
             };
             {
                 let mut frs = failed_rules_set.lock().await;
@@ -2972,6 +3004,12 @@ pub async fn run_command(
                 skip_reason: Some(format!("output_pattern discovery: {e}")),
                 max_rss_mb: None,
                 cpu_seconds: None,
+                caption: config.get_rule(&completed_rule).and_then(|r| {
+                    oxo_flow_core::executor::process::rule_report_caption(
+                        r,
+                        workdir_actual.as_ref(),
+                    )
+                }),
             };
             {
                 let mut frs = failed_rules_set.lock().await;
@@ -3192,6 +3230,12 @@ pub async fn run_command(
                     skip_reason: Some("blocked by failed upstream dependency".into()),
                     max_rss_mb: None,
                     cpu_seconds: None,
+                    caption: config.get_rule(name).and_then(|r| {
+                        oxo_flow_core::executor::process::rule_report_caption(
+                            r,
+                            workdir_actual.as_ref(),
+                        )
+                    }),
                 });
                 progress.inc(1);
                 if !is_tty {

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2217,7 +2217,7 @@ pub async fn run_command(
                         skip_reason: None,
                         max_rss_mb: None,
                         cpu_seconds: None,
-                        caption: config.get_rule(&rule_name).and_then(|r| {
+                        caption: config.get_rule(rule_name).and_then(|r| {
                             oxo_flow_core::executor::process::rule_report_caption(
                                 r,
                                 workdir_actual.as_ref(),
@@ -2352,7 +2352,7 @@ pub async fn run_command(
                     ),
                     max_rss_mb: None,
                     cpu_seconds: None,
-                    caption: config.get_rule(&rule_name).and_then(|r| {
+                    caption: config.get_rule(rule_name).and_then(|r| {
                         oxo_flow_core::executor::process::rule_report_caption(
                             r,
                             workdir_actual.as_ref(),

--- a/crates/oxo-flow-cli/src/commands/run_cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/run_cluster.rs
@@ -436,6 +436,7 @@ pub(crate) async fn run_on_cluster(
                 skip_reason: None,
                 max_rss_mb: None,
                 cpu_seconds: None,
+                caption: None,
             });
             ck.save_to_file(&path)
         })

--- a/crates/oxo-flow-core/benches/scheduling_bench.rs
+++ b/crates/oxo-flow-core/benches/scheduling_bench.rs
@@ -104,6 +104,7 @@ fn simulate_100(c: &mut Criterion) {
                         skip_reason: None,
                         max_rss_mb: None,
                         cpu_seconds: None,
+                        caption: None,
                     });
                 }
             }

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -286,6 +286,9 @@ impl BackendDriver {
                         skip_reason: Some("blocked by failed upstream dependency".into()),
                         max_rss_mb: None,
                         cpu_seconds: None,
+                        caption: plan.rules.get(&name).and_then(|sr| {
+                            crate::executor::process::rule_report_caption(&sr.rule, &sr.workdir)
+                        }),
                     });
                     done.insert(name.clone(), JobStatus::Skipped);
                     emit(
@@ -333,7 +336,9 @@ impl BackendDriver {
                     }
                     if !plan.rules.contains_key(&name) {
                         // Not schedulable (no shell/script) — mirror the local
-                        // executor's skip.
+                        // executor's skip. The rule has no plan entry to read
+                        // a declared caption from, so the record's caption is
+                        // always None here.
                         records.push(JobRecord {
                             rule: name.clone(),
                             status: JobStatus::Skipped,
@@ -347,6 +352,7 @@ impl BackendDriver {
                             skip_reason: Some("no shell or script defined".into()),
                             max_rss_mb: None,
                             cpu_seconds: None,
+                            caption: None,
                         });
                         done.insert(name.clone(), JobStatus::Skipped);
                         emit(
@@ -913,6 +919,10 @@ impl BackendDriver {
                                 skip_reason: None,
                                 max_rss_mb: acct.and_then(|a| a.max_rss_mb),
                                 cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
+                                caption: crate::executor::process::rule_report_caption(
+                                    &plan.rules[&f.rule].rule,
+                                    &plan.rules[&f.rule].workdir,
+                                ),
                             }
                         }
                         BackendJobStatus::Failed => {
@@ -943,6 +953,10 @@ impl BackendDriver {
                                 skip_reason: None,
                                 max_rss_mb: acct.and_then(|a| a.max_rss_mb),
                                 cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
+                                caption: crate::executor::process::rule_report_caption(
+                                    &plan.rules[&f.rule].rule,
+                                    &plan.rules[&f.rule].workdir,
+                                ),
                             }
                         }
                         BackendJobStatus::Cancelled => JobRecord {
@@ -961,6 +975,10 @@ impl BackendDriver {
                             skip_reason: Some("cancelled".into()),
                             max_rss_mb: acct.and_then(|a| a.max_rss_mb),
                             cpu_seconds: acct.and_then(|a| a.cpu_seconds).map(|s| s as f64),
+                            caption: crate::executor::process::rule_report_caption(
+                                &plan.rules[&f.rule].rule,
+                                &plan.rules[&f.rule].workdir,
+                            ),
                         },
                         _ => unreachable!("non-terminal states filtered above"),
                     };
@@ -1158,6 +1176,7 @@ fn return_record_failure(
         skip_reason: Some(format!("re-entry manifest: {e}")),
         max_rss_mb: None,
         cpu_seconds: None,
+        caption: None,
     });
     done.insert(f.rule.clone(), JobStatus::Failed);
 }

--- a/crates/oxo-flow-core/src/config/known_keys.rs
+++ b/crates/oxo-flow-core/src/config/known_keys.rs
@@ -253,6 +253,7 @@ const RULE_KEYS: &[&str] = &[
     "pre_exec",
     "priority",
     "protected_output",
+    "report",
     "required",
     "resource_hint",
     "resources",
@@ -466,12 +467,29 @@ enum Nesting {
     Config,
 }
 
+/// Keys of a rule-level `report = { file, caption }` annotation (issue #281).
+const RULE_REPORT_KEYS: &[&str] = &["caption", "file"];
+
 /// How the value stored under `key` nests.
 fn nesting(key: &str, value: &toml::Value) -> Nesting {
     match value {
         toml::Value::Table(_) if key == "config" => Nesting::Config,
         toml::Value::Table(_) => match nested_table(key) {
-            Some(keys) => Nesting::Table(keys),
+            Some(keys) => {
+                // `report` is ambiguous without location context: the
+                // top-level `[report]` table (format/sections/template) vs a
+                // rule-level `report = { file, caption }` annotation (issue
+                // #281). The key sets are disjoint, so affinity decides.
+                let is_rule_report = key == "report"
+                    && value
+                        .as_table()
+                        .is_some_and(|t| t.contains_key("file") || t.contains_key("caption"));
+                if is_rule_report {
+                    Nesting::Table(RULE_REPORT_KEYS)
+                } else {
+                    Nesting::Table(keys)
+                }
+            }
             None => Nesting::None,
         },
         toml::Value::Array(_) => {
@@ -958,6 +976,7 @@ mod tests {
             rule_metadata = { assay = "rna" }
             cache_key = "k"
             interpreter = "python"
+            report = { file = "notes/report.md", caption = "Alignment QC" }
         "#;
         let rule: crate::rule::Rule = toml::from_str(toml).expect("probe rule deserializes");
         let written = toml::to_string(&rule)

--- a/crates/oxo-flow-core/src/executor/checkpoint.rs
+++ b/crates/oxo-flow-core/src/executor/checkpoint.rs
@@ -173,6 +173,11 @@ pub struct RuleRunRecord {
     /// failure diagnosis. Absent when the rule produced no stderr.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stderr_tail: Option<String>,
+    /// The rule's resolved report caption (inline text or the content of its
+    /// `report.file`), captured at execution time (issue #281). Absent in
+    /// legacy checkpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
 }
 
 /// Persistent checkpoint state for resumable workflow execution.
@@ -456,6 +461,7 @@ impl CheckpointState {
                 exit_code: record.exit_code,
                 command: record.command.clone(),
                 stderr_tail: stderr_tail(record.stderr.as_deref()),
+                caption: record.caption.clone(),
             },
         );
     }

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -13,6 +13,18 @@ use std::sync::{Arc, LazyLock};
 use tokio::process::Command;
 use tokio::sync::{Mutex, Semaphore};
 
+/// Resolve a rule's report caption for the execution record (issue #281):
+/// inline `report` text directly, `report.file` read relative to `workdir`.
+/// Read failures degrade to `None` — a caption must never fail a run.
+pub fn rule_report_caption(rule: &Rule, workdir: &Path) -> Option<String> {
+    let report = rule.report.as_ref()?;
+    if let Some(text) = report.caption() {
+        return Some(text.to_owned());
+    }
+    let file = report.file()?;
+    std::fs::read_to_string(workdir.join(file)).ok()
+}
+
 use super::checkpoint::{cleanup_temp_outputs, validate_outputs};
 use super::security::{
     sanitize_shell_command, validate_path_safety, validate_shell_safety,
@@ -239,6 +251,10 @@ pub struct JobRecord {
     /// sampler never observed the child; issue #83 P1-13).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_seconds: Option<f64>,
+    /// The rule's resolved report caption (inline text or the content of
+    /// its `report.file`), captured at execution time (issue #281).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
 }
 
 /// Configuration for the executor.
@@ -1196,6 +1212,7 @@ impl LocalExecutor {
             skip_reason: None,
             max_rss_mb: None,
             cpu_seconds: None,
+            caption: rule_report_caption(rule, &self.config.workdir),
         };
 
         // Condition evaluation happens before any remote staging so a rule
@@ -2151,6 +2168,7 @@ impl LocalExecutor {
                     skip_reason: None,
                     max_rss_mb: None,
                     cpu_seconds: None,
+                    caption: rule_report_caption(rule, &self.config.workdir),
                 }
             })
             .collect()

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -549,6 +549,7 @@ fn checkpoint_record_run_persists_diagnostics() {
         skip_reason: None,
         max_rss_mb: None,
         cpu_seconds: None,
+        caption: Some("GATK germline variant calling (issue #281 caption).".to_string()),
     };
     state.record_run(&record);
     state.mark_failed("call");
@@ -563,6 +564,10 @@ fn checkpoint_record_run_persists_diagnostics() {
         Some("gatk HaplotypeCaller -I out.bam")
     );
     assert_eq!(run.stderr_tail.as_deref(), Some("gatk: command not found"));
+    assert_eq!(
+        run.caption.as_deref(),
+        Some("GATK germline variant calling (issue #281 caption).")
+    );
 }
 
 #[test]
@@ -582,6 +587,7 @@ fn checkpoint_stderr_tail_is_bounded() {
         skip_reason: None,
         max_rss_mb: None,
         cpu_seconds: None,
+        caption: None,
     };
     state.record_run(&record);
     let tail = state.rule_runs["noisy"].stderr_tail.as_deref().unwrap();

--- a/crates/oxo-flow-core/src/report.rs
+++ b/crates/oxo-flow-core/src/report.rs
@@ -1690,7 +1690,7 @@ fn render_section_html(html: &mut String, section: &ReportSection, heading_level
 
 use crate::config::WorkflowConfig;
 use crate::executor::CheckpointState;
-use crate::report_metrics::{MetricsScanner, ParsedMetrics};
+use crate::report_metrics::{CustomContent, CustomValue, MetricsScanner, ParsedMetrics};
 
 /// Classifies a workflow into a broad domain for report tailoring.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1795,6 +1795,8 @@ impl SectionRegistry {
         registry.register(Box::new(SampleMatrixGenerator));
         registry.register(Box::new(ProvenanceGenerator));
         registry.register(Box::new(TaskSummaryGenerator));
+        registry.register(Box::new(RuleCaptionsGenerator));
+        registry.register(Box::new(AggregateMetricsGenerator));
         registry
     }
 
@@ -2216,6 +2218,124 @@ impl ReportSectionGenerator for CommandManifestGenerator {
     }
 }
 
+/// Per-rule report captions (issue #281, the Snakemake `report()`
+/// equivalent): each rule's `report` annotation rendered as a markdown
+/// subsection, ordered by rule declaration order with one entry per
+/// executed instance. Caption resolution mirrors the execution-time capture
+/// in `rule_report_caption`: the checkpoint's stored caption wins (what the
+/// run actually read), then the declared inline caption, then the declared
+/// `report.file` re-read from the workdir — so reports also work without a
+/// checkpoint (or with a legacy one that never captured captions). Read
+/// failures degrade to a note; a caption never fails the report.
+struct RuleCaptionsGenerator;
+impl ReportSectionGenerator for RuleCaptionsGenerator {
+    fn name(&self) -> &str {
+        "rule-captions"
+    }
+    fn description(&self) -> &str {
+        "Rule-attached report captions (the `report` annotation, markdown)"
+    }
+    fn applicable(&self, ctx: &ReportContext) -> bool {
+        ctx.config.rules.iter().any(|r| r.report.is_some())
+    }
+    fn generate(&self, ctx: &ReportContext) -> Vec<ReportSection> {
+        let workdir = report_workdir(ctx);
+        let mut subsections = Vec::new();
+        for rule in &ctx.config.rules {
+            let Some(report) = rule.report.as_ref() else {
+                continue;
+            };
+            // Same instance-matching convention as CommandManifestGenerator:
+            // the rule name itself plus every expanded `{rule}_...` instance.
+            let mut runs: Vec<(&String, &crate::executor::checkpoint::RuleRunRecord)> = ctx
+                .checkpoint
+                .map(|c| {
+                    c.rule_runs
+                        .iter()
+                        .filter(|(name, _)| {
+                            *name == &rule.name || name.starts_with(&format!("{}_", rule.name))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            runs.sort_by(|a, b| a.0.cmp(b.0));
+
+            if runs.is_empty() {
+                // No execution record: fall back to the declared annotation
+                // so the section still shows what the author wrote.
+                let Some(caption) = Self::declared_caption(report, workdir.as_deref()) else {
+                    continue;
+                };
+                subsections.push(ReportSection {
+                    title: rule.name.clone(),
+                    id: sanitize_id(&format!("rule-captions-{}", rule.name)),
+                    content: ReportContent::Markdown { markdown: caption },
+                    subsections: vec![],
+                });
+                continue;
+            }
+            for (instance, run) in runs {
+                // Execution-time capture first — it is what the run saw.
+                let caption = match &run.caption {
+                    Some(text) => text.clone(),
+                    None => {
+                        // Legacy checkpoint (no captured caption): resolve
+                        // the declared annotation now, exactly like the
+                        // executor would have.
+                        match Self::declared_caption(report, workdir.as_deref()) {
+                            Some(text) => text,
+                            None => continue,
+                        }
+                    }
+                };
+                let title = if *instance == rule.name {
+                    rule.name.clone()
+                } else {
+                    instance.clone()
+                };
+                subsections.push(ReportSection {
+                    title,
+                    id: sanitize_id(&format!("rule-captions-{instance}")),
+                    content: ReportContent::Markdown { markdown: caption },
+                    subsections: vec![],
+                });
+            }
+        }
+        if subsections.is_empty() {
+            return Vec::new();
+        }
+        vec![ReportSection {
+            title: "Rule Captions".to_string(),
+            id: "rule-captions".to_string(),
+            content: ReportContent::Text {
+                text: "Per-rule report annotations captured from the workflow (markdown)."
+                    .to_string(),
+            },
+            subsections,
+        }]
+    }
+}
+
+impl RuleCaptionsGenerator {
+    /// Resolve the declared annotation (inline caption first, then
+    /// `report.file` relative to the workdir). Read failures yield `None` —
+    /// a missing caption file degrades to a note, never an error.
+    fn declared_caption(
+        report: &crate::rule::RuleReport,
+        workdir: Option<&std::path::Path>,
+    ) -> Option<String> {
+        if let Some(text) = report.caption() {
+            return Some(text.to_string());
+        }
+        let file = report.file()?;
+        let path = match workdir {
+            Some(wd) => wd.join(file),
+            None => std::path::PathBuf::from(file),
+        };
+        std::fs::read_to_string(&path).ok()
+    }
+}
+
 struct IoManifestGenerator;
 impl ReportSectionGenerator for IoManifestGenerator {
     fn name(&self) -> &str {
@@ -2563,6 +2683,183 @@ impl ReportSectionGenerator for MetricsGenerator {
             id: "metrics".to_string(),
             content: ReportContent::Text {
                 text: "QC metrics parsed from tool output files in the working directory."
+                    .to_string(),
+            },
+            subsections,
+        }]
+    }
+}
+
+/// MultiQC-style aggregate collector (issue #281): one sample × metric
+/// matrix across all parsed tools, plus any `*_mqc.json` custom content
+/// found in the scan. The per-(tool × sample) detail tables stay in the
+/// `metrics` section; this section is the cross-tool view that makes the
+/// report a credible MultiQC replacement for ported repos.
+struct AggregateMetricsGenerator;
+impl ReportSectionGenerator for AggregateMetricsGenerator {
+    fn name(&self) -> &str {
+        "aggregate-metrics"
+    }
+    fn description(&self) -> &str {
+        "Sample × metric matrix across tools, plus *_mqc.json custom content (MultiQC-style)"
+    }
+    fn applicable(&self, _ctx: &ReportContext) -> bool {
+        true
+    }
+    fn generate(&self, ctx: &ReportContext) -> Vec<ReportSection> {
+        let Some(workdir) = report_workdir(ctx) else {
+            return Vec::new();
+        };
+        let stats = MetricsScanner::new().scan_with_stats(&workdir);
+        // Skipped-only scans still surface their Scan Notes subsection —
+        // a scanner that hit files it could not parse must say so instead
+        // of hiding the section entirely (issue #83 P1-5 honesty rule).
+        if stats.parsed.is_empty() && stats.custom.is_empty() && stats.skipped == 0 {
+            return Vec::new();
+        }
+
+        let mut subsections = Vec::new();
+
+        // Sample × metric matrix across tools. Column keys are
+        // `tool.metric` (or `tool.metric[sample-suffix]` when multiple
+        // files contributed the same tool.metric for one sample — e.g.
+        // paired-end fastp runs); rows are samples, sorted.
+        let mut samples: std::collections::BTreeMap<
+            String,
+            Vec<(String, String, Option<QcStatusLevel>)>,
+        > = std::collections::BTreeMap::new();
+        for parsed in &stats.parsed {
+            let Some(sample) = parsed.sample.as_deref() else {
+                // Files without a sample prefix have no place in a
+                // sample-keyed matrix; their detail stays in `metrics`.
+                continue;
+            };
+            for metric in &parsed.metrics {
+                let column = format!("{}.{}", parsed.tool, metric.name);
+                samples.entry(sample.to_string()).or_default().push((
+                    column,
+                    format_metric_value(metric.value),
+                    metric.flag.clone(),
+                ));
+            }
+        }
+        if !samples.is_empty() {
+            // Disambiguate repeated (sample, column) pairs first: a second
+            // contribution to the same cell gets a numbered suffix
+            // (`tool.metric[2]`, e.g. `S1.flagstat` + `S1.flagstat.txt`) so
+            // both values stay visible instead of one clobbering the other.
+            // Column collection must run after this so the renamed cells
+            // line up with the headers.
+            for cells in samples.values_mut() {
+                let mut counts: std::collections::HashMap<String, usize> =
+                    std::collections::HashMap::new();
+                for (column, _, _) in cells.iter_mut() {
+                    let count = counts.entry(column.clone()).or_insert(0);
+                    *count += 1;
+                    if *count > 1 {
+                        *column = format!("{column}[{count}]");
+                    }
+                }
+            }
+            // Column order: first-seen order (the scan is deterministic, so
+            // this is byte-stable) — tools group naturally, mirroring how
+            // MultiQC lays out its matrix.
+            let mut columns: Vec<String> = Vec::new();
+            let mut seen = std::collections::HashSet::new();
+            for cells in samples.values() {
+                for (column, _, _) in cells {
+                    if seen.insert(column.clone()) {
+                        columns.push(column.clone());
+                    }
+                }
+            }
+            let mut headers = vec!["Sample".to_string()];
+            headers.extend(columns.iter().cloned());
+            let mut rows: Vec<Vec<String>> = Vec::new();
+            for (sample, cells) in &samples {
+                let mut row = vec![sample.clone()];
+                for column in &columns {
+                    let value = cells
+                        .iter()
+                        .find(|(c, _, _)| c == column)
+                        .map(|(_, v, _)| v.clone())
+                        .unwrap_or_else(|| "-".to_string());
+                    row.push(value);
+                }
+                rows.push(row);
+            }
+            subsections.push(ReportSection {
+                title: "Sample Matrix".to_string(),
+                id: "aggregate-sample-matrix".to_string(),
+                content: ReportContent::Table { headers, rows },
+                subsections: vec![],
+            });
+        }
+
+        // Custom content: one subsection per `*_mqc.json` file, in scan
+        // (sorted) order. Scalar-per-sample data already arrives as a
+        // single `value` column from the parser.
+        for content in &stats.custom {
+            let CustomContent { title, data } = content;
+            let mut metric_names: Vec<String> = Vec::new();
+            let mut seen = std::collections::HashSet::new();
+            for (_, pairs) in data {
+                for (metric, _) in pairs {
+                    if seen.insert(metric.clone()) {
+                        metric_names.push(metric.clone());
+                    }
+                }
+            }
+            let mut headers = vec!["Sample".to_string()];
+            headers.extend(metric_names.iter().cloned());
+            let rows: Vec<Vec<String>> = data
+                .iter()
+                .map(|(sample, pairs)| {
+                    let mut row = vec![sample.clone()];
+                    for metric in &metric_names {
+                        let cell = pairs
+                            .iter()
+                            .find(|(m, _)| m == metric)
+                            .map(|(_, v)| match v {
+                                CustomValue::Number(n) => format_metric_value(*n),
+                                CustomValue::Text(t) => t.clone(),
+                            })
+                            .unwrap_or_else(|| "-".to_string());
+                        row.push(cell);
+                    }
+                    row
+                })
+                .collect();
+            subsections.push(ReportSection {
+                title: title.clone(),
+                id: sanitize_id(&format!("mqc-{title}")),
+                content: ReportContent::Table { headers, rows },
+                subsections: vec![],
+            });
+        }
+
+        if stats.skipped > 0 {
+            subsections.push(ReportSection {
+                title: "Scan Notes".to_string(),
+                id: "aggregate-scan-notes".to_string(),
+                content: ReportContent::Text {
+                    text: format!(
+                        "{} file(s) matched known tool patterns but failed to parse",
+                        stats.skipped
+                    ),
+                },
+                subsections: vec![],
+            });
+        }
+
+        if subsections.is_empty() {
+            return Vec::new();
+        }
+        vec![ReportSection {
+            title: "Aggregate Metrics".to_string(),
+            id: "aggregate-metrics".to_string(),
+            content: ReportContent::Text {
+                text: "Cross-tool sample matrix and custom content from the working directory."
                     .to_string(),
             },
             subsections,
@@ -2949,6 +3246,7 @@ fn task_summary_section(rules: &[crate::rule::Rule]) -> ReportSection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::checkpoint::RuleRunRecord;
 
     #[test]
     fn report_workflow_git_sha_provenance_roundtrip() {
@@ -3031,6 +3329,7 @@ mod tests {
                 skip_reason: None,
                 max_rss_mb: None,
                 cpu_seconds: None,
+                caption: None,
             },
         );
 
@@ -3411,6 +3710,7 @@ mod tests {
                 skip_reason: None,
                 max_rss_mb: None,
                 cpu_seconds: None,
+                caption: None,
             },
         );
         let section = execution_time_chart(&records);
@@ -3460,6 +3760,7 @@ mod tests {
                 exit_code: Some(127),
                 command: Some("gatk HaplotypeCaller -I out.bam".to_string()),
                 stderr_tail: Some("gatk: command not found".to_string()),
+                caption: None,
             },
         );
         cp.checksums
@@ -3681,6 +3982,7 @@ input = ["out.bam"]
                 exit_code: Some(137),
                 command: None,
                 stderr_tail: Some("Killed".to_string()),
+                caption: None,
             },
         );
         let ctx = ctx_for(&config, Some(&cp), None);
@@ -3851,6 +4153,355 @@ shell = "echo hi"
         // Real table rendering, not a dead promise (issue #83 P1-10).
         assert!(!html.contains("interactive"));
         assert!(html.contains("<table>"));
+    }
+
+    // ── Issue #281: rule captions + aggregate metrics ─────────────────────
+
+    #[test]
+    fn rule_captions_inline_caption() {
+        let config = workflow_config(
+            r##"[[rules]]
+name = "qc"
+shell = "fastp -i in.fq"
+report = "# QC summary\nReads trimmed with fastp."
+"##,
+        );
+        let ctx = ctx_for(&config, None, None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let captions = sections.iter().find(|s| s.id == "rule-captions").unwrap();
+        assert_eq!(captions.title, "Rule Captions");
+        assert_eq!(captions.subsections.len(), 1);
+        assert_eq!(captions.subsections[0].title, "qc");
+        match &captions.subsections[0].content {
+            ReportContent::Markdown { markdown } => {
+                assert!(markdown.contains("fastp"));
+            }
+            _ => panic!("expected markdown content"),
+        }
+    }
+
+    #[test]
+    fn rule_captions_file_resolved_relative_to_workdir() {
+        let workdir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workdir.path().join("qc_note.md"),
+            "Alignment summary: 95% mapped.",
+        )
+        .unwrap();
+        let config = workflow_config(
+            r#"[[rules]]
+name = "align"
+shell = "bwa mem"
+report = { file = "qc_note.md" }
+"#,
+        );
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(workdir.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let captions = sections.iter().find(|s| s.id == "rule-captions").unwrap();
+        match &captions.subsections[0].content {
+            ReportContent::Markdown { markdown } => {
+                assert_eq!(markdown, "Alignment summary: 95% mapped.");
+            }
+            _ => panic!("expected markdown content"),
+        }
+    }
+
+    #[test]
+    fn rule_captions_render_per_executed_instance() {
+        let config = workflow_config(
+            r#"[[sample_groups]]
+name = "cohort"
+samples = ["S1", "S2"]
+
+[[rules]]
+name = "qc"
+shell = "fastp -i {sample}.fq"
+report = "Per-sample QC."
+"#,
+        );
+        let mut cp = fixture_checkpoint();
+        // The engine records expanded instances as `{rule}_{group}_{sample}`
+        // with the caption captured at execution time.
+        cp.rule_runs.insert(
+            "qc_cohort_S1".to_string(),
+            RuleRunRecord {
+                exit_code: Some(0),
+                command: Some("fastp -i S1.fq".to_string()),
+                stderr_tail: None,
+                caption: Some("S1: 1M reads, Q30 0.95.".to_string()),
+            },
+        );
+        cp.rule_runs.insert(
+            "qc_cohort_S2".to_string(),
+            RuleRunRecord {
+                exit_code: Some(0),
+                command: Some("fastp -i S2.fq".to_string()),
+                stderr_tail: None,
+                caption: None, // falls back to the declared annotation
+            },
+        );
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let captions = sections.iter().find(|s| s.id == "rule-captions").unwrap();
+        assert_eq!(captions.subsections.len(), 2);
+        assert_eq!(captions.subsections[0].title, "qc_cohort_S1");
+        assert_eq!(captions.subsections[1].title, "qc_cohort_S2");
+        match &captions.subsections[0].content {
+            ReportContent::Markdown { markdown } => {
+                assert!(markdown.contains("Q30 0.95"));
+            }
+            _ => panic!("expected markdown content"),
+        }
+        // The instance without a captured caption falls back to the
+        // declared inline annotation.
+        match &captions.subsections[1].content {
+            ReportContent::Markdown { markdown } => {
+                assert_eq!(markdown, "Per-sample QC.");
+            }
+            _ => panic!("expected markdown content"),
+        }
+    }
+
+    #[test]
+    fn rule_captions_without_runs_use_declared_annotation() {
+        // Checkpoint exists, but the rule never ran (or a legacy checkpoint
+        // recorded no rule_runs at all): the declared annotation still shows.
+        let config = workflow_config(
+            r#"[[rules]]
+name = "qc"
+shell = "fastp -i in.fq"
+report = "Per-sample QC for a rule with no execution record."
+"#,
+        );
+        let cp = fixture_checkpoint(); // rule_runs has only "call"
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let captions = sections.iter().find(|s| s.id == "rule-captions").unwrap();
+        assert_eq!(captions.subsections.len(), 1);
+        assert_eq!(captions.subsections[0].title, "qc");
+        match &captions.subsections[0].content {
+            ReportContent::Markdown { markdown } => {
+                assert!(markdown.contains("no execution record"));
+            }
+            _ => panic!("expected markdown content"),
+        }
+    }
+
+    #[test]
+    fn rule_captions_hidden_when_no_rule_has_report() {
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+        let cp = fixture_checkpoint();
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        assert!(!sections.iter().any(|s| s.id == "rule-captions"));
+    }
+
+    #[test]
+    fn rule_captions_missing_file_degrades_to_hidden() {
+        // A `report.file` pointing at a nonexistent file must not fail the
+        // report — the rule simply contributes no caption subsection.
+        let config = workflow_config(
+            r#"[[rules]]
+name = "qc"
+shell = "fastp"
+report = { file = "does_not_exist.md" }
+"#,
+        );
+        let ctx = ctx_for(&config, None, None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        assert!(!sections.iter().any(|s| s.id == "rule-captions"));
+    }
+
+    #[test]
+    fn aggregate_metrics_matrix_across_tools() {
+        let workdir = tempfile::tempdir().unwrap();
+        std::fs::write(workdir.path().join("S1.fastp.json"), fastp_fixture(1234)).unwrap();
+        std::fs::write(
+            workdir.path().join("S1.flagstat"),
+            "100 + 0 in total (QC-passed reads + QC-failed reads)\n90 + 0 mapped (90.00% : N/A)\n",
+        )
+        .unwrap();
+        std::fs::write(workdir.path().join("S2.fastp.json"), fastp_fixture(5678)).unwrap();
+
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(workdir.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let agg = sections
+            .iter()
+            .find(|s| s.id == "aggregate-metrics")
+            .unwrap();
+        assert_eq!(agg.title, "Aggregate Metrics");
+        let matrix = &agg.subsections[0];
+        assert_eq!(matrix.title, "Sample Matrix");
+        assert_eq!(matrix.id, "aggregate-sample-matrix");
+        match &matrix.content {
+            ReportContent::Table { headers, rows } => {
+                // First-seen column order: S1's fastp metrics, then S1's
+                // flagstat — tools group naturally.
+                assert_eq!(
+                    headers,
+                    &[
+                        "Sample",
+                        "fastp.total_reads",
+                        "fastp.q30_rate",
+                        "fastp.gc_content",
+                        "fastp.duplication_rate",
+                        "flagstat.total_reads",
+                        "flagstat.mapped_rate",
+                    ]
+                );
+                assert_eq!(rows.len(), 2);
+                let s1 = &rows[0];
+                assert_eq!(s1[0], "S1");
+                assert_eq!(s1[1], "1234");
+                assert_eq!(s1[2], "0.92");
+                assert_eq!(s1[5], "100");
+                assert_eq!(s1[6], "0.90");
+                let s2 = &rows[1];
+                assert_eq!(s2[0], "S2");
+                assert_eq!(s2[1], "5678");
+                // S2 has no flagstat file → honest gap, not a fabricated 0.
+                assert_eq!(s2[5], "-");
+            }
+            _ => panic!("expected matrix table"),
+        }
+
+        // Deterministic output.
+        let sections_b = SectionRegistry::with_defaults().generate(&ctx, None);
+        let json = |sections: &[ReportSection]| {
+            let mut r = Report::new("T", "w", "0.1");
+            r.generated_at = None;
+            for section in sections {
+                r.add_section(section.clone());
+            }
+            r.to_json().unwrap()
+        };
+        assert_eq!(json(&sections), json(&sections_b));
+    }
+
+    #[test]
+    fn aggregate_metrics_includes_mqc_custom_content() {
+        let workdir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workdir.path().join("summary_mqc.json"),
+            r#"{"title": "Assembly summary", "data": {"S1": {"n50": 12000, "busco": "95%"}, "S2": {"n50": 8000, "busco": "91%"}}}"#,
+        )
+        .unwrap();
+
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(workdir.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let agg = sections
+            .iter()
+            .find(|s| s.id == "aggregate-metrics")
+            .unwrap();
+        assert_eq!(agg.subsections.len(), 1);
+        let custom = &agg.subsections[0];
+        assert_eq!(custom.title, "Assembly summary");
+        assert_eq!(custom.id, "mqc-Assembly-summary");
+        match &custom.content {
+            ReportContent::Table { headers, rows } => {
+                // Metrics sorted per row; rows sorted by sample.
+                assert_eq!(headers, &["Sample", "busco", "n50"]);
+                assert_eq!(rows[0], &["S1", "95%", "12000"]);
+                assert_eq!(rows[1], &["S2", "91%", "8000"]);
+            }
+            _ => panic!("expected custom-content table"),
+        }
+    }
+
+    #[test]
+    fn aggregate_metrics_yml_counts_as_skipped_with_scan_notes() {
+        let workdir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workdir.path().join("notes_mqc.yml"),
+            "id: notes\ndata: {S1: 1}\n",
+        )
+        .unwrap();
+
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(workdir.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        // Only the Scan Notes subsection — the YAML file itself is skipped
+        // (no YAML parser in the workspace), but not silently.
+        let agg = sections
+            .iter()
+            .find(|s| s.id == "aggregate-metrics")
+            .unwrap();
+        assert_eq!(agg.subsections.len(), 1);
+        assert_eq!(agg.subsections[0].title, "Scan Notes");
+        match &agg.subsections[0].content {
+            ReportContent::Text { text } => {
+                assert!(text.contains("1 file(s) matched known tool patterns"));
+            }
+            _ => panic!("expected text subsection"),
+        }
+    }
+
+    #[test]
+    fn aggregate_metrics_hidden_without_workdir_or_content() {
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+
+        // (a) No workdir resolvable → hidden.
+        let cp = fixture_checkpoint();
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        assert!(!sections.iter().any(|s| s.id == "aggregate-metrics"));
+
+        // (b) Workdir exists but nothing parsed → hidden, never an empty
+        // table.
+        let empty = tempfile::tempdir().unwrap();
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(empty.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        assert!(!sections.iter().any(|s| s.id == "aggregate-metrics"));
+    }
+
+    #[test]
+    fn aggregate_metrics_disambiguates_duplicate_sample_cells() {
+        // `S1.flagstat` and `S1.flagstat.txt` both classify as flagstat for
+        // sample S1 — the second contribution to `flagstat.total_reads` gets
+        // a numbered suffix instead of clobbering the first.
+        let workdir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workdir.path().join("S1.flagstat"),
+            "100 + 0 in total (QC-passed reads + QC-failed reads)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            workdir.path().join("S1.flagstat.txt"),
+            "200 + 0 in total (QC-passed reads + QC-failed reads)\n",
+        )
+        .unwrap();
+
+        let config = workflow_config("[[rules]]\nname = \"hello\"\nshell = \"echo hi\"\n");
+        let mut cp = fixture_checkpoint();
+        cp.workdir = Some(workdir.path().display().to_string());
+        let ctx = ctx_for(&config, Some(&cp), None);
+        let sections = SectionRegistry::with_defaults().generate(&ctx, None);
+        let agg = sections
+            .iter()
+            .find(|s| s.id == "aggregate-metrics")
+            .unwrap();
+        match &agg.subsections[0].content {
+            ReportContent::Table { headers, rows } => {
+                assert_eq!(
+                    headers,
+                    &["Sample", "flagstat.total_reads", "flagstat.total_reads[2]"]
+                );
+                assert_eq!(rows[0], &["S1", "100", "200"]);
+            }
+            _ => panic!("expected matrix table"),
+        }
     }
 
     // ── Issue #83 P1-5: metrics adapters + sample matrix ─────────────────
@@ -4154,6 +4805,7 @@ shell = "bwa mem"
                 exit_code: Some(0),
                 command: Some("summarize.sh cohort_S1".to_string()),
                 stderr_tail: None,
+                caption: None,
             },
         );
         ck.rule_runs.insert(
@@ -4162,6 +4814,7 @@ shell = "bwa mem"
                 exit_code: Some(0),
                 command: Some("summarize.sh cohort_S2".to_string()),
                 stderr_tail: None,
+                caption: None,
             },
         );
         let ctx = ctx_for(&config, Some(&ck), None);

--- a/crates/oxo-flow-core/src/report_metrics/adapters.rs
+++ b/crates/oxo-flow-core/src/report_metrics/adapters.rs
@@ -7,7 +7,7 @@
 //! separator, no data rows) return [`crate::error::OxoFlowError::Report`];
 //! missing fields yield absent metrics instead of errors.
 
-use super::MetricValue;
+use super::{CustomContent, CustomValue, MetricValue};
 use crate::error::{OxoFlowError, Result};
 use crate::report::QcStatusLevel;
 
@@ -348,6 +348,78 @@ pub fn parse_kraken2_report(text: &str) -> Result<Vec<MetricValue>> {
     Ok(metrics)
 }
 
+/// Parse a MultiQC-style custom-content JSON file (issue #281):
+/// `{ "title": ..., "data": { sample: { metric: value, ... } | value } }`.
+///
+/// `data` values must be JSON objects mapping metric → value, or scalars —
+/// a scalar is accepted and rendered as a single `value` column. JSON
+/// objects are unordered, so rows are emitted in sorted sample order and
+/// each row's metric pairs in sorted metric order (byte-stable reports).
+/// Non-numeric JSON values are carried as `CustomValue::Text` verbatim.
+///
+/// `fallback_title` is the file stem (minus `_mqc.json`); used when the
+/// file carries no `title`. The workspace has no YAML dependency, so
+/// `*_mqc.yml` is out of scope for the scanner — `classify_filename`
+/// matches it and counts it as skipped instead.
+pub fn parse_mqc_json(text: &str, fallback_title: Option<&str>) -> Result<CustomContent> {
+    let json: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| report_parse_error("mqc", format!("custom content is not valid JSON: {e}")))?;
+
+    let title = json
+        .get("title")
+        .and_then(|t| t.as_str())
+        .map(|t| t.to_string())
+        .or_else(|| fallback_title.map(|t| t.to_string()))
+        .unwrap_or_else(|| "custom content".to_string());
+
+    let data_json = json
+        .get("data")
+        .ok_or_else(|| report_parse_error("mqc", "custom content is missing the `data` object"))?;
+
+    let mut rows: Vec<(String, Vec<(String, CustomValue)>)> = Vec::new();
+    match data_json {
+        // { sample: { metric: value, ... } }
+        serde_json::Value::Object(by_sample) => {
+            for (sample, metrics) in by_sample {
+                let pairs = match metrics {
+                    // A bare scalar per sample renders as one `value` column.
+                    serde_json::Value::Object(by_metric) => {
+                        let mut pairs: Vec<(String, CustomValue)> = by_metric
+                            .iter()
+                            .map(|(metric, value)| (metric.clone(), custom_value(value)))
+                            .collect();
+                        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+                        pairs
+                    }
+                    scalar => vec![("value".to_string(), custom_value(scalar))],
+                };
+                rows.push((sample.clone(), pairs));
+            }
+            rows.sort_by(|a, b| a.0.cmp(&b.0));
+        }
+        _ => {
+            return Err(report_parse_error(
+                "mqc",
+                "`data` must be an object mapping sample → metrics",
+            ));
+        }
+    }
+
+    Ok(CustomContent { title, data: rows })
+}
+
+/// Convert a JSON scalar into a [`CustomValue`]: numbers stay numeric,
+/// everything else becomes text.
+fn custom_value(value: &serde_json::Value) -> CustomValue {
+    match value {
+        serde_json::Value::Number(n) => CustomValue::Number(n.as_f64().unwrap_or(0.0)),
+        serde_json::Value::String(s) => CustomValue::Text(s.clone()),
+        serde_json::Value::Bool(b) => CustomValue::Text(b.to_string()),
+        serde_json::Value::Null => CustomValue::Text(String::new()),
+        other => CustomValue::Text(other.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -663,5 +735,101 @@ mod tests {
     fn kraken2_malformed_errors() {
         assert!(parse_kraken2_report("").is_err());
         assert!(parse_kraken2_report("no tabs here\n").is_err());
+    }
+
+    // ── MultiQC custom content (*_mqc.json, issue #281) ──────────────────
+
+    #[test]
+    fn mqc_object_data_happy_path() {
+        let content = parse_mqc_json(
+            r#"{
+                "title": "Assembly summary",
+                "data": {
+                    "S2": { "n50": 8000, "busco": "91%" },
+                    "S1": { "n50": 12000, "busco": "95%" }
+                }
+            }"#,
+            Some("assembly_summary"),
+        )
+        .unwrap();
+        assert_eq!(content.title, "Assembly summary");
+        // Rows sorted by sample; each row's pairs sorted by metric.
+        assert_eq!(
+            content.data,
+            vec![
+                (
+                    "S1".to_string(),
+                    vec![
+                        ("busco".to_string(), CustomValue::Text("95%".to_string())),
+                        ("n50".to_string(), CustomValue::Number(12000.0)),
+                    ]
+                ),
+                (
+                    "S2".to_string(),
+                    vec![
+                        ("busco".to_string(), CustomValue::Text("91%".to_string())),
+                        ("n50".to_string(), CustomValue::Number(8000.0)),
+                    ]
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn mqc_scalar_data_renders_single_value_column() {
+        let content = parse_mqc_json(r#"{"data": {"S1": 0.95, "S2": 0.91}}"#, None).unwrap();
+        assert_eq!(content.title, "custom content", "no title, no fallback");
+        assert_eq!(
+            content.data,
+            vec![
+                (
+                    "S1".to_string(),
+                    vec![("value".to_string(), CustomValue::Number(0.95))]
+                ),
+                (
+                    "S2".to_string(),
+                    vec![("value".to_string(), CustomValue::Number(0.91))]
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn mqc_title_falls_back_to_file_stem() {
+        let content = parse_mqc_json(r#"{"data": {"S1": {"x": 1}}}"#, Some("qc_rollup")).unwrap();
+        assert_eq!(content.title, "qc_rollup");
+    }
+
+    #[test]
+    fn mqc_non_numeric_values_stay_text() {
+        let content = parse_mqc_json(
+            r#"{"data": {"S1": {"flag": true, "note": null, "list": [1, 2]}}}"#,
+            None,
+        )
+        .unwrap();
+        let pairs = &content.data[0].1;
+        assert_eq!(
+            pairs,
+            &vec![
+                ("flag".to_string(), CustomValue::Text("true".to_string())),
+                ("list".to_string(), CustomValue::Text("[1,2]".to_string())),
+                ("note".to_string(), CustomValue::Text(String::new())),
+            ]
+        );
+    }
+
+    #[test]
+    fn mqc_invalid_json_is_an_error() {
+        assert!(parse_mqc_json("not json", None).is_err());
+    }
+
+    #[test]
+    fn mqc_missing_data_is_an_error() {
+        assert!(parse_mqc_json(r#"{"title": "orphan"}"#, None).is_err());
+    }
+
+    #[test]
+    fn mqc_non_object_data_is_an_error() {
+        assert!(parse_mqc_json(r#"{"data": [1, 2, 3]}"#, None).is_err());
     }
 }

--- a/crates/oxo-flow-core/src/report_metrics/mod.rs
+++ b/crates/oxo-flow-core/src/report_metrics/mod.rs
@@ -37,6 +37,27 @@ pub struct ParsedMetrics {
     pub metrics: Vec<MetricValue>,
 }
 
+/// A value in MultiQC-style custom content: numbers stay numeric (they
+/// feed matrix formatting); everything else is carried as text.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CustomValue {
+    Number(f64),
+    Text(String),
+}
+
+/// One `*_mqc.json` custom-content file (issue #281): MultiQC's
+/// custom-content subset — a `title` plus a `data` table mapping sample
+/// → metric → value (a scalar value per sample is accepted and rendered
+/// as a single `value` column).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomContent {
+    /// Display title: the file's `title` field, else the file stem.
+    pub title: String,
+    /// Rows in sorted sample order; each row's `(metric, value)` pairs
+    /// are sorted by metric for byte-stable output.
+    pub data: Vec<(String, Vec<(String, CustomValue)>)>,
+}
+
 /// Scanner result: what was parsed and — critically — what was not
 /// (a scanner that cannot report its own gaps looks like it covered
 /// everything, issue #83 P1-5).
@@ -44,6 +65,8 @@ pub struct ParsedMetrics {
 pub struct ScanStats {
     /// Successfully parsed metrics.
     pub parsed: Vec<ParsedMetrics>,
+    /// Custom content parsed from `*_mqc.json` files (issue #281).
+    pub custom: Vec<CustomContent>,
     /// Files that matched a known tool pattern but were skipped: parse
     /// failures, files larger than the size cap, non-UTF-8 content.
     pub skipped: usize,
@@ -190,6 +213,17 @@ impl MetricsScanner {
                 }
             };
 
+            // Custom content (`*_mqc.json`) is dispatched separately: it
+            // fills `stats.custom` instead of the parsed-metrics list, and
+            // its sample comes from the file's own data, not the filename.
+            if tool == "mqc" {
+                match adapters::parse_mqc_json(&text, sample.as_deref()) {
+                    Ok(content) => stats.custom.push(content),
+                    Err(_) => stats.skipped += 1,
+                }
+                continue;
+            }
+
             match adapters::parse_for_tool(tool, &text) {
                 Ok(metrics) if metrics.is_empty() => {
                     // Parsed cleanly but nothing extractable — not a
@@ -220,6 +254,12 @@ const TOOL_SUFFIXES: &[(&str, &str)] = &[
     (".bcftools.stats", "bcftools"),
     (".kraken2.report", "kraken2"),
     (".kraken.report", "kraken2"),
+    // MultiQC-style custom content (issue #281). Only JSON is parsed — the
+    // workspace has no YAML dependency, so `*_mqc.yml` files are handled by
+    // the explicit `_mqc.yml` check in `classify_filename` and skipped with
+    // an honest note. For `_mqc.json` the stem minus the suffix is a
+    // fallback title, not a sample.
+    ("_mqc.json", "mqc"),
 ];
 
 /// Classify a filename into `(tool, sample)`; `None` when no known tool
@@ -230,14 +270,25 @@ const TOOL_SUFFIXES: &[(&str, &str)] = &[
 /// `*.summary` → the part before `.summary`. A filename that is exactly the
 /// suffix (`fastp.json`) leaves an empty remainder → sample = `None`.
 fn classify_filename(name: &str) -> Option<(&'static str, Option<String>)> {
+    // `*_mqc.yml` files are MultiQC custom content we cannot parse (no YAML
+    // dependency in the workspace). They match here so the scanner counts
+    // them as skipped — visible in Scan Notes — instead of silently
+    // disappearing.
     let lower = name.to_lowercase();
+    if lower.ends_with("_mqc.yml") {
+        return Some(("mqc-yml", None));
+    }
     for (suffix, tool) in TOOL_SUFFIXES {
         if lower.ends_with(suffix) {
-            // Include the separator dot in the strip (S1.fastp.json minus
-            // ".fastp.json" = "S1"); a bare `fastp.json` has none.
+            // Include the separator character in the strip (S1.fastp.json
+            // minus ".fastp.json" = "S1"; sample_mqc.json minus
+            // "_mqc.json" = "sample"). A bare `fastp.json` has none.
             let mut strip_len = suffix.len();
             let before = lower.len().checked_sub(suffix.len() + 1);
-            if before.is_some_and(|i| lower.as_bytes()[i] == b'.') {
+            if before.is_some_and(|i| {
+                let b = lower.as_bytes()[i];
+                b == b'.' || b == b'_'
+            }) {
                 strip_len += 1;
             }
             let stripped = &name[..name.len() - strip_len];
@@ -417,5 +468,58 @@ mod tests {
             other => panic!("unexpected scanner outcome: {other:?}"),
         }
         let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644));
+    }
+
+    // ── Custom content (*_mqc.json / *_mqc.yml, issue #281) ─────────────
+
+    #[test]
+    fn scanner_routes_mqc_json_to_custom_content() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("assembly_mqc.json"),
+            r#"{"title": "Assembly summary", "data": {"S1": {"n50": 12000}}}"#,
+        )
+        .unwrap();
+
+        let stats = MetricsScanner::new().scan_with_stats(dir.path());
+        assert!(stats.parsed.is_empty());
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.custom.len(), 1);
+        assert_eq!(stats.custom[0].title, "Assembly summary");
+        assert_eq!(stats.custom[0].data.len(), 1);
+    }
+
+    #[test]
+    fn scanner_counts_mqc_yml_as_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("notes_mqc.yml"),
+            "id: notes\ndata: {S1: 1}\n",
+        )
+        .unwrap();
+
+        let stats = MetricsScanner::new().scan_with_stats(dir.path());
+        assert!(stats.custom.is_empty(), "no YAML parser in the workspace");
+        assert_eq!(stats.skipped, 1, "yml custom content is an honest skip");
+    }
+
+    #[test]
+    fn scanner_mqc_broken_json_counts_as_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("broken_mqc.json"), "not json").unwrap();
+
+        let stats = MetricsScanner::new().scan_with_stats(dir.path());
+        assert!(stats.custom.is_empty());
+        assert_eq!(stats.skipped, 1);
+    }
+
+    #[test]
+    fn scanner_mqc_title_falls_back_to_file_stem() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("rollup_mqc.json"), r#"{"data": {"S1": 5}}"#).unwrap();
+
+        let stats = MetricsScanner::new().scan_with_stats(dir.path());
+        assert_eq!(stats.custom.len(), 1);
+        assert_eq!(stats.custom[0].title, "rollup", "stem minus _mqc.json");
     }
 }

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -99,6 +99,105 @@ impl<'de> Deserialize<'de> for OptionalMode {
     }
 }
 
+/// Report annotation for a rule, rendered by the `rule-captions` report
+/// section. TOML forms: `report = "caption text"` or
+/// `report = { file = "path", caption = "caption text" }`.
+///
+/// Captions are text/markdown only (no figure embedding in v1); a `file`
+/// is a markdown/text file resolved relative to the workdir at render time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuleReport {
+    /// Inline caption text (markdown allowed).
+    Text(String),
+    /// Structured form: an optional markdown/text file (relative to the
+    /// workdir) and/or an optional inline caption.
+    Detailed {
+        /// Path to a markdown/text file, relative to the workdir.
+        file: Option<String>,
+        /// Inline caption text (markdown allowed).
+        caption: Option<String>,
+    },
+}
+
+impl Serialize for RuleReport {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Text(text) => serializer.serialize_str(text),
+            Self::Detailed { file, caption } => {
+                use serde::ser::SerializeStruct as _;
+                let mut len = 0;
+                if file.is_some() {
+                    len += 1;
+                }
+                if caption.is_some() {
+                    len += 1;
+                }
+                let mut state = serializer.serialize_struct("RuleReport", len)?;
+                if let Some(file) = file {
+                    state.serialize_field("file", file)?;
+                }
+                if let Some(caption) = caption {
+                    state.serialize_field("caption", caption)?;
+                }
+                state.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleReport {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = toml::Value::deserialize(deserializer)?;
+        match value {
+            toml::Value::String(s) => Ok(Self::Text(s)),
+            toml::Value::Table(map) => {
+                let field = |key: &str| -> Result<Option<String>, D::Error> {
+                    match map.get(key) {
+                        None | Some(toml::Value::String(_)) => Ok(map
+                            .get(key)
+                            .and_then(toml::Value::as_str)
+                            .map(str::to_owned)),
+                        Some(other) => Err(serde::de::Error::custom(format!(
+                            "report.{key} must be a string — got {other}"
+                        ))),
+                    }
+                };
+                let file = field("file")?;
+                let caption = field("caption")?;
+                if file.is_none() && caption.is_none() {
+                    return Err(serde::de::Error::custom(
+                        "report table needs at least one of `file` or `caption`",
+                    ));
+                }
+                Ok(Self::Detailed { file, caption })
+            }
+            other => Err(serde::de::Error::custom(format!(
+                "report must be a string or a table with `file`/`caption` — got {other}"
+            ))),
+        }
+    }
+}
+
+impl RuleReport {
+    /// The inline caption text, if any.
+    #[must_use]
+    pub fn caption(&self) -> Option<&str> {
+        match self {
+            Self::Text(text) => Some(text),
+            Self::Detailed { caption, .. } => caption.as_deref(),
+        }
+    }
+
+    /// The referenced markdown/text file path, if any.
+    #[must_use]
+    pub fn file(&self) -> Option<&str> {
+        match self {
+            Self::Text(_) => None,
+            Self::Detailed { file, .. } => file.as_deref(),
+        }
+    }
+}
+
 /// Parse a duration string like "5s", "30s", "2m", "1h", "1d" into seconds.
 ///
 /// Returns `None` if the format is invalid or would overflow.
@@ -994,6 +1093,14 @@ pub struct Rule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Report annotation rendered by the `rule-captions` section: inline
+    /// caption text, or `{ file = "…", caption = "…" }` where `file` is a
+    /// markdown/text file resolved relative to the workdir at render time.
+    /// Text/markdown only — no figure embedding (see issue #281).
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<RuleReport>,
+
     /// Conditional execution expression.
     ///
     /// The rule is only executed when this expression evaluates to true.
@@ -1457,6 +1564,12 @@ impl RuleBuilder {
     #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.rule.description = Some(description.into());
+        self
+    }
+
+    /// Set the rule's report annotation (inline caption text).
+    pub fn report(mut self, report: crate::rule::RuleReport) -> Self {
+        self.rule.report = Some(report);
         self
     }
 

--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -893,6 +893,7 @@ mod tests {
             skip_reason: None,
             max_rss_mb: None,
             cpu_seconds: None,
+            caption: None,
         });
 
         assert_eq!(state.status("a"), Some(JobStatus::Success));
@@ -1088,6 +1089,7 @@ mod tests {
             skip_reason: None,
             max_rss_mb: None,
             cpu_seconds: None,
+            caption: None,
         });
 
         // Both "left" and "right" should be ready
@@ -1621,6 +1623,7 @@ mod reentry_tests {
             skip_reason: None,
             max_rss_mb: None,
             cpu_seconds: None,
+            caption: None,
         });
         sched.add_rule("b");
         let ready = sched.ready_rules(&dag).unwrap();

--- a/docs/guide/src/commands/report.md
+++ b/docs/guide/src/commands/report.md
@@ -295,8 +295,10 @@ sections = ["universal", "workflow-info", "commands"]
 - Available built-in section IDs (generator names used by the filter):
   `universal`, `execution-status`, `failure-diagnosis`,
   `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`,
-  `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary` —
-  the rendered HTML id can differ from the generator name: `universal`
+  `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary`,
+  `software-versions`, `rule-captions`, `aggregate-metrics` — run
+  `oxo-flow report WF --list-sections` for the live list; the rendered
+  HTML id can differ from the generator name: `universal`
   renders the `dashboard` section, and `execution-status` renders both
   `execution-status` and `benchmarks`
 - The filter applies to **all** sections, including `task-summary`

--- a/docs/guide/src/how-to/generate-reports.md
+++ b/docs/guide/src/how-to/generate-reports.md
@@ -62,6 +62,9 @@ A generated report includes:
 | **Environment** | Engine version, platform, and the environments the workflow's rules declare |
 | **Provenance** | Engine version, workflow file sha256, checkpoint location |
 | **Task Summary** | Per-rule table of tasks, types, inputs, outputs, environments, and resources |
+| **Software Versions** | Tool/version table parsed from known version-reporting files under the workdir |
+| **Rule Captions** | Per-rule `report` annotations rendered as markdown (one subsection per executed instance) — set `report = "caption"` or `report = { file = "notes/qc.md", caption = "…" }` on a rule |
+| **Aggregate Metrics** | MultiQC-style sample × metric matrix across all parsed tools, plus `*_mqc.json` custom content |
 
 Sections adapt to available execution data — for example, **Execution
 Status** and **Failure Diagnosis** only appear with a checkpoint — and
@@ -84,7 +87,8 @@ sections = ["universal", "workflow-info", "commands", "failure-diagnosis"]
 > (`universal`, `execution-status`, `failure-diagnosis`,
 > `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`,
 > `environment`, `metrics`, `sample-matrix`, `provenance`,
-> `task-summary`). `template` is **consumed** (see below); `format` is
+> `task-summary`, `software-versions`, `rule-captions`,
+> `aggregate-metrics`). `template` is **consumed** (see below); `format` is
 > parsed but still unsupported: setting it makes the command warn (or fail
 > under `--strict`) instead of silently ignoring it — output formats are
 > selected via the CLI `-f` flag.

--- a/docs/guide/src/reference/reporting-system.md
+++ b/docs/guide/src/reference/reporting-system.md
@@ -202,7 +202,8 @@ sections = ["universal", "workflow-info", "commands", "failure-diagnosis"]
 name. Available names: `universal`, `execution-status`,
 `failure-diagnosis`, `clinical-compliance`, `workflow-info`, `commands`,
 `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`,
-`task-summary` — enumerable at runtime with
+`task-summary`, `software-versions`, `rule-captions`,
+`aggregate-metrics` — enumerable at runtime with
 `oxo-flow report WF --list-sections`.
 
 The filter name is the generator name; the rendered HTML id can differ —

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -504,7 +504,7 @@ sections = ["universal", "workflow-info", "commands", "clinical-compliance"]
 |---|---|---|
 | `template` | String | Report template: the built-in name `"report.html"`, or a template file path (workflow directory first, then cwd). Applies to HTML output only; a render failure warns and falls back to the default renderer |
 | `format` | Array | Parsed but **not supported yet** — setting it makes `report` warn (or fail under `--strict`); select the output format with `-f` instead |
-| `sections` | Array | Report sections to include. If empty (or omitted), all applicable generators run. Available built-in IDs: `universal`, `execution-status`, `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary` |
+| `sections` | Array | Report sections to include. If empty (or omitted), all applicable generators run. Available built-in IDs: `universal`, `execution-status`, `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary`, `software-versions`, `rule-captions`, `aggregate-metrics` (run `oxo-flow report --list-sections` for the live list) |
 
 ### How Sections Work
 
@@ -519,8 +519,41 @@ Each section ID maps to a registered `ReportSectionGenerator`:
 | `environment` | Available backends and oxo-flow version | Always |
 | `clinical-compliance` | ACMG/AMP classification, audit trail, biomarkers | Always |
 | `execution-status` | Per-rule execution status and benchmark metrics | Only with checkpoint |
+| `software-versions` | Tool/version table parsed from known version-reporting files (`*version*` filenames) | When version files are found |
+| `rule-captions` | Per-rule `report` annotations rendered as markdown — see [Rule Captions](#rule-captions) | When any rule declares `report` |
+| `aggregate-metrics` | MultiQC-style sample × metric matrix across tools, plus `*_mqc.json` custom content | When metric or custom-content files are found |
 
 The domain (DNA-seq, RNA-seq, epigenomics, or generic) is auto-detected from tool names in the workflow. Custom generators can be registered programmatically.
+
+### Rule Captions
+
+A rule can carry a `report` annotation — caption text rendered in the report's `rule-captions` section (the Snakemake `report()` equivalent). Two TOML forms:
+
+```toml
+[[rules]]
+name = "qc"
+shell = "fastp -i {sample}.fq"
+# Inline caption (markdown allowed):
+report = """
+# QC summary
+Reads trimmed with fastp; per-sample Q30 below.
+"""
+
+[[rules]]
+name = "align"
+shell = "bwa mem -t {threads} {input} > {output}"
+# Structured form: a markdown/text file relative to the workdir,
+# and/or an inline caption (at least one of the two):
+report = { file = "notes/alignment.md", caption = "Alignment QC" }
+```
+
+At render time each executed rule instance contributes one markdown subsection, ordered by rule declaration order:
+
+- The checkpoint's execution-time caption wins — it is what the run actually read (`report.file` content is captured when the rule completes, so a later edit to the file does not silently change a finished report).
+- Without an execution record (dry run, or a checkpoint from before this feature), the declared annotation is resolved at report time: inline caption first, then `report.file` relative to the workdir.
+- A missing or unreadable `report.file` never fails the report — the rule simply contributes no caption.
+
+Captions are text/markdown only; embedding figures is not supported in v1.
 
 ---
 
@@ -554,6 +587,7 @@ memory = "32G"
 | `shell` | String | No | Shell command to execute |
 | `script` | String | No | Script file path (auto-detects interpreter) |
 | `description` | String | No | Human-readable description of what this rule does |
+| `report` | String or Table | No | Report annotation rendered by the `rule-captions` report section. Inline text: `report = "# QC summary\nReads trimmed with fastp."` (markdown allowed). Or a table: `report = { file = "notes/qc.md", caption = "Alignment QC" }` where `file` is a markdown/text file resolved relative to the workdir (at least one of `file`/`caption` required) — see [Rule Captions](#rule-captions) |
 | `threads` | Integer | No | *(Deprecated)* CPU threads — use `resources.threads` instead. Still honored, but `oxo-flow lint` flags it with a W025 suggestion to move it under `[rules.resources]` |
 | `memory` | String | No | *(Deprecated)* Memory allocation — use `resources.memory` instead. Still honored, but `oxo-flow lint` flags it with a W025 suggestion to move it under `[rules.resources]` |
 | `resources` | Table | No | Full resource specification (threads, memory, gpu, disk, time_limit, partition, groups) |

--- a/docs/schema/oxoflow-v1.schema.json
+++ b/docs/schema/oxoflow-v1.schema.json
@@ -1876,6 +1876,18 @@
             "null"
           ],
           "description": "Rule-level output pattern override"
+        },
+        "report": {
+          "type": [
+            "string",
+            "array",
+            "object",
+            "boolean",
+            "number",
+            "integer",
+            "null"
+          ],
+          "description": "Schema synced from config whitelist (see known_keys.rs)"
         }
       }
     },


### PR DESCRIPTION
## Summary

Implements #281 (Engine M2 residual): rule-attached report captions + a MultiQC-style aggregate collector. Two independent pieces, both report-side only — no scheduling or execution semantics change.

### Part 1 — rule-attached report captions

- `Rule` gains an optional `report` field, two TOML forms:
  - inline text: `report = "## QC summary\nReads trimmed with fastp."`
  - detailed: `report = { file = "qc_note.md", caption = "fallback" }`
- `known_keys` validation accepts both; the top-level `[report]` table (issue #254) stays disambiguated by the presence of `file`/`caption` keys. JSON schema updated.
- Captions are resolved at execution time and persisted on `JobRecord`/`RuleRunRecord` (`caption`), so they survive resume exactly like `rule_runs`.
- New `RuleCaptions` section generator (after TaskSummary in `with_defaults()`):
  - one subsection per executed instance, execution order (same instance-matching convention as CommandManifest: exact name or `name_` prefix)
  - caption priority: checkpoint record → declared inline text → `report.file` read relative to the run workdir
  - read failures degrade silently; instances without a resolvable caption are skipped; the section hides when nothing resolves
  - text/markdown only — no figure embedding in v1 (per the issue's non-goals)

### Part 2 — MultiQC-style aggregate collector

- Scanner: `*_mqc.json` is classified as custom content and parsed into `{title, data}`:
  - `data` maps sample → metric → value; a bare scalar per sample renders as a single `value` column
  - rows sorted by sample, pairs sorted by metric (byte-stable output)
  - `title` falls back to the file stem (minus `_mqc.json`), then `"custom content"`
  - numbers stay numeric; strings/bools/null/arrays carry as text
- `*_mqc.yml` is matched but counted as an **honest skip** (visible in Scan Notes) — the workspace has no YAML dependency by design
- New `AggregateMetrics` section generator:
  - sample × metric matrix across tools (`tool.metric` columns in first-seen order — tools group naturally, MultiQC-style)
  - repeated `(sample, column)` pairs disambiguated with `[2]`-suffixes **before** headers are collected so both values stay visible (a paired-end fastp case renders `fastp.total_reads` + `fastp.total_reads[2]`)
  - one table per custom-content file, then Scan Notes for skipped/unreadable files
  - a skipped-only scan still surfaces its Scan Notes instead of hiding the section (issue #83 P1-5 honesty rule)

## Test plan

- 6 new `RuleCaptions` generator tests: inline caption, file-relative-to-workdir, per-executed-instance with checkpoint priority, declared-only when no runs, hidden when no rule declares `report`, missing file degrades to hidden
- 5 new `AggregateMetrics` generator tests: cross-tool matrix, mqc custom content table, `_mqc.yml` → Scan Notes, hidden without workdir/content, duplicate-cell disambiguation
- 7 new `parse_mqc_json` adapter tests: object/scalar happy paths, title fallback, text coercion (bool/null/array), invalid JSON / missing data / non-object data errors
- 4 new scanner tests: `_mqc.json` → `stats.custom`, `_mqc.yml` → skipped, broken mqc JSON → skipped, stem-title fallback
- Full workspace suite green: 1327 + 296 + ... all pass; `cargo fmt --check` and `cargo clippy -p oxo-flow-core --all-targets` clean

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
