### PR TITLE
fix: signal teardown checkpoint corruption; desktop opener injection; OCI version labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN cargo build --release -p oxo-flow-web -p oxo-flow-cli
 # "GLIBC_2.39 not found" (issue #276 docker-build gate).
 FROM debian:trixie-slim
 WORKDIR /app
+# Image version for the OCI LABEL below. Default tracks the released
+# workspace version; CI overrides with --build-arg VERSION=… at release
+# time so the label cannot drift from the published tag.
+ARG VERSION=0.16.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
@@ -56,7 +60,7 @@ EXPOSE 3000
 
 LABEL org.opencontainers.image.title="oxo-flow" \
       org.opencontainers.image.description="Bioinformatics pipeline engine" \
-      org.opencontainers.image.version="0.16.0" \
+      org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.licenses="Apache-2.0 AND LicenseRef-OxoFlow-Commercial" \
       org.opencontainers.image.vendor="Traitome" \
       org.opencontainers.image.authors="Shixiang Wang <w_shixiang@163.com>"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -64,6 +64,10 @@ RUN npm run build
 # ===== Runtime =====
 FROM debian:trixie-slim
 
+# ARGs are stage-scoped — re-declare so the OCI version LABEL below
+# resolves instead of rendering empty.
+ARG VERSION
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2779,6 +2779,14 @@ pub async fn run_command(
         // default disposition killing oxo-flow outright and orphaning every
         // child (PPID 1) with a half-written checkpoint.
         let join_result = tokio::select! {
+            // `biased` with join-next first: a result that is already
+            // reapable is ALWAYS drained before the signal branch can be
+            // taken. Without this, a signal landing in the same poll
+            // cycle as a completion races it at random — the teardown
+            // would then see the finished rule's id still in `task_rule`
+            // and record it Failed in the checkpoint.
+            biased;
+            result = join_set.join_next_with_id() => Some(result),
             received = async {
                 match signal_rx.changed().await {
                     Ok(()) => *signal_rx.borrow_and_update(),
@@ -2802,13 +2810,20 @@ pub async fn run_command(
                 // the signals' default dispositions.
                 None => None,
             },
-            result = join_set.join_next_with_id() => Some(result),
         };
         let Some(join_result) = join_result else {
             continue;
         };
         let (completed_rule, status, record) = match join_result {
-            Some(Ok((_id, v))) => v,
+            // Reaped: drop the id→rule link so a later signal teardown
+            // cannot record this rule Failed. (Only the panic branch
+            // used to remove the entry — every success or rule-level
+            // failure lingered here, so Ctrl-C marked ALL finished
+            // rules Failed in the checkpoint.)
+            Some(Ok((id, v))) => {
+                task_rule.remove(&id);
+                v
+            }
             Some(Err(e)) => {
                 if e.is_panic() {
                     tracing::error!("Task panicked: {e}");

--- a/crates/oxo-flow-desktop/Cargo.lock
+++ b/crates/oxo-flow-desktop/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "base64",
  "chrono",
  "csv",
+ "flate2",
  "fs2",
  "glob",
  "hex",

--- a/crates/oxo-flow-desktop/src/main.rs
+++ b/crates/oxo-flow-desktop/src/main.rs
@@ -37,8 +37,8 @@ use wry::WebViewBuilderExtUnix;
 
 use anyhow::{Context, Result};
 use fs2::FileExt;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tao::dpi::LogicalSize;
 use tao::event::{Event, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
@@ -86,8 +86,12 @@ fn run() -> Result<()> {
     let data_dir = app_data_dir().context("failed to locate a home directory for app data")?;
     std::fs::create_dir_all(&data_dir)
         .with_context(|| format!("failed to create data directory {}", data_dir.display()))?;
-    std::env::set_current_dir(&data_dir)
-        .with_context(|| format!("failed to change working directory to {}", data_dir.display()))?;
+    std::env::set_current_dir(&data_dir).with_context(|| {
+        format!(
+            "failed to change working directory to {}",
+            data_dir.display()
+        )
+    })?;
 
     // The embedded server writes logs/, oxo-flow.db, and serves the SPA —
     // mirror the CLI's tracing setup (human-readable, env-filterable).
@@ -102,9 +106,8 @@ fn run() -> Result<()> {
     // One shell per data directory: two instances would run two servers
     // against the same oxo-flow.db. The advisory lock releases automatically
     // when the process dies (no stale-lock cleanup needed).
-    let instance_lock = take_instance_lock().context(
-        "another oxo-flow desktop instance is already running for this user account",
-    )?;
+    let instance_lock = take_instance_lock()
+        .context("another oxo-flow desktop instance is already running for this user account")?;
 
     // Grab an ephemeral port, then start the embedded server on a tokio
     // runtime that outlives the event loop below.
@@ -142,9 +145,9 @@ fn run() -> Result<()> {
     runtime.spawn(async move {
         #[cfg(unix)]
         let interrupted = async {
-            use tokio::signal::unix::{signal, SignalKind as TkSignalKind};
-            let mut term = signal(TkSignalKind::terminate())
-                .expect("failed to install SIGTERM handler");
+            use tokio::signal::unix::{SignalKind as TkSignalKind, signal};
+            let mut term =
+                signal(TkSignalKind::terminate()).expect("failed to install SIGTERM handler");
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {}
                 _ = term.recv() => {}
@@ -202,8 +205,7 @@ fn run() -> Result<()> {
         return early_exit_result();
     }
 
-    let webview = build_webview(&window, &server_url, port)
-        .context("failed to create webview")?;
+    let webview = build_webview(&window, &server_url, port).context("failed to create webview")?;
     let _ = webview; // kept alive by wry's internal association with the window
 
     // The runtime is owned by the event-loop closure (tao's `run` never
@@ -382,9 +384,40 @@ fn is_app_origin(uri: &str, port: u16) -> bool {
     authority == format!("{HOST}:{port}")
 }
 
+/// Vet a URI for the OS browser opener: `http`/`https` scheme only (the
+/// comparison is case-insensitive per RFC 3986; the original spelling is
+/// preserved for the browser), no control characters. The OS openers
+/// dispatch every other scheme to its registered protocol HANDLER
+/// (`file://`, `ms-msdt:`, `search-ms:` — historic Windows-spawner
+/// vectors), and webview content is workflow-derived, so the scheme is
+/// pinned here rather than trusted to the opener. Control characters are
+/// rejected outright: argv isolation already contains them on every
+/// platform, but a crafted URI must fail loudly, not open a surprise
+/// target.
+fn vetted_external_uri(uri: &str) -> std::io::Result<&str> {
+    let scheme_ok = {
+        let lower = uri.to_ascii_lowercase();
+        lower.starts_with("http://") || lower.starts_with("https://")
+    };
+    if !scheme_ok {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("only http(s) URIs are opened externally, got: {uri}"),
+        ));
+    }
+    if uri.chars().any(char::is_control) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "URI contains control characters",
+        ));
+    }
+    Ok(uri)
+}
+
 /// Open a URI in the system browser (best-effort; failures are ignored —
 /// a missing `xdg-open` on a headless box must not crash the app).
 fn open_external(uri: &str) -> std::io::Result<()> {
+    let uri = vetted_external_uri(uri)?;
     #[cfg(target_os = "macos")]
     {
         std::process::Command::new("open")
@@ -401,8 +434,15 @@ fn open_external(uri: &str) -> std::io::Result<()> {
     }
     #[cfg(windows)]
     {
-        std::process::Command::new("cmd")
-            .args(["/c", "start", "", uri])
+        // NOT `cmd /c start`: cmd re-parses its command line, and Rust's
+        // argv quoting is not cmd quoting — an unquoted `&` is a command
+        // separator and an embedded `"` escapes the enclosing quote, so a
+        // crafted link in rendered content could execute commands.
+        // explorer.exe takes the URI as a single argv element (no shell
+        // re-parse) and hands it to the default browser; its odd
+        // exit-code-1-on-success is ignored (spawn result only).
+        std::process::Command::new("explorer")
+            .arg(uri)
             .spawn()
             .map(|_| ())
     }
@@ -480,7 +520,10 @@ mod tests {
     fn same_origin_is_app() {
         assert!(is_app_origin("http://127.0.0.1:4173/", 4173));
         assert!(is_app_origin("http://127.0.0.1:4173/api/health", 4173));
-        assert!(is_app_origin("http://127.0.0.1:4173/api/runs?x=1#frag", 4173));
+        assert!(is_app_origin(
+            "http://127.0.0.1:4173/api/runs?x=1#frag",
+            4173
+        ));
     }
 
     #[test]
@@ -504,5 +547,38 @@ mod tests {
         assert!(!is_app_origin("http://[::1]:4173/", 4173));
         // Userinfo trick: the host is evil.com, not the app.
         assert!(!is_app_origin("http://127.0.0.1:4173@evil.com/", 4173));
+    }
+
+    #[test]
+    fn external_uri_gate_accepts_http_https() {
+        assert!(vetted_external_uri("https://github.com/Traitome/oxo-flow").is_ok());
+        // Query separators and fragments are ordinary URI syntax — argv
+        // isolation (no shell) is what keeps them inert, so the gate must
+        // not charset-filter them away.
+        assert!(vetted_external_uri("http://example.com/docs?a=1&b=2#frag").is_ok());
+        // Scheme comparison is case-insensitive (RFC 3986).
+        assert!(vetted_external_uri("HTTPS://EXAMPLE.COM/").is_ok());
+    }
+
+    #[test]
+    fn external_uri_gate_rejects_other_schemes_and_control_chars() {
+        // Non-http(s) schemes dispatch to their registered protocol
+        // handler inside the OS opener — file/ms-msdt/search-ms are the
+        // historic spawner vectors, so the gate is a scheme allowlist,
+        // not a blocklist.
+        for uri in [
+            "file:///etc/passwd",
+            "ms-msdt:diagnostic",
+            "search-ms:q=secret",
+            "javascript:alert(1)",
+            "ftp://example.com/pub",
+            "HTTPX://example.com/",
+        ] {
+            assert!(vetted_external_uri(uri).is_err(), "must reject {uri}");
+        }
+        // Control characters: fail loudly instead of opening a surprise
+        // target.
+        assert!(vetted_external_uri("http://example.com/a\r\nX: 1").is_err());
+        assert!(vetted_external_uri("http://example.com/\0").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Three hardening fixes from the v0.16.0..HEAD review (web/desktop/CI sweep). Two HIGH, one MEDIUM.

### HIGH — CLI: signal teardown marked completed rules Failed in the checkpoint

Two defects in the run loop's signal path (`oxo-flow-cli/src/commands/run.rs`):

1. **`task_rule` entries were removed only in the task-panic branch** — every success and rule-level failure lingered in the id→rule map for the whole run. On SIGINT/SIGTERM, `terminate_on_signal` drains that map and records a Failed `JobRecord` + `mark_failed` per entry, so interrupting a run marked **every completed rule Failed**: the checkpoint audit trail lied about what succeeded, and a resume would re-execute finished work. The id is now dropped as soon as its result is reaped.
2. **`tokio::select!` picks among ready branches at random** — a signal landing in the same poll cycle as a completion could take the signal arm while the finished rule's result was still queued in the JoinSet (its id still in `task_rule`). The select is now `biased` with join-next polled first: a reapable result is always drained before the signal arm can run, so the teardown only ever sees genuinely in-flight rules.

### HIGH — Desktop: `cmd /c start` argument injection in `open_external`

On Windows, opening an external link ran `cmd /c start "" <uri>` — but `cmd` re-parses its command line and Rust's argv quoting is not cmd quoting: an unquoted `&` is a command separator and an embedded `"` escapes the enclosing quote. A crafted link in rendered content (workflow-derived HTML in the webview) could execute commands when clicked. The Windows arm now uses **explorer.exe**, which takes the URI as a single argv element (no shell re-parse). All platforms gain a scheme gate (`http`/`https` only, case-insensitive per RFC 3986, control chars rejected): the OS openers dispatch every other scheme to its registered protocol handler (`file://`, `ms-msdt:`, `search-ms:` — historic spawner vectors). Tests cover both sides of the gate; desktop suite 6/6 green.

### MEDIUM — Docker: OCI version labels

- `Dockerfile.release` declared `ARG VERSION` only in the `binaries` stage, so the runtime stage's `org.opencontainers.image.version` LABEL rendered **empty** on every published release image. Re-declared in the runtime stage.
- `./Dockerfile` hardcoded `0.16.0` in the same label (would drift on the next release) — parameterized as `ARG VERSION=0.16.0` with a `--build-arg` override path for CI.

Also refreshes the excluded desktop crate's stale `Cargo.lock` (`flate2` entry — a `--locked` desktop build against main would fail).

## Test plan

- [x] `cargo test -p oxo-flow-cli` — 189 passed, 0 failed
- [x] `cargo clippy -p oxo-flow-cli --all-targets` — clean; workspace `cargo fmt --all -- --check` — clean
- [x] Desktop crate: `cargo test` — 6 passed (2 new gate tests); `cargo fmt` applied
- [ ] CI (Windows arm of the desktop fix compiles under `cargo check --target x86_64-pc-windows-msvc` via the desktop job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
