### PR TITLE
fix: scan output_pattern as a [[values]] fan-out trigger (#296)

### DIFF
--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2131,11 +2131,34 @@ pub async fn run_command(
     // by the skip preprocessing below). A fresh run replays an empty record
     // and adds nothing; `--rerun` deliberately skips it so the producer
     // re-discovers the domain live.
+    // Gate (issue #296 follow-up): instantiate only when EVERY producer
+    // instance is already completed. A producer that still has to re-run
+    // keeps its consumers pending — the runtime discovery pass then
+    // instantiates them from the final domain union, so the final consumer
+    // set is the union of all per-instance slices (a partial replay would
+    // drain the pending set and silently drop the later slices).
     {
         let ck = checkpoint.lock().await;
         if !ck.output_pattern_domains.is_empty() && !rerun {
             config.discovered_output_patterns = ck.output_pattern_domains.clone();
-            let replayed = config.expand_output_pattern_consumers()?;
+            let all_producers_complete = ck.output_pattern_domains.keys().all(|template| {
+                config.rules.iter().all(|r| {
+                    r.output_pattern.is_none()
+                        || (config.expansion_templates.get(&r.name).map(String::as_str)
+                            != Some(template.as_str())
+                            && r.name != *template)
+                        || ck.completed_rules.contains(&r.name)
+                })
+            });
+            let replayed = if all_producers_complete {
+                config.expand_output_pattern_consumers()?
+            } else {
+                tracing::info!(
+                    "deferred output_pattern consumers stay pending: a producer instance \
+                     is not completed yet — the runtime discovery pass will instantiate them"
+                );
+                Vec::new()
+            };
             tracing::info!(
                 count = replayed.len(),
                 "replayed runtime-discovered output_pattern domains"
@@ -4997,16 +5020,29 @@ async fn process_output_pattern_discovery(
         return Ok(Vec::new());
     };
 
+    // 1. Scan the filesystem for this instance's output_pattern files.
+    //
     // A fully-bound baked pattern (issue #296) is a static contract:
     // plan-time fan-out already IS the domain and plan-time consumers hold
     // their DAG edges — discovery has nothing to enumerate and the
-    // zero-discovery warning below would be spurious.
-    if !config.output_pattern_needs_discovery(&instance) {
-        return Ok(Vec::new());
-    }
-
-    // 1. Scan the filesystem for this instance's output_pattern files.
-    let combos = config.discover_output_pattern_files(&instance, workdir)?;
+    // zero-discovery warning would be spurious. Deferred consumers can
+    // still be attached, though, when the binding came from a fan-out the
+    // engine baked itself (scatter writes its variable into the pattern):
+    // their domain is the instance's own bindings, not the filesystem, so
+    // contribute that directly instead of starving them silently.
+    let combos = if config.output_pattern_needs_discovery(&instance) {
+        config.discover_output_pattern_files(&instance, workdir)?
+    } else {
+        let bindings = config.instance_bindings(instance_name);
+        if bindings.is_empty()
+            || config
+                .pending_output_pattern_consumers_of(&template)
+                .is_empty()
+        {
+            return Ok(Vec::new());
+        }
+        vec![bindings]
+    };
     if combos.is_empty() {
         // Zero discoveries after producer success: loud, but legal — the
         // consumers stay uninstantiated (a later instance of the same

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -4997,6 +4997,14 @@ async fn process_output_pattern_discovery(
         return Ok(Vec::new());
     };
 
+    // A fully-bound baked pattern (issue #296) is a static contract:
+    // plan-time fan-out already IS the domain and plan-time consumers hold
+    // their DAG edges — discovery has nothing to enumerate and the
+    // zero-discovery warning below would be spurious.
+    if !config.output_pattern_needs_discovery(&instance) {
+        return Ok(Vec::new());
+    }
+
     // 1. Scan the filesystem for this instance's output_pattern files.
     let combos = config.discover_output_pattern_files(&instance, workdir)?;
     if combos.is_empty() {

--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -580,49 +580,17 @@ impl WorkflowConfig {
                 });
 
             // `[[values]]` fan-out: tables whose names appear in the rule —
-            // in inputs/outputs/shells and in `expand_inputs` patterns —
-            // become an additional Cartesian dimension, orthogonal to pairs
-            // and groups. `{values.name}` is the namespaced sibling of the
-            // bare `{name}` form.
+            // in inputs/outputs/shells, `expand_inputs` patterns, or its own
+            // `output_pattern` (issue #296) — become an additional Cartesian
+            // dimension, orthogonal to pairs and groups. `{values.name}` is
+            // the namespaced sibling of the bare `{name}` form.
             let expand_texts: Vec<&str> = all_text
                 .iter()
                 .copied()
                 .chain(rule.expand_inputs.iter().map(|e| e.pattern.as_str()))
                 .collect();
-            // The `[[values]]` TRIGGER text: `expand_texts` plus the rule's
-            // own `output_pattern` (issue #296) — the pattern is a
-            // production-domain declaration exactly as it already is for
-            // pair/group triggers, so a producer referencing a values table
-            // ONLY in its pattern fans out per value instead of baking a
-            // literal `{name}` token. Scoped: the fresh-wildcard
-            // consumer-deferral scan below keeps `expand_texts` — feeding
-            // the pattern there would make every producer defer on its OWN
-            // fresh wildcard (its pattern declares it).
-            let mut value_trigger_texts: Vec<&str> = expand_texts.clone();
-            if let Some(ref op) = rule.output_pattern {
-                value_trigger_texts.push(op);
-            }
-            let mut active_value_tables: Vec<&ValueGroup> = Vec::new();
-            for table in &self.values {
-                // Scan `value_trigger_texts` (all_text + expand_inputs
-                // patterns + output_pattern), not just the pair/group
-                // `trigger_text` (issue #268 item 1): a consumer that
-                // references a values table ONLY through an expand_inputs
-                // pattern (an aggregator gathering one file per table
-                // value) must still fan out per value — otherwise it keeps
-                // an empty `input` and, worse, loses the execution-DAG
-                // edges to its producers (the template graph infers them
-                // from the raw pattern). Per-value input selection
-                // continues to work below: each instance gathers the files
-                // matching its own binding of the pattern.
-                let referenced = value_trigger_texts.iter().any(|t| {
-                    t.contains(&format!("{{{}}}", table.name))
-                        || t.contains(&format!("{{values.{}}}", table.name))
-                });
-                if referenced {
-                    active_value_tables.push(table);
-                }
-            }
+            let active_value_tables = self.active_value_tables_for_rule(rule);
+            let active_value_tables: Vec<&ValueGroup> = active_value_tables.iter().collect();
             let uses_value_wildcard = !active_value_tables.is_empty();
 
             // output_pattern consumer detection (issue #227 item 5): a rule
@@ -720,38 +688,7 @@ impl WorkflowConfig {
             // order. Rules using no value table get a single empty combo —
             // the identity element, so the pair/group branches below run
             // exactly as before.
-            let mut value_combos: Vec<crate::wildcard::WildcardValues> =
-                vec![crate::wildcard::WildcardValues::new()];
-            for table in &active_value_tables {
-                // values_from resolves the fan-out from a config key at
-                // expansion time (issue #18 wave) — CLI --arg / profile
-                // driven dimensions. Falls back to the static `values`.
-                let effective: Vec<String> = match &table.values_from {
-                    Some(from) => {
-                        self.resolve_config_list(from)
-                            .ok_or_else(|| OxoFlowError::Validation {
-                                message: format!(
-                                    "[[values]] table '{}' values_from '{}' cannot be resolved",
-                                    table.name, from
-                                ),
-                                rule: None,
-                                suggestion: Some(format!(
-                                    "define '{from}' in [config] as a comma string or array"
-                                )),
-                            })?
-                    }
-                    None => table.values.clone(),
-                };
-                let mut next = Vec::with_capacity(value_combos.len() * effective.len());
-                for combo in &value_combos {
-                    for value in &effective {
-                        let mut c = combo.clone();
-                        c.insert(table.name.clone(), value.clone());
-                        next.push(c);
-                    }
-                }
-                value_combos = next;
-            }
+            let value_combos = self.cartesian_value_combos(&active_value_tables)?;
 
             if uses_pair_wildcard {
                 let orig_name = rule.name.clone();
@@ -1529,101 +1466,112 @@ impl WorkflowConfig {
                 current_input.extend(injected.clone());
                 rule.input = FilePatterns::List(current_input);
             }
-
-            // process expand_inputs
-            for exp in &rule.expand_inputs {
-                // `{meta.<column>}` inside an expand_inputs pattern is never
-                // resolved: per-instance metadata substitution
-                // (`apply_instance_meta`) has already run on the rule's own
-                // fields by the time this pass executes, and it never
-                // touches expand_inputs; the placeholder regex does not
-                // match dotted tokens either, so `variables` can never bind
-                // the reference. The pattern either expands with a literal
-                // `{meta.…}` token baked into every path or contributes
-                // zero inputs — warn so the author moves the reference into
-                // `input` (per-instance substitution applies there) or
-                // input_groups.
-                let meta_pattern = exp.pattern.contains("{meta.");
-                if meta_pattern {
-                    tracing::warn!(
-                        rule = %rule.name,
-                        pattern = %exp.pattern,
-                        "expand_inputs pattern references '{{meta.<column>}}' but per-instance metadata substitution ran BEFORE this pass — the token is never resolved (put the pattern in `input` for substitution, or use input_groups)"
-                    );
-                }
-                let mut variables = HashMap::new();
-                for (var_name, var_ref) in &exp.variables {
-                    if let Some(vals) = self.resolve_config_list(var_ref) {
-                        variables.insert(var_name.clone(), vals);
-                    } else if var_ref.starts_with('[') && var_ref.ends_with(']') {
-                        let inner = &var_ref[1..var_ref.len() - 1];
-                        let vals = inner
-                            .split(',')
-                            .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect();
-                        variables.insert(var_name.clone(), vals);
-                    } else {
-                        variables.insert(var_name.clone(), vec![var_ref.clone()]);
-                    }
-                }
-
-                // Bind this instance's own [[values]] values so `{assembler}`
-                // inside the expand pattern resolves per instance — the
-                // spades instance never sees the megahit value.
-                let bindings = self.expansion_values.get(&rule.name).cloned();
-                if let Some(bindings) = &bindings {
-                    for (name, value) in bindings {
-                        variables
-                            .entry(name.clone())
-                            .or_insert_with(|| vec![value.clone()]);
-                    }
-                }
-
-                // Same per-instance binding for pair wildcards: `{pair_id}`
-                // (and the other pair keys) inside an expand pattern resolve
-                // to THIS instance's pair, so a per-pair gather rule picks up
-                // its own pair's files only (snakemake-style; the
-                // cohort-level `pair_id = "config.pairs_list"` variable form
-                // still wins when declared explicitly).
-                if let Some(pair_bindings) = self.expansion_pairs.get(&rule.name) {
-                    for (name, value) in pair_bindings {
-                        variables
-                            .entry(name.clone())
-                            .or_insert_with(|| vec![value.clone()]);
-                    }
-                }
-
-                let mut expanded = crate::wildcard::cartesian_expand(&exp.pattern, &variables);
-                // A pattern WITH wildcards that contributes zero inputs
-                // means every wildcard lacked a provided value — usually
-                // an author oversight (config key left empty), never a
-                // silent success. Name the pattern so the author can see
-                // which input quietly disappeared (#254 family guard).
-                if expanded.is_empty()
-                    && !meta_pattern
-                    && !crate::wildcard::extract_wildcards(&exp.pattern).is_empty()
-                {
-                    tracing::warn!(
-                        rule = %rule.name,
-                        pattern = %exp.pattern,
-                        "expand_inputs pattern contributed zero inputs — none of its wildcards had provided values (config list empty or key missing?)"
-                    );
-                }
-                // Resolve the `{values.name}` namespace form per instance.
-                if let Some(bindings) = &bindings {
-                    for path in &mut expanded {
-                        *path = crate::wildcard::expand_values_namespace(path, bindings);
-                    }
-                }
-                let mut current_input = rule.input.to_vec();
-                current_input.extend(expanded);
-                rule.input = FilePatterns::List(current_input);
-            }
+            self.materialize_expand_inputs(rule);
         }
 
         self.rules = final_rules;
         Ok(())
+    }
+
+    /// Materialize one rule's `expand_inputs` patterns into concrete
+    /// `input` entries, in place. Variables resolve from the config lists
+    /// the pattern declares, then from this instance's own
+    /// `[[values]]`/`[[pairs]]` bindings — the spades instance never sees
+    /// the megahit files.
+    ///
+    /// Shared by the plan-time post-loop above and the runtime
+    /// output_pattern-consumer instantiation, whose deferred templates
+    /// never pass through the plan-time pass.
+    fn materialize_expand_inputs(&self, rule: &mut Rule) {
+        for exp in &rule.expand_inputs {
+            // `{meta.<column>}` inside an expand_inputs pattern is never
+            // resolved: per-instance metadata substitution
+            // (`apply_instance_meta`) has already run on the rule's own
+            // fields by the time this pass executes, and it never
+            // touches expand_inputs; the placeholder regex does not
+            // match dotted tokens either, so `variables` can never bind
+            // the reference. The pattern either expands with a literal
+            // `{meta.…}` token baked into every path or contributes
+            // zero inputs — warn so the author moves the reference into
+            // `input` (per-instance substitution applies there) or
+            // input_groups.
+            let meta_pattern = exp.pattern.contains("{meta.");
+            if meta_pattern {
+                tracing::warn!(
+                    rule = %rule.name,
+                    pattern = %exp.pattern,
+                    "expand_inputs pattern references '{{meta.<column>}}' but per-instance metadata substitution ran BEFORE this pass — the token is never resolved (put the pattern in `input` for substitution, or use input_groups)"
+                );
+            }
+            let mut variables = HashMap::new();
+            for (var_name, var_ref) in &exp.variables {
+                if let Some(vals) = self.resolve_config_list(var_ref) {
+                    variables.insert(var_name.clone(), vals);
+                } else if var_ref.starts_with('[') && var_ref.ends_with(']') {
+                    let inner = &var_ref[1..var_ref.len() - 1];
+                    let vals = inner
+                        .split(',')
+                        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    variables.insert(var_name.clone(), vals);
+                } else {
+                    variables.insert(var_name.clone(), vec![var_ref.clone()]);
+                }
+            }
+
+            // Bind this instance's own [[values]] values so `{assembler}`
+            // inside the expand pattern resolves per instance — the
+            // spades instance never sees the megahit value.
+            let bindings = self.expansion_values.get(&rule.name).cloned();
+            if let Some(bindings) = &bindings {
+                for (name, value) in bindings {
+                    variables
+                        .entry(name.clone())
+                        .or_insert_with(|| vec![value.clone()]);
+                }
+            }
+
+            // Same per-instance binding for pair wildcards: `{pair_id}`
+            // (and the other pair keys) inside an expand pattern resolve
+            // to THIS instance's pair, so a per-pair gather rule picks up
+            // its own pair's files only (snakemake-style; the
+            // cohort-level `pair_id = "config.pairs_list"` variable form
+            // still wins when declared explicitly).
+            if let Some(pair_bindings) = self.expansion_pairs.get(&rule.name) {
+                for (name, value) in pair_bindings {
+                    variables
+                        .entry(name.clone())
+                        .or_insert_with(|| vec![value.clone()]);
+                }
+            }
+
+            let mut expanded = crate::wildcard::cartesian_expand(&exp.pattern, &variables);
+            // A pattern WITH wildcards that contributes zero inputs
+            // means every wildcard lacked a provided value — usually
+            // an author oversight (config key left empty), never a
+            // silent success. Name the pattern so the author can see
+            // which input quietly disappeared (#254 family guard).
+            if expanded.is_empty()
+                && !meta_pattern
+                && !crate::wildcard::extract_wildcards(&exp.pattern).is_empty()
+            {
+                tracing::warn!(
+                    rule = %rule.name,
+                    pattern = %exp.pattern,
+                    "expand_inputs pattern contributed zero inputs — none of its wildcards had provided values (config list empty or key missing?)"
+                );
+            }
+            // Resolve the `{values.name}` namespace form per instance.
+            if let Some(bindings) = &bindings {
+                for path in &mut expanded {
+                    *path = crate::wildcard::expand_values_namespace(path, bindings);
+                }
+            }
+            let mut current_input = rule.input.to_vec();
+            current_input.extend(expanded);
+            rule.input = FilePatterns::List(current_input);
+        }
     }
 
     /// Apply the per-instance `{meta.<column>}` substitution (issue #227
@@ -2242,6 +2190,87 @@ impl WorkflowConfig {
     /// combo is merged with the instance's own bindings (`[[values]]` /
     /// `[[pairs]]`) so the FULL wildcard map is reconstructed — the
     /// per-sample union source for downstream consumers.
+    /// The `[[values]]` tables this rule references — its fan-out
+    /// dimension set, in declaration order. The trigger text is the
+    /// rule's consumer fields plus its own `output_pattern` (issue #296):
+    /// the pattern is a production-domain declaration exactly as it
+    /// already is for pair/group triggers, so a pattern-only reference
+    /// fans out per value instead of baking a literal `{name}` token.
+    /// Scoped to this scan only — the fresh-wildcard consumer-deferral
+    /// scan keeps the pattern excluded, otherwise every producer would
+    /// defer on its OWN fresh wildcard (its pattern declares it).
+    ///
+    /// Returns owned clones so the caller can hold the set across
+    /// `&mut self` bookkeeping while expanding a rule borrowed from
+    /// `self.rules`.
+    fn active_value_tables_for_rule(&self, rule: &Rule) -> Vec<ValueGroup> {
+        let mut texts: Vec<&str> = rule.input.iter().map(String::as_str).collect();
+        texts.extend(rule.output.iter().map(String::as_str));
+        if let Some(ref shell) = rule.shell {
+            texts.push(shell);
+        }
+        if let Some(ref when) = rule.when {
+            texts.push(when);
+        }
+        texts.extend(rule.expand_inputs.iter().map(|e| e.pattern.as_str()));
+        if let Some(ref op) = rule.output_pattern {
+            texts.push(op);
+        }
+        self.values
+            .iter()
+            .filter(|table| {
+                texts.iter().any(|t| {
+                    t.contains(&format!("{{{}}}", table.name))
+                        || t.contains(&format!("{{values.{}}}", table.name))
+                })
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Cartesian product of the active tables, deterministic: the last
+    /// referenced table varies fastest, mirroring declaration order. No
+    /// tables yields a single empty combo — the identity element, so
+    /// downstream loops run exactly as before.
+    fn cartesian_value_combos(
+        &self,
+        active_value_tables: &[&ValueGroup],
+    ) -> Result<Vec<crate::wildcard::WildcardValues>> {
+        let mut value_combos: Vec<crate::wildcard::WildcardValues> =
+            vec![crate::wildcard::WildcardValues::new()];
+        for table in active_value_tables {
+            // values_from resolves the fan-out from a config key at
+            // expansion time (issue #18 wave) — CLI --arg / profile
+            // driven dimensions. Falls back to the static `values`.
+            let effective: Vec<String> = match &table.values_from {
+                Some(from) => {
+                    self.resolve_config_list(from)
+                        .ok_or_else(|| OxoFlowError::Validation {
+                            message: format!(
+                                "[[values]] table '{}' values_from '{}' cannot be resolved",
+                                table.name, from
+                            ),
+                            rule: None,
+                            suggestion: Some(format!(
+                                "define '{from}' in [config] as a comma string or array"
+                            )),
+                        })?
+                }
+                None => table.values.clone(),
+            };
+            let mut next = Vec::with_capacity(value_combos.len() * effective.len());
+            for combo in &value_combos {
+                for value in &effective {
+                    let mut c = combo.clone();
+                    c.insert(table.name.clone(), value.clone());
+                    next.push(c);
+                }
+            }
+            value_combos = next;
+        }
+        Ok(value_combos)
+    }
+
     /// Whether a producer instance's baked output_pattern still carries
     /// wildcards for the runtime discovery pass to enumerate (issue #296).
     /// A fully-bound pattern — every wildcard consumed by plan-time
@@ -2324,10 +2353,13 @@ impl WorkflowConfig {
     /// Instantiate every pending consumer whose producer's discovered
     /// domain is non-empty: one instance per combo, named from the
     /// consumer template plus the producer-pattern wildcard values in
-    /// pattern order (deterministic across runs and resume). Idempotent:
-    /// instantiated consumers leave the pending set; a re-expansion
-    /// rebuilds the pending set from templates and re-instantiates the
-    /// same names.
+    /// pattern order (deterministic across runs and resume). The
+    /// consumer's own `[[values]]` dimension — skipped at plan time by the
+    /// deferral — projects here as an extra Cartesian axis (issue #296
+    /// follow-up), and its `expand_inputs` patterns materialize into the
+    /// instance's input. Idempotent: instantiated consumers leave the
+    /// pending set; a re-expansion rebuilds the pending set from templates
+    /// and re-instantiates the same names.
     pub fn expand_output_pattern_consumers(&mut self) -> Result<Vec<String>> {
         // Resolve each consumer's producer BEFORE draining the pending set
         // — `output_pattern_producer_of` consults it too.
@@ -2379,62 +2411,114 @@ impl WorkflowConfig {
                     .map(|w| combo.get(w).cloned().unwrap_or_default())
                     .collect::<Vec<String>>()
             });
-            for combo in sorted {
-                let mut name = consumer.name.clone();
-                for w in &pattern_wildcards {
-                    name.push('_');
-                    name.push_str(&crate::wildcard::sanitize_instance_value(
-                        combo.get(w).map(String::as_str).unwrap_or_default(),
-                    ));
-                }
-                if self.rules.iter().any(|r| r.name == name) {
-                    // A previous instance of THIS consumer (post-reentry
-                    // re-expansion) is an idempotent no-op; any other
-                    // collision is a genuine naming conflict.
-                    if self
-                        .expansion_templates
-                        .get(&name)
-                        .is_some_and(|t| t == &consumer.name)
-                    {
-                        continue;
+            // The consumer's OWN `[[values]]` dimension (issue #296
+            // follow-up): a deferred template skips plan-time fan-out, so
+            // project its tables here. Tables already bound by the
+            // producer's domain are excluded — shared wildcards ride the
+            // discovered combos, and projecting them again would contradict
+            // those bindings.
+            let bound_keys: std::collections::HashSet<&str> = domain
+                .iter()
+                .flat_map(|combo| combo.keys())
+                .map(String::as_str)
+                .collect();
+            let own_tables: Vec<ValueGroup> = self
+                .active_value_tables_for_rule(&consumer)
+                .into_iter()
+                .filter(|table| !bound_keys.contains(table.name.as_str()))
+                .collect();
+            let own_table_refs: Vec<&ValueGroup> = own_tables.iter().collect();
+            let own_combos = self.cartesian_value_combos(&own_table_refs)?;
+            // Precompute the naming suffixes so the owned table set can be
+            // dropped before the `&mut self` bookkeeping below.
+            let own_dimensions: Vec<(crate::wildcard::WildcardValues, String)> = own_combos
+                .iter()
+                .map(|own| (own.clone(), value_instance_suffix(own, &own_table_refs)))
+                .collect();
+            // Values-major nesting mirrors the plan-time fan-out branches.
+            for (own, own_suffix) in &own_dimensions {
+                for combo in &sorted {
+                    // Merge the producer-domain binding with the consumer's
+                    // own values binding — disjoint by construction.
+                    let mut merged = (*combo).clone();
+                    merged.extend(own.clone());
+                    let mut name = consumer.name.clone();
+                    name.push_str(own_suffix);
+                    for w in &pattern_wildcards {
+                        name.push('_');
+                        name.push_str(&crate::wildcard::sanitize_instance_value(
+                            combo.get(w).map(String::as_str).unwrap_or_default(),
+                        ));
                     }
-                    return Err(OxoFlowError::DuplicateRule { name });
+                    if self.rules.iter().any(|r| r.name == name) {
+                        // A previous instance of THIS consumer (post-reentry
+                        // re-expansion) is an idempotent no-op; any other
+                        // collision is a genuine naming conflict.
+                        if self
+                            .expansion_templates
+                            .get(&name)
+                            .is_some_and(|t| t == &consumer.name)
+                        {
+                            continue;
+                        }
+                        return Err(OxoFlowError::DuplicateRule { name });
+                    }
+                    let mut instance = consumer.clone();
+                    instance.name = name.clone();
+                    instance.input = expand_rule_patterns(&consumer.input, &merged);
+                    instance.output = expand_rule_patterns(&consumer.output, &merged);
+                    if let Some(ref shell) = consumer.shell {
+                        instance.shell = Some(expand_rule_shell(shell, &merged));
+                    }
+                    if let Some(ref log) = consumer.log {
+                        instance.log = Some(expand_rule_shell(log, &merged));
+                    }
+                    if let Some(ref op) = consumer.output_pattern {
+                        instance.output_pattern = Some(expand_rule_shell(op, &merged));
+                    }
+                    if let Some(ref when) = consumer.when
+                        && when.contains("wildcard.")
+                    {
+                        instance.when = Some(Self::bake_wildcard_when(when, &merged));
+                    }
+                    expand_command_text_fields(&mut instance, &consumer, |s| {
+                        expand_rule_shell(s, &merged)
+                    });
+                    self.apply_instance_meta(&mut instance, &merged);
+                    // Bake the instance's bound wildcards into the
+                    // expand_inputs patterns first (mirroring `input` /
+                    // `output` above): the producer-domain keys live only
+                    // in `merged`, so without this the gather never
+                    // resolves. The materialization pass then handles the
+                    // remaining config-variable references.
+                    for exp in &mut instance.expand_inputs {
+                        let is_wildcarded = crate::wildcard::has_wildcards(&exp.pattern)
+                            || crate::wildcard::contains_values_namespace(&exp.pattern);
+                        if is_wildcarded
+                            && let Ok(baked) =
+                                crate::wildcard::expand_pattern(&exp.pattern, &merged)
+                        {
+                            exp.pattern = crate::wildcard::expand_values_namespace(&baked, &merged);
+                        }
+                    }
+                    self.materialize_expand_inputs(&mut instance);
+                    // Readiness attribution (issue #63): the producer-pattern
+                    // wildcard bindings of this instance.
+                    let samples: Vec<String> = pattern_wildcards
+                        .iter()
+                        .filter_map(|w| merged.get(w).cloned())
+                        .collect();
+                    if !samples.is_empty() {
+                        self.expansion_samples.insert(name.clone(), samples);
+                    }
+                    if !own.is_empty() {
+                        self.expansion_values.insert(name.clone(), own.clone());
+                    }
+                    self.expansion_templates
+                        .insert(name.clone(), consumer.name.clone());
+                    self.rules.push(instance);
+                    new_names.push(name);
                 }
-                let mut instance = consumer.clone();
-                instance.name = name.clone();
-                instance.input = expand_rule_patterns(&consumer.input, combo);
-                instance.output = expand_rule_patterns(&consumer.output, combo);
-                if let Some(ref shell) = consumer.shell {
-                    instance.shell = Some(expand_rule_shell(shell, combo));
-                }
-                if let Some(ref log) = consumer.log {
-                    instance.log = Some(expand_rule_shell(log, combo));
-                }
-                if let Some(ref op) = consumer.output_pattern {
-                    instance.output_pattern = Some(expand_rule_shell(op, combo));
-                }
-                if let Some(ref when) = consumer.when
-                    && when.contains("wildcard.")
-                {
-                    instance.when = Some(Self::bake_wildcard_when(when, combo));
-                }
-                expand_command_text_fields(&mut instance, &consumer, |s| {
-                    expand_rule_shell(s, combo)
-                });
-                self.apply_instance_meta(&mut instance, combo);
-                // Readiness attribution (issue #63): the producer-pattern
-                // wildcard bindings of this instance.
-                let samples: Vec<String> = pattern_wildcards
-                    .iter()
-                    .filter_map(|w| combo.get(w).cloned())
-                    .collect();
-                if !samples.is_empty() {
-                    self.expansion_samples.insert(name.clone(), samples);
-                }
-                self.expansion_templates
-                    .insert(name.clone(), consumer.name.clone());
-                self.rules.push(instance);
-                new_names.push(name);
             }
         }
         self.pending_output_pattern = still_pending;

--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -2183,13 +2183,6 @@ impl WorkflowConfig {
     // Runtime-discovered output fan-out (issue #227 item 5)
     // -----------------------------------------------------------------------
 
-    /// Scan the filesystem for the files this producer instance has just
-    /// created. The instance's BAKED `output_pattern` (bound wildcards
-    /// already resolved, `{config.x}` expanded from the workflow config)
-    /// is matched against the tree rooted at `root`; every discovered
-    /// combo is merged with the instance's own bindings (`[[values]]` /
-    /// `[[pairs]]`) so the FULL wildcard map is reconstructed — the
-    /// per-sample union source for downstream consumers.
     /// The `[[values]]` tables this rule references — its fan-out
     /// dimension set, in declaration order. The trigger text is the
     /// rule's consumer fields plus its own `output_pattern` (issue #296):
@@ -2271,20 +2264,30 @@ impl WorkflowConfig {
         Ok(value_combos)
     }
 
-    /// Whether a producer instance's baked output_pattern still carries
-    /// wildcards for the runtime discovery pass to enumerate (issue #296).
-    /// A fully-bound pattern — every wildcard consumed by plan-time
+    /// Whether a producer instance's baked output_pattern still carries a
+    /// placeholder for the runtime discovery pass to enumerate (issue
+    /// #296). A fully-bound pattern — every wildcard consumed by plan-time
     /// fan-out, e.g. a `[[values]]`-only reference — is a static contract:
     /// the plan-time instances already ARE the domain and plan-time
     /// consumers hold their DAG edges, so running discovery on it can only
-    /// emit the spurious "matched no files" warning.
+    /// emit the spurious "matched no files" warning. Any residual brace
+    /// token (including dotted `{values.x}` / `{config.x}` / `{meta.x}`
+    /// forms the wildcard extractor does not see) keeps discovery on so
+    /// the scan — or at minimum its zero-match warning — stays loud.
     pub fn output_pattern_needs_discovery(&self, instance: &Rule) -> bool {
         instance
             .output_pattern
             .as_deref()
-            .is_some_and(|p| !crate::wildcard::extract_wildcards(p).is_empty())
+            .is_some_and(|p| p.contains('{'))
     }
 
+    /// Scan the filesystem for the files this producer instance has just
+    /// created. The instance's BAKED `output_pattern` (bound wildcards
+    /// already resolved, `{config.x}` expanded from the workflow config)
+    /// is matched against the tree rooted at `root`; every discovered
+    /// combo is merged with the instance's own bindings (`[[values]]` /
+    /// `[[pairs]]`) so the FULL wildcard map is reconstructed — the
+    /// per-sample union source for downstream consumers.
     pub fn discover_output_pattern_files(
         &self,
         instance: &Rule,
@@ -2419,41 +2422,94 @@ impl WorkflowConfig {
             });
             // The consumer's OWN `[[values]]` dimension (issue #296
             // follow-up): a deferred template skips plan-time fan-out, so
-            // project its tables here. Tables already bound by the
-            // producer's domain are excluded — shared wildcards ride the
-            // discovered combos, and projecting them again would contradict
-            // those bindings.
-            let bound_keys: std::collections::HashSet<&str> = domain
-                .iter()
-                .flat_map(|combo| combo.keys())
-                .map(String::as_str)
-                .collect();
+            // project its tables here, mirroring the plan-time branches —
+            // constraints filtered, per-instance `when` gates evaluated.
+            // Tables the producer's PATTERN declares are excluded: their
+            // wildcards ride the pattern suffixes and arrive bound in
+            // every combo.
             let own_tables: Vec<ValueGroup> = self
                 .active_value_tables_for_rule(&consumer)
                 .into_iter()
-                .filter(|table| !bound_keys.contains(table.name.as_str()))
+                .filter(|table| !pattern_wildcards.iter().any(|w| w == &table.name))
                 .collect();
             let own_table_refs: Vec<&ValueGroup> = own_tables.iter().collect();
-            let own_combos = self.cartesian_value_combos(&own_table_refs)?;
-            // Precompute the naming suffixes so the owned table set can be
-            // dropped before the `&mut self` bookkeeping below.
-            let own_dimensions: Vec<(crate::wildcard::WildcardValues, String)> = own_combos
+            // Plan-time parity: constraint-filter the projected combos
+            // exactly as the values fan-out branches do.
+            let compiled_constraints = self
+                .wildcard_constraints
                 .iter()
-                .map(|own| (own.clone(), value_instance_suffix(own, &own_table_refs)))
+                .map(|(name, pattern)| {
+                    regex::Regex::new(pattern)
+                        .map(|re| (name.clone(), re))
+                        .map_err(|e| OxoFlowError::Wildcard {
+                            rule: String::new(),
+                            message: format!(
+                                "invalid regex constraint '{pattern}' for wildcard '{name}': {e}"
+                            ),
+                        })
+                })
+                .collect::<Result<HashMap<_, _>>>()?;
+            let own_combos: Vec<crate::wildcard::WildcardValues> = self
+                .cartesian_value_combos(&own_table_refs)?
+                .into_iter()
+                .filter(|combo| {
+                    crate::wildcard::validate_wildcard_constraints_compiled(
+                        combo,
+                        &compiled_constraints,
+                    )
+                    .is_ok()
+                })
+                .collect();
+            // `config_values` is loop-invariant (mirrors `self.config`).
+            let config_values: HashMap<String, toml::Value> = self
+                .config
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             // Values-major nesting mirrors the plan-time fan-out branches.
-            for (own, own_suffix) in &own_dimensions {
+            for own in &own_combos {
                 for combo in &sorted {
-                    // Merge the producer-domain binding with the consumer's
-                    // own values binding — disjoint by construction.
+                    // Per-combo projection: keys the producer combo already
+                    // binds come from the combo itself, so a table covered
+                    // by only SOME producer instances still projects for
+                    // the uncovered slice instead of vanishing.
                     let mut merged = combo.clone();
-                    merged.extend(own.clone());
+                    merged.extend(
+                        own.iter()
+                            .filter(|(k, _)| !combo.contains_key(*k))
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    // Plan-time parity: evaluate the per-instance `when`
+                    // gate (both namespaces baked first) — non-matching
+                    // combos never become instances; survivors carry the
+                    // baked verdict for the execution-time re-check.
+                    let mut baked_when = consumer.when.clone();
+                    if let Some(ref when) = consumer.when
+                        && (when.contains("wildcard.") || when.contains("{meta."))
+                    {
+                        let combo_values = Self::expansion_when_context(&merged);
+                        let baked = Self::bake_wildcard_when(when, &merged);
+                        let baked = Self::bake_meta_when(&baked, &self.metadata, &merged);
+                        if !crate::executor::process::evaluate_condition_with_wildcards_and_base_dir(
+                            &baked,
+                            &config_values,
+                            &combo_values,
+                            self.base_dir.as_deref(),
+                        ) {
+                            continue;
+                        }
+                        baked_when = Some(baked);
+                    }
+                    // Naming suffix from the EFFECTIVE bindings: a table
+                    // carried by the producer combo names the instance with
+                    // the combo's value, a projected one with its own.
+                    let own_suffix = value_instance_suffix(&merged, &own_table_refs);
                     if let Some(name) = self.instantiate_output_pattern_consumer(
                         &consumer,
                         &merged,
-                        own,
-                        own_suffix,
+                        &own_suffix,
                         &pattern_wildcards,
+                        baked_when,
                     )? {
                         new_names.push(name);
                     }
@@ -2499,16 +2555,17 @@ impl WorkflowConfig {
     }
 
     /// Build, register, and file one deferred-consumer instance from a
-    /// merged binding combo (producer domain ⊕ own values). Returns the
-    /// instance name, or `None` for the idempotent no-op case (see
+    /// merged binding combo (producer domain ⊕ own values). `baked_when`
+    /// carries the caller's evaluated-and-baked `when` verdict. Returns
+    /// the instance name, or `None` for the idempotent no-op case (see
     /// [`Self::consumer_instance_name`]).
     fn instantiate_output_pattern_consumer(
         &mut self,
         consumer: &Rule,
         merged: &crate::wildcard::WildcardValues,
-        own: &crate::wildcard::WildcardValues,
         own_suffix: &str,
         pattern_wildcards: &[String],
+        baked_when: Option<String>,
     ) -> Result<Option<String>> {
         let Some(name) =
             self.consumer_instance_name(consumer, merged, own_suffix, pattern_wildcards)?
@@ -2528,14 +2585,15 @@ impl WorkflowConfig {
         if let Some(ref op) = consumer.output_pattern {
             instance.output_pattern = Some(expand_rule_shell(op, merged));
         }
-        if let Some(ref when) = consumer.when
-            && when.contains("wildcard.")
-        {
-            instance.when = Some(Self::bake_wildcard_when(when, merged));
-        }
+        instance.when = baked_when;
         expand_command_text_fields(&mut instance, consumer, |s| expand_rule_shell(s, merged));
         self.apply_instance_meta(&mut instance, merged);
-        self.bake_expand_inputs_bindings(&mut instance, merged);
+        // Record the FULL binding set BEFORE materializing: the
+        // expand_inputs pass resolves unbound pattern keys from it
+        // (declared `variables` still win), and downstream chains reading
+        // `instance_bindings` see the same bindings the instance text was
+        // baked from.
+        self.expansion_values.insert(name.clone(), merged.clone());
         self.materialize_expand_inputs(&mut instance);
         // Readiness attribution (issue #63): the producer-pattern
         // wildcard bindings of this instance.
@@ -2546,34 +2604,10 @@ impl WorkflowConfig {
         if !samples.is_empty() {
             self.expansion_samples.insert(name.clone(), samples);
         }
-        if !own.is_empty() {
-            self.expansion_values.insert(name.clone(), own.clone());
-        }
         self.expansion_templates
             .insert(name.clone(), consumer.name.clone());
         self.rules.push(instance);
         Ok(Some(name))
-    }
-
-    /// Bake the instance's bound wildcards into its `expand_inputs`
-    /// patterns (mirroring `input` / `output`): the producer-domain keys
-    /// live only in the merged combo, so without this the gather never
-    /// resolves. The materialization pass then handles the remaining
-    /// config-variable references.
-    fn bake_expand_inputs_bindings(
-        &self,
-        instance: &mut Rule,
-        merged: &crate::wildcard::WildcardValues,
-    ) {
-        for exp in &mut instance.expand_inputs {
-            let is_wildcarded = crate::wildcard::has_wildcards(&exp.pattern)
-                || crate::wildcard::contains_values_namespace(&exp.pattern);
-            if is_wildcarded
-                && let Ok(baked) = crate::wildcard::expand_pattern(&exp.pattern, merged)
-            {
-                exp.pattern = crate::wildcard::expand_values_namespace(&baked, merged);
-            }
-        }
     }
 
     /// Resolve split values from SplitConfig.

--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -589,19 +589,33 @@ impl WorkflowConfig {
                 .copied()
                 .chain(rule.expand_inputs.iter().map(|e| e.pattern.as_str()))
                 .collect();
+            // The `[[values]]` TRIGGER text: `expand_texts` plus the rule's
+            // own `output_pattern` (issue #296) — the pattern is a
+            // production-domain declaration exactly as it already is for
+            // pair/group triggers, so a producer referencing a values table
+            // ONLY in its pattern fans out per value instead of baking a
+            // literal `{name}` token. Scoped: the fresh-wildcard
+            // consumer-deferral scan below keeps `expand_texts` — feeding
+            // the pattern there would make every producer defer on its OWN
+            // fresh wildcard (its pattern declares it).
+            let mut value_trigger_texts: Vec<&str> = expand_texts.clone();
+            if let Some(ref op) = rule.output_pattern {
+                value_trigger_texts.push(op);
+            }
             let mut active_value_tables: Vec<&ValueGroup> = Vec::new();
             for table in &self.values {
-                // Scan `expand_texts` (all_text + expand_inputs patterns),
-                // not just `trigger_text` (issue #268 item 1): a consumer
-                // that references a values table ONLY through an
-                // expand_inputs pattern (an aggregator gathering one file
-                // per table value) must still fan out per value — otherwise
-                // it keeps an empty `input` and, worse, loses the
-                // execution-DAG edges to its producers (the template graph
-                // infers them from the raw pattern). Per-value input
-                // selection continues to work below: each instance gathers
-                // the files matching its own binding of the pattern.
-                let referenced = expand_texts.iter().any(|t| {
+                // Scan `value_trigger_texts` (all_text + expand_inputs
+                // patterns + output_pattern), not just the pair/group
+                // `trigger_text` (issue #268 item 1): a consumer that
+                // references a values table ONLY through an expand_inputs
+                // pattern (an aggregator gathering one file per table
+                // value) must still fan out per value — otherwise it keeps
+                // an empty `input` and, worse, loses the execution-DAG
+                // edges to its producers (the template graph infers them
+                // from the raw pattern). Per-value input selection
+                // continues to work below: each instance gathers the files
+                // matching its own binding of the pattern.
+                let referenced = value_trigger_texts.iter().any(|t| {
                     t.contains(&format!("{{{}}}", table.name))
                         || t.contains(&format!("{{values.{}}}", table.name))
                 });
@@ -2228,6 +2242,20 @@ impl WorkflowConfig {
     /// combo is merged with the instance's own bindings (`[[values]]` /
     /// `[[pairs]]`) so the FULL wildcard map is reconstructed — the
     /// per-sample union source for downstream consumers.
+    /// Whether a producer instance's baked output_pattern still carries
+    /// wildcards for the runtime discovery pass to enumerate (issue #296).
+    /// A fully-bound pattern — every wildcard consumed by plan-time
+    /// fan-out, e.g. a `[[values]]`-only reference — is a static contract:
+    /// the plan-time instances already ARE the domain and plan-time
+    /// consumers hold their DAG edges, so running discovery on it can only
+    /// emit the spurious "matched no files" warning.
+    pub fn output_pattern_needs_discovery(&self, instance: &Rule) -> bool {
+        instance
+            .output_pattern
+            .as_deref()
+            .is_some_and(|p| !crate::wildcard::extract_wildcards(p).is_empty())
+    }
+
     pub fn discover_output_pattern_files(
         &self,
         instance: &Rule,

--- a/crates/oxo-flow-core/src/config/expand.rs
+++ b/crates/oxo-flow-core/src/config/expand.rs
@@ -1485,16 +1485,11 @@ impl WorkflowConfig {
     fn materialize_expand_inputs(&self, rule: &mut Rule) {
         for exp in &rule.expand_inputs {
             // `{meta.<column>}` inside an expand_inputs pattern is never
-            // resolved: per-instance metadata substitution
-            // (`apply_instance_meta`) has already run on the rule's own
-            // fields by the time this pass executes, and it never
-            // touches expand_inputs; the placeholder regex does not
-            // match dotted tokens either, so `variables` can never bind
-            // the reference. The pattern either expands with a literal
-            // `{meta.…}` token baked into every path or contributes
-            // zero inputs — warn so the author moves the reference into
-            // `input` (per-instance substitution applies there) or
-            // input_groups.
+            // resolved: per-instance metadata substitution has already run
+            // on the rule's own fields by the time this pass executes, and
+            // `variables` can never bind the dotted token either. Warn so
+            // the author moves the reference into `input` (per-instance
+            // substitution applies there) or input_groups.
             let meta_pattern = exp.pattern.contains("{meta.");
             if meta_pattern {
                 tracing::warn!(
@@ -1503,49 +1498,7 @@ impl WorkflowConfig {
                     "expand_inputs pattern references '{{meta.<column>}}' but per-instance metadata substitution ran BEFORE this pass — the token is never resolved (put the pattern in `input` for substitution, or use input_groups)"
                 );
             }
-            let mut variables = HashMap::new();
-            for (var_name, var_ref) in &exp.variables {
-                if let Some(vals) = self.resolve_config_list(var_ref) {
-                    variables.insert(var_name.clone(), vals);
-                } else if var_ref.starts_with('[') && var_ref.ends_with(']') {
-                    let inner = &var_ref[1..var_ref.len() - 1];
-                    let vals = inner
-                        .split(',')
-                        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
-                    variables.insert(var_name.clone(), vals);
-                } else {
-                    variables.insert(var_name.clone(), vec![var_ref.clone()]);
-                }
-            }
-
-            // Bind this instance's own [[values]] values so `{assembler}`
-            // inside the expand pattern resolves per instance — the
-            // spades instance never sees the megahit value.
-            let bindings = self.expansion_values.get(&rule.name).cloned();
-            if let Some(bindings) = &bindings {
-                for (name, value) in bindings {
-                    variables
-                        .entry(name.clone())
-                        .or_insert_with(|| vec![value.clone()]);
-                }
-            }
-
-            // Same per-instance binding for pair wildcards: `{pair_id}`
-            // (and the other pair keys) inside an expand pattern resolve
-            // to THIS instance's pair, so a per-pair gather rule picks up
-            // its own pair's files only (snakemake-style; the
-            // cohort-level `pair_id = "config.pairs_list"` variable form
-            // still wins when declared explicitly).
-            if let Some(pair_bindings) = self.expansion_pairs.get(&rule.name) {
-                for (name, value) in pair_bindings {
-                    variables
-                        .entry(name.clone())
-                        .or_insert_with(|| vec![value.clone()]);
-                }
-            }
-
+            let variables = self.expand_pattern_variables(exp, &rule.name);
             let mut expanded = crate::wildcard::cartesian_expand(&exp.pattern, &variables);
             // A pattern WITH wildcards that contributes zero inputs
             // means every wildcard lacked a provided value — usually
@@ -1563,7 +1516,7 @@ impl WorkflowConfig {
                 );
             }
             // Resolve the `{values.name}` namespace form per instance.
-            if let Some(bindings) = &bindings {
+            if let Some(bindings) = self.expansion_values.get(&rule.name) {
                 for path in &mut expanded {
                     *path = crate::wildcard::expand_values_namespace(path, bindings);
                 }
@@ -1572,6 +1525,53 @@ impl WorkflowConfig {
             current_input.extend(expanded);
             rule.input = FilePatterns::List(current_input);
         }
+    }
+
+    /// Resolve one `expand_inputs` pattern's variable table: config
+    /// references, inline `[a, b]` lists, literal values — then this
+    /// instance's own `[[values]]`/`[[pairs]]` bindings so `{assembler}`
+    /// resolves per instance (the spades instance never sees the megahit
+    /// files). Explicit variable declarations win over instance bindings.
+    fn expand_pattern_variables(
+        &self,
+        exp: &crate::rule::ExpandConfig,
+        rule_name: &str,
+    ) -> HashMap<String, Vec<String>> {
+        let mut variables = HashMap::new();
+        for (var_name, var_ref) in &exp.variables {
+            if let Some(vals) = self.resolve_config_list(var_ref) {
+                variables.insert(var_name.clone(), vals);
+            } else if var_ref.starts_with('[') && var_ref.ends_with(']') {
+                let inner = &var_ref[1..var_ref.len() - 1];
+                let vals = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                variables.insert(var_name.clone(), vals);
+            } else {
+                variables.insert(var_name.clone(), vec![var_ref.clone()]);
+            }
+        }
+        // Pair wildcards follow the same per-instance rule: `{pair_id}`
+        // inside an expand pattern resolves to THIS instance's pair, so a
+        // per-pair gather rule picks up its own pair's files only
+        // (snakemake-style; the cohort-level
+        // `pair_id = "config.pairs_list"` variable form above still wins).
+        for bindings in [
+            self.expansion_values.get(rule_name),
+            self.expansion_pairs.get(rule_name),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for (name, value) in bindings {
+                variables
+                    .entry(name.clone())
+                    .or_insert_with(|| vec![value.clone()]);
+            }
+        }
+        variables
     }
 
     /// Apply the per-instance `{meta.<column>}` substitution (issue #227
@@ -2404,12 +2404,18 @@ impl WorkflowConfig {
             // pattern wildcard values so instantiation order (and the
             // reported names) is deterministic across runs and resume —
             // the discovery walkers see filesystem order, which is not.
-            let mut sorted: Vec<&crate::wildcard::WildcardValues> = domain.iter().collect();
-            sorted.sort_by_key(|combo| {
-                pattern_wildcards
-                    .iter()
-                    .map(|w| combo.get(w).cloned().unwrap_or_default())
-                    .collect::<Vec<String>>()
+            // Cloned owned so the `discovered_output_patterns` borrow ends
+            // here: the instantiation helper takes `&mut self` across the
+            // loop below.
+            let mut sorted: Vec<crate::wildcard::WildcardValues> = domain.to_vec();
+            sorted.sort_by(|a, b| {
+                let key = |combo: &crate::wildcard::WildcardValues| {
+                    pattern_wildcards
+                        .iter()
+                        .map(|w| combo.get(w).cloned().unwrap_or_default())
+                        .collect::<Vec<String>>()
+                };
+                key(a).cmp(&key(b))
             });
             // The consumer's OWN `[[values]]` dimension (issue #296
             // follow-up): a deferred template skips plan-time fan-out, so
@@ -2440,89 +2446,134 @@ impl WorkflowConfig {
                 for combo in &sorted {
                     // Merge the producer-domain binding with the consumer's
                     // own values binding — disjoint by construction.
-                    let mut merged = (*combo).clone();
+                    let mut merged = combo.clone();
                     merged.extend(own.clone());
-                    let mut name = consumer.name.clone();
-                    name.push_str(own_suffix);
-                    for w in &pattern_wildcards {
-                        name.push('_');
-                        name.push_str(&crate::wildcard::sanitize_instance_value(
-                            combo.get(w).map(String::as_str).unwrap_or_default(),
-                        ));
+                    if let Some(name) = self.instantiate_output_pattern_consumer(
+                        &consumer,
+                        &merged,
+                        own,
+                        own_suffix,
+                        &pattern_wildcards,
+                    )? {
+                        new_names.push(name);
                     }
-                    if self.rules.iter().any(|r| r.name == name) {
-                        // A previous instance of THIS consumer (post-reentry
-                        // re-expansion) is an idempotent no-op; any other
-                        // collision is a genuine naming conflict.
-                        if self
-                            .expansion_templates
-                            .get(&name)
-                            .is_some_and(|t| t == &consumer.name)
-                        {
-                            continue;
-                        }
-                        return Err(OxoFlowError::DuplicateRule { name });
-                    }
-                    let mut instance = consumer.clone();
-                    instance.name = name.clone();
-                    instance.input = expand_rule_patterns(&consumer.input, &merged);
-                    instance.output = expand_rule_patterns(&consumer.output, &merged);
-                    if let Some(ref shell) = consumer.shell {
-                        instance.shell = Some(expand_rule_shell(shell, &merged));
-                    }
-                    if let Some(ref log) = consumer.log {
-                        instance.log = Some(expand_rule_shell(log, &merged));
-                    }
-                    if let Some(ref op) = consumer.output_pattern {
-                        instance.output_pattern = Some(expand_rule_shell(op, &merged));
-                    }
-                    if let Some(ref when) = consumer.when
-                        && when.contains("wildcard.")
-                    {
-                        instance.when = Some(Self::bake_wildcard_when(when, &merged));
-                    }
-                    expand_command_text_fields(&mut instance, &consumer, |s| {
-                        expand_rule_shell(s, &merged)
-                    });
-                    self.apply_instance_meta(&mut instance, &merged);
-                    // Bake the instance's bound wildcards into the
-                    // expand_inputs patterns first (mirroring `input` /
-                    // `output` above): the producer-domain keys live only
-                    // in `merged`, so without this the gather never
-                    // resolves. The materialization pass then handles the
-                    // remaining config-variable references.
-                    for exp in &mut instance.expand_inputs {
-                        let is_wildcarded = crate::wildcard::has_wildcards(&exp.pattern)
-                            || crate::wildcard::contains_values_namespace(&exp.pattern);
-                        if is_wildcarded
-                            && let Ok(baked) =
-                                crate::wildcard::expand_pattern(&exp.pattern, &merged)
-                        {
-                            exp.pattern = crate::wildcard::expand_values_namespace(&baked, &merged);
-                        }
-                    }
-                    self.materialize_expand_inputs(&mut instance);
-                    // Readiness attribution (issue #63): the producer-pattern
-                    // wildcard bindings of this instance.
-                    let samples: Vec<String> = pattern_wildcards
-                        .iter()
-                        .filter_map(|w| merged.get(w).cloned())
-                        .collect();
-                    if !samples.is_empty() {
-                        self.expansion_samples.insert(name.clone(), samples);
-                    }
-                    if !own.is_empty() {
-                        self.expansion_values.insert(name.clone(), own.clone());
-                    }
-                    self.expansion_templates
-                        .insert(name.clone(), consumer.name.clone());
-                    self.rules.push(instance);
-                    new_names.push(name);
                 }
             }
         }
         self.pending_output_pattern = still_pending;
         Ok(new_names)
+    }
+
+    /// The instance name for one (own-values × producer-domain) combo:
+    /// consumer template, own-values suffix, then the producer-pattern
+    /// wildcard values in pattern order. `Ok(None)` signals an idempotent
+    /// no-op — a re-expansion (checkpoint re-entry) re-producing a name
+    /// THIS consumer already instantiated; any other collision is a
+    /// genuine naming conflict.
+    fn consumer_instance_name(
+        &self,
+        consumer: &Rule,
+        combo: &crate::wildcard::WildcardValues,
+        own_suffix: &str,
+        pattern_wildcards: &[String],
+    ) -> Result<Option<String>> {
+        let mut name = consumer.name.clone();
+        name.push_str(own_suffix);
+        for w in pattern_wildcards {
+            name.push('_');
+            name.push_str(&crate::wildcard::sanitize_instance_value(
+                combo.get(w).map(String::as_str).unwrap_or_default(),
+            ));
+        }
+        if self.rules.iter().any(|r| r.name == name) {
+            if self
+                .expansion_templates
+                .get(&name)
+                .is_some_and(|t| t == &consumer.name)
+            {
+                return Ok(None);
+            }
+            return Err(OxoFlowError::DuplicateRule { name });
+        }
+        Ok(Some(name))
+    }
+
+    /// Build, register, and file one deferred-consumer instance from a
+    /// merged binding combo (producer domain ⊕ own values). Returns the
+    /// instance name, or `None` for the idempotent no-op case (see
+    /// [`Self::consumer_instance_name`]).
+    fn instantiate_output_pattern_consumer(
+        &mut self,
+        consumer: &Rule,
+        merged: &crate::wildcard::WildcardValues,
+        own: &crate::wildcard::WildcardValues,
+        own_suffix: &str,
+        pattern_wildcards: &[String],
+    ) -> Result<Option<String>> {
+        let Some(name) =
+            self.consumer_instance_name(consumer, merged, own_suffix, pattern_wildcards)?
+        else {
+            return Ok(None);
+        };
+        let mut instance = consumer.clone();
+        instance.name = name.clone();
+        instance.input = expand_rule_patterns(&consumer.input, merged);
+        instance.output = expand_rule_patterns(&consumer.output, merged);
+        if let Some(ref shell) = consumer.shell {
+            instance.shell = Some(expand_rule_shell(shell, merged));
+        }
+        if let Some(ref log) = consumer.log {
+            instance.log = Some(expand_rule_shell(log, merged));
+        }
+        if let Some(ref op) = consumer.output_pattern {
+            instance.output_pattern = Some(expand_rule_shell(op, merged));
+        }
+        if let Some(ref when) = consumer.when
+            && when.contains("wildcard.")
+        {
+            instance.when = Some(Self::bake_wildcard_when(when, merged));
+        }
+        expand_command_text_fields(&mut instance, consumer, |s| expand_rule_shell(s, merged));
+        self.apply_instance_meta(&mut instance, merged);
+        self.bake_expand_inputs_bindings(&mut instance, merged);
+        self.materialize_expand_inputs(&mut instance);
+        // Readiness attribution (issue #63): the producer-pattern
+        // wildcard bindings of this instance.
+        let samples: Vec<String> = pattern_wildcards
+            .iter()
+            .filter_map(|w| merged.get(w).cloned())
+            .collect();
+        if !samples.is_empty() {
+            self.expansion_samples.insert(name.clone(), samples);
+        }
+        if !own.is_empty() {
+            self.expansion_values.insert(name.clone(), own.clone());
+        }
+        self.expansion_templates
+            .insert(name.clone(), consumer.name.clone());
+        self.rules.push(instance);
+        Ok(Some(name))
+    }
+
+    /// Bake the instance's bound wildcards into its `expand_inputs`
+    /// patterns (mirroring `input` / `output`): the producer-domain keys
+    /// live only in the merged combo, so without this the gather never
+    /// resolves. The materialization pass then handles the remaining
+    /// config-variable references.
+    fn bake_expand_inputs_bindings(
+        &self,
+        instance: &mut Rule,
+        merged: &crate::wildcard::WildcardValues,
+    ) {
+        for exp in &mut instance.expand_inputs {
+            let is_wildcarded = crate::wildcard::has_wildcards(&exp.pattern)
+                || crate::wildcard::contains_values_namespace(&exp.pattern);
+            if is_wildcarded
+                && let Ok(baked) = crate::wildcard::expand_pattern(&exp.pattern, merged)
+            {
+                exp.pattern = crate::wildcard::expand_values_namespace(&baked, merged);
+            }
+        }
     }
 
     /// Resolve split values from SplitConfig.

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -6599,6 +6599,342 @@ fn output_pattern_unrelated_wildcard_is_not_a_fresh_reference() {
     );
 }
 
+// ── Issue #296: [[values]] fan-out trigger must scan output_pattern ────────
+
+#[test]
+fn output_pattern_values_only_reference_fans_out_per_value() {
+    // A producer referencing a [[values]] table ONLY in its output_pattern
+    // must fan out per value — the pattern is a production-domain
+    // declaration exactly as it already is for pair/group triggers. Before
+    // the fix the rule stayed a single instance with the literal
+    // `{assembler}` token baked into its pattern, while per-value
+    // consumers (which DO fan out via expand_inputs) lost their producer.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296"
+
+        [[values]]
+        name = "assembler"
+        values = ["spades", "megahit"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/{assembler}/part.txt"
+        shell = "scripts/build_all.sh"
+
+        [[rules]]
+        name = "summarize"
+        expand_inputs = [{ pattern = "results/{assembler}/part.txt" }]
+        output = ["results/summary_{assembler}.txt"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    // The producer fans out per value, pattern baked per instance.
+    let spades = config
+        .get_rule("assemble_assembler_spades")
+        .expect("spades producer instance");
+    assert_eq!(
+        spades.output_pattern.as_deref(),
+        Some("results/spades/part.txt")
+    );
+    assert_eq!(
+        config
+            .expansion_values
+            .get("assemble_assembler_spades")
+            .and_then(|v| v.get("assembler").map(String::as_str)),
+        Some("spades")
+    );
+    let megahit = config
+        .get_rule("assemble_assembler_megahit")
+        .expect("megahit producer instance");
+    assert_eq!(
+        megahit.output_pattern.as_deref(),
+        Some("results/megahit/part.txt")
+    );
+
+    // The values-bound pattern wildcard is NOT fresh: no producer
+    // registration and no consumer deferral — plan-time values fan-out is
+    // the domain.
+    assert!(config.output_pattern_producers.is_empty());
+    assert!(config.pending_output_pattern.is_empty());
+
+    // End-to-end ordering (the second half of the bug): before the DAG
+    // registered output_pattern producer-side, the per-value consumers had
+    // NO edge to their producer and the execution order ran them FIRST.
+    // The expansion pass materializes each consumer's expand_inputs pattern
+    // to its own concrete path, so the edge is exact and per-value.
+    let dag = crate::WorkflowDag::from_rules(&config.rules).unwrap();
+    assert_eq!(
+        dag.dependencies("summarize_assembler_spades").unwrap(),
+        vec!["assemble_assembler_spades"]
+    );
+    assert_eq!(
+        dag.dependencies("summarize_assembler_megahit").unwrap(),
+        vec!["assemble_assembler_megahit"]
+    );
+    let order = dag.execution_order().unwrap();
+    let spades_pos = |name: &str| order.iter().position(|n| n == name).unwrap();
+    assert!(
+        spades_pos("assemble_assembler_spades") < spades_pos("summarize_assembler_spades"),
+        "producer must order before its consumer: {order:?}"
+    );
+}
+
+#[test]
+fn output_pattern_values_and_pair_dimensions_compose_through_pattern() {
+    // Orthogonal fan-out through the pattern: a producer whose
+    // output_pattern carries BOTH a values wildcard and a pair wildcard
+    // fans out over the Cartesian product, with every bound wildcard
+    // baked per instance (mirrors the pair-branch pattern baking).
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-pair.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-pair"
+
+        [[values]]
+        name = "assembler"
+        values = ["spades", "megahit"]
+
+        [[pairs]]
+        pair_id = "P1"
+        experiment = "S1"
+        control = "S2"
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/{pair_id}/{assembler}/part.txt"
+        shell = "scripts/build_all.sh"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names.len(), 2, "one instance per pair × value: {names:?}");
+    let p1 = config
+        .get_rule("assemble_assembler_spades_P1")
+        .expect("P1×spades");
+    assert_eq!(
+        p1.output_pattern.as_deref(),
+        Some("results/P1/spades/part.txt")
+    );
+    let p2 = config
+        .get_rule("assemble_assembler_megahit_P1")
+        .expect("P1×megahit");
+    assert_eq!(
+        p2.output_pattern.as_deref(),
+        Some("results/P1/megahit/part.txt")
+    );
+}
+
+#[test]
+fn output_pattern_values_reference_respects_per_instance_when() {
+    // The `when` gate applies to instances born from a pattern-only
+    // values reference exactly as it does for shell-triggered fan-out:
+    // non-matching combos never enter the plan.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-when.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-when"
+
+        [[values]]
+        name = "assembler"
+        values = ["spades", "megahit"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/{assembler}/part.txt"
+        when = "wildcard.assembler != 'megahit'"
+        shell = "scripts/build_all.sh"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let names: Vec<&str> = config.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["assemble_assembler_spades"],
+        "megahit gated off: {names:?}"
+    );
+    assert_eq!(
+        config
+            .get_rule("assemble_assembler_spades")
+            .and_then(|r| r.output_pattern.as_deref()),
+        Some("results/spades/part.txt")
+    );
+}
+
+#[test]
+fn output_pattern_fully_bound_by_values_needs_no_discovery() {
+    // Issue #296: once plan-time values fan-out has bound every wildcard,
+    // the baked pattern is a static contract — runtime discovery has
+    // nothing to enumerate and would only emit the spurious
+    // "matched no files" warning. A pattern with a residual fresh
+    // wildcard still needs discovery.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-bound.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-bound"
+
+        [[values]]
+        name = "assembler"
+        values = ["spades"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/{assembler}/part.txt"
+        shell = "scripts/build_all.sh"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let spades = config
+        .get_rule("assemble_assembler_spades")
+        .expect("values instance");
+    assert!(
+        !config.output_pattern_needs_discovery(spades),
+        "fully-bound pattern: nothing left to discover"
+    );
+
+    // A pattern whose wildcards are not all bound by fan-out sources
+    // (here: a fresh wildcard the runtime must enumerate) keeps discovery.
+    let mut fresh = spades.clone();
+    fresh.output_pattern = Some("results/spades/{part}.txt".to_string());
+    assert!(config.output_pattern_needs_discovery(&fresh));
+}
+
+#[test]
+fn output_pattern_values_and_fresh_wildcards_compose_end_to_end() {
+    // Mixed pattern: the values dimension fans out at PLAN time (baked per
+    // instance) while the fresh wildcard stays runtime-discovered per
+    // instance. The domain union across producer instances feeds the
+    // deferred consumer with BOTH bindings.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-mixed.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-mixed"
+
+        [[values]]
+        name = "assembler"
+        values = ["spades", "megahit"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/{assembler}/{chunk}.txt"
+        shell = "scripts/build_all.sh"
+
+        [[rules]]
+        name = "collect"
+        input = ["results/{assembler}/{chunk}.txt"]
+        output = ["out/{assembler}_{chunk}.txt"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    // Registration: only the fresh wildcard is claimed; the values
+    // wildcard is plan-time bound.
+    assert_eq!(
+        config
+            .output_pattern_producers
+            .get("chunk")
+            .map(String::as_str),
+        Some("assemble")
+    );
+    // Per-value instances with the values wildcard baked, the fresh one
+    // intact, and the deferred consumer still pending.
+    assert_eq!(
+        config
+            .get_rule("assemble_assembler_spades")
+            .and_then(|r| r.output_pattern.as_deref()),
+        Some("results/spades/{chunk}.txt")
+    );
+    assert_eq!(
+        config
+            .get_rule("assemble_assembler_megahit")
+            .and_then(|r| r.output_pattern.as_deref()),
+        Some("results/megahit/{chunk}.txt")
+    );
+    assert!(config.get_rule("collect").is_none());
+    assert_eq!(config.pending_output_pattern.len(), 1);
+
+    // The producer instances complete: each discovers its own slice, with
+    // the values binding merged into every discovered combo.
+    for (assembler, chunks) in [("spades", &["1", "2"][..]), ("megahit", &["1"][..])] {
+        let path = dir.path().join(format!("results/{assembler}"));
+        std::fs::create_dir_all(&path).unwrap();
+        for chunk in chunks {
+            std::fs::write(path.join(format!("{chunk}.txt")), chunk).unwrap();
+        }
+        let instance = config
+            .get_rule(&format!("assemble_assembler_{assembler}"))
+            .cloned()
+            .unwrap();
+        let combos = config
+            .discover_output_pattern_files(&instance, dir.path())
+            .unwrap();
+        assert_eq!(combos.len(), chunks.len());
+        for combo in &combos {
+            assert_eq!(
+                combo.get("assembler").map(String::as_str),
+                Some(assembler),
+                "values binding merged into the discovered combo"
+            );
+        }
+        config.contribute_output_pattern_domain("assemble", combos);
+    }
+
+    // Consumers instantiate per (values × discovered) combo with both
+    // bindings baked.
+    let new_names = config.expand_output_pattern_consumers().unwrap();
+    let mut sorted = new_names.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec!["collect_megahit_1", "collect_spades_1", "collect_spades_2"]
+    );
+    let c = config.get_rule("collect_spades_1").expect("spades_1");
+    assert_eq!(c.input.to_vec(), vec!["results/spades/1.txt"]);
+    assert_eq!(c.output.to_vec(), vec!["out/spades_1.txt"]);
+}
+
 // ── Issue #283: long-read dimension in sheet mode ──────────────────────────
 
 #[test]

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -6831,6 +6831,134 @@ fn output_pattern_fully_bound_by_values_needs_no_discovery() {
     let mut fresh = spades.clone();
     fresh.output_pattern = Some("results/spades/{part}.txt".to_string());
     assert!(config.output_pattern_needs_discovery(&fresh));
+
+    // A residual DOTTED token ({values.x}/{config.x}/{meta.x}) is invisible
+    // to the wildcard extractor but still means "never baked" — discovery
+    // (or at least its zero-match warning) must stay loud.
+    let mut dotted = spades.clone();
+    dotted.output_pattern = Some("results/{values.assembler}/part.txt".to_string());
+    assert!(config.output_pattern_needs_discovery(&dotted));
+}
+
+#[test]
+fn output_pattern_deferred_consumer_own_values_respect_constraints() {
+    // Plan-time parity, part 1: `wildcard_constraints` filter the projected
+    // own-values combos exactly as they filter the plan-time fan-out — a
+    // combo the static workflow would never create must not appear because
+    // the rule happened to be deferred.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-constr.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-constr"
+
+        [wildcard_constraints]
+        caller = "^(freebayes|bcftools)$"
+
+        [[values]]
+        name = "caller"
+        values = ["freebayes", "bcftools", "deepvariant"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/asm/{chunk}.txt"
+        shell = "scripts/build_chunks.sh"
+
+        [[rules]]
+        name = "call"
+        input = ["results/asm/{chunk}.txt"]
+        output = ["vcfs/{caller}/{chunk}.vcf"]
+        shell = "cp {input} {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    let path = dir.path().join("results/asm/1.txt");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "x").unwrap();
+    let instance = config.get_rule("assemble").cloned().unwrap();
+    let combos = config
+        .discover_output_pattern_files(&instance, dir.path())
+        .unwrap();
+    config.contribute_output_pattern_domain("assemble", combos);
+
+    let new_names = config.expand_output_pattern_consumers().unwrap();
+    let mut sorted = new_names.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec!["call_caller_bcftools_1", "call_caller_freebayes_1"],
+        "deepvariant is constraint-filtered out of the projection"
+    );
+}
+
+#[test]
+fn output_pattern_deferred_consumer_expand_inputs_declared_variables_win() {
+    // Plan-time parity, part 2: a declared `variables` reference in an
+    // expand_inputs pattern keeps its cohort-gather semantics at runtime —
+    // the deferred instance's own binding must not collapse the pattern to
+    // a single file.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-declared.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-declared"
+
+        [config]
+        all_parts = "1,2,3"
+
+        [[rules]]
+        name = "split"
+        output_pattern = "results/chunks/{part}.txt"
+        shell = "scripts/build_chunks.sh"
+
+        [[rules]]
+        name = "rollup"
+        input = []
+        expand_inputs = [
+            { pattern = "results/chunks/{part}.txt", variables = { part = "config.all_parts" } }
+        ]
+        output = ["results/all.txt"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+
+    for part in ["1", "2", "3"] {
+        let path = dir.path().join(format!("results/chunks/{part}.txt"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, part).unwrap();
+    }
+    let instance = config.get_rule("split").cloned().unwrap();
+    let combos = config
+        .discover_output_pattern_files(&instance, dir.path())
+        .unwrap();
+    config.contribute_output_pattern_domain("split", combos);
+
+    let new_names = config.expand_output_pattern_consumers().unwrap();
+    assert_eq!(new_names.len(), 3);
+    let r = config.get_rule("rollup_1").expect("instance");
+    assert_eq!(
+        r.input.to_vec(),
+        vec![
+            "results/chunks/1.txt",
+            "results/chunks/2.txt",
+            "results/chunks/3.txt"
+        ],
+        "the declared config-parts gather survives runtime instantiation"
+    );
 }
 
 #[test]
@@ -6993,14 +7121,12 @@ fn output_pattern_deferred_consumer_projects_own_values_dimension() {
     sorted.sort();
     assert_eq!(
         sorted,
-        vec![
-            "call_caller_bcftools_1",
-            "call_caller_bcftools_2",
-            "call_caller_freebayes_1",
-            "call_caller_freebayes_2",
-        ],
-        "one instance per own value × discovered chunk"
+        vec!["call_caller_freebayes_1", "call_caller_freebayes_2"],
+        "one instance per surviving own value × discovered chunk — \
+         the bcftools combos are gated off at instantiation, exactly as \
+         the plan-time values fan-out would have dropped them"
     );
+    assert!(config.get_rule("call_caller_bcftools_1").is_none());
     let fb = config
         .get_rule("call_caller_freebayes_1")
         .expect("instance");
@@ -7014,22 +7140,9 @@ fn output_pattern_deferred_consumer_projects_own_values_dimension() {
         Some("freebayes"),
         "the projected binding is recorded for downstream attribution"
     );
-    // `when` bakes from the MERGED combo (own values + producer domain) —
-    // bake-only, mirroring the runtime path: the execution-time re-check
-    // prunes the gated-off instances.
-    assert_eq!(
-        config
-            .get_rule("call_caller_bcftools_1")
-            .and_then(|r| r.when.clone()),
-        Some("'bcftools' != 'bcftools'".to_string()),
-        "the own-dimension binding is baked into when for execution-time pruning"
-    );
-    assert_eq!(
-        config
-            .get_rule("call_caller_freebayes_1")
-            .and_then(|r| r.when.clone()),
-        Some("'freebayes' != 'bcftools'".to_string())
-    );
+    // Survivors carry the per-instance `when` baked from the MERGED combo
+    // (own values + producer domain) for the execution-time re-check.
+    assert_eq!(fb.when.as_deref(), Some("'freebayes' != 'bcftools'"));
     assert!(config.pending_output_pattern.is_empty());
 }
 

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -6935,6 +6935,146 @@ fn output_pattern_values_and_fresh_wildcards_compose_end_to_end() {
     assert_eq!(c.output.to_vec(), vec!["out/spades_1.txt"]);
 }
 
+#[test]
+fn output_pattern_deferred_consumer_projects_own_values_dimension() {
+    // Follow-up to #296: a deferred consumer's OWN `[[values]]` dimension
+    // must survive runtime instantiation. The template skips plan-time
+    // fan-out (the fresh-wildcard deferral runs first), so the projection
+    // happens here — one instance per (own value × discovered combo),
+    // with both bindings baked and `expansion_values` recorded. Tables
+    // already bound by the producer's domain (shared wildcards) ride the
+    // combos instead of projecting a contradictory second copy.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-own.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-own"
+
+        [[values]]
+        name = "caller"
+        values = ["freebayes", "bcftools"]
+
+        [[rules]]
+        name = "assemble"
+        output_pattern = "results/asm/{chunk}.txt"
+        shell = "scripts/build_chunks.sh"
+
+        [[rules]]
+        name = "call"
+        input = ["results/asm/{chunk}.txt"]
+        output = ["vcfs/{caller}/{chunk}.vcf"]
+        shell = "cp {input} {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    assert_eq!(config.pending_output_pattern.len(), 1);
+
+    for chunk in ["1", "2"] {
+        let path = dir.path().join(format!("results/asm/{chunk}.txt"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, chunk).unwrap();
+    }
+    let instance = config.get_rule("assemble").cloned().unwrap();
+    let combos = config
+        .discover_output_pattern_files(&instance, dir.path())
+        .unwrap();
+    assert_eq!(combos.len(), 2);
+    config.contribute_output_pattern_domain("assemble", combos);
+
+    let new_names = config.expand_output_pattern_consumers().unwrap();
+    let mut sorted = new_names.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec![
+            "call_caller_bcftools_1",
+            "call_caller_bcftools_2",
+            "call_caller_freebayes_1",
+            "call_caller_freebayes_2",
+        ],
+        "one instance per own value × discovered chunk"
+    );
+    let fb = config
+        .get_rule("call_caller_freebayes_1")
+        .expect("instance");
+    assert_eq!(fb.input.to_vec(), vec!["results/asm/1.txt"]);
+    assert_eq!(fb.output.to_vec(), vec!["vcfs/freebayes/1.vcf"]);
+    assert_eq!(
+        config
+            .expansion_values
+            .get("call_caller_freebayes_1")
+            .and_then(|v| v.get("caller").map(String::as_str)),
+        Some("freebayes"),
+        "the projected binding is recorded for downstream attribution"
+    );
+    assert!(config.pending_output_pattern.is_empty());
+}
+
+#[test]
+fn output_pattern_deferred_consumer_expand_inputs_materialize() {
+    // A deferred consumer that gathers via `expand_inputs` must get its
+    // patterns materialized into concrete inputs at instantiation — the
+    // plan-time pass never touches deferred templates, so without this
+    // the instance runs with an empty input.
+    let dir = tempfile::tempdir().unwrap();
+    let workflow_path = dir.path().join("v296-gather.oxoflow");
+    std::fs::write(
+        &workflow_path,
+        r#"
+        [workflow]
+        name = "v296-gather"
+
+        [[rules]]
+        name = "split"
+        output_pattern = "results/chunks/{part}.txt"
+        shell = "scripts/build_chunks.sh"
+
+        [[rules]]
+        name = "rollup"
+        input = []
+        expand_inputs = [{ pattern = "results/chunks/{part}.txt", variables = {} }]
+        output = ["results/all.txt"]
+        shell = "cat {input} > {output}"
+        "#,
+    )
+    .unwrap();
+
+    let mut config = WorkflowConfig::from_file(&workflow_path).unwrap();
+    config.apply_defaults();
+    config.expand_wildcards().unwrap();
+    assert_eq!(config.pending_output_pattern.len(), 1);
+
+    for part in ["1", "2", "3"] {
+        let path = dir.path().join(format!("results/chunks/{part}.txt"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, part).unwrap();
+    }
+    let instance = config.get_rule("split").cloned().unwrap();
+    let combos = config
+        .discover_output_pattern_files(&instance, dir.path())
+        .unwrap();
+    config.contribute_output_pattern_domain("split", combos);
+
+    let new_names = config.expand_output_pattern_consumers().unwrap();
+    assert_eq!(
+        new_names,
+        vec!["rollup_1", "rollup_2", "rollup_3"],
+        "no own values dimension: identity naming, one instance per combo"
+    );
+    let r = config.get_rule("rollup_1").expect("instance");
+    assert_eq!(
+        r.input.to_vec(),
+        vec!["results/chunks/1.txt"],
+        "expand_inputs materialized into the runtime instance's input"
+    );
+}
+
 // ── Issue #283: long-read dimension in sheet mode ──────────────────────────
 
 #[test]

--- a/crates/oxo-flow-core/src/config/tests.rs
+++ b/crates/oxo-flow-core/src/config/tests.rs
@@ -6965,6 +6965,7 @@ fn output_pattern_deferred_consumer_projects_own_values_dimension() {
         name = "call"
         input = ["results/asm/{chunk}.txt"]
         output = ["vcfs/{caller}/{chunk}.vcf"]
+        when = "wildcard.caller != 'bcftools'"
         shell = "cp {input} {output}"
         "#,
     )
@@ -7012,6 +7013,22 @@ fn output_pattern_deferred_consumer_projects_own_values_dimension() {
             .and_then(|v| v.get("caller").map(String::as_str)),
         Some("freebayes"),
         "the projected binding is recorded for downstream attribution"
+    );
+    // `when` bakes from the MERGED combo (own values + producer domain) —
+    // bake-only, mirroring the runtime path: the execution-time re-check
+    // prunes the gated-off instances.
+    assert_eq!(
+        config
+            .get_rule("call_caller_bcftools_1")
+            .and_then(|r| r.when.clone()),
+        Some("'bcftools' != 'bcftools'".to_string()),
+        "the own-dimension binding is baked into when for execution-time pruning"
+    );
+    assert_eq!(
+        config
+            .get_rule("call_caller_freebayes_1")
+            .and_then(|r| r.when.clone()),
+        Some("'freebayes' != 'bcftools'".to_string())
     );
     assert!(config.pending_output_pattern.is_empty());
 }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -78,6 +78,13 @@ impl WorkflowDag {
         let mut graph = DiGraph::new();
         let mut name_to_node = HashMap::new();
         let mut output_to_node: HashMap<String, Vec<NodeIndex>> = HashMap::new();
+        // Strings claimed via `output_pattern` (issue #296). They register
+        // producer-side for exact matching, but are EXCLUDED from the
+        // template matchers below: a raw pattern like `refs/{build}/bt2.gz`
+        // regex-matches arbitrary concrete inputs (`refs/legacy/bt2.gz`)
+        // that no dataflow connects, and the fabricated edges can serialize
+        // unrelated rules or fabricate cycles.
+        let mut pattern_claims: HashSet<String> = HashSet::new();
 
         // Step 1: Add all rules as nodes
         for (idx, rule) in rules.iter().enumerate() {
@@ -106,7 +113,9 @@ impl WorkflowDag {
             // level, and the expand_inputs pass below matches consumer
             // patterns against the baked instance patterns.
             if let Some(ref op) = rule.output_pattern {
-                output_to_node.entry(expand(op)).or_default().push(node);
+                let claimed = expand(op);
+                pattern_claims.insert(claimed.clone());
+                output_to_node.entry(claimed).or_default().push(node);
             }
         }
 
@@ -133,8 +142,10 @@ impl WorkflowDag {
         // `variants/{sample}.g.vcf.gz` → `^variants/(?P<sample>\S+)\.g\.vcf\.gz$`).
         // Outputs referencing `{config.x}` cannot compile a valid regex group
         // name — those are skipped (None) and simply never match.
+        // Output_pattern claims stay out (see `pattern_claims`).
         let template_matchers: Vec<(String, Option<Regex>)> = producer_outputs
             .iter()
+            .filter(|(output, _)| !pattern_claims.contains(output))
             .map(|(output, _)| {
                 let matcher = if output.contains('{') {
                     crate::wildcard::pattern_to_regex(output).ok()
@@ -2277,6 +2288,23 @@ mod tests {
         assert_eq!(
             dag.producer_of("results/spades/part.txt"),
             Some("assemble_assembler_spades")
+        );
+    }
+
+    #[test]
+    fn output_pattern_claims_never_template_match_concrete_inputs() {
+        // Issue #296 review finding: a raw output_pattern registered
+        // producer-side must exact-match only. It must NOT join the
+        // template matchers — `refs/{build}/bt2.gz` regex-matches any
+        // concrete `refs/<x>/bt2.gz` input, and the fabricated edge can
+        // serialize unrelated rules or fabricate a cycle.
+        let mut producer = make_rule("index_ref", vec![], vec![]);
+        producer.output_pattern = Some("refs/{build}/bt2.gz".to_string());
+        let consumer = make_rule("align_legacy", vec!["refs/legacy/bt2.gz"], vec!["aln.bam"]);
+        let dag = WorkflowDag::from_rules(&[producer, consumer]).unwrap();
+        assert!(
+            dag.dependencies("align_legacy").unwrap().is_empty(),
+            "a pattern claim must not claim a concrete input it does not produce"
         );
     }
 

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -100,6 +100,14 @@ impl WorkflowDag {
             for output in &rule.output {
                 output_to_node.entry(expand(output)).or_default().push(node);
             }
+            // Issue #296: an output_pattern is a producer-side declaration
+            // too. Registering it lets pattern-only producers (no `output`
+            // entries) link their consumers: exact matches at template
+            // level, and the expand_inputs pass below matches consumer
+            // patterns against the baked instance patterns.
+            if let Some(ref op) = rule.output_pattern {
+                output_to_node.entry(expand(op)).or_default().push(node);
+            }
         }
 
         // Step 2: Add edges based on input/output matching.
@@ -2222,6 +2230,54 @@ mod tests {
         });
         let dag = WorkflowDag::from_rules(&[producer, consumer]).unwrap();
         assert_eq!(dag.dependencies("multiqc").unwrap(), vec!["fastqc_raw"]);
+    }
+
+    #[test]
+    fn output_pattern_registers_producer_side_for_template_matching() {
+        // Issue #296: the output_pattern itself is a producer-side
+        // declaration. A consumer's raw expand_inputs pattern carrying the
+        // same wildcard literals exact-matches it — this is the edge the
+        // template-level graph (the catalog's source) must show for
+        // pattern-only producers.
+        let mut producer = make_rule("assemble", vec![], vec![]);
+        producer.output_pattern = Some("results/{assembler}/part.txt".to_string());
+        let mut consumer = make_rule("summarize", vec![], vec!["results/summary.txt"]);
+        consumer.expand_inputs.push(crate::rule::ExpandConfig {
+            pattern: "results/{assembler}/part.txt".to_string(),
+            variables: HashMap::new(),
+        });
+        let dag = WorkflowDag::from_rules(&[producer, consumer]).unwrap();
+        assert_eq!(dag.dependencies("summarize").unwrap(), vec!["assemble"]);
+    }
+
+    #[test]
+    fn expand_inputs_consumer_matches_baked_output_pattern_precisely() {
+        // Issue #296: a [[values]]-fanned output_pattern producer bakes its
+        // pattern per instance, and the expansion pass materializes a
+        // values consumer's expand_inputs pattern into ITS OWN concrete
+        // paths (the spades instance never sees megahit files). The baked
+        // producer pattern must be registered producer-side so the
+        // concrete consumer input exact-matches it — and only it: the
+        // per-value edge precision pinned by #268 item 1 holds.
+        let mut p1 = make_rule("assemble_assembler_spades", vec![], vec![]);
+        p1.output_pattern = Some("results/spades/part.txt".to_string());
+        let mut p2 = make_rule("assemble_assembler_megahit", vec![], vec![]);
+        p2.output_pattern = Some("results/megahit/part.txt".to_string());
+        let consumer = make_rule(
+            "summarize_assembler_spades",
+            vec!["results/spades/part.txt"],
+            vec!["results/summary_spades.txt"],
+        );
+        let dag = WorkflowDag::from_rules(&[p1, p2, consumer]).unwrap();
+        assert_eq!(
+            dag.dependencies("summarize_assembler_spades").unwrap(),
+            vec!["assemble_assembler_spades"]
+        );
+        // producer_of attributes the produced file to its pattern owner.
+        assert_eq!(
+            dag.producer_of("results/spades/part.txt"),
+            Some("assemble_assembler_spades")
+        );
     }
 
     #[test]

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -1543,7 +1543,19 @@ shell = "{assembler} -o {output} {input}"
 ```
 
 - Every rule referencing `{assembler}` (bare form) or `{values.assembler}`
-  (namespaced form) expands into one instance per value.
+  (namespaced form) expands into one instance per value. The reference may
+  live in any trigger field — inputs, outputs, shell, `when`,
+  `expand_inputs` patterns, **or the rule's `output_pattern`** (issue
+  #296): a pattern-only reference fans the producer out per value with the
+  pattern baked per instance, exactly as it already does for
+  `{sample}`/pair wildcards.
+
+  ```toml
+  [[rules]]
+  name = "assemble"
+  output_pattern = "results/{assembler}/chunks.txt"   # fans out per value
+  shell = "scripts/build_all.sh"
+  ```
 - `values_from = "config.x"` resolves the value list from a config key at
   expansion time — a comma string (`"u1,u2"`) or array, the same semantics
   as `expand_inputs` config references. CLI `--arg x=u1,u2` or a profile
@@ -2511,6 +2523,16 @@ Semantics:
 - `{config.x}` in the pattern resolves from the workflow config before the
   scan; discovered files are literals, so exact-match edge inference works
   as usual.
+- A `[[values]]` wildcard in the pattern is **not** fresh — it is a
+  plan-time bound dimension (issue #296). The producer fans out per value
+  with the pattern baked per instance, the pattern is registered
+  producer-side in the DAG (so a per-value consumer's materialized input
+  exact-matches its own producer instance), and a pattern whose wildcards
+  are all bound this way skips the runtime scan entirely — the static
+  instances already are the domain. Mixed patterns
+  (`results/{assembler}/{chunk}.txt`) compose: the values dimension bakes
+  per instance while the fresh wildcard stays runtime-discovered, and the
+  deferred consumers instantiate over the union with both bindings.
 - Plan time: a consumer referencing a fresh wildcard has an empty domain and
   instantiates **nothing**; it is deferred whole (its own
   `[[values]]`/`[[pairs]]`/sample fan-out is baked from the producer's

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -583,7 +583,7 @@ memory = "32G"
 | `name` | String | **Yes** | Unique rule identifier |
 | `input` | Array of strings | **Yes** | Input file paths |
 | `output` | Array of strings | **Yes** | Output file paths |
-| `output_pattern` | String | No | Runtime-discovered output pattern: outputs enumerated by a filesystem scan after the rule completes; downstream consumers of its wildcard instantiate per discovered value. Mutually exclusive with `output`/`transform`/`input_groups` — see [Runtime-Discovered Outputs](#runtime-discovered-outputs-output_pattern) |
+| `output_pattern` | String | No | Runtime-discovered output pattern: outputs enumerated by a filesystem scan after the rule completes; downstream consumers of its wildcard instantiate per discovered value. A `[[values]]` wildcard in the pattern is a plan-time fan-out trigger instead (issue #296). Mutually exclusive with `output`/`transform`/`input_groups` — see [Runtime-Discovered Outputs](#runtime-discovered-outputs-output_pattern) |
 | `shell` | String | No | Shell command to execute |
 | `script` | String | No | Script file path (auto-detects interpreter) |
 | `description` | String | No | Human-readable description of what this rule does |

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -2537,10 +2537,13 @@ Semantics:
   instantiates **nothing**; it is deferred whole. Wildcards shared with the
   producer's pattern ride the discovered bindings; `[[values]]` tables the
   consumer references on its own project as an extra Cartesian dimension at
-  instantiation (issue #296 follow-up). A consumer declared **before** its
-  producer is legal but warned. Referencing two producers' fresh wildcards
-  in one rule is a v1 error; a chain — a rule that is both consumer and
-  producer of fresh wildcards — is supported.
+  instantiation, under the same plan-time semantics as a static fan-out —
+  `wildcard_constraints` filtered and per-instance `when` gates evaluated,
+  so gated-off combos never become instances (issue #296 follow-up). A
+  consumer declared **before** its producer is legal but warned.
+  Referencing two producers' fresh wildcards in one rule is a v1 error; a
+  chain — a rule that is both consumer and producer of fresh wildcards —
+  is supported.
 - Runtime: when a producer **instance** completes, the engine scans its
   pattern and unions the discovered values into the producer template's
   domain. When **all** of the producer's instances have completed, the
@@ -2551,12 +2554,13 @@ Semantics:
   forward-safety comes from completion ordering, not DAG topology, exactly
   like checkpoint re-entry.
 - Interaction with `resume`: the discovered domains are persisted
-  (persist-first, before fan-out). A resume replays the **partial**
-  persisted domain to instantiate consumers for the producer instances
-  that already succeeded; when a failed instance is retried and succeeds,
-  the fan-out is idempotent and only the new values extend the consumer
-  set — partial progress across a resume is preserved, and the final
-  consumer set equals the union of all per-instance discoveries.
+  (persist-first, before fan-out). A resume replays the persisted domain
+  and instantiates the deferred consumers only when **every** producer
+  instance is already completed; when a failed instance still has to
+  re-run, its consumers stay pending and the live runtime pass
+  instantiates them from the final domain union — the final consumer set
+  equals the union of all per-instance discoveries, never a partial
+  slice.
 - Zero discoveries after producer success is **loud**: a warning is emitted
   and the consumers stay uninstantiated (a later producer instance may
   still contribute). A producer **failure** leaves the consumers

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -2534,19 +2534,22 @@ Semantics:
   per instance while the fresh wildcard stays runtime-discovered, and the
   deferred consumers instantiate over the union with both bindings.
 - Plan time: a consumer referencing a fresh wildcard has an empty domain and
-  instantiates **nothing**; it is deferred whole (its own
-  `[[values]]`/`[[pairs]]`/sample fan-out is baked from the producer's
-  discovered bindings). A consumer declared **before** its producer is
-  legal but warned. Referencing two producers' fresh wildcards in one rule
-  is a v1 error; a chain — a rule that is both consumer and producer of
-  fresh wildcards — is supported.
+  instantiates **nothing**; it is deferred whole. Wildcards shared with the
+  producer's pattern ride the discovered bindings; `[[values]]` tables the
+  consumer references on its own project as an extra Cartesian dimension at
+  instantiation (issue #296 follow-up). A consumer declared **before** its
+  producer is legal but warned. Referencing two producers' fresh wildcards
+  in one rule is a v1 error; a chain — a rule that is both consumer and
+  producer of fresh wildcards — is supported.
 - Runtime: when a producer **instance** completes, the engine scans its
   pattern and unions the discovered values into the producer template's
   domain. When **all** of the producer's instances have completed, the
-  deferred consumers are instantiated (one instance per domain value,
-  deterministically named `consumer_<values>`), and the new instances are
-  inserted forward into the remaining plan — forward-safety comes from
-  completion ordering, not DAG topology, exactly like checkpoint re-entry.
+  deferred consumers are instantiated (one instance per domain value × own
+  values binding, deterministically named `consumer_<own values>_<values>`,
+  with `expand_inputs` patterns materialized into concrete inputs), and the
+  new instances are inserted forward into the remaining plan —
+  forward-safety comes from completion ordering, not DAG topology, exactly
+  like checkpoint re-entry.
 - Interaction with `resume`: the discovered domains are persisted
   (persist-first, before fan-out). A resume replays the **partial**
   persisted domain to instantiate consumers for the producer instances


### PR DESCRIPTION
## Problem

`[[values]]` fan-out scanned `expand_texts` (inputs/outputs/shell/`when` + `expand_inputs` patterns) while the pair/group triggers scan `trigger_text` which **also includes `output_pattern`**. A producer referencing a values table **only** in its `output_pattern` therefore:

1. stayed a **single instance** with the literal `{assembler}` token baked into its pattern;
2. left its per-value consumers with **no DAG edge** — empirically the execution order ran `summarize_*` **before** `assemble`;
3. hit the runtime discovery pass on a literal-brace pattern that can never match, emitting a spurious warning.

## Core design (019da24)

**Why the naive fix is wrong:** adding `output_pattern` to the shared `expand_texts` would make every fresh-wildcard producer defer on its OWN fresh wildcard. The fix scopes the trigger set: `value_trigger_texts = expand_texts + output_pattern` feeds only the `active_value_tables` scan; the consumer-deferral scan keeps `expand_texts`.

- **expand.rs**: `active_value_tables_for_rule` (owned clones) + `cartesian_value_combos` extraction.
- **dag.rs**: `output_pattern` registered producer-side in `output_to_node` → exact, per-value edges from materialized consumer inputs (the #268 precision is preserved; a regex reverse-matching pass was tried and rejected).
- **run.rs**: `output_pattern_needs_discovery` — a fully-bound baked pattern skips discovery and the spurious warning.

## Deferred consumers keep their own values dimension (d2c0dcb, 22f1e4a, da066a7)

A fresh-wildcard consumer is deferred whole at plan time, so its own `[[values]]` dimension never materialized and its `expand_inputs` patterns never resolved. Runtime instantiation now:

- projects the consumer's independent values tables as an extra Cartesian axis (`consumer_<own values>_<values>` naming, `expansion_values` carrying the FULL binding set, merged-combo `when` baking);
- materializes `expand_inputs` via a helper shared with the plan-time post-loop;
- **plan-time parity** (review round 2): `wildcard_constraints` filter the projected combos and per-instance `when` gates are **evaluated** at instantiation — gated-off combos never become phantom plan nodes;
- per-combo projection: a table covered by only some producer instances still projects for the uncovered slice (the old union-level filter silently dropped it).

## Review-hardened correctness (da066a7)

The second review wave confirmed six correctness findings; all verified and fixed:

- **constraint parity** — deferred no longer bypasses `wildcard_constraints`;
- **declared-variables precedence** — a declared `variables = { part = "config.all_parts" }` cohort gather survives runtime instantiation (the binding pre-bake was removed in favor of recording full bindings before materialization);
- **when parity** — gated-off combos are dropped at instantiation, not materialized as phantom nodes;
- **scatter-fed patterns** — a fully-bound pattern whose binding came from scatter contributes the instance's own bindings as the domain instead of starving its consumers;
- **dotted tokens** — any residual brace (including `{values.x}`) keeps discovery or its warning loud;
- **no fabricated DAG edges** — output_pattern claims are excluded from the template matchers (a raw pattern could regex-claim unrelated concrete inputs, fabricating serialization or cycles);
- **resume union** — the checkpoint replay instantiates deferred consumers only when every producer instance is completed; otherwise they stay pending for the live pass, so the final consumer set is the union of all slices (a partial replay used to drain the pending set and silently drop later slices).

## Test plan

- [x] `make ci` green locally on every pushed commit (fmt, clippy -D warnings, build, workspace tests, schema-drift, audit, frontend lint)
- [x] New fixtures verified RED before each fix; 1370 tests total
- [x] Pre-existing semantics preserved (#268 precision, #227 deferral, checkpoint replay)
- [x] CI green on earlier waves

Closes #296