### PR TITLE
fix: close out #299 (-t when-gate pruning) and #300 (conda env diagnosis)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -1005,10 +1005,7 @@ pub async fn run_command(
             .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
             .with_context(|| "failed to resolve target rules")?;
         for skipped in &skipped_targets {
-            eprintln!(
-                "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
-                "Note:".yellow()
-            );
+            print_target_skipped_note(skipped, &when_false_rules);
         }
         if filtered_order.is_empty() {
             emit_run_json_summary(json, "failed", &workflow, &RunCounts::default(), vec![]);
@@ -2120,10 +2117,7 @@ pub async fn run_command(
                     .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
                     .with_context(|| "failed to resolve target rules")?;
                 for skipped in &skipped_targets {
-                    eprintln!(
-                        "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
-                        "Note:".yellow()
-                    );
+                    print_target_skipped_note(skipped, &when_false_rules);
                 }
                 filtered
             };
@@ -2160,10 +2154,7 @@ pub async fn run_command(
                         .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
                         .with_context(|| "failed to resolve target rules")?;
                     for skipped in &skipped_targets {
-                        eprintln!(
-                            "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
-                            "Note:".yellow()
-                        );
+                        print_target_skipped_note(skipped, &when_false_rules);
                     }
                     filtered
                 };
@@ -4094,10 +4085,7 @@ pub async fn dry_run_command(
             .execution_order_for_targets_skipping(&target_refs, &when_false_rules)
             .with_context(|| "failed to resolve target rules")?;
         for skipped in &skipped_targets {
-            eprintln!(
-                "{} target '{skipped}' is when-gated false — it never runs; removed from the execution set (its upstream was pruned too)",
-                "Note:".yellow()
-            );
+            print_target_skipped_note(skipped, &when_false_rules);
         }
         filtered
     };
@@ -5091,6 +5079,26 @@ fn rule_timings(state: &CheckpointState) -> (Vec<(&str, f64)>, f64) {
     timings.sort_by(|a, b| b.1.total_cmp(&a.1));
     let total = timings.iter().map(|(_, secs)| secs).sum();
     (timings, total)
+}
+
+/// Explain a target removed from a targeted execution set. A target present
+/// in `when_false_rules` has its OWN false gate; one absent from the set was
+/// cascade-pruned because an UPSTREAM gate is false — the old single message
+/// claimed both were "when-gated false", which read as nonsense for gate-less
+/// rules (issue #299).
+fn print_target_skipped_note(skipped: &str, when_false_rules: &std::collections::HashSet<String>) {
+    let detail = if when_false_rules.contains(skipped) {
+        format!(
+            "target '{skipped}' is when-gated false — it never runs; \
+             removed from the execution set (its upstream was pruned too)"
+        )
+    } else {
+        format!(
+            "target '{skipped}' is unreachable — its upstream is when-gated \
+             false; removed from the execution set"
+        )
+    };
+    eprintln!("{} {detail}", "Note:".yellow());
 }
 
 pub async fn handle_status(

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -73,6 +73,14 @@ pub trait EnvironmentBackend: Send + Sync {
 /// identical specs keep deduplicating. Non-file specs (inline strings)
 /// keep the plain name.
 fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String> {
+    conda_env_name_parts(kind, spec).map(|(_, full)| full)
+}
+
+/// `(plain name, name with content-hash suffix)` for a file-backed conda
+/// spec — the split form of [`conda_env_name_from_spec`], exposed so the
+/// missing-env diagnosis (issue #300) can name both the derivation and the
+/// plain name an older env may have been created under.
+fn conda_env_name_parts(kind: &str, spec: &str) -> Result<(String, String)> {
     // Try reading the YAML file to extract `name:` field
     let file_content = std::fs::read(spec).ok();
     let from_yaml = file_content
@@ -103,6 +111,7 @@ fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String> {
             .unwrap_or(spec)
             .to_string()
     });
+    let base_name = name.clone();
     // Content-hash suffix for file-backed specs (issue #159).
     if let Some(bytes) = file_content {
         use sha2::Digest;
@@ -115,7 +124,7 @@ fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        Ok(name)
+        Ok((base_name, name))
     } else {
         Err(OxoFlowError::Environment {
             kind: kind.to_string(),
@@ -123,6 +132,97 @@ fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String> {
                 "invalid environment name '{name}' derived from spec '{spec}': names may contain only alphanumerics, '_' and '-'"
             ),
         })
+    }
+}
+
+/// Parse `conda env list` output into the set of NAMED environments. Named
+/// rows lead with the env name; unnamed prefix installs lead with an
+/// absolute path (contains `/`) and are excluded — they are not reachable
+/// via `-n` anyway.
+fn parse_conda_env_list(output: &str) -> HashSet<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|name| !name.contains('/') && *name != "*")
+        .map(str::to_string)
+        .collect()
+}
+
+/// The #300 diagnosis for a missing hash-suffixed env: `None` when there is
+/// nothing useful to say (plain-name spec, or the suffixed env exists),
+/// otherwise the full advice text. Pure so the decision stays unit-tested.
+fn missing_env_advice(
+    base: &str,
+    full: &str,
+    spec: &str,
+    existing: &HashSet<String>,
+) -> Option<String> {
+    if base == full || existing.contains(full) {
+        return None;
+    }
+    let hash8 = full.strip_prefix(base)?.strip_prefix('-')?;
+    if existing.contains(base) {
+        Some(format!(
+            "conda env '{full}' does not exist, but env '{base}' does — it was \
+             likely created from the same spec before the content-hash suffix \
+             (issue #159). Either symlink it (ln -s …/envs/{base} …/envs/{full}), \
+             rename it, or drop --skip-env-setup so the engine builds '{full}' itself"
+        ))
+    } else {
+        Some(format!(
+            "create it with `conda env create -n {full} -f {spec}` or drop \
+             --skip-env-setup (content hash {hash8} derives from '{spec}')"
+        ))
+    }
+}
+
+/// Warn once per env when `--skip-env-setup` is set but the hash-suffixed
+/// env the rendered commands reference does not exist (issue #300): without
+/// this, the rule dies much later inside conda with a bare
+/// `EnvironmentLocationNotFound` that never explains how the name was
+/// derived or that a plain-name env may already hold the same content.
+/// One `conda env list` per process; one warning per env name.
+pub fn diagnose_skipped_conda_env(kind: &str, spec: &str) {
+    static ENV_LIST: std::sync::OnceLock<Option<HashSet<String>>> = std::sync::OnceLock::new();
+    static DIAGNOSED: std::sync::OnceLock<std::sync::Mutex<HashSet<String>>> =
+        std::sync::OnceLock::new();
+
+    // The hash suffix is a conda/mamba file-spec scheme; the env inventory
+    // command is conda's (mamba-only boxes may not have it — skip silently).
+    if kind != "conda" {
+        return;
+    }
+    let Ok((base, full)) = conda_env_name_parts(kind, spec) else {
+        return;
+    };
+    if base == full {
+        return; // inline spec — no suffix, nothing to diagnose
+    }
+
+    let diagnosed = DIAGNOSED.get_or_init(|| std::sync::Mutex::new(HashSet::new()));
+    if !diagnosed
+        .lock()
+        .expect("env diagnosis mutex poisoned")
+        .insert(full.clone())
+    {
+        return; // already warned for this env
+    }
+
+    let envs = ENV_LIST.get_or_init(|| {
+        std::process::Command::new("conda")
+            .args(["env", "list"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| parse_conda_env_list(&String::from_utf8_lossy(&o.stdout)))
+    });
+    let Some(envs) = envs.as_ref() else {
+        return;
+    };
+    if let Some(advice) = missing_env_advice(&base, &full, spec, envs) {
+        eprintln!("⚠ env setup skipped: {advice}");
     }
 }
 
@@ -1795,6 +1895,72 @@ impl EnvironmentResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Missing-env diagnosis (issue #300) ─────────────────────────
+
+    #[test]
+    fn conda_env_name_parts_splits_base_and_hash_suffix() {
+        // File-backed spec: `name:` field + content-hash suffix.
+        let dir = tempfile::tempdir().unwrap();
+        let spec = dir.path().join("checkm2.yaml");
+        std::fs::write(&spec, "name: checkm2\ndependencies:\n  - checkm2\n").unwrap();
+        let (base, full) = conda_env_name_parts("conda", spec.to_str().unwrap()).unwrap();
+        assert_eq!(base, "checkm2");
+        assert!(full.starts_with("checkm2-") && full.len() == base.len() + 9);
+        // Same content → same suffix; different content → different suffix.
+        let (_, full_again) = conda_env_name_parts("conda", spec.to_str().unwrap()).unwrap();
+        assert_eq!(full, full_again);
+        std::fs::write(&spec, "name: checkm2\ndependencies:\n  - checkm2==1.1\n").unwrap();
+        let (_, full_other) = conda_env_name_parts("conda", spec.to_str().unwrap()).unwrap();
+        assert_ne!(full, full_other);
+    }
+
+    #[test]
+    fn conda_env_name_parts_inline_spec_has_no_suffix() {
+        // An inline string (not a readable file) keeps the plain name —
+        // nothing for the missing-env diagnosis to explain.
+        let (base, full) = conda_env_name_parts("conda", "some-env").unwrap();
+        assert_eq!(base, full);
+    }
+
+    #[test]
+    fn parse_conda_env_list_keeps_named_envs_only() {
+        let output = "# conda environments:\n#\nbase                  *  /opt/conda\ncheckm2                  /opt/conda/envs/checkm2\n/opt/conda/envs/unnamed-prefix\n\n";
+        let envs = parse_conda_env_list(output);
+        assert!(envs.contains("base") && envs.contains("checkm2"));
+        assert!(
+            !envs.iter().any(|e| e.contains('/')),
+            "prefix paths excluded: {envs:?}"
+        );
+        assert!(!envs.contains("*"));
+    }
+
+    #[test]
+    fn missing_env_advice_covers_both_fallbacks_and_silence() {
+        let envs: HashSet<String> = ["checkm2", "base"].into_iter().map(String::from).collect();
+        // Plain-name env exists → symlink/rename advice.
+        let advice =
+            missing_env_advice("checkm2", "checkm2-08dc2a29", "envs/checkm2.yaml", &envs).unwrap();
+        assert!(advice.contains("symlink") && advice.contains("checkm2-08dc2a29"));
+        // Plain-name env missing → create advice naming the derivation.
+        let empty: HashSet<String> = HashSet::new();
+        let advice =
+            missing_env_advice("checkm2", "checkm2-08dc2a29", "envs/checkm2.yaml", &empty).unwrap();
+        assert!(advice.contains("conda env create -n checkm2-08dc2a29 -f envs/checkm2.yaml"));
+        // Suffixed env exists → silent.
+        let with_full: HashSet<String> = ["checkm2-08dc2a29".to_string()].into();
+        assert_eq!(
+            missing_env_advice(
+                "checkm2",
+                "checkm2-08dc2a29",
+                "envs/checkm2.yaml",
+                &with_full
+            ),
+            None
+        );
+        // Inline spec (no suffix) → silent.
+        assert_eq!(missing_env_advice("qc", "qc", "qc", &empty), None);
+    }
 
     // ── Container workdir absolutization ───────────────────────────
 

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -650,6 +650,16 @@ impl LocalExecutor {
     }
     async fn ensure_environment_ready(&self, rule: &Rule) -> Result<()> {
         if self.config.skip_env_setup {
+            // With setup skipped, a missing hash-suffixed conda env used to
+            // surface only as conda's opaque EnvironmentLocationNotFound at
+            // rule time. Diagnose it here instead: name the derivation and
+            // the plain-name fallback when one exists (issue #300).
+            match (&rule.environment.conda, &rule.environment.mamba) {
+                (Some(spec), None) if rule.environment.conda_prefix.is_none() => {
+                    crate::environment::diagnose_skipped_conda_env("conda", spec);
+                }
+                _ => {}
+            }
             return Ok(());
         }
         let env_spec = &rule.environment;

--- a/docs/guide/src/reference/environment-system.md
+++ b/docs/guide/src/reference/environment-system.md
@@ -94,6 +94,13 @@ Use `--skip-env-setup` when environments are pre-built:
 oxo-flow run pipeline.oxoflow --skip-env-setup
 ```
 
+With the flag set, the engine does not create anything — a rule whose env
+is missing fails inside conda. For file-backed conda specs it therefore
+checks `conda env list` up front and names the expected `<name>-<hash8>`
+env before running: if an env under the plain `<name>` exists, it was
+likely built from the same spec before the content-hash suffix — symlink
+or rename it, build the suffixed env, or drop `--skip-env-setup`.
+
 ---
 
 ## Backend Implementations
@@ -102,6 +109,7 @@ oxo-flow run pipeline.oxoflow --skip-env-setup
 
 - **Detection**: Checks for `conda` on `$PATH`
 - **Resolution**: Parses YAML environment file
+- **Naming**: A file-backed spec resolves to the env name `<name>-<hash8>`, where `<name>` is the YAML's `name:` field (falling back to the file stem) and `<hash8>` is the first 4 bytes of the spec's SHA-256 as 8 hex chars — two workflows shipping different YAMLs under the same name then build into distinct envs instead of silently sharing one (issue #159). Same content → same name, so identical specs deduplicate. Pre-create envs with exactly that name (`conda env create -n <name>-<hash8> -f envs/spec.yaml`); the engine prints the expected name when it detects the env is missing under `--skip-env-setup`
 - **Activation**: Runs `conda run --no-capture-output -n <env_name> bash -c 'export PATH="$CONDA_PREFIX/bin:$PATH"; <command>'` — `--no-capture-output` (conda ≥ 4.13) keeps stdout/stderr live, and the `PATH` prefix makes the rule see the env's own tools first
 - **Caching**: Environments are created once and reused across rules that share the same YAML file
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3795,6 +3795,105 @@ shell = "echo C"
 }
 
 #[test]
+fn cli_dry_run_targeted_does_not_prune_meta_when_rules() {
+    // Issue #299 regression: `-t` planning re-evaluated `when` clauses with
+    // an empty metadata context, so meta-bearing gates — and every gate-less
+    // rule downstream of them — were falsely pruned as "when-gated false"
+    // (live: the mag workflow's targeted runs were unusable). #293's
+    // per-instance meta baking fixed the verdicts; these assertions pin it.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("meta.tsv"),
+        "pair_id\texperiment\treads_2\nP1\tS1\tS1_2.fq.gz\nP2\tS2\t\n",
+    )
+    .unwrap();
+
+    let write_wf = |reads_sheet: &str, path: &std::path::Path| {
+        fs::write(
+            path,
+            format!(
+                r#"[workflow]
+name = "repro299"
+version = "1.0.0"
+metadata_file = "meta.tsv"
+
+[config]
+reads_sheet = "{reads_sheet}"
+
+[[pairs]]
+pair_id = "P1"
+experiment = "S1"
+
+[[pairs]]
+pair_id = "P2"
+experiment = "S2"
+
+[[rules]]
+name = "prep"
+output = ["{{pair_id}}/reads_1.fq.gz"]
+shell = "mkdir -p {{pair_id}} && touch {{output[0]}}"
+
+[[rules]]
+name = "megahit"
+input = ["{{pair_id}}/reads_1.fq.gz"]
+output = ["{{pair_id}}/contigs.fa"]
+when = "config.reads_sheet == '' || {{meta.reads_2}} != ''"
+shell = "touch {{output[0]}}"
+
+[[rules]]
+name = "multiqc"
+input = ["{{pair_id}}/contigs.fa"]
+output = ["report/{{pair_id}}.txt"]
+shell = "touch {{output[0]}}"
+"#
+            ),
+        )
+        .unwrap();
+    };
+    let empty_sheet = dir.path().join("empty_sheet.oxoflow");
+    write_wf("", &empty_sheet);
+    let with_sheet = dir.path().join("with_sheet.oxoflow");
+    write_wf("sheet.tsv", &with_sheet);
+
+    // Empty sheet: `config.reads_sheet == ''` decides — BOTH megahit
+    // instances are live, and the gate-less multiqc must survive targeting.
+    for target in ["megahit", "multiqc"] {
+        oxo_flow_cmd()
+            .args(["dry-run", empty_sheet.to_str().unwrap(), "-t", target])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("when-gated false").not())
+            .stderr(predicate::str::contains("prep_P1"))
+            .stderr(predicate::str::contains("prep_P2"));
+    }
+    oxo_flow_cmd()
+        .args(["dry-run", empty_sheet.to_str().unwrap(), "-t", "megahit"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("megahit_P1"))
+        .stderr(predicate::str::contains("megahit_P2"));
+
+    // Reads sheet set: the meta disjunct decides per instance — P1 (reads_2
+    // non-empty) stays, P2 (empty cell) is genuinely gated at expansion, so
+    // megahit_P2 never enters the DAG. multiqc_P2 stays LISTED (it has no
+    // gate of its own; its missing input is surfaced as a readiness warning,
+    // a separate semantic from #299's false pruning).
+    oxo_flow_cmd()
+        .args(["dry-run", with_sheet.to_str().unwrap(), "-t", "megahit"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("megahit_P1"))
+        .stderr(predicate::str::contains("megahit_P2").not());
+    oxo_flow_cmd()
+        .args(["dry-run", with_sheet.to_str().unwrap(), "-t", "multiqc"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("when-gated false").not())
+        .stderr(predicate::str::contains("multiqc_P1"))
+        .stderr(predicate::str::contains("megahit_P2").not());
+}
+
+#[test]
 fn cli_dry_run_shows_thread_and_env_info() {
     oxo_flow_cmd()
         .args(["dry-run", "examples/gallery/07_wgs_germline.oxoflow"])


### PR DESCRIPTION
Closes #299, closes #300

## #299 — targeted runs falsely pruning "when-gated false" rules

**Root cause already fixed on main by #293.** The issue was observed on the 0.16.0 release binary: `-t` planning re-evaluated `when` clauses with an empty metadata context, so `{meta.*}`-bearing gates (and every rule downstream of them, gate-less or not) were falsely pruned. #293's per-instance meta baking moved the verdict to expansion time, where the instance's metadata row is available — this PR verifies and pins that fix:

- Reproduced the mag shape (pairs + `metadata_file` + `when = "config.reads_sheet == '' || {meta.reads_2} != ''"` + a gate-less downstream rule) on current main: no false pruning, and genuine per-instance gating still works (the instance with an empty `reads_2` cell is gated, its sibling is not).
- New end-to-end regression test (`cli_dry_run_targeted_does_not_prune_meta_when_rules`) covering both config variants, the meta-bearing target, and the gate-less downstream target.
- Fixed the misleading note: a target cascade-pruned because an **upstream** gate is false was reported as "target 'X' is when-gated false — it never runs", which read as nonsense for gate-less rules (exactly what the issue observed for `multiqc`). The note now distinguishes "its own `when` gate is false" from "unreachable — its upstream is when-gated false" (`print_target_skipped_note`, applied at all four print sites).

Out of scope, noted: a gate-less rule downstream of a when-gated instance still appears in the targeted plan with a missing-input readiness warning (execution-time semantics, #200 territory).

## #300 — opaque failure for hash-suffixed conda envs

The hash suffix itself (#159) is correct — the failure mode was the problem. When `--skip-env-setup` is set and the `<name>-<hash8>` env is missing, the rule died inside conda with a bare `EnvironmentLocationNotFound`. Now:

- `conda_env_name_from_spec` is refactored into `conda_env_name_parts` so the diagnosis names both the plain name and the suffixed name.
- The executor's skip-setup path runs a diagnosis before execution: one `conda env list` per process, one warning per env name. When the suffixed env is missing it says exactly how the name was derived and what to do — symlink/rename an existing plain-name env, `conda env create -n <name>-<hash8> -f <spec>`, or drop `--skip-env-setup`.
- Auto-reuse of a plain-name env was deliberately NOT implemented: its content cannot be verified against the spec, which is precisely what the #159 hash prevents.
- Conda-only (the inventory command is conda's), skipped for prefix installs where named envs are not used.
- Naming rule documented in the environment-system reference (Conda backend + Skipping Setup sections).

Verified end-to-end with a stubbed `conda` shim: the warning fires before execution and names `checkm2-<hash8>` plus the plain-name fallback.

## Verification

- `cargo fmt --check` clean; clippy `-p oxo-flow-core -p oxo-flow-cli --all-targets` clean
- `cargo test -p oxo-flow-core --lib`: 1357 passed (4 new)
- `cargo test -p oxo-flow-cli --bin oxo-flow`: 190 passed
- `cargo test --test cli_integration`: 256 passed (1 new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)