### PR TITLE
feat: data-dependent DAG pruning — when gates over runtime-produced files (#282)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,6 +2978,7 @@ dependencies = [
  "criterion",
  "csv",
  "filetime",
+ "flate2",
  "fs2",
  "glob",
  "hex",

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1152,6 +1152,10 @@ pub async fn run_command(
         }
         ck.set_workdir(&absolutize(workdir.as_deref().unwrap_or(&workdir_default))?);
     }
+    // Same absolutized run workdir, reused by the config-change replay below
+    // (issue #282): runtime file functions in `when` resolve their relative
+    // paths against it so threshold changes get real verdicts.
+    let run_workdir = absolutize(workdir.as_deref().unwrap_or(&workdir_default))?;
 
     // Changed config keys → only rules referencing them (plus DAG downstream)
     // are invalidated; edited rule definitions are caught by fingerprints.
@@ -1163,7 +1167,7 @@ pub async fn run_command(
     };
     let (change_report, mut force_rules, completed_in_run) = {
         let mut ck = checkpoint.lock().await;
-        let report = oxo_flow_core::config_impact::detect_config_changes(
+        let report = oxo_flow_core::config_impact::detect_config_changes_with_replay(
             &mut ck,
             &config.rules,
             &dag,
@@ -1172,6 +1176,8 @@ pub async fn run_command(
             &config.workflow.interpreter_map,
             config.defaults.shell_prelude.as_deref(),
             Some(&workflow_dir),
+            Some(&run_workdir),
+            Some(&config),
         );
         let force_rules: std::collections::HashSet<String> =
             report.invalidated.iter().cloned().collect();

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -206,7 +206,7 @@ pub fn preview_run_plan(
     // 1. Config-impact invalidation (issue #62) — on the clone only.
     // `file_exists(...)` in `when` resolves against the workflow root
     // (issue #241) — same root as run and plan-time expansion.
-    let config_report = oxo_flow_core::config_impact::detect_config_changes(
+    let config_report = oxo_flow_core::config_impact::detect_config_changes_with_replay(
         &mut clone,
         &config.rules,
         dag,
@@ -215,6 +215,8 @@ pub fn preview_run_plan(
         interpreter_map,
         config.defaults.shell_prelude.as_deref(),
         config.base_dir(),
+        Some(workdir),
+        Some(config),
     );
     let config_invalidated: HashSet<String> = config_report.invalidated.iter().cloned().collect();
     // Issue #142 M1: rules whose fingerprint differed only in the

--- a/crates/oxo-flow-cli/src/commands/run_preview.rs
+++ b/crates/oxo-flow-cli/src/commands/run_preview.rs
@@ -784,11 +784,28 @@ pub(crate) fn when_condition_false(
                 .or_insert_with(|| toml::Value::String(v.clone()));
         }
     }
-    !oxo_flow_core::executor::process::evaluate_condition_with_wildcards_and_base_dir(
+    // Every rule output of this run is pending at plan time: an existing
+    // file at one of those paths is a previous run's leftover that the
+    // producer will overwrite, so its stale value must not decide the
+    // gate here (issue #282 review). The verdict is deferred (true) and
+    // re-checked at execution time.
+    let pending_outputs: Vec<String> = config
+        .rules
+        .iter()
+        .flat_map(|r| {
+            let mut outs = r.output.to_vec();
+            if let Some(p) = &r.output_pattern {
+                outs.push(p.clone());
+            }
+            outs
+        })
+        .collect();
+    !oxo_flow_core::executor::process::evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
         condition,
         &config_values,
         &HashMap::new(),
         config.base_dir(),
+        &pending_outputs,
     )
 }
 

--- a/crates/oxo-flow-core/Cargo.toml
+++ b/crates/oxo-flow-core/Cargo.toml
@@ -39,6 +39,8 @@ reqwest = { workspace = true, features = ["blocking"] }
 hex = { workspace = true }
 tempfile = { workspace = true }
 csv = "1.4.0"
+# FASTQ gzip decompression for `reads_count()` runtime `when` gates (#282)
+flate2 = "1.0"
 async-trait = { workspace = true }
 aws-sdk-s3 = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }

--- a/crates/oxo-flow-core/src/config_impact.rs
+++ b/crates/oxo-flow-core/src/config_impact.rs
@@ -23,7 +23,7 @@
 use crate::config::ReferenceDef;
 use crate::dag::WorkflowDag;
 use crate::executor::checkpoint::CheckpointState;
-use crate::executor::process::evaluate_condition_with_wildcards_and_base_dir;
+use crate::executor::process::evaluate_condition_with_workdir_and_base_dir;
 use crate::rule::{FilePatterns, Rule};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -455,6 +455,45 @@ pub fn detect_config_changes(
     shell_prelude: Option<&str>,
     base_dir: Option<&Path>,
 ) -> ConfigChangeReport {
+    detect_config_changes_with_replay(
+        checkpoint,
+        rules,
+        dag,
+        current,
+        sensitive_keys,
+        interpreter_map,
+        shell_prelude,
+        base_dir,
+        None,
+        None,
+    )
+}
+
+/// [`detect_config_changes`] with runtime-gate replay (issue #282).
+///
+/// `workdir` is the run's working directory: runtime file functions in
+/// `when` strings (`reads_count` / `wc_lines` / `file_size`) resolve their
+/// relative paths against it, so a *threshold* change (e.g.
+/// `config.min_reads`) re-evaluates each instance's gate on the files the
+/// previous run produced and flips/keeps the verdict like any other gate —
+/// instead of being vacuously true and needing `--force`. `config` supplies
+/// the per-instance wildcard bindings (`[[values]]` / `[[pairs]]`) that the
+/// executor will merge into the gate's wildcard context, so replay sees
+/// exactly the paths the executor will see. `None` workdir / no config
+/// keeps the plan-time semantics (missing file → deferred-true).
+#[allow(clippy::too_many_arguments)] // replay needs plan+run context; all optional except checkpoint/rules
+pub fn detect_config_changes_with_replay(
+    checkpoint: &mut CheckpointState,
+    rules: &[Rule],
+    dag: &WorkflowDag,
+    current: &HashMap<String, toml::Value>,
+    sensitive_keys: &HashSet<String>,
+    interpreter_map: &HashMap<String, String>,
+    shell_prelude: Option<&str>,
+    base_dir: Option<&Path>,
+    workdir: Option<&Path>,
+    config: Option<&crate::config::WorkflowConfig>,
+) -> ConfigChangeReport {
     // A checkpoint with neither snapshot nor fingerprints predates config
     // tracking: bootstrap only (no invalidation) — documented one-time window.
     let is_legacy =
@@ -540,16 +579,30 @@ pub fn detect_config_changes(
     // The same evaluator the executor uses at execution time, with an empty
     // wildcard context: expansion bakes kept instances' bindings into their
     // `when` as literals, which this evaluator resolves identically.
+    //
+    // Runtime file functions (issue #282): with a run workdir, per-instance
+    // bindings are merged into the wildcard context (exactly what
+    // `execute_rule_with_bindings` hands the executor) so path arguments
+    // like `'{sample}/trimmed/{sample}.fq.gz'` expand, and the evaluator
+    // runs with the workdir — a produced file yields its real verdict, so a
+    // threshold change flips the gate and invalidates just the boundary
+    // samples. Rules with no stored runtime verdict (never run / older
+    // checkpoint) defer at plan time (missing file → true) and stay in the
+    // conservative one-time adoption window below.
     let current_verdicts: HashMap<String, bool> = rules
         .iter()
         .filter_map(|rule| {
             rule.when.as_ref().map(|condition| {
+                let wildcard_values: HashMap<String, String> = config
+                    .map(|cfg| cfg.instance_bindings(&rule.name))
+                    .unwrap_or_default();
                 (
                     rule.name.clone(),
-                    evaluate_condition_with_wildcards_and_base_dir(
+                    evaluate_condition_with_workdir_and_base_dir(
                         condition,
                         current,
-                        &HashMap::new(),
+                        &wildcard_values,
+                        workdir,
                         base_dir,
                     ),
                 )
@@ -1991,6 +2044,238 @@ mod tests {
         assert_eq!(report.when_gate_exempt, vec!["b".to_string()]);
         assert!(report.invalidated.is_empty());
         assert!(checkpoint.is_completed("b"));
+    }
+
+    #[test]
+    fn runtime_file_gate_replay_flips_at_threshold_boundary() {
+        // Issue #282: a runtime `when` gate (`reads_count(...) >
+        // config.min_reads`) gets REAL verdicts during config-change replay —
+        // per-instance bindings expand `{sample}` in the path, the file is
+        // read from the run workdir, and a threshold change flips only the
+        // samples whose verdict actually changed. Completed samples whose
+        // verdict is unchanged stay exempt; downstream invalidation follows
+        // the flip.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("trimmed")).unwrap();
+        // S1 = 2 records (below old threshold, above new one); S2 = 10
+        // records (above both) — only S1's gate flips. Both fixtures are
+        // real gzip streams: the counter sniffs the .gz extension and a
+        // plain-text body would fail to decode (fail-closed → false).
+        let mut gz1 = flate2::write::GzEncoder::new(
+            std::fs::File::create(dir.path().join("trimmed/S1.fq.gz")).unwrap(),
+            flate2::Compression::default(),
+        );
+        std::io::Write::write_all(&mut gz1, b"@r1\nACGT\n+\nIIII\n@r2\nTGCA\n+\nIIII\n").unwrap();
+        gz1.finish().unwrap();
+        let mut gz = flate2::write::GzEncoder::new(
+            std::fs::File::create(dir.path().join("trimmed/S2.fq.gz")).unwrap(),
+            flate2::Compression::default(),
+        );
+        for rec in ["@r", "ACGT\n", "+\n", "IIII\n"] {
+            for i in 0..10 {
+                std::io::Write::write_all(&mut gz, format!("{rec}{i}\n").as_bytes()).unwrap();
+            }
+        }
+        gz.finish().unwrap();
+
+        let workflow_path = dir.path().join("wf.oxoflow");
+        std::fs::write(
+            &workflow_path,
+            r#"
+            [workflow]
+            name = "gate"
+
+            [config]
+            min_reads = 5
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[rules]]
+            name = "filter"
+            input = []
+            output = ["trimmed/{sample}.fq.gz"]
+            when = "reads_count('trimmed/{sample}.fq.gz') > config.min_reads"
+            shell = "touch {output[0]}"
+            "#,
+        )
+        .unwrap();
+        let mut config = crate::config::WorkflowConfig::from_file(&workflow_path).unwrap();
+        config.expand_wildcards().unwrap();
+
+        let rules = config.rules.clone();
+
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let workdir = dir.path();
+
+        // Run 1 (bootstrap): empty checkpoint records verdicts — S1 false
+        // (2 <= 5), S2 true (10 > 5) — without invalidating anything.
+        let mut checkpoint = CheckpointState::new();
+        let report = detect_config_changes_with_replay(
+            &mut checkpoint,
+            &rules,
+            &dag,
+            &typed_cfg(&[("min_reads", toml::Value::Integer(5))]),
+            &HashSet::new(),
+            &HashMap::new(),
+            None,
+            None,
+            Some(workdir),
+            Some(&config),
+        );
+        assert!(report.is_legacy, "first run must bootstrap");
+        assert_eq!(
+            checkpoint.when_verdicts.get("filter_cohort_S1"),
+            Some(&false)
+        );
+        assert_eq!(
+            checkpoint.when_verdicts.get("filter_cohort_S2"),
+            Some(&true)
+        );
+
+        for name in ["filter_cohort_S1", "filter_cohort_S2"] {
+            checkpoint.mark_completed(
+                name,
+                super::super::executor::checkpoint::BenchmarkRecord {
+                    rule: name.to_string(),
+                    wall_time_secs: 1.0,
+                    max_memory_mb: None,
+                    memory_limit_mb: None,
+                    cpu_seconds: None,
+                    retries: 0,
+                },
+            );
+        }
+
+        // Run 2: threshold drops 5 → 1. S1 flips false→true (its output was
+        // wrongly withheld) — flip-invalidate; S2's verdict is unchanged
+        // (true) — exempt from re-run.
+        let report = detect_config_changes_with_replay(
+            &mut checkpoint,
+            &rules,
+            &dag,
+            &typed_cfg(&[("min_reads", toml::Value::Integer(1))]),
+            &HashSet::new(),
+            &HashMap::new(),
+            None,
+            None,
+            Some(workdir),
+            Some(&config),
+        );
+        assert_eq!(
+            report.when_flip_invalidated,
+            vec!["filter_cohort_S1".to_string()]
+        );
+        assert_eq!(
+            report.when_gate_exempt,
+            vec!["filter_cohort_S2".to_string()]
+        );
+        assert!(!checkpoint.is_completed("filter_cohort_S1"));
+        assert!(checkpoint.is_completed("filter_cohort_S2"));
+        // The updated verdicts are persisted for the next diff.
+        assert_eq!(
+            checkpoint.when_verdicts.get("filter_cohort_S1"),
+            Some(&true)
+        );
+    }
+
+    #[test]
+    fn runtime_file_gate_replay_fails_closed_when_output_missing() {
+        // No trimmed/ outputs on disk: replay must not defer (that is plan-
+        // time behavior) — it fails closed, so both instances record false
+        // during bootstrap. A later threshold change replays to false again;
+        // since the verdict is unchanged the completions stay exempt from
+        // this channel (a missing-output producer's consumers are still
+        // invalidated through the ordinary output-fingerprint path).
+        let dir = tempfile::tempdir().unwrap();
+        let workflow_path = dir.path().join("wf.oxoflow");
+        std::fs::write(
+            &workflow_path,
+            r#"
+            [workflow]
+            name = "gate"
+
+            [config]
+            min_reads = 5
+
+            [[sample_groups]]
+            name = "cohort"
+            samples = ["S1", "S2"]
+
+            [[rules]]
+            name = "filter"
+            input = []
+            output = ["trimmed/{sample}.fq.gz"]
+            when = "reads_count('trimmed/{sample}.fq.gz') > config.min_reads"
+            shell = "touch {output[0]}"
+            "#,
+        )
+        .unwrap();
+        let mut config = crate::config::WorkflowConfig::from_file(&workflow_path).unwrap();
+        config.expand_wildcards().unwrap();
+
+        let rules = config.rules.clone();
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mut checkpoint = CheckpointState::new();
+        let report = detect_config_changes_with_replay(
+            &mut checkpoint,
+            &rules,
+            &dag,
+            &typed_cfg(&[("min_reads", toml::Value::Integer(5))]),
+            &HashSet::new(),
+            &HashMap::new(),
+            None,
+            None,
+            Some(dir.path()),
+            Some(&config),
+        );
+        assert!(report.is_legacy);
+        assert_eq!(
+            checkpoint.when_verdicts.get("filter_cohort_S1"),
+            Some(&false)
+        );
+        assert_eq!(
+            checkpoint.when_verdicts.get("filter_cohort_S2"),
+            Some(&false)
+        );
+
+        for name in ["filter_cohort_S1", "filter_cohort_S2"] {
+            checkpoint.mark_completed(
+                name,
+                super::super::executor::checkpoint::BenchmarkRecord {
+                    rule: name.to_string(),
+                    wall_time_secs: 1.0,
+                    max_memory_mb: None,
+                    memory_limit_mb: None,
+                    cpu_seconds: None,
+                    retries: 0,
+                },
+            );
+        }
+
+        // Threshold change with files still missing: both instances replay
+        // to false again — verdict unchanged → exempt (no invalidation from
+        // the flip channel).
+        let report = detect_config_changes_with_replay(
+            &mut checkpoint,
+            &rules,
+            &dag,
+            &typed_cfg(&[("min_reads", toml::Value::Integer(1))]),
+            &HashSet::new(),
+            &HashMap::new(),
+            None,
+            None,
+            Some(dir.path()),
+            Some(&config),
+        );
+        assert!(
+            report.when_flip_invalidated.is_empty(),
+            "{:?}",
+            report.when_flip_invalidated
+        );
+        assert_eq!(report.when_gate_exempt.len(), 2);
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -3150,7 +3150,35 @@ pub fn evaluate_condition_with_wildcards_and_base_dir(
         wildcard_values,
         base_dir,
         None,
+        None,
     )
+    .into_bool()
+}
+
+/// Plan-time evaluation with the run's **pending outputs** (issue #282
+/// review): `pending_outputs` holds the output paths/patterns of every
+/// rule in the workflow. A runtime file-function atom that references one
+/// of them defers even when a file already exists on disk — a previous
+/// run's leftover that this run's producer will overwrite — so the stale
+/// value cannot decide the gate at plan time. The caller decides the
+/// run-root for relative pending paths by passing patterns the way they
+/// appear in the config; atom paths expand the same way.
+pub fn evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
+    condition: &str,
+    config_values: &HashMap<String, toml::Value>,
+    wildcard_values: &HashMap<String, String>,
+    base_dir: Option<&std::path::Path>,
+    pending_outputs: &[String],
+) -> bool {
+    evaluate_condition_inner(
+        condition.trim(),
+        config_values,
+        wildcard_values,
+        base_dir,
+        None,
+        Some(pending_outputs),
+    )
+    .into_bool()
 }
 
 /// Condition evaluation in the **execution-time phase** (issue #282):
@@ -3177,7 +3205,52 @@ pub fn evaluate_condition_with_workdir_and_base_dir(
         wildcard_values,
         base_dir,
         workdir,
+        None,
     )
+    .into_bool()
+}
+
+/// Does a concrete path match an output pattern? `{name}` tokens are
+/// wildcard slots (same grammar the DAG uses to match producer outputs —
+/// see `pattern_to_regex`); a literal pattern matches itself.
+fn path_matches_output(path: &str, pattern: &str) -> bool {
+    if pattern == path {
+        return true;
+    }
+    crate::wildcard::pattern_to_regex(pattern)
+        .ok()
+        .is_some_and(|re| re.is_match(path))
+}
+
+/// Tri-state verdict for a `when` condition (issue #282 review). `Yes`/`No`
+/// are decided. `Deferred` means a runtime file-function atom referenced a
+/// file that cannot be read yet in the plan-time phase — the verdict
+/// belongs to the execution-time re-check. Composition is Kleene-style so
+/// deferral survives `!`, `&&`, and `||` (a negated or chained deferred
+/// atom must not collapse to a plan-time decision that prunes instances);
+/// the bool-returning wrappers collapse `Deferred` to `true`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConditionVerdict {
+    Yes,
+    No,
+    Deferred,
+}
+
+impl ConditionVerdict {
+    fn decided(value: bool) -> Self {
+        if value {
+            ConditionVerdict::Yes
+        } else {
+            ConditionVerdict::No
+        }
+    }
+
+    fn into_bool(self) -> bool {
+        match self {
+            ConditionVerdict::Yes | ConditionVerdict::Deferred => true,
+            ConditionVerdict::No => false,
+        }
+    }
 }
 
 fn evaluate_condition_inner(
@@ -3186,13 +3259,14 @@ fn evaluate_condition_inner(
     wildcard_values: &HashMap<String, String>,
     base_dir: Option<&std::path::Path>,
     workdir: Option<&std::path::Path>,
-) -> bool {
+    pending_outputs: Option<&[String]>,
+) -> ConditionVerdict {
     let s = s.trim();
     if s.is_empty() || s == "true" {
-        return true;
+        return ConditionVerdict::Yes;
     }
     if s == "false" {
-        return false;
+        return ConditionVerdict::No;
     }
     if s.starts_with('(') && s.ends_with(')') && balanced_parens(s) {
         return evaluate_condition_inner(
@@ -3201,46 +3275,76 @@ fn evaluate_condition_inner(
             wildcard_values,
             base_dir,
             workdir,
+            pending_outputs,
         );
     }
     if let Some(idx) = find_top_level_op(s, "||") {
-        return evaluate_condition_inner(
+        let lhs = evaluate_condition_inner(
             &s[..idx],
             config_values,
             wildcard_values,
             base_dir,
             workdir,
-        ) || evaluate_condition_inner(
+            pending_outputs,
+        );
+        // Kleene OR: a decided Yes short-circuits; otherwise a Deferred on
+        // either side defers the whole disjunction.
+        if lhs == ConditionVerdict::Yes {
+            return ConditionVerdict::Yes;
+        }
+        return match evaluate_condition_inner(
             &s[idx + 2..],
             config_values,
             wildcard_values,
             base_dir,
             workdir,
-        );
+            pending_outputs,
+        ) {
+            ConditionVerdict::Yes => ConditionVerdict::Yes,
+            ConditionVerdict::Deferred => ConditionVerdict::Deferred,
+            ConditionVerdict::No => lhs,
+        };
     }
     if let Some(idx) = find_top_level_op(s, "&&") {
-        return evaluate_condition_inner(
+        let lhs = evaluate_condition_inner(
             &s[..idx],
             config_values,
             wildcard_values,
             base_dir,
             workdir,
-        ) && evaluate_condition_inner(
+            pending_outputs,
+        );
+        // Kleene AND: a decided No short-circuits; otherwise a Deferred on
+        // either side defers the whole conjunction.
+        if lhs == ConditionVerdict::No {
+            return ConditionVerdict::No;
+        }
+        return match evaluate_condition_inner(
             &s[idx + 2..],
             config_values,
             wildcard_values,
             base_dir,
             workdir,
-        );
+            pending_outputs,
+        ) {
+            ConditionVerdict::No => ConditionVerdict::No,
+            ConditionVerdict::Deferred => ConditionVerdict::Deferred,
+            ConditionVerdict::Yes => lhs,
+        };
     }
     if let Some(rest) = s.strip_prefix('!') {
-        return !evaluate_condition_inner(
+        return match evaluate_condition_inner(
             rest.trim(),
             config_values,
             wildcard_values,
             base_dir,
             workdir,
-        );
+            pending_outputs,
+        ) {
+            ConditionVerdict::Yes => ConditionVerdict::No,
+            ConditionVerdict::No => ConditionVerdict::Yes,
+            ConditionVerdict::Deferred => ConditionVerdict::Deferred,
+        };
     }
     // `len(...)` — cardinality of a config value (issue #252): array length,
     // string char count, table key count. An absent key has length 0 (nothing
@@ -3273,12 +3377,12 @@ fn evaluate_condition_inner(
         if after.is_empty() {
             // Bare `len(config.x)` — true when the value exists and is
             // non-empty.
-            return n.is_some_and(|n| n > 0);
+            return ConditionVerdict::decided(n.is_some_and(|n| n > 0));
         }
         for op in &["==", "!=", ">=", "<=", ">", "<"] {
             if let Some(rhs) = after.strip_prefix(op) {
                 let rhs_num = rhs.trim().parse::<i64>().unwrap_or(i64::MIN);
-                return match *op {
+                return ConditionVerdict::decided(match *op {
                     "==" => n == Some(rhs_num),
                     "!=" => n != Some(rhs_num),
                     ">=" => n.is_some_and(|n| n >= rhs_num),
@@ -3286,20 +3390,20 @@ fn evaluate_condition_inner(
                     ">" => n.is_some_and(|n| n > rhs_num),
                     "<" => n.is_some_and(|n| n < rhs_num),
                     _ => false,
-                };
+                });
             }
         }
-        return false;
+        return ConditionVerdict::No;
     }
     if let Some(inner) = s
         .strip_prefix("file_exists(")
         .and_then(|s| s.strip_suffix(')'))
     {
         let path = inner.trim().trim_matches('"').trim_matches('\'');
-        return match base_dir {
+        return ConditionVerdict::decided(match base_dir {
             Some(root) if !Path::new(path).is_absolute() => root.join(path).exists(),
             _ => Path::new(path).exists(),
-        };
+        });
     }
     // Runtime file-reading functions (issue #282): `reads_count(path)`,
     // `wc_lines(path)`, `file_size(path)` — a small pure-read stdlib so
@@ -3313,13 +3417,14 @@ fn evaluate_condition_inner(
     // against `workdir` when one is supplied (execution time and
     // config-change replay): a missing file there means the producer has
     // not delivered it, so the atom fails closed. Without a workdir (plan
-    // time) a missing file leaves the atom **true** — the output cannot
-    // exist yet, so the verdict is deferred to the execution-time re-check
-    // and expansion must not drop the instance. A file that already exists
-    // evaluates to its real value in both phases. Intended as positive
-    // atoms: a deferred-true placeholder composes like any `true`, so
-    // negated or `&&`-chained forms with plan-false partners resolve at
-    // plan time with the placeholder, not the eventual runtime verdict.
+    // time) a file the run has not produced yet leaves the atom
+    // **Deferred** — the verdict is made at the execution-time re-check and
+    // expansion must not drop the instance. Composition is Kleene-style
+    // (`!`/`&&`/`||` propagate the deferral; see [`ConditionVerdict`]), so
+    // negated or chained forms are equally safe at plan time. A file that
+    // exists and is not an output of the run evaluates to its real value in
+    // both phases (a prior run's own output being overwritten this run
+    // counts as pending via `pending_outputs`).
     for name in ["reads_count", "wc_lines", "file_size"] {
         let Some(rest) = s.strip_prefix(name) else {
             continue;
@@ -3340,9 +3445,17 @@ fn evaluate_condition_inner(
         } else {
             workdir.map_or_else(|| PathBuf::from(&expanded), |root| root.join(&expanded))
         };
-        // Plan-time deferral: the referenced output cannot exist yet.
-        if !candidate.exists() && workdir.is_none() {
-            return true;
+        // Plan-time deferral: the referenced output cannot exist yet, or it
+        // exists only as a previous run's leftover that this run's producer
+        // will overwrite (`pending_outputs`).
+        let exists = candidate.exists();
+        if workdir.is_none()
+            && (!exists
+                || pending_outputs.is_some_and(|pending| {
+                    pending.iter().any(|p| path_matches_output(p, &expanded))
+                }))
+        {
+            return ConditionVerdict::Deferred;
         }
         let n = match name {
             "file_size" => std::fs::metadata(&candidate).ok().map(|md| md.len() as i64),
@@ -3352,12 +3465,12 @@ fn evaluate_condition_inner(
         let Some(n) = n else {
             // Missing or unreadable at the deciding phase: the producer has
             // not delivered the file — fail closed.
-            return false;
+            return ConditionVerdict::No;
         };
         if after.is_empty() {
             // Bare `reads_count('x')` — true when a non-empty value was
             // read (consistent with bare `len(config.x)`).
-            return n > 0;
+            return ConditionVerdict::decided(n > 0);
         }
         for op in &["==", "!=", ">=", "<=", ">", "<"] {
             if let Some(rhs_text) = after.strip_prefix(op) {
@@ -3377,9 +3490,9 @@ fn evaluate_condition_inner(
                     // Unresolvable threshold (absent config key,
                     // non-numeric): the gate cannot be established — the
                     // same absent-key behavior as `compare_config_value`.
-                    return false;
+                    return ConditionVerdict::No;
                 };
-                return match *op {
+                return ConditionVerdict::decided(match *op {
                     "==" => n == rhs_num,
                     "!=" => n != rhs_num,
                     ">=" => n >= rhs_num,
@@ -3387,20 +3500,28 @@ fn evaluate_condition_inner(
                     ">" => n > rhs_num,
                     "<" => n < rhs_num,
                     _ => false,
-                };
+                });
             }
         }
-        return false;
+        return ConditionVerdict::No;
     }
     for op in &["==", "!=", ">=", "<=", ">", "<"] {
         if let Some(idx) = find_top_level_op(s, op) {
             let lhs = s[..idx].trim();
             let rhs = s[idx + op.len()..].trim();
             if let Some(key) = lhs.strip_prefix("config.") {
-                return compare_config_value(config_values.get(key), op, rhs);
+                return ConditionVerdict::decided(compare_config_value(
+                    config_values.get(key),
+                    op,
+                    rhs,
+                ));
             }
             if let Some(key) = lhs.strip_prefix("wildcard.") {
-                return compare_wildcard_value(wildcard_values.get(key), op, rhs);
+                return ConditionVerdict::decided(compare_wildcard_value(
+                    wildcard_values.get(key),
+                    op,
+                    rhs,
+                ));
             }
             // Literal-vs-literal comparison: produced by expansion-time
             // when baking (per-instance wildcard values substituted into
@@ -3409,19 +3530,19 @@ fn evaluate_condition_inner(
             if let Some(l) = strip_quotes(lhs)
                 && let Some(r) = strip_quotes(rhs)
             {
-                return compare_strings(l, r, op);
+                return ConditionVerdict::decided(compare_strings(l, r, op));
             }
         }
     }
     if let Some(key) = s.strip_prefix("config.") {
-        return match config_values.get(key) {
+        return ConditionVerdict::decided(match config_values.get(key) {
             Some(toml::Value::Boolean(b)) => *b,
             Some(toml::Value::String(sv)) => !sv.is_empty() && sv != "false" && sv != "0",
             Some(toml::Value::Integer(i)) => *i != 0,
             Some(toml::Value::Float(f)) => *f != 0.0,
             Some(_) => true,
             None => false,
-        };
+        });
     }
     if let Some(key) = s.strip_prefix("wildcard.") {
         // Truthiness of a wildcard binding. An absent key is false — an
@@ -3430,12 +3551,12 @@ fn evaluate_condition_inner(
         // expansion kept are baked with their per-instance values, so this
         // strict rule only vetoes rules whose wildcard reference is
         // genuinely unresolvable.
-        return match wildcard_values.get(key) {
+        return ConditionVerdict::decided(match wildcard_values.get(key) {
             Some(v) => !v.is_empty() && v != "false" && v != "0",
             None => false,
-        };
+        });
     }
-    true
+    ConditionVerdict::Yes
 }
 
 /// Element count of a config/wildcard value for `len(...)` (issue #252).
@@ -3454,8 +3575,9 @@ fn len_of_value(val: Option<&toml::Value>) -> Option<i64> {
 /// FASTQ record count for `reads_count(path)` (issue #282): every 4 lines
 /// are one record. Plain and gzip-compressed (`.gz`, streamed through
 /// `MultiGzDecoder`) files are supported; BAM/CRAM is out of scope for v1
-/// (documented — needs a BGZF parser, not line arithmetic). Blank lines
-/// don't count toward the record total.
+/// (documented — needs a BGZF parser, not line arithmetic). The count is
+/// the streamed line total divided by 4 — every line counts, including
+/// blank ones.
 fn count_fastq_records(path: &Path) -> Option<i64> {
     const RECORD_LINES: i64 = 4;
     let lines = count_lines_streamed(
@@ -3466,10 +3588,15 @@ fn count_fastq_records(path: &Path) -> Option<i64> {
     Some(lines / RECORD_LINES)
 }
 
-/// Total line count for `wc_lines(path)` (issue #282): plain text only —
-/// binary formats are outside the stdlib's contract.
+/// Total line count for `wc_lines(path)` (issue #282): plain and
+/// gzip-compressed (`.gz`, same detection as `reads_count`) text files —
+/// the line count of the *decompressed* content.
 fn count_text_lines(path: &Path) -> Option<i64> {
-    count_lines_streamed(path, false)
+    count_lines_streamed(
+        path,
+        path.extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("gz")),
+    )
 }
 
 /// Stream a file line by line, decompressing on the fly when `gzip` is set

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -6,6 +6,7 @@ use crate::storage::StorageResolver;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1219,16 +1220,47 @@ impl LocalExecutor {
             // instance's bindings into its `when`, so an unbound key here
             // genuinely cannot be met (false — rule skipped), never a
             // kept instance's veto.
-            if !evaluate_condition_with_wildcards_and_base_dir(
+            //
+            // The workdir-aware entry (issue #282) lets runtime file
+            // functions (`reads_count` / `wc_lines` / `file_size`) resolve
+            // relative paths against the run's workdir and decide on real
+            // file contents; missing files fail closed here instead of
+            // deferring like they do at plan time.
+            let verdict = evaluate_condition_with_workdir_and_base_dir(
                 condition,
                 &config_values,
                 wildcard_values,
+                Some(&self.config.workdir),
                 self.config.base_dir.as_deref(),
-            ) {
+            );
+            if !verdict {
                 record.status = JobStatus::Skipped;
                 record.skip_reason = Some("condition evaluated to false".to_string());
                 record.finished_at = Some(Utc::now());
+                // Issue #282: persist the runtime verdict so config-change
+                // replay compares real gates (real-vs-real) instead of the
+                // plan-time deferral. Dry runs must not pollute the
+                // checkpoint — they decide nothing (the gate here runs
+                // before the dry-run return below).
+                if !self.config.dry_run
+                    && let Some(ck) = &self.config.checkpoint
+                {
+                    ck.lock()
+                        .await
+                        .when_verdicts
+                        .insert(rule.name.clone(), false);
+                }
                 return Ok(record);
+            }
+            // Verdict true: record it too, so a later threshold change that
+            // flips this gate invalidates the completed output (issue #282).
+            if !self.config.dry_run
+                && let Some(ck) = &self.config.checkpoint
+            {
+                ck.lock()
+                    .await
+                    .when_verdicts
+                    .insert(rule.name.clone(), true);
             }
         }
 
@@ -3094,7 +3126,40 @@ pub fn evaluate_condition_with_wildcards_and_base_dir(
     wildcard_values: &HashMap<String, String>,
     base_dir: Option<&std::path::Path>,
 ) -> bool {
-    evaluate_condition_inner(condition.trim(), config_values, wildcard_values, base_dir)
+    evaluate_condition_inner(
+        condition.trim(),
+        config_values,
+        wildcard_values,
+        base_dir,
+        None,
+    )
+}
+
+/// Condition evaluation in the **execution-time phase** (issue #282):
+/// runtime file-reading functions (`reads_count` / `wc_lines` /
+/// `file_size`) resolve relative paths against `workdir` — the run's
+/// working directory, the same root every shell command runs in — and a
+/// referenced file that does not exist evaluates **false**: the gate
+/// decides the instance here (its producer already ran, so a missing file
+/// means the gate's precondition is not met). Callers without a workdir
+/// (plan contexts) get the deferred semantics of
+/// [`evaluate_condition_with_wildcards_and_base_dir`] instead: a missing
+/// file leaves the atom **true** so instances survive expansion and the
+/// verdict is made at execution time.
+pub fn evaluate_condition_with_workdir_and_base_dir(
+    condition: &str,
+    config_values: &HashMap<String, toml::Value>,
+    wildcard_values: &HashMap<String, String>,
+    workdir: Option<&std::path::Path>,
+    base_dir: Option<&std::path::Path>,
+) -> bool {
+    evaluate_condition_inner(
+        condition.trim(),
+        config_values,
+        wildcard_values,
+        base_dir,
+        workdir,
+    )
 }
 
 fn evaluate_condition_inner(
@@ -3102,6 +3167,7 @@ fn evaluate_condition_inner(
     config_values: &HashMap<String, toml::Value>,
     wildcard_values: &HashMap<String, String>,
     base_dir: Option<&std::path::Path>,
+    workdir: Option<&std::path::Path>,
 ) -> bool {
     let s = s.trim();
     if s.is_empty() || s == "true" {
@@ -3116,18 +3182,47 @@ fn evaluate_condition_inner(
             config_values,
             wildcard_values,
             base_dir,
+            workdir,
         );
     }
     if let Some(idx) = find_top_level_op(s, "||") {
-        return evaluate_condition_inner(&s[..idx], config_values, wildcard_values, base_dir)
-            || evaluate_condition_inner(&s[idx + 2..], config_values, wildcard_values, base_dir);
+        return evaluate_condition_inner(
+            &s[..idx],
+            config_values,
+            wildcard_values,
+            base_dir,
+            workdir,
+        ) || evaluate_condition_inner(
+            &s[idx + 2..],
+            config_values,
+            wildcard_values,
+            base_dir,
+            workdir,
+        );
     }
     if let Some(idx) = find_top_level_op(s, "&&") {
-        return evaluate_condition_inner(&s[..idx], config_values, wildcard_values, base_dir)
-            && evaluate_condition_inner(&s[idx + 2..], config_values, wildcard_values, base_dir);
+        return evaluate_condition_inner(
+            &s[..idx],
+            config_values,
+            wildcard_values,
+            base_dir,
+            workdir,
+        ) && evaluate_condition_inner(
+            &s[idx + 2..],
+            config_values,
+            wildcard_values,
+            base_dir,
+            workdir,
+        );
     }
     if let Some(rest) = s.strip_prefix('!') {
-        return !evaluate_condition_inner(rest.trim(), config_values, wildcard_values, base_dir);
+        return !evaluate_condition_inner(
+            rest.trim(),
+            config_values,
+            wildcard_values,
+            base_dir,
+            workdir,
+        );
     }
     // `len(...)` — cardinality of a config value (issue #252): array length,
     // string char count, table key count. An absent key has length 0 (nothing
@@ -3188,6 +3283,97 @@ fn evaluate_condition_inner(
             _ => Path::new(path).exists(),
         };
     }
+    // Runtime file-reading functions (issue #282): `reads_count(path)`,
+    // `wc_lines(path)`, `file_size(path)` — a small pure-read stdlib so
+    // `when` can gate on runtime-produced values, e.g.
+    // `reads_count('{sample}/trimmed/{sample}.fq.gz') > config.min_reads`.
+    // Only these three names are recognized, only `when` strings reach this
+    // evaluator, and each function just opens a file and counts — no shell,
+    // no arbitrary code. `{wildcard}` tokens in the path expand against the
+    // caller's wildcard context (unbound tokens cannot exist on disk and
+    // fall into the missing-file semantics below). Relative paths resolve
+    // against `workdir` when one is supplied (execution time and
+    // config-change replay): a missing file there means the producer has
+    // not delivered it, so the atom fails closed. Without a workdir (plan
+    // time) a missing file leaves the atom **true** — the output cannot
+    // exist yet, so the verdict is deferred to the execution-time re-check
+    // and expansion must not drop the instance. A file that already exists
+    // evaluates to its real value in both phases. Intended as positive
+    // atoms: a deferred-true placeholder composes like any `true`, so
+    // negated or `&&`-chained forms with plan-false partners resolve at
+    // plan time with the placeholder, not the eventual runtime verdict.
+    for name in ["reads_count", "wc_lines", "file_size"] {
+        let Some(rest) = s.strip_prefix(name) else {
+            continue;
+        };
+        if !rest.starts_with('(') {
+            continue;
+        }
+        let Some(close) = find_matching_paren(&rest[1..]) else {
+            continue;
+        };
+        let arg = rest[1..1 + close].trim();
+        let after = rest[close + 2..].trim();
+        let raw_path = arg.trim_matches('"').trim_matches('\'');
+        let expanded = crate::wildcard::expand_pattern(raw_path, wildcard_values)
+            .unwrap_or_else(|_| raw_path.to_string());
+        let candidate = if Path::new(&expanded).is_absolute() {
+            PathBuf::from(&expanded)
+        } else {
+            workdir.map_or_else(|| PathBuf::from(&expanded), |root| root.join(&expanded))
+        };
+        // Plan-time deferral: the referenced output cannot exist yet.
+        if !candidate.exists() && workdir.is_none() {
+            return true;
+        }
+        let n = match name {
+            "file_size" => std::fs::metadata(&candidate).ok().map(|md| md.len() as i64),
+            "reads_count" => count_fastq_records(&candidate),
+            _ => count_text_lines(&candidate),
+        };
+        let Some(n) = n else {
+            // Missing or unreadable at the deciding phase: the producer has
+            // not delivered the file — fail closed.
+            return false;
+        };
+        if after.is_empty() {
+            // Bare `reads_count('x')` — true when a non-empty value was
+            // read (consistent with bare `len(config.x)`).
+            return n > 0;
+        }
+        for op in &["==", "!=", ">=", "<=", ">", "<"] {
+            if let Some(rhs_text) = after.strip_prefix(op) {
+                let rhs_text = rhs_text.trim();
+                // The threshold is a number literal or a `config.*`
+                // reference (`> config.min_reads`) — typed config values
+                // are read directly, string values (e.g. merged from
+                // wildcard bindings) parse.
+                let rhs_num = if let Some(key) = rhs_text.strip_prefix("config.") {
+                    config_values
+                        .get(key.trim())
+                        .and_then(runtime_threshold_as_i64)
+                } else {
+                    rhs_text.parse::<i64>().ok()
+                };
+                let Some(rhs_num) = rhs_num else {
+                    // Unresolvable threshold (absent config key,
+                    // non-numeric): the gate cannot be established — the
+                    // same absent-key behavior as `compare_config_value`.
+                    return false;
+                };
+                return match *op {
+                    "==" => n == rhs_num,
+                    "!=" => n != rhs_num,
+                    ">=" => n >= rhs_num,
+                    "<=" => n <= rhs_num,
+                    ">" => n > rhs_num,
+                    "<" => n < rhs_num,
+                    _ => false,
+                };
+            }
+        }
+        return false;
+    }
     for op in &["==", "!=", ">=", "<=", ">", "<"] {
         if let Some(idx) = find_top_level_op(s, op) {
             let lhs = s[..idx].trim();
@@ -3243,6 +3429,62 @@ fn len_of_value(val: Option<&toml::Value>) -> Option<i64> {
         Some(toml::Value::Array(items)) => Some(items.len() as i64),
         Some(toml::Value::String(s)) => Some(s.chars().count() as i64),
         Some(toml::Value::Table(t)) => Some(t.len() as i64),
+        _ => None,
+    }
+}
+
+/// FASTQ record count for `reads_count(path)` (issue #282): every 4 lines
+/// are one record. Plain and gzip-compressed (`.gz`, streamed through
+/// `MultiGzDecoder`) files are supported; BAM/CRAM is out of scope for v1
+/// (documented — needs a BGZF parser, not line arithmetic). Blank lines
+/// don't count toward the record total.
+fn count_fastq_records(path: &Path) -> Option<i64> {
+    const RECORD_LINES: i64 = 4;
+    let lines = count_lines_streamed(
+        path,
+        path.extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("gz")),
+    )?;
+    Some(lines / RECORD_LINES)
+}
+
+/// Total line count for `wc_lines(path)` (issue #282): plain text only —
+/// binary formats are outside the stdlib's contract.
+fn count_text_lines(path: &Path) -> Option<i64> {
+    count_lines_streamed(path, false)
+}
+
+/// Stream a file line by line, decompressing on the fly when `gzip` is set
+/// (`MultiGzDecoder` handles concatenated gzip members, the form
+/// chunked FASTQ pipelines produce). Returns `None` when the file cannot
+/// be opened or read — the caller's missing-file semantics.
+fn count_lines_streamed(path: &Path, gzip: bool) -> Option<i64> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut lines = 0i64;
+    if gzip {
+        let reader = std::io::BufReader::new(flate2::read::MultiGzDecoder::new(file));
+        for line in reader.lines() {
+            line.ok()?;
+            lines += 1;
+        }
+    } else {
+        let reader = std::io::BufReader::new(file);
+        for line in reader.lines() {
+            line.ok()?;
+            lines += 1;
+        }
+    }
+    Some(lines)
+}
+
+/// Numeric threshold for a runtime file-function comparison: typed config
+/// integers/floats read directly, strings parsed (values merged from
+/// wildcard bindings arrive as strings).
+fn runtime_threshold_as_i64(value: &toml::Value) -> Option<i64> {
+    match value {
+        toml::Value::Integer(i) => Some(*i),
+        toml::Value::Float(f) => Some(*f as i64),
+        toml::Value::String(s) => s.trim().parse::<i64>().ok(),
         _ => None,
     }
 }

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -920,6 +920,170 @@ fn file_exists_resolves_against_base_dir_not_cwd() {
 }
 
 #[test]
+fn runtime_when_functions_count_real_files() {
+    // Issue #282: `reads_count` / `wc_lines` / `file_size` evaluate against
+    // real files in the run's workdir — data-dependent gating on files a
+    // previous rule produced during this run.
+    use super::process::evaluate_condition_with_workdir_and_base_dir;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = HashMap::new();
+    let empty = HashMap::new();
+
+    // Plain FASTQ: 2 records (8 lines).
+    let fq = dir.path().join("sample.fq");
+    std::fs::write(&fq, "@r1\nACGT\n+\nIIII\n@r2\nTGCA\n+\nIIII\n").unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq') == 2",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq') > 2",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Gzipped FASTQ counts identically (flate2 MultiGzDecoder).
+    let fq_gz = dir.path().join("sample.fq.gz");
+    let gz_file = std::fs::File::create(&fq_gz).unwrap();
+    let mut enc = flate2::write::GzEncoder::new(gz_file, flate2::Compression::default());
+    std::io::Write::write_all(
+        &mut enc,
+        b"@r1\nACGT\n+\nIIII\n@r2\nTGCA\n+\nIIII\n@r3\nAAAA\n+\nIIII\n",
+    )
+    .unwrap();
+    enc.finish().unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq.gz') == 3",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Bare call: truthiness = records > 0.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq')",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // wc_lines counts plain text lines; file_size reads the file length.
+    std::fs::write(dir.path().join("list.txt"), "a\nb\nc\n").unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "wc_lines('list.txt') == 3",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    let size = std::fs::metadata(dir.path().join("list.txt"))
+        .unwrap()
+        .len();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        &format!("file_size('list.txt') == {size}"),
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // The full operator set works against `config.` thresholds (2 records
+    // vs. a threshold of 1: three comparisons pass, three fail).
+    let mut typed = HashMap::new();
+    typed.insert("min_reads".to_string(), toml::Value::Integer(1));
+    for (expr, expected) in [
+        ("reads_count('sample.fq') > config.min_reads", true),
+        ("reads_count('sample.fq') >= config.min_reads", true),
+        ("reads_count('sample.fq') < config.min_reads", false),
+        ("reads_count('sample.fq') <= config.min_reads", false),
+        ("reads_count('sample.fq') == config.min_reads", false),
+        ("reads_count('sample.fq') != config.min_reads", true),
+    ] {
+        assert_eq!(
+            evaluate_condition_with_workdir_and_base_dir(
+                expr,
+                &typed,
+                &empty,
+                Some(dir.path()),
+                None
+            ),
+            expected,
+            "operator check failed for: {expr}"
+        );
+    }
+
+    // String-valued config thresholds parse as numbers too.
+    let mut str_cfg = HashMap::new();
+    str_cfg.insert(
+        "min_reads".to_string(),
+        toml::Value::String("2".to_string()),
+    );
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq') >= config.min_reads",
+        &str_cfg,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Absolute paths bypass workdir joining.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        &format!("wc_lines('{}') == 3", dir.path().join("list.txt").display()),
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Unknown file at EXECUTION time fails closed (verdict false).
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('missing.fq') > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // The same unknown file at PLAN time defers (verdict true) — the
+    // rule's producer has not run yet, so the gate must not prune it.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('missing.fq') > 0",
+        &config,
+        &empty,
+        None,
+        None
+    ));
+
+    // `{wildcard}` tokens in the path expand against the wildcard map.
+    let mut wildcards = HashMap::new();
+    wildcards.insert("sample".to_string(), "sample".to_string());
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('{sample}.fq') == 2",
+        &config,
+        &wildcards,
+        Some(dir.path()),
+        None
+    ));
+
+    // Malformed comparisons (missing/unparseable threshold) fail closed.
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "reads_count('sample.fq') > config.nope",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+}
+
+#[test]
 fn evaluate_condition_literal_comparisons_compare_for_real() {
     use super::process::evaluate_condition_with_wildcards;
 
@@ -2181,6 +2345,129 @@ async fn scratch_rule_pre_exec_runs_in_scratch_with_absolute_inputs() {
     assert!(scratch_entries(workdir.path()).is_empty());
 }
 
+#[tokio::test]
+async fn runtime_when_gate_consumes_producer_output() {
+    // Issue #282 end-to-end: a consumer's data-dependent `when` gate reads
+    // files its producer wrote earlier in THIS run's workdir. Planning
+    // defers on the missing files (both consumer instances kept); execution
+    // judges real content — S1 (2 records) clears a threshold of 1, S2
+    // (10 records) fails one of 50 — and every verdict lands in the
+    // checkpoint for later config-change replay.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("raw")).unwrap();
+    std::fs::write(
+        dir.path().join("raw/S1.fq"),
+        "@r1\nACGT\n+\nIIII\n@r2\nTGCA\n+\nIIII\n",
+    )
+    .unwrap();
+    let mut s2 = String::new();
+    for i in 0..10 {
+        s2.push_str(&format!("@r{i}\nACGT\n+\nIIII\n"));
+    }
+    std::fs::write(dir.path().join("raw/S2.fq"), s2).unwrap();
+    let workflow_path = dir.path().join("gate.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "gate"
+
+        [config]
+        min_reads = 5
+
+        [[sample_groups]]
+        name = "cohort"
+        samples = ["S1", "S2"]
+
+        [[rules]]
+        name = "trim"
+        input = ["raw/{sample}.fq"]
+        output = ["trimmed/{sample}.fq"]
+        shell = "cp {input[0]} {output[0]}"
+
+        [[rules]]
+        name = "filter"
+        input = ["trimmed/{sample}.fq"]
+        output = ["filtered/{sample}.fq"]
+        when = "reads_count('trimmed/{sample}.fq') > config.min_reads"
+        shell = "cp {input[0]} {output[0]}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = crate::config::WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.expand_wildcards().unwrap();
+    // Plan time: trimmed/ outputs do not exist yet, so the gate defers and
+    // BOTH consumer instances survive planning.
+    for name in ["filter_cohort_S1", "filter_cohort_S2"] {
+        assert!(
+            config.rules.iter().any(|r| r.name == name),
+            "{name} must survive planning (deferred gate)"
+        );
+    }
+
+    let checkpoint = std::sync::Arc::new(tokio::sync::Mutex::new(CheckpointState::new()));
+    let executor = LocalExecutor::new(ExecutorConfig {
+        workdir: dir.path().to_path_buf(),
+        checkpoint: Some(checkpoint.clone()),
+        dry_run: false,
+        ..Default::default()
+    });
+
+    // Producers run first — plain copies, no gate.
+    for sample in ["S1", "S2"] {
+        let instance = config
+            .rules
+            .iter()
+            .find(|r| r.name == format!("trim_cohort_{sample}"))
+            .unwrap();
+        let wildcards = HashMap::from([("sample".to_string(), sample.to_string())]);
+        let record = executor
+            .execute_rule_with_config(instance, &wildcards, &HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(record.status, JobStatus::Success, "trim {sample}");
+        assert!(dir.path().join(format!("trimmed/{sample}.fq")).exists());
+    }
+
+    // S1: 2 records clear the threshold of 1 → the consumer executes.
+    let mut loose = HashMap::new();
+    loose.insert("min_reads".to_string(), toml::Value::Integer(1));
+    let s1 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "filter_cohort_S1")
+        .unwrap();
+    let wildcards_s1 = HashMap::from([("sample".to_string(), "S1".to_string())]);
+    let record = executor
+        .execute_rule_with_config(s1, &wildcards_s1, &loose)
+        .await
+        .unwrap();
+    assert_eq!(record.status, JobStatus::Success, "filter S1 passes gate");
+    assert!(dir.path().join("filtered/S1.fq").exists());
+
+    // S2: 10 records vs a threshold of 50 → the gate prunes at execution
+    // time (Skipped, no output produced).
+    let mut strict = HashMap::new();
+    strict.insert("min_reads".to_string(), toml::Value::Integer(50));
+    let s2 = config
+        .rules
+        .iter()
+        .find(|r| r.name == "filter_cohort_S2")
+        .unwrap();
+    let wildcards_s2 = HashMap::from([("sample".to_string(), "S2".to_string())]);
+    let record = executor
+        .execute_rule_with_config(s2, &wildcards_s2, &strict)
+        .await
+        .unwrap();
+    assert_eq!(record.status, JobStatus::Skipped, "filter S2 fails gate");
+    assert!(!dir.path().join("filtered/S2.fq").exists());
+
+    // Both verdicts are recorded for config-change replay.
+    let ck = checkpoint.lock().await;
+    assert_eq!(ck.when_verdicts.get("filter_cohort_S1"), Some(&true));
+    assert_eq!(ck.when_verdicts.get("filter_cohort_S2"), Some(&false));
+}
 #[tokio::test]
 async fn meta_when_gate_runs_se_and_skips_pe_instances() {
     // methylseq-style endedness gate driven by the sample metadata table

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -1090,6 +1090,146 @@ fn runtime_when_functions_count_real_files() {
 }
 
 #[test]
+fn wc_lines_decompresses_gzip_like_reads_count() {
+    // Issue #282 review: `wc_lines` must decompress `.gz` inputs the same
+    // way `reads_count` does — the count is of the decompressed content.
+    use super::process::evaluate_condition_with_workdir_and_base_dir;
+
+    let dir = tempfile::tempdir().unwrap();
+    let gz = dir.path().join("list.txt.gz");
+    let mut enc = flate2::write::GzEncoder::new(
+        std::fs::File::create(&gz).unwrap(),
+        flate2::Compression::default(),
+    );
+    std::io::Write::write_all(&mut enc, b"a\nb\nc\n").unwrap();
+    enc.finish().unwrap();
+
+    let config = HashMap::new();
+    let empty = HashMap::new();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "wc_lines('list.txt.gz') == 3",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+}
+
+#[test]
+fn runtime_when_defer_survives_negation_and_chaining() {
+    // Issue #282 review: plan-time deferral is Kleene — `!`, `&&`, `||`
+    // over a deferred atom must stay deferred (collapsed to true by the
+    // wrapper), never collapse to a plan-time decision that prunes.
+    use super::process::evaluate_condition_with_wildcards_and_base_dir;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = HashMap::new();
+    let empty = HashMap::new();
+
+    // At plan time (no workdir) the file does not exist: the atom defers,
+    // and its negation stays deferred too (collapsed to true by the
+    // wrapper) — the pre-Kleene bug inverted it to a decided false that
+    // pruned the instance.
+    assert!(evaluate_condition_with_wildcards_and_base_dir(
+        "!reads_count('trimmed/out.fq') > 0",
+        &config,
+        &empty,
+        None
+    ));
+    assert!(!evaluate_condition_with_wildcards_and_base_dir(
+        "reads_count('trimmed/out.fq') > 0 && config.enabled",
+        &HashMap::from([("enabled".to_string(), toml::Value::Boolean(false))]),
+        &empty,
+        None
+    ));
+    // Deferred || No stays deferred (true), while No || No is false.
+    assert!(evaluate_condition_with_wildcards_and_base_dir(
+        "reads_count('trimmed/out.fq') > 0 || config.enabled",
+        &HashMap::from([("enabled".to_string(), toml::Value::Boolean(false))]),
+        &empty,
+        None
+    ));
+    assert!(!evaluate_condition_with_wildcards_and_base_dir(
+        "config.off || config.also_off",
+        &HashMap::from([
+            ("off".to_string(), toml::Value::Boolean(false)),
+            ("also_off".to_string(), toml::Value::Boolean(false))
+        ]),
+        &empty,
+        None
+    ));
+    // Execution time (workdir set, file still missing) is decided, not
+    // deferred: fail closed, and the negation is a real negation there
+    // (atom false → !atom true).
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "!reads_count('trimmed/out.fq') > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+}
+
+#[test]
+fn runtime_when_defers_on_pending_outputs_even_if_file_exists() {
+    // Issue #282 review: at plan time, a file that is an output of this
+    // run's rules is *pending* even when it exists on disk (a previous
+    // run's leftover that the producer will overwrite) — the stale value
+    // must not decide the gate.
+    use super::process::evaluate_condition_with_wildcards_base_dir_and_pending_outputs;
+
+    let dir = tempfile::tempdir().unwrap();
+    let stale = dir.path().join("stale.txt");
+    std::fs::write(&stale, "x\n").unwrap();
+    let config = HashMap::new();
+    let empty = HashMap::new();
+    // Plan time resolves atom paths against the process cwd; the test uses
+    // absolute paths so the tempdir file is the one being read.
+    let stale = stale.display().to_string();
+
+    // Stale leftover matching a pending output pattern defers (true), even
+    // though the file exists and its real value is 1.
+    assert!(
+        evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
+            &format!("wc_lines('{stale}') == 1"),
+            &config,
+            &empty,
+            None,
+            &["results/{name}.txt".to_string()]
+        )
+    );
+    // A concrete pending path defers too.
+    assert!(
+        evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
+            &format!("wc_lines('{stale}') == 1"),
+            &config,
+            &empty,
+            None,
+            std::slice::from_ref(&stale)
+        )
+    );
+    // The same file with NO pending match reads its real value.
+    assert!(
+        !evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
+            &format!("wc_lines('{stale}') == 3"),
+            &config,
+            &empty,
+            None,
+            &["other/{name}.txt".to_string()]
+        )
+    );
+    // Execution time ignores pending outputs entirely (workdir set): the
+    // real value decides.
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "wc_lines('stale.txt') == 3",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+}
+
+#[test]
 fn evaluate_condition_literal_comparisons_compare_for_real() {
     use super::process::evaluate_condition_with_wildcards;
 

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -55,6 +55,51 @@ directory) — the same root every other engine path uses — so the gate reads
 the same no matter which directory you launch `oxo-flow` from. Absolute
 paths pass through unchanged.
 
+### Data-dependent gates (runtime functions)
+
+`when` can also inspect files produced earlier in the same run — the gate
+becomes data-dependent (issue #282). Three read-only functions are
+available in `when` strings:
+
+| Function | Reads | Returns |
+|---|---|---|
+| `reads_count(path)` | FASTQ (plain or `.gz`) | record count (lines ÷ 4) |
+| `wc_lines(path)` | any text file (plain or `.gz`) | line count |
+| `file_size(path)` | any file | size in bytes |
+| `file_exists(path)` | — | 1/0 existence probe |
+
+```toml
+[[rules]]
+name  = "downsample_qc"
+when  = "reads_count('trimmed/{sample}.fq.gz') > config.min_reads"
+input = ["trimmed/{sample}.fq.gz"]
+output = ["qc/downsample_report.txt"]
+shell = "seqkit stats {input[0]} > {output[0]}"
+```
+
+**Phase semantics.** The file is resolved against the run workdir (absolute
+paths pass through; `{sample}` and other wildcards expand from the
+instance context). Because a gate may reference a file its producer has
+not written yet, the two phases behave differently:
+
+- **Planning** (`oxo-flow dry-run`, DAG build): a missing file makes the
+  condition evaluate to `true`, so the rule stays in the plan and is
+  judged later — a plan-time gate never prunes a rule whose producer
+  simply has not run.
+- **Execution**: a missing or unreadable file makes the condition
+  evaluate to `false` (fail-closed) — a gate that cannot count what it
+  was asked to count does not run the rule.
+
+Verdicts are recorded in the checkpoint; when a threshold like
+`config.min_reads` changes between runs, only instances whose recorded
+verdict actually flipped are invalidated (see "Resume & checkpoints").
+
+**Scope limits.** These functions are intentionally restricted to pure
+file reads — no shell, no globbing beyond `{wildcard}` expansion, and
+`reads_count` assumes 4-line FASTQ records (BAM/BGZF support is planned
+for a future release). Only `when` strings may call them; `shell`, `input`,
+and `output` still cannot read the filesystem at plan time.
+
 ### Wildcard-scoped conditions (`wildcard.<key>`)
 
 Conditions can reference the pair/group expansion context through the

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -64,7 +64,7 @@ available in `when` strings:
 | Function | Reads | Returns |
 |---|---|---|
 | `reads_count(path)` | FASTQ (plain or `.gz`) | record count (lines ÷ 4, truncated) |
-| `wc_lines(path)` | any plain-text file (gzip is **not** decompressed) | line count |
+| `wc_lines(path)` | any text file (plain or `.gz`) | line count of the decompressed content |
 | `file_size(path)` | any file | size in bytes |
 | `file_exists(path)` | — | 1/0 existence probe |
 
@@ -82,15 +82,13 @@ paths pass through; `{sample}` and other wildcards expand from the
 instance context). Because a gate may reference a file its producer has
 not written yet, the two phases behave differently:
 
-- **Planning** (`oxo-flow dry-run`, DAG build): a missing file makes the
-  condition evaluate to `true`, so the rule stays in the plan and is
-  judged later. Caveat: this defer-when-missing guarantee applies to the
-  runtime-function atom itself — if the gate *negates* it
-  (`!reads_count(...)`) or chains it with `&&`, the negated/combined
-  expression can still resolve to `false` at plan time and prune the
-  rule. Also note the functions read any file that *already exists*
-  (e.g. a previous run's output) at plan time, not just ones produced
-  later in the same run.
+- **Planning** (`oxo-flow dry-run`, DAG build): a runtime-function atom
+  whose file is missing — or whose file is an output of this run but
+  still holds a previous run's stale value — makes the whole gate defer:
+  it evaluates to `true` and the rule stays in the plan to be judged
+  again at execution time. The defer propagates through `!`, `&&`, `||`
+  and parentheses (three-valued logic), so a negated or chained gate is
+  never pruned at plan time just because its file is not ready.
 - **Execution**: a missing or unreadable file makes the condition
   evaluate to `false` (fail-closed) — a gate that cannot count what it
   was asked to count does not run the rule.

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -63,8 +63,8 @@ available in `when` strings:
 
 | Function | Reads | Returns |
 |---|---|---|
-| `reads_count(path)` | FASTQ (plain or `.gz`) | record count (lines ÷ 4) |
-| `wc_lines(path)` | any text file (plain or `.gz`) | line count |
+| `reads_count(path)` | FASTQ (plain or `.gz`) | record count (lines ÷ 4, truncated) |
+| `wc_lines(path)` | any plain-text file (gzip is **not** decompressed) | line count |
 | `file_size(path)` | any file | size in bytes |
 | `file_exists(path)` | — | 1/0 existence probe |
 
@@ -84,8 +84,13 @@ not written yet, the two phases behave differently:
 
 - **Planning** (`oxo-flow dry-run`, DAG build): a missing file makes the
   condition evaluate to `true`, so the rule stays in the plan and is
-  judged later — a plan-time gate never prunes a rule whose producer
-  simply has not run.
+  judged later. Caveat: this defer-when-missing guarantee applies to the
+  runtime-function atom itself — if the gate *negates* it
+  (`!reads_count(...)`) or chains it with `&&`, the negated/combined
+  expression can still resolve to `false` at plan time and prune the
+  rule. Also note the functions read any file that *already exists*
+  (e.g. a previous run's output) at plan time, not just ones produced
+  later in the same run.
 - **Execution**: a missing or unreadable file makes the condition
   evaluate to `false` (fail-closed) — a gate that cannot count what it
   was asked to count does not run the rule.

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -559,7 +559,7 @@ memory = "32G"
 | `resources` | Table | No | Full resource specification (threads, memory, gpu, disk, time_limit, partition, groups) |
 | `environment` | Table | No | Environment specification |
 | `transform` | Table | No | Unified scatter-gather operator (split → map → combine) |
-| `when` | String | No | Conditional expression — skip rule when `false` |
+| `when` | String | No | Conditional expression — skip rule when `false`. May call read-only runtime functions (`reads_count`, `wc_lines`, `file_size`, `file_exists`) that inspect files in the run workdir; see [Data-Dependent `when` Gates](#data-dependent-when-gates) |
 | `envvars` | Table | No | Dictionary of environment variables to inject |
 | `params` | Table | No | User-defined parameters for shell templates |
 | `pre_exec` | String | No | Command to run *before* the main shell command |
@@ -1945,12 +1945,47 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `len(config.<key>)` | `len(config.gene_sets) > 0` | Element count comparison: array items, string characters, or table keys, compared against a whole number (`==`, `!=`, `>=`, `<=`, `>`, `<`). A missing key counts as 0. Bare `len(config.<key>)` is truthy when non-empty. Note a bare `config.<key>` array is truthy even when empty — `len(...) > 0` is the "list is non-empty" gate. Comparing against a non-numeric literal is a lint warning (W029) and always evaluates false |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test. Relative paths resolve against the **workflow root** (the workflow file's directory), not the process working directory, and every evaluation site (plan time, execution re-check, config-change analysis) resolves the same way. In per-instance predicates (`wildcard.<key>` / `{meta.<column>}`) it is evaluated at **plan time** — the instance set is fixed when the DAG is built, so files produced mid-run cannot gate instances; express those with `{meta.*}` (plan-time bakeable) or an execution-time `config` gate instead |
+| `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines (plain or `.gz`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |
 | `<expr> && <expr>` | `config.run_qc && config.min_cov >= 20` | Logical AND |
 | `<expr> \|\| <expr>` | `config.wgs \|\| config.wes` | Logical OR |
 | `(<expr>)` | `(config.a && config.b) \|\| config.c` | Grouping |
+
+### Data-Dependent `when` Gates
+
+The runtime functions `reads_count(path)`, `wc_lines(path)`, and
+`file_size(path)` let a `when` gate inspect files produced earlier in the
+same run (issue #282) — e.g. skip a variant caller on samples whose
+trimmed FASTQ has too few records:
+
+```toml
+[[rules]]
+name  = "call_variants"
+when  = "reads_count('trimmed/{sample}.fq.gz') > config.min_reads"
+input = ["trimmed/{sample}.fq.gz"]
+output = ["variants/{sample}.vcf.gz"]
+shell = "caller --input {input[0]} --output {output[0]}"
+```
+
+- **Path resolution** — relative paths join against the run **workdir**;
+  absolute paths pass through. `{sample}` and other wildcards expand from
+  the instance context before the read.
+- **Phase semantics** — at *plan time* a missing file defers (`true`, the
+  rule stays in the plan because its producer may not have run); at
+  *execution time* a missing or unreadable file fails closed (`false`, the
+  rule is skipped). `oxo-flow dry-run` never prunes on these gates.
+- **Formats** — `reads_count` counts 4-line FASTQ records in plain or
+  gzip files; `wc_lines` streams lines of plain or gzip text; `file_size`
+  returns the byte length. BAM/BGZF indexing is planned for a future
+  release.
+- **Change tracking** — recorded verdicts participate in config-change
+  replay: changing a threshold referenced by such a gate (e.g.
+  `config.min_reads`) re-evaluates only the instances whose verdict
+  actually flipped, keeping completed unchanged instances exempt.
+- **Scope** — only `when` strings may call these functions; `shell`,
+  `input`, and `output` cannot read the filesystem at plan time.
 
 ### Unbound wildcard keys evaluate false
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1945,7 +1945,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `len(config.<key>)` | `len(config.gene_sets) > 0` | Element count comparison: array items, string characters, or table keys, compared against a whole number (`==`, `!=`, `>=`, `<=`, `>`, `<`). A missing key counts as 0. Bare `len(config.<key>)` is truthy when non-empty. Note a bare `config.<key>` array is truthy even when empty — `len(...) > 0` is the "list is non-empty" gate. Comparing against a non-numeric literal is a lint warning (W029) and always evaluates false |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test. Relative paths resolve against the **workflow root** (the workflow file's directory), not the process working directory, and every evaluation site (plan time, execution re-check, config-change analysis) resolves the same way. In per-instance predicates (`wildcard.<key>` / `{meta.<column>}`) it is evaluated at **plan time** — the instance set is fixed when the DAG is built, so files produced mid-run cannot gate instances; express those with `{meta.*}` (plan-time bakeable) or an execution-time `config` gate instead |
-| `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines (plain or `.gz`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
+| `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines (plain text only — gzip is **not** decompressed by `wc_lines`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |
@@ -1975,11 +1975,19 @@ shell = "caller --input {input[0]} --output {output[0]}"
 - **Phase semantics** — at *plan time* a missing file defers (`true`, the
   rule stays in the plan because its producer may not have run); at
   *execution time* a missing or unreadable file fails closed (`false`, the
-  rule is skipped). `oxo-flow dry-run` never prunes on these gates.
+  rule is skipped). The defer guarantee applies to the runtime-function
+  atom itself: negating it (`!reads_count(...)`) or chaining it with `&&`
+  can resolve to `false` at plan time and prune the rule, and a file that
+  already exists at plan time (e.g. a previous run's output) is read
+  immediately. Planning with `oxo-flow dry-run` therefore reflects any
+  pre-existing files, but never prunes on a gate whose target file does
+  not exist yet.
 - **Formats** — `reads_count` counts 4-line FASTQ records in plain or
-  gzip files; `wc_lines` streams lines of plain or gzip text; `file_size`
-  returns the byte length. BAM/BGZF indexing is planned for a future
-  release.
+  gzip files (the record count is truncated — a trailing partial record
+  does not round up); `wc_lines` streams lines of **plain-text** files
+  only (gzip is not decompressed — pointing it at a `.gz` counts the raw
+  compressed bytes); `file_size` returns the byte length. BAM/BGZF
+  indexing is planned for a future release.
 - **Change tracking** — recorded verdicts participate in config-change
   replay: changing a threshold referenced by such a gate (e.g.
   `config.min_reads`) re-evaluates only the instances whose verdict

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -2039,7 +2039,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `config.<key> > N` | `config.min_cov >= 20` | Numeric comparison (`>`, `>=`, `<`, `<=`) |
 | `len(config.<key>)` | `len(config.gene_sets) > 0` | Element count comparison: array items, string characters, or table keys, compared against a whole number (`==`, `!=`, `>=`, `<=`, `>`, `<`). A missing key counts as 0. Bare `len(config.<key>)` is truthy when non-empty. Note a bare `config.<key>` array is truthy even when empty — `len(...) > 0` is the "list is non-empty" gate. Comparing against a non-numeric literal is a lint warning (W029) and always evaluates false |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test. Relative paths resolve against the **workflow root** (the workflow file's directory), not the process working directory, and every evaluation site (plan time, execution re-check, config-change analysis) resolves the same way. In per-instance predicates (`wildcard.<key>` / `{meta.<column>}`) it is evaluated at **plan time** — the instance set is fixed when the DAG is built, so files produced mid-run cannot gate instances; express those with `{meta.*}` (plan-time bakeable) or an execution-time `config` gate instead |
-| `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines (plain text only — gzip is **not** decompressed by `wc_lines`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
+| `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines of the decompressed content (plain or `.gz`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |
@@ -2066,22 +2066,22 @@ shell = "caller --input {input[0]} --output {output[0]}"
 - **Path resolution** — relative paths join against the run **workdir**;
   absolute paths pass through. `{sample}` and other wildcards expand from
   the instance context before the read.
-- **Phase semantics** — at *plan time* a missing file defers (`true`, the
-  rule stays in the plan because its producer may not have run); at
-  *execution time* a missing or unreadable file fails closed (`false`, the
-  rule is skipped). The defer guarantee applies to the runtime-function
-  atom itself: negating it (`!reads_count(...)`) or chaining it with `&&`
-  can resolve to `false` at plan time and prune the rule, and a file that
-  already exists at plan time (e.g. a previous run's output) is read
-  immediately. Planning with `oxo-flow dry-run` therefore reflects any
-  pre-existing files, but never prunes on a gate whose target file does
-  not exist yet.
+- **Phase semantics** — at *plan time* a runtime-function atom whose file
+  is missing — or whose file is an output of this run but still holds a
+  previous run's stale value — defers (`true`, the rule stays in the plan
+  because its producer may not have run yet); at *execution time* a
+  missing or unreadable file fails closed (`false`, the rule is skipped).
+  The defer propagates through `!`, `&&`, `||` and parentheses
+  (three-valued logic), so a negated or chained gate is never pruned at
+  plan time just because its target file is not ready. Planning with
+  `oxo-flow dry-run` therefore never prunes on a gate whose target file
+  does not exist yet.
 - **Formats** — `reads_count` counts 4-line FASTQ records in plain or
   gzip files (the record count is truncated — a trailing partial record
-  does not round up); `wc_lines` streams lines of **plain-text** files
-  only (gzip is not decompressed — pointing it at a `.gz` counts the raw
-  compressed bytes); `file_size` returns the byte length. BAM/BGZF
-  indexing is planned for a future release.
+  does not round up); `wc_lines` streams lines of the **decompressed**
+  content for plain or gzip files (same `.gz` detection as `reads_count`);
+  `file_size` returns the byte length. BAM/BGZF indexing is planned for
+  a future release.
 - **Change tracking** — recorded verdicts participate in config-change
   replay: changing a threshold referenced by such a gate (e.g.
   `config.min_reads`) re-evaluates only the instances whose verdict


### PR DESCRIPTION
# feat: data-dependent DAG pruning — `when` gates over runtime-produced files (#282)

Closes #282.

## What

Extends `when` expressions with three **read-only runtime functions** that inspect files in the run workdir, making gates data-dependent (issue #282, Engine M1):

| Function | Reads | Returns |
|---|---|---|
| `reads_count(path)` | FASTQ, plain or `.gz` | record count (lines ÷ 4) |
| `wc_lines(path)` | any text file, plain or `.gz` | line count |
| `file_size(path)` | any file | size in bytes |

```toml
[[rules]]
name  = "call_variants"
when  = "reads_count('trimmed/{sample}.fq.gz') > config.min_reads"
input = ["trimmed/{sample}.fq.gz"]
output = ["variants/{sample}.vcf.gz"]
```

The DAG is now pruned by what upstream rules **actually produced**, not just static config.

## Design (per issue discussion)

**Phase semantics** — the two phases deliberately disagree on missing files:

- **Plan time** (dry-run, DAG build, config-change analysis): missing file → deferred `true`. A gate never prunes a rule whose producer simply has not run yet.
- **Execution time**: missing or unreadable file → fail-closed `false`. A gate that cannot count what it was asked to count does not run the rule.

**Checkpoint integration** — execution-time verdicts are recorded per instance (`when_verdicts`). `detect_config_changes_with_replay` now re-evaluates runtime gates with per-instance wildcard bindings (`[[values]]`/`[[pairs]]`/`[[sample_groups]]` expansions) against the real workdir: a threshold change (e.g. `config.min_reads`) invalidates **only the instances whose verdict actually flipped**; unchanged completed instances stay exempt. This upgrades the #198 when-flip channel from config-only predicates to data-dependent ones.

**Post-rule DAG splice** — the gate runs inside `execute_rule_inner` before dry-run short-circuit; a `false` verdict marks the instance `Skipped`, which the scheduler treats as done, so downstream consumers see consistent state without scheduler changes.

## Scope limits (v1)

- Plain + gzip files only; `reads_count` assumes 4-line FASTQ records (BAM/BGZF deferred to v2).
- Only `when` strings may call these functions — `shell`/`input`/`output` remain plan-time surface.
- No shell, no globbing; only `{wildcard}` expansion in paths.

## Tests

- Evaluator unit test: real files (plain/gz FASTQ, text), all six comparison ops vs `config.` thresholds (int + string), bare-call truthiness, absolute paths, wildcard-expanded paths, plan-defer vs execution-fail-closed, malformed threshold → false.
- Replay tests: threshold flip invalidates only the flipped instance (`filter_cohort_S1`) while the unchanged instance stays exempt; missing-output replay fails closed with no spurious invalidation.
- E2E: producer (`trim`) writes `trimmed/{sample}.fq`; consumer gate reads it — plan time defers (both instances kept), S1 executes (2 > 1), S2 is Skipped (10 < 50), verdicts land in the checkpoint.

Full workspace: 1309 core lib tests + all crate suites green; `cargo fmt` + `cargo clippy --workspace --all-targets` clean.

## Docs

- `docs/guide/src/how-to/conditional-rules.md` — new "Data-dependent gates" section (function table, phase semantics, workdir resolution, scope limits).
- `docs/guide/src/reference/workflow-format.md` — `when` row updated + new "Data-Dependent `when` Gates" reference section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
