### PR TITLE
docs: fix three drift findings in the report/web reference pages

### DIFF
--- a/docs/guide/src/how-to/generate-reports.md
+++ b/docs/guide/src/how-to/generate-reports.md
@@ -83,7 +83,6 @@ A generated report includes:
 | **Provenance** | Engine version, workflow file sha256, checkpoint location |
 | **Software Versions** | Declared software per rule, nf-core-style: docker `image:tag`, module `tool/version`, env files with sha256 hashes — static declaration, runtime package versions deliberately not recorded |
 | **Task Summary** | Per-rule table of tasks, types, inputs, outputs, environments, and resources |
-| **Software Versions** | Tool/version table parsed from known version-reporting files under the workdir |
 | **Rule Captions** | Per-rule `report` annotations rendered as markdown (one subsection per executed instance) — set `report = "caption"` or `report = { file = "notes/qc.md", caption = "…" }` on a rule |
 | **Aggregate Metrics** | MultiQC-style sample × metric matrix across all parsed tools, plus `*_mqc.json` custom content |
 

--- a/docs/guide/src/reference/web-system-architecture.md
+++ b/docs/guide/src/reference/web-system-architecture.md
@@ -232,7 +232,7 @@ Rate limiting and SSE:
 └── /pipeline/{id}          # DAG edit API: /command, /undo, /redo
 ```
 (See [Web API](./web-api.md) for the complete API reference — the OpenAPI 3.1 spec is CODE-GENERATED via utoipa and served live at `GET /api/openapi.json` on any running server.)
-(Old `/workflows/*` endpoints marked `#[deprecated]` exist only as unserved legacy modules — see [Legacy Modules](#legacy-modules-deprecated-since-080).)
+(Old `/workflows/*` endpoints are marked `#[deprecated]` in the source and exist only as unserved legacy modules.)
 
 ---
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -519,7 +519,7 @@ Each section ID maps to a registered `ReportSectionGenerator`:
 | `environment` | Available backends and oxo-flow version | Always |
 | `clinical-compliance` | ACMG/AMP classification, audit trail, biomarkers | Always |
 | `execution-status` | Per-rule execution status and benchmark metrics | Only with checkpoint |
-| `software-versions` | Tool/version table parsed from known version-reporting files (`*version*` filenames) | When version files are found |
+| `software-versions` | Declared software per rule, nf-core-style: docker `image:tag`, module `tool/version`, env files with sha256 hashes — static declaration, runtime package versions deliberately not recorded (see [Reporting](reporting-system.md#software-versions-section)) | When any rule declares an environment |
 | `rule-captions` | Per-rule `report` annotations rendered as markdown — see [Rule Captions](#rule-captions) | When any rule declares `report` |
 | `aggregate-metrics` | MultiQC-style sample × metric matrix across tools, plus `*_mqc.json` custom content | When metric or custom-content files are found |
 


### PR DESCRIPTION
## Summary

Three in-range docs-drift findings from the v0.16.0..HEAD review, all verified against the code:

1. **workflow-format.md — false `software-versions` description.** The row claimed a "tool/version table parsed from known version-reporting files (`*version*` filenames)". No such collector exists (`grep -rn '*version*' crates/` finds nothing); `SoftwareVersionsGenerator::generate` renders the **declared** software per rule (docker `image:tag`, module `tool/version`, env files with sha256 hashes) and returns nothing when no rule declares an environment. The row now matches [reporting-system.md](https://github.com/Traitome/oxo-flow/blob/main/docs/guide/src/reference/reporting-system.md) and the generator's own description.
2. **generate-reports.md — duplicate contradictory rows.** The section table carried two `Software Versions` rows (one correct, one stale); dropped the stale one.
3. **web-system-architecture.md — dangling anchor.** `[Legacy Modules](#legacy-modules-deprecated-since-080)` pointed at a heading that exists nowhere in the book; the parenthetical now stands alone.

## Test plan

- [x] Verified each claim against `crates/oxo-flow-core/src/software_versions.rs` and `reporting-system.md`
- [x] No remaining `version-reporting` / `legacy-modules-deprecated` references in `docs/guide/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)