### PR TITLE
fix: resolve all nine #297 review follow-ups (web/cli/CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,12 @@ jobs:
             exit 1
           fi
           echo "Re-running: $FAILED"
-          if cargo test --workspace -- --exact $FAILED; then
+          # One argument per test via a real array: an unquoted $FAILED
+          # word-splits on spaces too, and a fully-quoted one arrives as a
+          # single --exact filter containing newlines and matches nothing
+          # (issue #297 item 8).
+          mapfile -t FAILED_LIST <<< "$FAILED"
+          if cargo test --workspace -- --exact "${FAILED_LIST[@]}"; then
             echo "::warning::FAILED tests passed on re-run — classified as load-timing flakes (issue #249)"
             exit 0
           fi
@@ -1083,17 +1088,23 @@ jobs:
 
   # ─── Docker: publish the image to ghcr.io (GitHub Packages) ───────────────
   # Two channels with distinct jobs:
-  #   docker-publish         — main pushes → :main, built from source
-  #                            (Dockerfile). This is the regression gate:
-  #                            the shipped Dockerfile must keep compiling.
-  #   docker-publish-release — release tags/dispatch → :<version> + :latest,
+  #   docker-publish-main-{amd64,arm64} + docker-publish
+  #                         — main pushes → per-arch source builds
+  #                            (Dockerfile) pushed as :main-<arch>, then a
+  #                            manifest job merges them into :main so
+  #                            arm64 hosts pulling :main get a native image
+  #                            instead of a broken amd64-only one (issue
+  #                            #297 item 9). This is the regression gate:
+  #                            the shipped Dockerfile must keep compiling
+  #                            on both arches.
+  #   docker-publish-release — release tags/dispatch → :<version> (+ :latest
+  #                            and :<major.minor> after the smoke gate),
   #                            multi-arch (amd64+arm64) from the prebuilt
   #                            release binaries (Dockerfile.release,
   #                            SHA256-verified), so the image is
-  #                            byte-identical with the release tarballs and
-  #                            arm64 hosts get a native image.
-  docker-publish:
-    name: Docker (publish :main to ghcr.io)
+  #                            byte-identical with the release tarballs.
+  docker-publish-main-amd64:
+    name: Docker (build :main amd64 → ghcr.io)
     runs-on: ubuntu-latest
     needs: [sync-version, test, docker-build]
     if: >-
@@ -1115,19 +1126,49 @@ jobs:
       - name: Compute image name
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/oxo-flow" >> "$GITHUB_ENV"
 
-      - name: Compute image tags
-        id: tags
-        run: |
-          # Main pushes get a moving :main tag instead of a misleading
-          # :latest (release tags are published by docker-publish-release).
-          TAGS="${IMAGE}:main"
-          {
-            echo "tags<<EOF"
-            echo "$TAGS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Publishing tags:"
-          echo "$TAGS"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE }}:main-amd64
+          labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha,scope=main-amd64
+          cache-to: type=gha,mode=max,scope=main-amd64
+
+  docker-publish-main-arm64:
+    name: Docker (build :main arm64 → ghcr.io)
+    # Native arm64 runner (free for public repos) — building the Rust image
+    # under QEMU emulation would take hours, which is why :main used to ship
+    # amd64-only (issue #297 item 9).
+    runs-on: ubuntu-24.04-arm
+    needs: [sync-version, test, docker-build]
+    if: >-
+      always() &&
+      needs.docker-build.result == 'success' &&
+      (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
+      needs.test.result == 'success' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.sync-version.outputs.updated_sha || github.sha }}
+
+      - name: Compute image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/oxo-flow" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1139,15 +1180,56 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (arm64)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ env.IMAGE }}:main-arm64
           labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=main-arm64
+          cache-to: type=gha,mode=max,scope=main-arm64
+
+  docker-publish:
+    name: Docker (publish :main manifest to ghcr.io)
+    runs-on: ubuntu-latest
+    needs: [sync-version, test, docker-publish-main-amd64, docker-publish-main-arm64]
+    if: >-
+      always() &&
+      needs.docker-publish-main-amd64.result == 'success' &&
+      needs.docker-publish-main-arm64.result == 'success' &&
+      (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
+      needs.test.result == 'success' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # repository_owner is "Traitome" (uppercase) but ghcr requires lowercase
+      # image paths — force it down (${VAR,,} bash lowercase).
+      - name: Compute image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/oxo-flow" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge per-arch images into the moving :main manifest
+        run: |
+          # imagetools create is registry-side: it assembles a manifest list
+          # referencing the two just-pushed per-arch images and pushes it as
+          # :main. Main pushes get this moving tag instead of a misleading
+          # :latest (release tags are published by docker-publish-release).
+          docker buildx imagetools create \
+            -t "${IMAGE}:main" \
+            "${IMAGE}:main-amd64" "${IMAGE}:main-arm64"
+          docker buildx imagetools inspect "${IMAGE}:main"
 
       - name: Smoke-test the pushed image (health endpoint)
         run: |
@@ -1168,17 +1250,24 @@ jobs:
 
   # Release channel: assembles the image from the prebuilt release binaries
   # (no cargo build) as a multi-arch manifest (amd64 + arm64), publishing
-  # ghcr.io/traitome/oxo-flow:<version> + :latest. Runs only on release
-  # tags / dispatch-with-tag, and only after the release job has actually
-  # uploaded the artifacts — the binaries it installs come from that
-  # release, verified against SHA256SUMS.txt inside Dockerfile.release.
+  # ghcr.io/traitome/oxo-flow:<version>, then — only after the version-tag
+  # image passed the smoke test — promoting :latest and :<major.minor> from
+  # it server-side. Runs on release tags / dispatch-with-tag, and after the
+  # release job has uploaded the artifacts — the binaries it installs come
+  # from that release, verified against SHA256SUMS.txt inside
+  # Dockerfile.release. A dispatch with publish_images_only=true skips the
+  # release pipeline entirely (release job → 'skipped') and publishes from
+  # the EXISTING release's artifacts — that mode is what makes the
+  # publish_images_only input functional instead of a no-op (issue #297
+  # item 3).
   docker-publish-release:
     name: Docker (publish release to ghcr.io)
     runs-on: ubuntu-latest
     needs: [sync-version, test, release]
     if: >-
       always() &&
-      needs.release.result == 'success' &&
+      (needs.release.result == 'success' ||
+       (needs.release.result == 'skipped' && inputs.publish_images_only == true)) &&
       (needs.sync-version.result == 'success' || needs.sync-version.result == 'skipped') &&
       needs.test.result == 'success' &&
       (startsWith(github.ref, 'refs/tags/v') ||
@@ -1211,6 +1300,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve version (sync-version is skipped in publish_images_only mode)
+        run: |
+          set -euo pipefail
+          # Normal releases get the version from sync-version; a
+          # publish_images_only dispatch re-publishes an EXISTING release,
+          # so the version comes from the tag input instead (same fallback
+          # as the docker-build-release validation leg).
+          if [ -n "$SYNC_VERSION" ]; then
+            echo "VERSION=$SYNC_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+          fi
+          echo "Publishing version: $VERSION"
+        env:
+          SYNC_VERSION: ${{ needs.sync-version.outputs.version }}
+          TAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || github.ref_name }}
+
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
@@ -1218,19 +1324,22 @@ jobs:
           file: ./Dockerfile.release
           # VERSION is the synced release version; the Dockerfile resolves
           # the per-arch tarball triple from TARGETARCH at build time.
-          build-args: VERSION=${{ needs.sync-version.outputs.version }}
+          build-args: VERSION=${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64
           push: true
+          # Only the immutable version tag is pushed here. :latest (and the
+          # rolling :<major.minor>) are promoted from it AFTER the smoke
+          # test below — tagging :latest in this step would publish a broken
+          # release as "latest" with no gate (issue #297 item 2).
           tags: |
-            ${{ env.IMAGE }}:${{ needs.sync-version.outputs.version }}
-            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ env.VERSION }}
           labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           provenance: false
 
       - name: Smoke-test the pushed image (health endpoint, native arch)
         run: |
-          docker pull "${IMAGE}:${{ needs.sync-version.outputs.version }}"
-          docker run -d --name oxo-flow-pub -p 3000:3000 "${IMAGE}:${{ needs.sync-version.outputs.version }}"
+          docker pull "${IMAGE}:${VERSION}"
+          docker run -d --name oxo-flow-pub -p 3000:3000 "${IMAGE}:${VERSION}"
           for i in $(seq 1 20); do
             if curl -sf http://localhost:3000/api/health | grep -q '"status":"ok"'; then
               echo "published release image healthy"
@@ -1243,6 +1352,28 @@ jobs:
           docker logs oxo-flow-pub || true
           docker rm -f oxo-flow-pub > /dev/null || true
           exit 1
+
+      - name: Promote :latest and :<major.minor> (smoke-gated, both arches)
+        run: |
+          set -euo pipefail
+          # Server-side re-tag of the pushed multi-arch manifest list — no
+          # rebuild, so BOTH platforms carry over (a docker tag+push here
+          # would replace the manifest with a single-arch image).
+          MAJOR_MINOR="${VERSION%.*}"
+          # Re-publishing an OLD release (publish_images_only dispatch) must
+          # not drag :latest backwards — only the repo's actual latest
+          # release gets the :latest alias; older ones keep their immutable
+          # version tag and gain only the rolling :<major.minor>.
+          LATEST_TAG=$(curl -sf "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" \
+            | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4 || true)
+          if [ -n "$LATEST_TAG" ] && [ "$LATEST_TAG" != "$RELEASE_TAG" ]; then
+            echo "::warning::${RELEASE_TAG} is not the latest release (${LATEST_TAG}) — promoting only :${MAJOR_MINOR}, :latest stays with ${LATEST_TAG}"
+            docker buildx imagetools create -t "${IMAGE}:${MAJOR_MINOR}" "${IMAGE}:${VERSION}"
+            exit 0
+          fi
+          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${VERSION}"
+          docker buildx imagetools create -t "${IMAGE}:${MAJOR_MINOR}" "${IMAGE}:${VERSION}"
+          echo "promoted ${IMAGE}:${VERSION} → :latest and :${MAJOR_MINOR}"
 
   # ─── Frontend: build + e2e (Playwright against the real server) ──────────
   frontend:

--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ conda install -c bioconda oxo-flow-cli
 
 ### Run with Docker
 
-Pre-built images are published to GitHub Container Registry on every release (and every push to `main`). Release images are multi-arch (`linux/amd64` + `linux/arm64`, so Apple silicon and ARM servers pull a native image); `:main` is amd64-only and compiled from source:
+Pre-built images are published to GitHub Container Registry on every release (and every push to `main`). Release images are multi-arch (`linux/amd64` + `linux/arm64`, so Apple silicon and ARM servers pull a native image). `:latest` moves only after the release image passes a health smoke test; a rolling `:<major.minor>` tag (e.g. `:0.16`) tracks the newest patch of each minor line, and `:main` is a multi-arch dev build from source:
 
 ```bash
 # Web UI at http://localhost:3000 (CLI is inside the same image)
 docker run -d --name oxo-flow -p 3000:3000 ghcr.io/traitome/oxo-flow:latest
 
-# Pin a release
+# Pin a release (or track a minor line)
 docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16.0
+docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16
 
 # CLI one-shot usage (workflow files mounted from the host)
 docker run --rm -v "$PWD:/work" -w /work ghcr.io/traitome/oxo-flow:latest \

--- a/crates/oxo-flow-cli/src/commands/ai_template.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_template.rs
@@ -20,6 +20,21 @@ async fn fetch_reference(fetcher: &FetchUrlTool, url: &str) -> Result<String, St
     fetcher.execute(&arguments).await.map_err(|e| e.to_string())
 }
 
+/// Largest prefix of `s` with at most `max_bytes` bytes, cut at a char
+/// boundary. Byte-slicing (`&s[..n]`) panics when `n` lands inside a
+/// multi-byte UTF-8 sequence — CJK reference text routinely does (issue
+/// #297 item 6).
+fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Where the generated workflow lands.
 ///
 /// `-o` documents two shapes: a file path, and a directory signalled by a
@@ -181,7 +196,7 @@ pub async fn generate_workflow(
         match fetch_reference(&fetcher, url).await {
             Ok(text) => {
                 let preview = if text.len() > 300 {
-                    format!("{}...", &text[..300])
+                    format!("{}...", truncate_utf8(&text, 300))
                 } else {
                     text.clone()
                 };
@@ -202,7 +217,7 @@ pub async fn generate_workflow(
         match std::fs::read_to_string(path) {
             Ok(content) => {
                 let preview = if content.len() > 2000 {
-                    format!("{}...", &content[..2000])
+                    format!("{}...", truncate_utf8(&content, 2000))
                 } else {
                     content.clone()
                 };
@@ -625,6 +640,21 @@ fn validate_basic_structure(toml: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_utf8_cuts_at_char_boundary() {
+        // Issue #297 item 6: `&text[..300]` panicked when byte 300 split a
+        // multi-byte UTF-8 char — CJK reference text hit this on every fetch.
+        let cjk = "样本".repeat(150); // 3-byte chars; byte 298 lands inside char 100
+        assert_eq!(truncate_utf8(&cjk, 298).len(), 297);
+        assert!(truncate_utf8(&cjk, 298).ends_with("样"));
+        // A 4-byte emoji spanning byte 300 is dropped whole, no panic.
+        let emoji = format!("{}🧬y", "x".repeat(299));
+        assert_eq!(truncate_utf8(&emoji, 300), "x".repeat(299));
+        // Short input is returned as-is; ASCII cut at a boundary is exact.
+        assert_eq!(truncate_utf8("short", 300), "short");
+        assert_eq!(truncate_utf8(&"a".repeat(400), 300).len(), 300);
+    }
 
     #[test]
     fn extract_toml_from_code_fence() {

--- a/crates/oxo-flow-cli/src/commands/publish.rs
+++ b/crates/oxo-flow-cli/src/commands/publish.rs
@@ -99,6 +99,7 @@ pub fn publish_command(
 
     // Copy all env/script files to temp dir and compute checksums
     for (rel_path, abs_path) in &referenced_files {
+        ensure_safe_bundle_path(rel_path)?;
         let checksum = compute_sha256(abs_path)?;
         let dest = temp_dir.join(rel_path);
         if let Some(parent) = dest.parent() {
@@ -230,6 +231,10 @@ pub fn publish_command(
             $builder.append_path_with_name(&wf_dest, wf_filename)?;
             // Add all env/script files
             for (rel_path, _abs_path) in &referenced_files {
+                // Backstop for the archive entry names themselves: a `../`
+                // entry would be a zip-slip on the consumer side even if the
+                // temp-dir copy above had somehow tolerated it.
+                ensure_safe_bundle_path(rel_path)?;
                 let dest = temp_dir.join(rel_path);
                 $builder.append_path_with_name(&dest, rel_path)?;
             }
@@ -284,6 +289,33 @@ pub fn publish_command(
     );
     eprintln!("  checksums: {} files verified (SHA-256)", checksum_count);
 
+    Ok(())
+}
+
+/// Reject bundle member paths that could escape the bundle root: absolute
+/// paths and `..` components. `referenced_files` paths come straight from
+/// workflow TOML (`metadata_file` / `pairs_file` / include references), so
+/// a hostile workflow must not steer `temp_dir.join(rel)` outside the
+/// staging dir on the publisher's machine, or plant `../` entry names the
+/// consumer-side extractor would follow (issue #297 item 7; POSIX-only —
+/// oxo-flow targets Linux/macOS).
+fn ensure_safe_bundle_path(rel_path: &str) -> Result<()> {
+    if rel_path.is_empty() {
+        anyhow::bail!("bundle path is empty");
+    }
+    let path = Path::new(rel_path);
+    if path.is_absolute() {
+        anyhow::bail!(
+            "bundle path '{rel_path}' is absolute — bundle members must be \
+             relative to the workflow dir"
+        );
+    }
+    if path
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        anyhow::bail!("bundle path '{rel_path}' contains '..' — it would escape the bundle root");
+    }
     Ok(())
 }
 
@@ -362,6 +394,11 @@ fn scan_workflow_env_files(
         // flattened to the archive root).
         for key in &["pairs_file", "sample_groups_file", "metadata_file"] {
             if let Some(file_path) = wf.get(key).and_then(|v| v.as_str()) {
+                // These three come straight from workflow TOML — a hostile
+                // workflow must not steer bundle members outside the bundle
+                // (issue #297 item 7). Fail the publish loudly rather than
+                // silently trimming the reference.
+                ensure_safe_bundle_path(file_path)?;
                 let abs_path = workflow_dir.join(file_path);
                 if abs_path.exists() {
                     if !referenced_files.iter().any(|(name, _)| name == file_path) {

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -3085,6 +3085,33 @@ pub async fn run_command(
             }
         }
 
+        // Skipped producers (issue #297 item 4): an outputs-up-to-date or
+        // condition-false skip never reaches discovery, so the producer's
+        // deferred consumers silently vanish from THIS run's plan. A
+        // checkpointed domain from an earlier success is replayed on resume,
+        // but a skip with no recorded domain leaves them uninstantiated for
+        // good — name both sides so the disappearance is attributable. A
+        // skip is not a failure, so unlike the block above this stays a
+        // warning and does not enter the failure summary.
+        if status == oxo_flow_core::executor::JobStatus::Skipped
+            && let Some(producer_template) = config.output_pattern_template_of(&completed_rule)
+        {
+            let consumers = config.pending_output_pattern_consumers_of(&producer_template);
+            if !consumers.is_empty() {
+                eprintln!(
+                    "{} {} not instantiated — output_pattern producer '{}' was skipped",
+                    "Warning:".bold().yellow(),
+                    consumers.join(", "),
+                    producer_template
+                );
+                tracing::warn!(
+                    producer = %producer_template,
+                    consumers = ?consumers,
+                    "skipped output_pattern producer leaves deferred consumers uninstantiated"
+                );
+            }
+        }
+
         // Abort on first failure when not in keep_going mode.
         let fc = fail_count.load(std::sync::atomic::Ordering::Relaxed);
         if fc > 0

--- a/crates/oxo-flow-web/src/domains/ai/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/ai/handlers.rs
@@ -241,6 +241,22 @@ pub async fn explain(
     .map_err(|e| err(StatusCode::BAD_REQUEST, "AI_EXPLAIN_ERROR", e))
 }
 
+/// Run a blocking filesystem walk off the async worker thread.
+///
+/// `block_in_place` tells the multi-threaded runtime this worker is about
+/// to block so it can move other tasks elsewhere — but it PANICS on a
+/// current-thread runtime (unit tests, embedded callers), so the flavor is
+/// checked first and the walk runs inline there (same contract as
+/// `auth::service::blocking_crypto`; issue #297 item 5).
+fn blocking_dir_walk<T>(op: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(op)
+        }
+        _ => op(),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/api/ai/interpret",
@@ -275,7 +291,7 @@ pub async fn interpret(
                 // minor). The blocking-pool hop is only worth it when a
                 // workdir exists; otherwise stay on the cheap path.
                 let wd = wd.to_string();
-                tokio::task::block_in_place(|| {
+                blocking_dir_walk(|| {
                     let mut summary = String::new();
                     if let Ok(entries) = std::fs::read_dir(&wd) {
                         for entry in entries.filter_map(|e| e.ok()) {

--- a/crates/oxo-flow-web/src/workspace.rs
+++ b/crates/oxo-flow-web/src/workspace.rs
@@ -96,11 +96,14 @@ pub fn inputs_directory(username: &str) -> Result<PathBuf> {
 /// CLI executes in the run/pipeline dir, so data-referencing workflows
 /// (`metadata_file`, input globs) failed pre-execution for web-only users.
 ///
-/// The WHOLE inputs tree is mirrored (skipping files that already exist in
-/// the destination, so pipeline re-runs keep newer local outputs), because
-/// which files a workflow needs is a parse-time property (`metadata_file`,
-/// input globs) the HTTP layer should not re-derive. Returns the number of
-/// files copied.
+/// The WHOLE inputs tree is mirrored, because which files a workflow needs
+/// is a parse-time property (`metadata_file`, input globs) the HTTP layer
+/// should not re-derive. A destination file is skipped only while it is at
+/// least as new as the staged source — so a re-uploaded input (source
+/// newer than the stale copy) is refreshed instead of being shadowed by it
+/// forever (issue #297 item 1), while a newer LOCAL file (a pipeline output
+/// sharing the staged path, written after staging) still survives
+/// re-staging. Returns the number of files copied.
 pub fn stage_user_inputs(username: &str, run_dir: &Path) -> Result<usize> {
     let root = inputs_directory(username)?;
     if !root.is_dir() {
@@ -125,7 +128,7 @@ pub fn stage_user_inputs(username: &str, run_dir: &Path) -> Result<usize> {
                 continue;
             };
             let dest = run_dir.join(rel);
-            if dest.exists() {
+            if dest_is_current(&dest, &meta) {
                 continue;
             }
             if let Some(parent) = dest.parent() {
@@ -138,6 +141,27 @@ pub fn stage_user_inputs(username: &str, run_dir: &Path) -> Result<usize> {
         }
     }
     Ok(copied)
+}
+
+/// True when `dest` already carries content at least as new as the staged
+/// source (whose metadata is `src_meta`): destination mtime same-or-newer
+/// than the source's. Compares instead of merely checking existence so a
+/// re-uploaded input (source newer than the stale copy) replaces it (issue
+/// #297 item 1) while newer local outputs are left alone. Size is
+/// deliberately NOT part of the check — freshness is an mtime property,
+/// and a same-size stale copy must still be refreshed.
+fn dest_is_current(dest: &Path, src_meta: &fs::Metadata) -> bool {
+    let Ok(dest_meta) = fs::metadata(dest) else {
+        return false; // missing (or unreadable) → stage it
+    };
+    if !dest_meta.is_file() {
+        return false; // a directory/symlink in the way → replace with the file
+    }
+    match (src_meta.modified().ok(), dest_meta.modified().ok()) {
+        (Some(src_m), Some(dest_m)) => src_m <= dest_m,
+        // Filesystems without mtime: cannot compare — refresh.
+        _ => false,
+    }
 }
 
 /// Retrieve the persistent working directory of a saved pipeline (issue #69).
@@ -170,6 +194,11 @@ pub fn setup_pipeline_directory(username: &str, pipeline_id: &str) -> Result<Pat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Serializes the tests that `set_current_dir` into a temp cwd —
+    /// `stage_user_inputs` resolves `workspace/…` relative to the process
+    /// cwd, so two concurrent cwd-dancing tests would stomp each other.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn get_pipeline_directory_returns_persistent_path() {
@@ -238,6 +267,7 @@ mod tests {
         // `inputs_directory` resolves `workspace/…` RELATIVE to the process
         // cwd (the same convention `setup_run_directory` follows at request
         // time), so the test runs inside a temp cwd.
+        let _cwd = CWD_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
@@ -266,6 +296,69 @@ mod tests {
         assert_eq!(second, 0, "existing files are not re-copied");
         assert!(run_dir.join("meta.tsv").is_file());
         assert!(run_dir.join("data/raw.txt").is_file());
+    }
+
+    #[test]
+    fn stage_user_inputs_refreshes_stale_copy_from_newer_upload() {
+        // Issue #297 item 1: `dest.exists()` alone kept a stale run-dir copy
+        // serving forever after the user re-uploaded the input. A newer
+        // upload must replace it; a newer LOCAL file (pipeline output on the
+        // staged path) must survive re-staging.
+        let _cwd = CWD_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        std::fs::create_dir_all("workspace/users/alice/inputs").unwrap();
+        std::fs::write("workspace/users/alice/inputs/meta.tsv", "v1\n").unwrap();
+        let run_dir = tmp.path().join("workspace/users/alice/runs/r1");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        assert_eq!(stage_user_inputs("alice", &run_dir).unwrap(), 1);
+
+        // Second run: the pipeline overwrote the staged copy with a local
+        // result (older than nothing), and the user re-uploaded meta.tsv.
+        let staged = run_dir.join("meta.tsv");
+        std::fs::write(&staged, "stale local copy\n").unwrap();
+        set_mtime(&staged, older());
+        std::fs::write("workspace/users/alice/inputs/meta.tsv", "v2 re-upload\n").unwrap();
+
+        let second = stage_user_inputs("alice", &run_dir).unwrap();
+
+        // A local file newer than its staged source is NOT clobbered.
+        let kept = run_dir.join("kept.txt");
+        std::fs::write(&kept, "pipeline output\n").unwrap();
+        std::fs::write("workspace/users/alice/inputs/kept.txt", "older upload\n").unwrap();
+        set_mtime(
+            std::path::Path::new("workspace/users/alice/inputs/kept.txt"),
+            older(),
+        );
+        let third = stage_user_inputs("alice", &run_dir).unwrap();
+
+        std::env::set_current_dir(prev).unwrap();
+
+        assert_eq!(second, 1, "the newer upload replaces the stale copy");
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), "v2 re-upload\n");
+        assert_eq!(third, 0, "both files current — nothing left to stage");
+        assert_eq!(
+            std::fs::read_to_string(&kept).unwrap(),
+            "pipeline output\n",
+            "a newer local file survives re-staging"
+        );
+    }
+
+    /// Set a file's mtime into the recent past (deterministically older than
+    /// anything written by the test body itself).
+    fn older() -> std::time::SystemTime {
+        std::time::SystemTime::now() - std::time::Duration::from_secs(120)
+    }
+
+    fn set_mtime(path: &std::path::Path, t: std::time::SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(t))
+            .unwrap();
     }
 
     #[test]

--- a/docs/guide/src/tutorials/installation.md
+++ b/docs/guide/src/tutorials/installation.md
@@ -124,14 +124,17 @@ Desktop users may prefer the `.deb` / `.rpm` / `.AppImage` /
 
 Images are published to GitHub Container Registry automatically on every release and every push to `main`.
 Release images are multi-arch (`linux/amd64` + `linux/arm64`) and are assembled from the
-SHA256-verified release binaries; `:main` is amd64-only and compiled from source:
+SHA256-verified release binaries. `:latest` moves only after the release image passes a health
+smoke test, `:<major.minor>` (e.g. `:0.16`) tracks the newest patch of a minor line, and `:main`
+is a multi-arch dev build compiled from source:
 
 ```bash
 # Web UI at http://localhost:3000
 docker run -d --name oxo-flow -p 3000:3000 ghcr.io/traitome/oxo-flow:latest
 
-# Pin a specific release
+# Pin a specific release (or track a minor line)
 docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16.0
+docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16
 
 # CLI one-shot usage — mount your workflow directory
 docker run --rm -v "$PWD:/work" -w /work ghcr.io/traitome/oxo-flow:latest \

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -4818,6 +4818,62 @@ fn cli_run_ref_build_fails_with_clear_error() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn cli_publish_rejects_traversal_in_metadata_file() {
+    // Issue #297 item 7: `metadata_file` et al. come straight from workflow
+    // TOML — a `..` reference must fail the publish (both to protect the
+    // staging dir and to keep `../` out of archive entry names, which would
+    // be a zip-slip on the consumer side).
+    let dir = tempfile::tempdir().unwrap();
+    let wf_dir = dir.path().join("wf");
+    fs::create_dir_all(&wf_dir).unwrap();
+    fs::write(dir.path().join("outside.txt"), "secret\n").unwrap();
+    let wf = wf_dir.join("trav_meta.oxoflow");
+    fs::write(
+        &wf,
+        "[workflow]\nname = \"trav\"\nversion = \"1.0.0\"\nmetadata_file = \"../outside.txt\"\n\n[[rules]]\nname = \"s\"\noutput = [\"out.txt\"]\nshell = \"echo done > {output[0]}\"\n",
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["publish", wf.to_str().unwrap()])
+        .current_dir(&wf_dir)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("escape the bundle root"));
+
+    assert!(
+        !wf_dir.join("trav_meta-bundle.tar.zst").exists(),
+        "no archive may be produced from a traversal workflow"
+    );
+}
+
+#[test]
+fn cli_publish_rejects_absolute_bundle_path() {
+    // An absolute reference would become an absolute ARCHIVE member name —
+    // an extractor following it writes outside the unpack root, so the
+    // publish must fail instead of producing the bundle.
+    let dir = tempfile::tempdir().unwrap();
+    let outside = dir.path().join("outside-abs.txt");
+    fs::write(&outside, "data\n").unwrap();
+    let wf = dir.path().join("abs_meta.oxoflow");
+    fs::write(
+        &wf,
+        format!(
+            "[workflow]\nname = \"abs\"\nversion = \"1.0.0\"\nmetadata_file = {:?}\n\n[[rules]]\nname = \"s\"\noutput = [\"out.txt\"]\nshell = \"echo done > {{output[0]}}\"\n",
+            outside.display().to_string()
+        ),
+    )
+    .unwrap();
+
+    oxo_flow_cmd()
+        .args(["publish", wf.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("is absolute"));
+}
+
+#[test]
 fn cli_publish_creates_bundle() {
     let dir = tempfile::tempdir().unwrap();
     let wf = dir.path().join("pub_test.oxoflow");


### PR DESCRIPTION
Closes #297

## Medium

1. **Stale-file shadowing (workspace.rs)** — `stage_user_inputs` now compares mtimes instead of skipping on `dest.exists()`: a re-uploaded input (source newer than the stale copy) refreshes it, while a newer local file (pipeline output sharing the staged path) still survives re-staging. The two cwd-dancing tests are serialized behind a mutex (they raced once both existed).
2. **`:latest` smoke gate (ci.yml)** — `docker-publish-release` pushes only the immutable `:<version>` tag first, smoke-tests it, then promotes `:latest` and a new rolling `:<major.minor>` tag server-side via `docker buildx imagetools create` (both arches carried over — a `docker tag`+push would have replaced the manifest with a single-arch image). A guard also stops an old release re-published via `publish_images_only` from dragging `:latest` backwards.
3. **`publish_images_only` functional (ci.yml)** — `docker-publish-release` now also runs when the `release` job was skipped *for that mode*, resolving the version from the tag input (same fallback as the `docker-build-release` validation leg). Previously the mode silently published nothing.
4. **Skipped producers warn (run.rs)** — an executor-returned `Skipped` on an output_pattern producer now names its deferred consumers ("…not instantiated — output_pattern producer 'X' was skipped") instead of letting them vanish from the plan. Warning only: a skip is not a failure, so it does not enter the failure summary.

## Low

5. **`block_in_place` guard (ai/handlers.rs)** — wrapped in a runtime-flavor check (inline on current-thread runtimes), mirroring `auth::service::blocking_crypto`; no panic under `#[tokio::test]`.
6. **CJK-safe truncation (ai_template.rs)** — `truncate_utf8` (char-boundary walk) replaces `&text[..300]` / `&content[..2000]`, which panicked when the cut landed inside a multi-byte char. Unit test covers 3-byte CJK and a 4-byte emoji spanning the cut.
7. **Bundle path traversal (publish.rs)** — `ensure_safe_bundle_path` rejects absolute paths and `..` components at collection (`metadata_file`/`pairs_file`/`sample_groups_file`), temp-dir copy, and archive-entry time. POSIX-only per the supported-platform matrix (Linux/macOS). Two new integration tests; note the tar crate already rejected `..` entry names at build time — the fix moves the failure earlier, with a clear message, and stops the temp-dir write from escaping first.
8. **`$FAILED` splitting (ci.yml)** — the retry list is passed to `--exact` as a real array (`mapfile -t`), so spaces in test names can't split and quoting can't collapse the list.
9. **`:main` multi-arch (ci.yml)** — split into `docker-publish-main-amd64` (ubuntu-latest) and `docker-publish-main-arm64` (native `ubuntu-24.04-arm`, free for public repos) pushing `:main-<arch>` with per-arch GHA cache scopes, then a manifest job merges them into `:main` and smoke-tests it. arm64 hosts pulling `:main` now get a working image.

Docs: README + installation guide updated for the new tag semantics.

## Verification

- `cargo fmt --check` clean; `cargo clippy -p oxo-flow-cli -p oxo-flow-web --all-targets` clean
- `cargo test -p oxo-flow-web --lib`: 297 passed
- `cargo test -p oxo-flow-cli --bin oxo-flow`: 190 passed
- `cargo test --test cli_integration`: 255 passed (incl. 2 new traversal tests, 8 publish tests, 2 output_pattern tests)
- ci.yml parses (14 jobs, needs-graph verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)