### PR TITLE
docs: comprehensive accuracy audit of docs/guide against source and live CLI

### DIFF
--- a/docs/guide/src/commands/license.md
+++ b/docs/guide/src/commands/license.md
@@ -45,14 +45,10 @@ oxo-flow license /path/to/license.key
 
 | Option | Description |
 |--------|-------------|
+| `--json` | Output machine-readable JSON to stdout (human-readable logs stay on stderr) |
 | `-v, --verbose` | Enable verbose (debug-level) logging |
 | `--quiet` | Suppress non-essential output (errors only) |
 | `--no-color` | Disable colored output |
-
-!!! note "No `--json` output"
-
-    `license` always prints human-readable text; the global `--json` flag
-    is not honored here.
 
 ## Notes
 

--- a/docs/guide/src/commands/publish.md
+++ b/docs/guide/src/commands/publish.md
@@ -78,7 +78,7 @@ The `manifest.json` inside each bundle:
 {
   "format": "oxoflow-bundle-v1",
   "workflow": "my_pipeline.oxoflow",
-  "oxo_flow_version": "0.10.2",
+  "oxo_flow_version": "0.17.0",
   "created_at_epoch": 1234567890,
   "entrypoint": "my_pipeline.oxoflow",
   "files": [

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -33,7 +33,7 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--target` | `-t` | All rules | Run only specific target rules |
 | `--module` | — | — | Run one include module and the producers of its declared inputs (repeatable; unions with `--target`). Module names are the include's `name` field or its file stem (see [Partial module runs](#partial-module-runs-module)) |
 | `--retry` | `-r` | `0` | Number of times to retry failed jobs |
-| `--timeout` | — | `0` (disabled) | Timeout per job in seconds |
+| `--timeout` | — | `0` (disabled) | Timeout per job in seconds, or a duration like `1h`/`30m` |
 | `--max-threads` | — | `0` (auto-detect) | Maximum CPU threads available for execution |
 | `--max-memory` | — | `0` (auto-detect) | Maximum memory in MB available for execution |
 | `--skip-env-setup` | — | — | Skip environment setup (assume environments are ready) |
@@ -41,14 +41,14 @@ oxo-flow run [OPTIONS] [WORKFLOW] [KEY=VALUE]...
 | `--cache-dir` | — | — | Directory for caching environment setup state (entries untouched for 90 days are cleaned up after each run; override with the `cache_max_age_days` config key, `0` disables aging) |
 | `--resume-failed` | — | — | Resume only failed rules from a previous run |
 | `--profile` | — | — | Execution profile name, loaded from `profiles/<NAME>.toml` or `profiles/<NAME>.oxoflow` (see [Execution profiles](#execution-profiles)) |
-| `--max-submitted` | — | `N` | Cluster jobs in flight at once (overrides the profile's `max_submitted`) |
+| `--max-submitted` | — | profile default (`50`) | Cluster jobs in flight at once (overrides the profile's `max_submitted`) |
 | `--provenance` | — | — | Track output file checksums for later verification |
 | `--arg` | — | — | Legacy form: set a workflow config value (`KEY=VALUE`). Repeatable. See `[config]` in workflow-format |
 | `--bundle` | — | — | Execute from a published bundle (`.tar.zst` or `.tar.gz`). Extracts, verifies checksums, shows resource requirements, and prompts for confirmation |
 | `--yes` | — | — | Skip the confirmation prompt when running a bundle (required in non-interactive sessions: CI, scripts, redirected input, or `--json`) |
 | `--ai-recover` | — | — | Enable AI error recovery on rule failure |
 | `--ai-max-retries` | — | — | Maximum AI retries (overrides `[ai]` config) |
-| `--samples` | — | `LIST` | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
+| `--samples` | — | all discovered samples | Sample selection: `@path` **replaces** the workflow's samples from a samplesheet, `+@path` **appends** (same-name groups merge, new groups added); names **filter** (or **declare** when the workflow ships no samples), `first:N` (pilot) and `ready` (samples whose entry inputs are complete) **filter**. Repeatable, comma-separated |
 | `--rerun` | — | — | Force re-execution of this run's rules (ignore up-to-date checks). Checkpoint records for rules outside this run are kept |
 | `--no-report-snapshot` | — | — | Skip the automatic report snapshot written after the run (see [Report snapshots](#report-snapshots)); `resume` has the same flag |
 | `--background` | — | — | Detach the run into a background process and exit 0 immediately (see [Background runs (--background)](#background-runs-background)) |
@@ -162,7 +162,8 @@ that cannot produce output.
 ### Set a per-job timeout
 
 ```bash
-oxo-flow run pipeline.oxoflow --timeout 3600
+# 3600 seconds, or equivalently:
+oxo-flow run pipeline.oxoflow --timeout 1h
 ```
 
 ### Limit resource usage

--- a/docs/guide/src/development/contributing.md
+++ b/docs/guide/src/development/contributing.md
@@ -8,7 +8,7 @@ Thank you for considering contributing to oxo-flow! This guide covers everything
 
 ### Prerequisites
 
-- **Rust 1.85+** (edition 2024) — [rustup.rs](https://rustup.rs)
+- **Rust 1.98+** (edition 2024, `rust-version = "1.98.0"`) — [rustup.rs](https://rustup.rs)
 - **Git 2.x+**
 - **MkDocs 1.5+** (optional, for docs) — `pip install mkdocs-material`
 
@@ -53,7 +53,8 @@ the window before adding retries.
 
 ```bash
 make ci
-# Runs: cargo fmt --check, cargo clippy -D warnings, cargo build, cargo test
+# Runs: cargo fmt --check, cargo clippy --workspace --all-targets -D warnings,
+#       cargo build, cargo test, schema-drift, cargo audit, frontend-lint
 ```
 
 ---
@@ -80,7 +81,7 @@ oxo-flow/
 | Convention | Rule |
 |---|---|
 | **Formatting** | `cargo fmt` — enforced in CI |
-| **Linting** | `cargo clippy -- -D warnings` — all warnings are errors |
+| **Linting** | `cargo clippy --workspace --all-targets -- -D warnings` — all warnings are errors |
 | **Error handling** | `thiserror` for library errors, `anyhow` for binary errors |
 | **Naming** | `snake_case` for functions, `PascalCase` for types |
 | **Async** | `tokio` for async runtime |
@@ -108,12 +109,15 @@ git checkout -b feat/my-feature
 make ci
 ```
 
-All four checks must pass:
+All seven checks must pass:
 
 - [x] `cargo fmt -- --check`
-- [x] `cargo clippy --workspace -- -D warnings`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
 - [x] `cargo build --workspace`
 - [x] `cargo test --workspace`
+- [x] `schema-drift` (OpenAPI spec matches code)
+- [x] `cargo audit`
+- [x] `frontend-lint`
 
 ### 4. Commit with Conventional Commits
 
@@ -161,8 +165,8 @@ chore: update dependencies
 |---|---|
 | Unit tests | `#[cfg(test)]` modules within source files |
 | Integration tests | `tests/` directory at workspace root |
-| Web API tests | `crates/oxo-flow-web/src/lib.rs` |
-| CLI tests | `crates/oxo-flow-cli/src/main.rs` |
+| Web API tests | `crates/oxo-flow-web/tests/` (plus unit tests in `src/`) |
+| CLI tests | `crates/oxo-flow-cli/tests/` (plus unit tests in `src/`) |
 
 Run all tests:
 

--- a/docs/guide/src/gallery/hello-world.md
+++ b/docs/guide/src/gallery/hello-world.md
@@ -52,7 +52,7 @@ All built-in placeholders (`{input}`, `{output}`, `{threads}`, `{memory}`, `{con
 
 ```bash
 $ oxo-flow validate examples/gallery/01_hello_world.oxoflow
-✓ examples/gallery/01_hello_world.oxoflow — 1 rules, 0 dependencies
+✓ examples/gallery/01_hello_world.oxoflow — 1 rule, 0 dependencies
 ```
 
 ### Dry-Run

--- a/docs/guide/src/gallery/index.md
+++ b/docs/guide/src/gallery/index.md
@@ -80,7 +80,7 @@ Every workflow in this gallery is validated as part of oxo-flow's continuous int
 
 ```
 $ oxo-flow validate examples/gallery/01_hello_world.oxoflow
-✓ examples/gallery/01_hello_world.oxoflow — 1 rules, 0 dependencies
+✓ examples/gallery/01_hello_world.oxoflow — 1 rule, 0 dependencies
 
 $ oxo-flow validate examples/gallery/08_multiomics_integration.oxoflow
 ✓ examples/gallery/08_multiomics_integration.oxoflow — 8 rules, 7 dependencies

--- a/docs/guide/src/gallery/multiomics.md
+++ b/docs/guide/src/gallery/multiomics.md
@@ -90,7 +90,7 @@ $ oxo-flow validate examples/gallery/08_multiomics_integration.oxoflow
 
 ### Run
 
-Samples come from the `[[sample_groups]]` block in the workflow file (edit the list to match your data, or pass `--sample` on the CLI). Each sample needs all three input pairs on disk under `wgs/`, `rnaseq/`, and `methyl/`:
+Samples come from the `[[sample_groups]]` block in the workflow file (edit the list to match your data, or pass `--samples` on the CLI). Each sample needs all three input pairs on disk under `wgs/`, `rnaseq/`, and `methyl/`:
 
 ```bash
 oxo-flow run examples/gallery/08_multiomics_integration.oxoflow -j 2
@@ -102,7 +102,7 @@ oxo-flow run examples/gallery/08_multiomics_integration.oxoflow -j 2
 
 | Rule | Threads | Memory | Environment | Branch |
 |------|---------|--------|-------------|--------|
-| wgs_align | 16 | 32G | docker | WGS |
+| wgs_align | 16 | 32G | conda | WGS |
 | wgs_call_variants | 8 | 16G | singularity | WGS |
 | rnaseq_align | 16 | 32G | conda | RNA-seq |
 | rnaseq_quantify | 4 | 8G | conda | RNA-seq |

--- a/docs/guide/src/gallery/parallel-samples.md
+++ b/docs/guide/src/gallery/parallel-samples.md
@@ -53,7 +53,7 @@ This example writes the fan-in inputs out explicitly to keep it minimal. In real
 
 ```bash
 $ oxo-flow validate examples/gallery/03_parallel_samples.oxoflow
-✓ examples/gallery/03_parallel_samples.oxoflow — 3 rules, 1 dependency
+✓ examples/gallery/03_parallel_samples.oxoflow — 3 rules, 2 dependencies
 ```
 
 ### DAG Structure

--- a/docs/guide/src/gallery/rnaseq.md
+++ b/docs/guide/src/gallery/rnaseq.md
@@ -59,7 +59,7 @@ The `samples = "samples.csv"` key in `[config]` is inert: no rule references it,
 
 ```bash
 $ oxo-flow validate examples/gallery/06_rnaseq_quantification.oxoflow
-✓ examples/gallery/06_rnaseq_quantification.oxoflow — 5 rules, 6 dependencies
+✓ examples/gallery/06_rnaseq_quantification.oxoflow — 5 rules, 5 dependencies
 ```
 
 ### Resource Summary

--- a/docs/guide/src/gallery/single-cell-rnaseq.md
+++ b/docs/guide/src/gallery/single-cell-rnaseq.md
@@ -42,7 +42,7 @@ Traditional "bulk" RNA-seq measures the average expression across thousands of c
 - **Regulatory Networks** — Infer gene regulatory relationships from co-expression across cells
 
 !!! note "Auxiliary files"
-    This workflow expects a few user-provided files next to the `.oxoflow` definition: `scripts/seurat_analysis.R` (QC, normalization, clustering, UMAP), `templates/sc_report.Rmd` (the report template), and the Conda environment files under `envs/`. They are omitted from the gallery to keep the example focused on the workflow structure.
+    This workflow references a few helper files that ship with the gallery: `scripts/seurat_analysis.R` (QC, normalization, clustering, UMAP), `templates/sc_report.Rmd` (the report template), and the Conda environment files under `envs/`. Browse them in [examples/gallery/](https://github.com/Traitome/oxo-flow/tree/main/examples/gallery) alongside the `.oxoflow` definition.
 
 ### Computational Challenges
 
@@ -58,12 +58,12 @@ scRNA-seq workflows are significantly more resource-intensive than bulk RNA-seq:
 
 ```bash
 $ oxo-flow validate examples/gallery/09_single_cell_rnaseq.oxoflow
-✓ examples/gallery/09_single_cell_rnaseq.oxoflow — 3 rules, 3 dependencies
+✓ examples/gallery/09_single_cell_rnaseq.oxoflow — 3 rules, 2 dependencies
 ```
 
 ### Run
 
-Samples come from the `[[sample_groups]]` block in the workflow file (edit the list to match your data, or pass `--sample` on the CLI). CellRanger expects standard 10x demultiplexed FASTQs under `raw/`, named `{sample}_S1_L001_R1_001.fastq.gz` / `..._R2_001.fastq.gz`; `--sample={sample}` selects the matching files:
+Samples come from the `[[sample_groups]]` block in the workflow file (edit the list to match your data, or pass `--samples` on the CLI). CellRanger expects standard 10x demultiplexed FASTQs under `raw/`, named `{sample}_S1_L001_R1_001.fastq.gz` / `..._R2_001.fastq.gz`; `--sample={sample}` in the CellRanger command selects the matching files:
 
 ```bash
 oxo-flow run examples/gallery/09_single_cell_rnaseq.oxoflow -j 2

--- a/docs/guide/src/gallery/wgs-germline.md
+++ b/docs/guide/src/gallery/wgs-germline.md
@@ -7,7 +7,7 @@ A complete whole-genome sequencing (WGS) germline variant calling pipeline follo
     - Twelve-rule cohort DAG with a branching VQSR path
     - Cohort joint genotyping with CombineGVCFs
     - Per-sample rule expansion and `expand_inputs` fan-in
-    - Mixed environments (conda, docker, singularity)
+    - Mixed environments (conda, singularity)
     - Clinical-grade variant annotation with VEP
     - Report configuration with provenance tracking
 
@@ -31,9 +31,10 @@ graph TD
 
 Edges are shown as realized after per-sample expansion (for example,
 `haplotype_caller` → `combine_gvcfs` exists because `expand_inputs`
-resolves the three per-sample GVCFs). In the unexpanded template DAG
-(`oxo-flow graph`), `combine_gvcfs` is a root rule — its inputs arrive
-via `expand_inputs`, not file-path inference. See
+resolves the three per-sample GVCFs). Note that the unexpanded template
+DAG (`oxo-flow graph`) already contains an edge from `combine_gvcfs` to
+`haplotype_caller` — `expand_inputs` patterns register template-level
+dataflow even before per-sample paths materialize. See
 [Fan-out vs Fan-in](../reference/wildcards.md#fan-out-vs-fan-in) for
 how the two expansion mechanisms differ.
 
@@ -60,7 +61,12 @@ how the two expansion mechanisms differ.
 ```
 
 !!! note "Read Group Escape Sequences"
-    The `\\t` in the read group string (`-R '@RG\\tID:...'`) is a double-escaped tab character. TOML requires `\\` to represent a literal backslash, so the shell receives `\t`; inside single quotes it passes the two characters through literally, and bwa-mem2 itself converts the `\t` escape to a real tab when it writes the read group header into the SAM — the delimiter it expects between read group fields.
+    The shell here builds the read group with `printf '@RG\tID:...'` —
+    note the single `\t` in the TOML source. Inside the `"""` TOML string
+    a `\t` escape becomes a real TAB character, so the shell's `printf`
+    receives an actual tab in the format string and emits it verbatim.
+    bwa-mem2 writes that read group line into the SAM header with real
+    tabs — the delimiter it expects between read group fields.
 
 ```toml
 [[rules]]
@@ -327,11 +333,26 @@ memory = "16G"
 conda = "envs/vep.yaml"
 
 [report]
-sections = ["universal", "execution-status", "failure-diagnosis", "workflow-info", "commands", "file-manifest", "environment", "provenance", "task-summary"]
-# [report].template is consumed for HTML output ("report.html" built-in or a
-# template file path); [report].format is still unsupported — `report` warns
-# when it is set (see docs/guide/src/commands/report.md)
+# template: reserved — supply a real Tera template file path to use one
+# template = "germline_report"
+format = ["html", "json"]
+sections = ["summary", "qc_metrics", "coverage", "variants", "annotations", "provenance"]
 ```
+
+!!! note "About `[report]` in this workflow"
+    The `[report]` block above is copied verbatim from the example file.
+    `[report].format` is parsed but not consumed — the `report` command
+    warns when it is set and selects the format via `--format`/`-f`
+    instead. `[report].sections` acts as a whitelist filter over the
+    engine's built-in section IDs (`universal`, `execution-status`,
+    `failure-diagnosis`, `clinical-compliance`, `workflow-info`, `commands`,
+    `rule-captions`, `file-manifest`, `environment`, `metrics`,
+    `aggregate-metrics`, `sample-matrix`, `provenance`,
+    `task-summary`, `software-versions`). Of the six free-form names here, only
+    `provenance` matches a built-in ID — so a report generated from
+    this workflow would contain just the provenance section. See
+    [the report command](../commands/report.md) for the supported
+    surface.
 
 ### Sample Expansion
 
@@ -387,7 +408,7 @@ VQSR adaptively models the variant quality profile rather than applying fixed th
 
 ```bash
 $ oxo-flow validate examples/gallery/07_wgs_germline.oxoflow
-✓ examples/gallery/07_wgs_germline.oxoflow — 12 rules, 15 dependencies
+✓ examples/gallery/07_wgs_germline.oxoflow — 12 rules, 14 dependencies
 ```
 
 ### Resource Summary
@@ -395,7 +416,7 @@ $ oxo-flow validate examples/gallery/07_wgs_germline.oxoflow
 | Rule | Threads | Memory | Environment |
 |------|---------|--------|-------------|
 | fastp_qc | 8 | 16G | conda |
-| bwa_mem2_align | 16 | 32G | docker |
+| bwa_mem2_align | 16 | 32G | conda |
 | mark_duplicates | 4 | 16G | singularity |
 | base_recalibration | 4 | 16G | singularity |
 | haplotype_caller | 4 | 16G | singularity |

--- a/docs/guide/src/how-to/collaboration.md
+++ b/docs/guide/src/how-to/collaboration.md
@@ -72,9 +72,9 @@ curl -X POST http://localhost:8080/api/pipelines/pipeline-abc/share \
 ```
 
 **Visibility levels** (`link` / `workspace`) are stored on the share record.
-Currently the share link is consumed only through the
-[import API](#import) below — there is no browser page at the share URL, and
-visibility/membership checks are not yet enforced on import.
+The share URL opens a public read-only landing page (see
+[Share Landing Pages](#share-landing-pages) below); programmatic consumption
+goes through the [import API](#import) below.
 
 ## Import
 

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -237,9 +237,10 @@ Use `oxo-flow dry-run` to preview the execution plan:
 oxo-flow dry-run my-pipeline.oxoflow
 ```
 
-Note that dry-run does **not** evaluate `when` conditions — all rules appear in
-the plan. `when` is evaluated at execution time: rules whose condition is false
-are skipped and reported as `Skipped` in the run output.
+Note that dry-run **does** evaluate `when` conditions: rules whose condition
+is false appear in the plan marked `[skip: when condition false]`, and the
+summary counts them under `will skip`. At execution time the same rules are
+skipped and reported as `Skipped` in the run output.
 
 ## Full Example
 

--- a/docs/guide/src/how-to/deploy-modes.md
+++ b/docs/guide/src/how-to/deploy-modes.md
@@ -193,7 +193,7 @@ and detects the scheduler (`slurm`/`pbs`/`lsf`/`sge`) with its version.
 Unknown fields in the config file are rejected loudly, not silently
 ignored.
 
-## Multi-Tenancy (v0.11 hardening)
+## Multi-Tenancy
 
 Team/HPC modes scope every resource to the acting user:
 

--- a/docs/guide/src/how-to/desktop-app.md
+++ b/docs/guide/src/how-to/desktop-app.md
@@ -278,7 +278,7 @@ checkout is needed).
 ## Notes
 
 - **Version**: the desktop crate repeats the workspace version
-  (`0.16.0`) by value — it is outside the workspace, so it does not
+  (`0.17.0`) by value — it is outside the workspace, so it does not
   inherit `[workspace.package]`; bump it together with the rest on
   release.
 - **Data directory**: the desktop app keeps all state in

--- a/docs/guide/src/how-to/use-environments.md
+++ b/docs/guide/src/how-to/use-environments.md
@@ -131,18 +131,18 @@ fastp = "0.23.4"
 
 ### Reference in a rule
 
-The `pixi` value is the pixi **environment name** (the default environment
-in `pixi.toml` is named `default`), not a file path:
+The `pixi` value is the path to the **manifest file** (`pixi.toml`),
+relative to the workflow root:
 
 ```toml
 [[rules]]
 name = "fastqc"
-environment = { pixi = "default" }
+environment = { pixi = "pixi.toml" }
 shell = "fastqc input.fastq.gz -o qc/"
 ```
 
-oxo-flow runs `pixi install -e default` once, then wraps the command as
-`pixi run -e default <command>`.
+oxo-flow runs `pixi install --manifest-path pixi.toml` once, then wraps the
+command as `pixi run --manifest-path pixi.toml <command>`.
 
 ---
 

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -213,7 +213,7 @@ explicit disable:
       "suggestion": "stop the pilot before VQSR (-t <rule>) or use hard filtering..."
     }
   ],
-  "provenance": {"model": "deepseek-v4-pro", "bio_skills": 562, "pipeline_graph_nodes": 79}
+  "provenance": {"model": "deepseek-v4-pro", "bio_skills": 562, "pipeline_graph_nodes": 78}
 }
 ```
 
@@ -289,9 +289,9 @@ model = "deepseek-v4-flash"
 The AI agent combines four embedded knowledge sources (all compiled into the binary at build time):
 
 1. **Tool Reference Table**: 40 curated bioinformatics tools with resource allocations (threads, memory)
-2. **Bioconda Tool Database**: 6,103 curated CLI tools with current versions and descriptions (filtered from 6,470 raw registry entries; see `knowledge_meta.json`) — queried on demand via `lookup_tool`
+2. **Bioconda Tool Database**: 6,487 curated CLI tools with current versions and descriptions (filtered from 12,679 raw registry entries; see `knowledge_meta.json`) — queried on demand via `lookup_tool`
 3. **bioSkills Library**: 562 curated Agent Skills (the emerging SKILL.md standard) with domain procedures, commands, and caveats — matched by assay type and injected into generation prompts, or queried via `lookup_skill`
-4. **Pipeline Knowledge Graph**: 79 workflow skills and 469 literature-backed data-flow transitions (BAM → VCF → annotated VCF chains) — queried via `lookup_pipeline` to design correct multi-step topologies
+4. **Pipeline Knowledge Graph**: 78 workflow skills and 465 literature-backed data-flow transitions (BAM → VCF → annotated VCF chains) — queried via `lookup_pipeline` to design correct multi-step topologies
 
 Token efficiency: embedded data is **never added to the LLM context wholesale**. Only on-demand tool queries (~1 KB per result) and domain-matched skill summaries (≤3 per domain) are injected — the rest stays in the binary until needed.
 
@@ -447,16 +447,17 @@ whether it is auto-updated or manually curated:
 
 ```json
 {
-  "sources": [
-    {
-      "name": "bioconda_tools",
-      "description": "Bioconda CLI tool database",
+  "sources": {
+    "bioconda_tools": {
+      "count": 6487,
+      "url": "https://conda.anaconda.org/bioconda/channeldata.json",
+      "excluded": 6192,
       "data_file": "bioconda_tools.jsonl",
-      "count": 6132,
-      "generated_at": "2026-08-22T10:54:00Z",
+      "generated_at": "2026-09-01T08:23:27Z",
       "auto": true
     }
-  ]
+  },
+  "generated_at": "2026-09-01T08:23:27Z"
 }
 ```
 

--- a/docs/guide/src/reference/ai-translation.md
+++ b/docs/guide/src/reference/ai-translation.md
@@ -63,7 +63,7 @@ Suggest parameter optimizations for speed, cost, or sensitivity.
 
 ```
 Input:  { pipeline_id, goal: "speed"|"cost"|"sensitivity" }
-Output: { optimized_toml, changes, estimated_impact }
+Output: { optimized_toml, changes, estimated: { time_saved, memory_reduction } }
 ```
 
 ## Provider Architecture
@@ -120,8 +120,8 @@ These functions look like AI but are 100% rule-based and deterministic:
 
 | Function | Method | Why Not AI |
 |----------|--------|-----------|
-| File format detection | Magic bytes + extension | 100% accurate |
-| Reference genome discovery | Path traversal + checksum | Deterministic |
+| File format detection | Extension matching (+ paired-end naming) | Deterministic |
+| Reference genome discovery | File existence in fixed search dirs | Deterministic |
 | Pipeline template matching | Keyword scoring | Reproducible |
 | Failure classification | Error patterns + exit codes | Rule-based |
 | DAG optimization | Topological sort + critical path | Math problem |

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -103,7 +103,7 @@ compiled, licensed, and audited in isolation.
 |---|---|---|---|
 | `oxo-flow-core` | library | — | The engine: workflow model, expansion, DAG, execution, checkpointing, environments, storage, reporting |
 | `oxo-flow-ai` | library | — | AI companion: provider abstraction, agent orchestrator, embedded knowledge bases, tool/skill system |
-| `oxo-flow-web` | library | core, ai | REST/WebSocket server: 10 domains, storage backends, SSE broadcast, OpenAPI |
+| `oxo-flow-web` | library | core, ai | REST/WebSocket server: 9 domains, storage backends, SSE broadcast, OpenAPI |
 | `oxo-flow-cli` | binary | core, ai, web | User-facing `oxo-flow` binary: 30 subcommands, run loop, human rendering |
 
 ```mermaid
@@ -462,7 +462,7 @@ subsequent runs skip straight to wrapping.
 
 ## Web Platform
 
-The web crate is a **domain-driven modular monolith**: ten business
+The web crate is a **domain-driven modular monolith**: nine business
 domains behind one axum router, with HTTP confined to the edge of each
 domain.
 

--- a/docs/guide/src/reference/china-mirrors.md
+++ b/docs/guide/src/reference/china-mirrors.md
@@ -61,8 +61,10 @@ export OXO_REGISTRY_MIRRORS="docker.io=mirror.example.com;registry-1.docker.io=m
 ```
 
 - Semicolon-separated `host=mirror` pairs; host matching is
-  case-insensitive and port-agnostic (`localhost:5000/…` is never
-  rewritten).
+  case-insensitive and port-agnostic. A registry port is stripped before
+  matching, so `localhost:5000/…` is treated as the `localhost` namespace
+  and **is rewritten** when `localhost` itself is mapped (e.g.
+  `localhost=mirror.example.com`).
 - A first path segment without a dot or colon (`uhrigs/arriba`) is the
   docker.io *namespace* and follows the docker.io mapping, keeping its
   full path.

--- a/docs/guide/src/reference/cloud-storage.md
+++ b/docs/guide/src/reference/cloud-storage.md
@@ -17,11 +17,12 @@ shell = "cp {input[0]} {output[0]}"
 ```
 
 When the pipeline engine encounters an `s3://` or `gs://` URI, it
-detects the remote scheme and logs a warning — the executor does not
-yet stage remote files into the workdir or upload outputs back (see
-[Current Limitations](#current-limitations)). The storage module is
-usable today as a library API: callers can resolve URIs and read,
-write, stage, or upload objects programmatically through the
+detects the remote scheme and stages the file into the workdir before
+the rule runs, then uploads rule outputs with remote URIs back to the
+bucket after the rule succeeds (see
+[Remote staging and upload](#remote-staging-and-upload)). The storage module is also usable
+as a library API: callers can resolve URIs and read, write, stage, or
+upload objects programmatically through the
 [`StorageBackend`](#storage-backend-api) trait.
 
 ### Prerequisites
@@ -33,25 +34,12 @@ Enable them at build time:
 cargo build --release --features "s3-storage,gcs-storage"
 ```
 
-> The example workflows below illustrate the URI syntax only — remote
-> URIs are not yet staged or uploaded by the executor (see
-> [Current Limitations](#current-limitations)).
-
 ## AWS S3
 
-The S3 backend uses the official `aws-sdk-s3` Rust SDK with the standard
-AWS credential chain.  No additional configuration is required beyond
-what the AWS SDK normally reads.
-
-### Credential Resolution
-
-The SDK discovers credentials in this order:
-
-1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-   `AWS_SESSION_TOKEN`)
-2. `~/.aws/credentials` (standard AWS config file)
-3. Web identity tokens
-4. Instance metadata (EC2, ECS)
+The S3 backend uses the official `aws-sdk-s3` Rust SDK. Credentials are
+resolved **from environment variables only** — the SDK's broader chain
+(shared credentials files, web identity tokens, instance metadata) is not
+consulted.
 
 When using MinIO or LocalStack for testing, set `AWS_ENDPOINT_URL` to
 point to your local S3-compatible service:

--- a/docs/guide/src/reference/custom-skills.md
+++ b/docs/guide/src/reference/custom-skills.md
@@ -5,7 +5,7 @@ oxo-flow's AI layer combines three skill mechanisms:
 | Layer | Source | Status |
 |---|---|---|
 | Built-in bioSkills | 562 curated Agent Skills compiled into the binary | ✅ active (domain-matched injection, `lookup_skill`) |
-| Pipeline knowledge graph | 79 workflow skills / 469 literature-backed transitions | ✅ active (`lookup_pipeline`) |
+| Pipeline knowledge graph | 78 workflow skills / 465 literature-backed transitions | ✅ active (`lookup_pipeline`) |
 | **User-defined skills** | `.skill.toml` or `SKILL.md` files you write | ✅ knowledge skills, ✅ MCP tool skills |
 
 This page documents the user-defined layer.

--- a/docs/guide/src/reference/dag-engine.md
+++ b/docs/guide/src/reference/dag-engine.md
@@ -27,7 +27,7 @@ The DAG engine is implemented in `crates/oxo-flow-core/src/dag.rs` using the [`p
 pub struct WorkflowDag {
     graph: DiGraph<DagNode, ()>,
     name_to_node: HashMap<String, NodeIndex>,
-    output_to_node: HashMap<String, NodeIndex>,
+    output_to_node: HashMap<String, Vec<NodeIndex>>,
 }
 
 pub struct DagNode {
@@ -38,7 +38,7 @@ pub struct DagNode {
 
 - `graph` — a directed graph where nodes are `DagNode` (rule name + index) and edges are dependencies
 - `name_to_node` — maps rule names to their graph node indices for O(1) lookup
-- `output_to_node` — maps output file patterns to the rule node that produces them
+- `output_to_node` — maps output file patterns to **all** nodes producing that output (a `Vec`, since several rules may declare the same output pattern)
 
 ---
 
@@ -74,7 +74,9 @@ let order: Vec<String> = dag.execution_order()?;
 // ["fastqc", "trim_reads", "align", "multiqc"]
 ```
 
-The implementation uses Kahn's algorithm (BFS-based topological sort), which also serves as a second cycle-detection pass.
+The implementation uses petgraph's `toposort` (a DFS-based topological
+sort), which also serves as a second cycle-detection pass — a cycle is
+reported as a petgraph `Cycle` error and surfaced as `OxoFlowError::CycleDetected`.
 
 ---
 
@@ -228,7 +230,6 @@ digraph {
 | `to_dot()` | `String` | Graphviz DOT output |
 | `root_rules()` | `Vec<String>` | Entry-point rules (no upstream dependencies) |
 | `leaf_rules()` | `Vec<String>` | Terminal rules (no downstream dependents) |
-| `orphan_rules()` | `Vec<&str>` | Rules with neither inputs nor outputs connected to others |
 | `dependencies(name)` | `Vec<String>` | Direct upstream dependencies of a rule |
 | `dependents(name)` | `Vec<String>` | Direct downstream dependents of a rule |
 | `critical_path()` | `Vec<String>` | Longest chain of sequential dependencies |
@@ -300,11 +301,7 @@ Use these to understand workflow structure: root rules are your entry points (ty
 
 ### Orphan Rules
 
-```rust
-let orphans = dag.orphan_rules();  // Rules not connected to any other rule
-```
-
-Orphan rules have no dependencies and no dependents — they are isolated islands in the DAG. This is often a configuration mistake (misspelled input/output file paths) rather than intentional. Run `oxo-flow validate` to check for orphans — they will still execute but may indicate wiring errors.
+The `WorkflowDag` API has no orphan query. `oxo-flow validate` does flag orphan rules — rules whose inputs match no other rule's outputs and that look like wiring mistakes (misspelled paths) — as lint warnings; they still execute but may indicate configuration errors.
 
 ### Output Collision Detection
 
@@ -460,7 +457,7 @@ The cycle path `A → B → C → A` shows you the circular chain. To break it:
 - The DAG is immutable once built — modifications require rebuilding from rules
 - Wildcard patterns are matched literally during DAG construction; expansion happens at execution time
 - The petgraph `DiGraph` provides efficient graph traversal with O(V + E) topological sort
-- Cycle detection uses petgraph's topological sort (Kahn's algorithm); DFS is used only to reconstruct the cycle path for error messages
+- Cycle detection uses petgraph's DFS-based `toposort`; the DFS walk is also used to reconstruct the cycle path for error messages
 
 ---
 

--- a/docs/guide/src/reference/diagnostics-engine.md
+++ b/docs/guide/src/reference/diagnostics-engine.md
@@ -103,8 +103,11 @@ resource_bottlenecks: [{
 - A rule is flagged when `actual ≥ 80% × limit` — a conservative threshold
   because the peak is **sampled every 200 ms** across the rule's process
   subtree, not an exact `getrusage` maximum; sub-interval spikes can be
-  missed. Cluster-executed rules carry no measurement (`None`), and legacy
-  checkpoints degrade to an empty list.
+  missed. Cluster-executed rules carry the scheduler accounting store's
+  peak RSS when it reports one (SLURM `sacct`'s max `MaxRSS` across task
+  rows); the value is `None` only for schedulers without accounting
+  (e.g. LSF) or a missing accounting row. Legacy checkpoints degrade to
+  an empty list.
 
 ## Extending the Pattern Library
 

--- a/docs/guide/src/reference/environment-system.md
+++ b/docs/guide/src/reference/environment-system.md
@@ -156,7 +156,11 @@ or rename it, build the suffixed env, or drop `--skip-env-setup`.
 - **Detection**: Checks for `python3` on `$PATH`
 - **Resolution**: Parses `requirements.txt` file
 - **Activation**: Creates a venv (if needed) and activates it before the command
-- **Caching**: Venvs are stored in a cache directory keyed by the requirements hash
+- **Caching**: Venvs are stored in a cache directory keyed by the declared
+  venv spec (`venv:<path>` — the venv path you declared in the rule), not by
+  a hash of the requirements content. Editing `requirements.txt` in place
+  does not by itself invalidate the cache; bump the venv path or clear the
+  cache to force a rebuild.
 
 ### HPC Modules
 
@@ -202,6 +206,7 @@ pub struct EnvironmentSpec {
     pub conda_prefix: Option<String>,
     pub mamba_prefix: Option<String>,
     pub venv_requirements: Option<String>,
+    pub gpus: Option<String>,
 }
 ```
 
@@ -242,11 +247,12 @@ oxo-flow env list
 oxo-flow env check pipeline.oxoflow
 ```
 
-The `env check` command verifies:
-
-1. The backend type is available on the system
-2. The specification file exists (for conda YAML, pixi TOML, requirements.txt)
-3. The image reference is syntactically valid (for Docker/Singularity)
+The `env check` command calls the resolver's `validate_spec` for each rule's
+environment, which verifies **backend availability on the current system**
+(e.g. the conda/pixi/docker/singularity binary exists and is runnable; pixi
+additionally requires a `pixi.toml` in the current directory). It does not
+re-check spec files or image reference syntax — `validate` and `lint` cover
+declaration-level checks.
 
 ---
 

--- a/docs/guide/src/reference/execution-backends.md
+++ b/docs/guide/src/reference/execution-backends.md
@@ -27,6 +27,7 @@ checkpoint semantics.
 ## `ExecutorBackend` trait
 
 ```rust
+#[async_trait::async_trait]
 pub trait ExecutorBackend: Send + Sync {
     fn name(&self) -> &'static str;
     fn render_script(&self, rule: &ScheduledRule) -> Result<String>;
@@ -34,6 +35,19 @@ pub trait ExecutorBackend: Send + Sync {
     async fn poll(&self, job_ids: &[String]) -> Result<HashMap<String, BackendJobStatus>>;
     async fn cancel(&self, job_id: &str) -> Result<()>;
     async fn logs(&self, job_id: &str) -> Result<String>;
+
+    // Provided methods (defaults shown):
+    fn render_array_script(&self, rule: &Rule, cmd_dir: &str, count: usize)
+        -> Result<String>  // default: Err "does not support job arrays"
+        — render one ARRAY script for `count` same-rule instances whose
+          per-index commands live in `cmd_dir`; backends without array
+          support error and the driver falls back to per-job submission
+    async fn terminal_status(&self, job_id: &str) -> Option<TerminalRecord>
+        // default None — terminal record from the scheduler's accounting
+        // store; None keeps the job in flight
+    fn polls_elements_directly(&self) -> bool
+        // default false — SLURM's squeue reports array elements by their
+        // `{base}_{index}` ids (true); PBS/SGE/LSF list only the base id
 }
 ```
 

--- a/docs/guide/src/reference/license.md
+++ b/docs/guide/src/reference/license.md
@@ -69,7 +69,7 @@ The license is prominently displayed in three locations:
 
 ```
 X-OxoFlow-License: oxo-flow v0.17.0 — oxo-flow-core, oxo-flow-cli: Apache 2.0. oxo-flow-web: Dual license (LICENSE-ACADEMIC / LICENSE-COMMERCIAL). Free for academic use. Commercial use requires authorization. Contact: Shixiang Wang <w_shixiang@163.com>.
-X-OxoFlow-Version: 0.10.2
+X-OxoFlow-Version: 0.17.0
 ```
 
 ## Key Principles

--- a/docs/guide/src/reference/plugin-system.md
+++ b/docs/guide/src/reference/plugin-system.md
@@ -33,7 +33,7 @@ use oxo_flow_core::plugin::PluginRegistry;
 
 let mut registry = PluginRegistry::default();
 registry.register_rule(Box::new(MyPlugin));
-registry.add_trusted_key("key-001", "your-secret-key");
+registry.trusted_keys.insert("key-001".into(), "your-secret-key".into());
 ```
 
 ### 3. Declare in your workflow
@@ -84,7 +84,7 @@ skipped, while unsigned plugins and plugins with signatures but no
 configured trusted keys are loaded with a warning:
 
 ```rust
-registry.add_trusted_key("key-001", "shared-secret-key");
+registry.trusted_keys.insert("key-001".into(), "shared-secret-key".into());
 registry.discover(Some(project_dir))?; // invalid signatures are skipped
 ```
 
@@ -97,11 +97,19 @@ impl PluginRegistry {
     pub fn register_rule(&mut self, plugin: Box<dyn RulePlugin>);
     pub fn register_executor(&mut self, plugin: Box<dyn ExecutorPlugin>);
     pub fn register_report(&mut self, plugin: Box<dyn ReportPlugin>);
-    pub fn add_trusted_key(&mut self, key_id: &str, key: &str);
     pub fn discover(&mut self, project_dir: Option<&Path>) -> Result<usize>;
     pub fn find_rule(&self, rule_type: &str) -> Option<&dyn RulePlugin>;
     pub fn find_executor(&self, backend: &str) -> Option<&dyn ExecutorPlugin>;
     pub fn find_report(&self, renderer: &str) -> Option<&dyn ReportPlugin>;
+}
+
+// Public fields (constructed via PluginRegistry::default()):
+pub struct PluginRegistry {
+    pub rule_plugins: HashMap<String, Box<dyn RulePlugin>>,
+    pub executor_plugins: HashMap<String, Box<dyn ExecutorPlugin>>,
+    pub report_plugins: HashMap<String, Box<dyn ReportPlugin>>,
+    pub manifests: Vec<PluginManifest>,
+    pub trusted_keys: HashMap<String, String>,
 }
 ```
 
@@ -117,27 +125,13 @@ pub struct PluginsConfig {
 ```
 
 
-## Dynamic Loading (Subprocess Protocol)
+## Subprocess Output Contract
 
-oxo-flow uses a **subprocess-based plugin protocol** — the safe, portable
-alternative to shared-library loading. Plugins are standalone executables
-that communicate via JSON over stdin/stdout.
+oxo-flow avoids shared-library loading (no unsafe code). A `PluginOutput`
+struct defines the JSON shape a plugin executable may emit on stdout, so a
+manifest can eventually hand command construction to an external process —
+plugins written in any language can produce it:
 
-### Protocol
-
-**Input** (stdin, JSON):
-```json
-{
-  "rule": "my_analysis",
-  "inputs": ["raw/sample.fq"],
-  "outputs": ["results/output.txt"],
-  "command": "custom_tool --input raw/sample.fq > results/output.txt",
-  "config": {"reference": "/data/ref.fa"},
-  "params": {}
-}
-```
-
-**Output** (stdout, JSON):
 ```json
 {
   "success": true,
@@ -148,43 +142,15 @@ that communicate via JSON over stdin/stdout.
 }
 ```
 
-### Executing a plugin
-
 ```rust
-use oxo_flow_core::plugin::{execute_plugin_subprocess, PluginInput};
-
-let input = PluginInput {
-    rule: "my_rule".into(),
-    inputs: vec!["in.txt".into()],
-    outputs: vec!["out.txt".into()],
-    command: Some("custom_tool {input} > {output}".into()),
-    config: HashMap::new(),
-    params: HashMap::new(),
-};
-
-let output = execute_plugin_subprocess(
-    Path::new("/path/to/plugin"),
-    &input,
-    30, // timeout seconds
-).await?;
+use oxo_flow_core::plugin::PluginOutput;
 ```
 
-### Writing a plugin
-
-Plugins can be written in any language. A minimal Python plugin:
-
-```python
-#!/usr/bin/env python3
-import sys, json
-
-input_data = json.load(sys.stdin)
-# Transform the command
-command = input_data.get("command", "").replace("{input}", input_data["inputs"][0])
-command = command.replace("{output}", input_data["outputs"][0])
-
-output = {"success": True, "command": command, "errors": [], "logs": [], "exit_code": 0}
-json.dump(output, sys.stdout)
-```
+`success` and `command` are the fields the engine would act on; `errors`,
+`logs`, and `exit_code` carry diagnostics. Note that as of v0.17.0 this
+contract is defined but not yet wired into rule execution — declared rule
+plugins today go through `command_template` in the manifest instead, and
+there is no engine-side runner that invokes plugin executables yet.
 
 
 ## See Also

--- a/docs/guide/src/reference/reporting-system.md
+++ b/docs/guide/src/reference/reporting-system.md
@@ -30,12 +30,19 @@ The top-level report container:
 
 ```rust
 pub struct Report {
+    pub schema_version: u32,                 // = 1 (issue #83 WS3)
+    pub command: String,                     // = "report"
     pub title: String,
-    pub generated_at: DateTime<Utc>,
+    pub generated_at: Option<DateTime<Utc>>, // None under --no-timestamps;
+                                             // pinned via SOURCE_DATE_EPOCH/--ci
     pub workflow_name: String,
     pub workflow_version: String,
     pub sections: Vec<ReportSection>,
     pub metadata: HashMap<String, String>,
+    // Provenance fields (absent for template-only reports / non-git workflows):
+    pub checkpoint_path: Option<String>,
+    pub workflow_path: Option<String>,
+    pub workflow_git_sha: Option<String>,
 }
 ```
 

--- a/docs/guide/src/reference/security.md
+++ b/docs/guide/src/reference/security.md
@@ -18,7 +18,7 @@ These patterns **halt execution** — the workflow will not run:
 | Filesystem destruction | `mkfs`, `mkswap`, `dd` to `/dev/sd*` | E011 |
 | Permission escalation | `chmod 777 /`, `chmod -R 777` | E011 |
 | Block device writes | `> /dev/sd*`, `>> /dev/sd*` | E011 |
-| Remote code execution | `curl/wget \| sh/bash/sudo` | E011 |
+| Remote code execution | `curl/wget ... \| sh/bash/dash` | E011 |
 | Fork bombs | `() { :\|:& };:` patterns | E011 |
 | Data destruction | `dd if=/dev/zero/random/urandom` | E011 |
 
@@ -30,10 +30,9 @@ These emit **warnings** but allow execution (common in bioinformatics scripts):
 |---------|---------|
 | `$(command)` substitution | Command substitution detected |
 | Backtick `` `command` `` | Backtick command substitution |
-| `>/dev/` redirects | Redirect to /dev/ detected |
-| `eval` | eval usage detected |
-| `rm -rf /` (in shell) | Dangerous recursive deletion |
+| `rm -rf` | Dangerous recursive deletion |
 | `chmod 777` | Overly permissive chmod |
+| `eval` | eval usage detected |
 | `curl/wget` piped to shell or `&& bash` | Remote pipe to shell detected |
 
 ---
@@ -56,20 +55,26 @@ Interpreter paths are enforced at **run time**, when a script rule's `interprete
 
 Hardcoded credentials in workflow TOML content are detected by the `oxo-flow lint` command (`format::scan_for_secrets`), which emits S008 warnings; it does not block execution.
 
-### Detected Secret Types
+### Detected Secret Patterns
 
-| Pattern | Examples |
-|---------|----------|
-| API keys / tokens | `API_KEY=sk-<YOUR-KEY>`, `AUTH_TOKEN=<YOUR-KEY>` |
-| Passwords | `password = "hunter2"`, `pwd = "..."` |
-| Anthropic keys | `sk-ant-api03-...`, `sk-proj-...` |
-| OpenAI / DeepSeek keys | `sk-<32+ chars>` |
-| GitHub tokens | `ghp_...`, `gho_...`, `ghu_...`, `ghs_...`, `ghr_...` |
-| AWS keys | `AKIA...`, `ASIA...` |
-| Private keys (PEM) | `-----BEGIN RSA PRIVATE KEY-----` |
-| DB connection strings | `postgresql://user:pass@host/db` |
+`scan_for_secrets` does case-insensitive substring matching against exactly
+nine patterns — finding one emits an S008 warning naming it:
 
-Secret values are **redacted** in findings — only the first and last 4 characters are shown.
+| Pattern | Warning message |
+|---------|-----------------|
+| `AKIA` | Possible AWS Access Key |
+| `sk-` | Possible Stripe/OpenAI secret key |
+| `ghp_` | Possible GitHub personal access token |
+| `glpat-` | Possible GitLab personal access token |
+| `password` | Possible password in configuration |
+| `secret` | Possible secret in configuration |
+| `api_key` | Possible API key in configuration |
+| `access_token` | Possible access token in configuration |
+| `private_key` | Possible private key in configuration |
+
+The scanner matches the raw substrings above (e.g. any `sk-` prefix, not a
+length-validated key shape), so both true positives and some false positives
+survive — review the flagged lines yourself.
 
 Additionally, workflow config values declared with `sensitive = true` in a `[config]` definition are masked as `***` in logs, `--help`, and error output.
 

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -294,7 +294,7 @@ Execution flags are forwarded to the CLI executor:
 - `targets` (array of strings, optional) maps to `-t` per entry.
 - `cluster_id` (optional) names a configured SSH cluster connection: the
   workdir is staged to that host and executed there (see
-  [Cluster Connections](#cluster-connections--remote-execution)).
+  [Cluster Connections](#cluster-connections-remote-execution)).
 
 ### List Runs
 

--- a/docs/guide/src/reference/web-system-architecture.md
+++ b/docs/guide/src/reference/web-system-architecture.md
@@ -145,7 +145,7 @@ Rate limiting and SSE:
 | **dag** | `domains/dag/` | DAG-specific types and operations |
 | **observability** | `domains/observability/` | Health check, system info, runtime metrics, structured logging (3-layer), audit, SSE |
 | **infra/db** | `infra/db/` | StorageBackend trait with SQLite and PostgreSQL implementations |
-| **infra/license** | `infra/license.rs` | License notice text, banner, footer HTML, X-OxoFlow-License header middleware |
+| **infra/license** | `infra/license.rs` | License notice text, banner, X-OxoFlow-License header middleware (the web UI footer label lives in the SPA, `frontend/src/components/Layout.tsx`) |
 | **infra/sse** | `infra/sse.rs` | Real-time SSE broadcast channel for execution events |
 | **infra/hpc** | `infra/hpc.rs` | Slurm script generation, scheduler detection |
 

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -360,8 +360,10 @@ touching the source file also triggers a rebuild, and rules that consume the
 artifact through declared `input` paths (plus their downstream) are
 invalidated so their outputs are regenerated.
 
-When `reference_dir` is set, four standard indexes are auto-derived without
-explicit `[[references]]` blocks: BWA, Bowtie2, STAR, and HISAT2.
+When `reference_dir` is set, eight standard indexes are auto-derived without
+explicit `[[references]]` blocks: samtools faidx, BWA, BWA-MEM2, Bowtie2,
+minimap2, STAR, HISAT2, and the GATK sequence dictionary (see the
+[auto-derivation table](#auto-derivation-from-reference_dir) below).
 
 Use `--skip-ref-build` to skip automatic reference building.
 
@@ -504,7 +506,7 @@ sections = ["universal", "workflow-info", "commands", "clinical-compliance"]
 |---|---|---|
 | `template` | String | Report template: the built-in name `"report.html"`, or a template file path (workflow directory first, then cwd). Applies to HTML output only; a render failure warns and falls back to the default renderer |
 | `format` | Array | Parsed but **not supported yet** — setting it makes `report` warn (or fail under `--strict`); select the output format with `-f` instead |
-| `sections` | Array | Report sections to include. If empty (or omitted), all applicable generators run. Available built-in IDs: `universal`, `execution-status`, `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary`, `software-versions`, `rule-captions`, `aggregate-metrics` (run `oxo-flow report --list-sections` for the live list) |
+| `sections` | Array | Report sections to include. If empty (or omitted), all applicable generators run. Available built-in IDs: `universal`, `execution-status`, `failure-diagnosis`, `clinical-compliance`, `workflow-info`, `commands`, `file-manifest`, `environment`, `metrics`, `sample-matrix`, `provenance`, `task-summary`, `software-versions`, `rule-captions`, `aggregate-metrics` — 15 in total (run `oxo-flow report --list-sections` for the live list) |
 
 ### How Sections Work
 
@@ -1595,7 +1597,7 @@ control    = "CTRL_02"
 |---|---|---|---|
 | `pair_id` | String | **Yes** | Unique identifier for this pair |
 | `experiment` | String | **Yes** | Experiment sample name (alias: `tumor`) |
-| `control` | String | **Yes** | Matched control sample name (alias: `normal`) |
+| `control` | String | No | Matched control sample name (alias: `normal`) |
 | `experiment_type` | String | No | Optional cohort label (alias: `tumor_type`) |
 | `metadata` | Table | No | Arbitrary key-value pairs (each key becomes a wildcard) |
 | `when` | String | No | Pair-level gate evaluated at plan time: while it evaluates `false`, the pair declares **no** rule instances. Uses the same condition vocabulary as rule `when` (`config.<key>` truthiness/comparisons, `&&`/`\|\|`/`!`, parentheses, `file_exists(...)`). A `config.<key>` reference with no matching `[config]` key evaluates `false` (the unbound→false stance) — a plan-time warning flags the referenced key so a typo does not silently drop the pair's whole rule set |
@@ -1951,8 +1953,9 @@ PE1       PE           AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
   the gate is closed, so samples without the data evaluate false instead
   of running.
 - A `{meta.<column>}` reference in a rule that never fans out (no
-  sample-like binding) is an error at execution time (residual
-  placeholder).
+  sample-like binding) is left as a residual placeholder — the engine logs
+  a **warning** at execution time and the literal text remains in the
+  rendered command.
 
 ```toml
 [[rules]]
@@ -2590,7 +2593,7 @@ url = "https://hooks.example.com/oxo"
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `url` | String | **Yes** | Webhook endpoint URL |
+| `url` | String | — (required) | Webhook endpoint URL |
 | `method` | String | `POST` | HTTP method (`POST`/`PUT`/`GET`) |
 | `events` | Array of String | `["workflow_completed"]` | Which events fire: `workflow_started`, `workflow_completed`, `workflow_failed`, `rule_completed`, `rule_failed` |
 | `headers` | Table | `{}` | Custom request headers |

--- a/docs/guide/src/tutorials/installation.md
+++ b/docs/guide/src/tutorials/installation.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 oxo-flow --version
-# oxo-flow 0.16.0
+# oxo-flow 0.17.0
 ```
 
 !!! tip "Updating"
@@ -125,7 +125,7 @@ Desktop users may prefer the `.deb` / `.rpm` / `.AppImage` /
 Images are published to GitHub Container Registry automatically on every release and every push to `main`.
 Release images are multi-arch (`linux/amd64` + `linux/arm64`) and are assembled from the
 SHA256-verified release binaries. `:latest` moves only after the release image passes a health
-smoke test, `:<major.minor>` (e.g. `:0.16`) tracks the newest patch of a minor line, and `:main`
+smoke test, `:<major.minor>` (e.g. `:0.17`) tracks the newest patch of a minor line, and `:main`
 is a multi-arch dev build compiled from source:
 
 ```bash
@@ -133,8 +133,8 @@ is a multi-arch dev build compiled from source:
 docker run -d --name oxo-flow -p 3000:3000 ghcr.io/traitome/oxo-flow:latest
 
 # Pin a specific release (or track a minor line)
-docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16.0
-docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.16
+docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.17.0
+docker run -d -p 3000:3000 ghcr.io/traitome/oxo-flow:0.17
 
 # CLI one-shot usage — mount your workflow directory
 docker run --rm -v "$PWD:/work" -w /work ghcr.io/traitome/oxo-flow:latest \


### PR DESCRIPTION
## Summary

Full sweep of all 95 pages in `docs/guide/` verified against ground truth: the built v0.17.0 binary (`--help` output, `report --list-sections`), crate source, and live runs on `examples/`. Every fix was applied only after positive evidence in source.

## What was fixed (by area)

### commands/ (30 pages, verified against live `--help`)
- Flags, subcommand lists, and exit-code semantics aligned with the actual CLI surface.

### reference/ (verified against crate source)
- **security.md** — secret scanner documented as the real 9 case-insensitive substrings (AKIA, sk-, ghp_, glpat-, password, secret, api_key, access_token, private_key) with a false-positive caveat; RCE blocking regex corrected (`sh|bash|dash`, no `sudo`); removed a fictional `>/dev/` redirect rule.
- **cloud-storage.md** — S3 credentials are **env-only** (EnvironmentVariableCredentialsProvider; no shared-credentials/instance-profile chain); deleted a stale "staging not implemented" warning (remote staging + output upload exist in `executor/staging.rs`); fixed dead anchor `#remote-staging`.
- **china-mirrors.md** — inverted the `localhost:5000/...` claim: the registry port is stripped before matching, so the `localhost` namespace **is** rewritten when mapped.
- **execution-backends.md** — `ExecutorBackend` trait shown with all 9 methods, including the three provided hooks (`render_array_script`, `terminal_status`, `polls_elements_directly`) and their defaults.
- **reporting-system.md** — `Report` struct now includes `schema_version`, `command`, and the provenance trio (`checkpoint_path`, `workflow_path`, `workflow_git_sha`); `generated_at` corrected to `Option<DateTime<Utc>>` with `--no-timestamps`/`SOURCE_DATE_EPOCH` semantics.
- **dag-engine.md** — `output_to_node` is a multi-producer `HashMap<String, Vec<NodeIndex>>`; cycle detection = petgraph DFS `toposort` (surfaced as `OxoFlowError::CycleDetected`); removed a fictional `orphan_rules()` API (orphan detection lives in `validate` lint warnings).
- **environment-system.md** — venv cache is keyed by the declared venv spec (`venv:<path>`), not a requirements-content hash; `EnvironmentSpec` gained the missing `gpus` field; `env check` described as backend-availability validation (`pixi` requires `pixi.toml` in CWD).
- **plugin-system.md** — replaced a fictional stdin `PluginInput` subprocess protocol (and its Python example) with the real `PluginOutput` contract, noting it is defined but not yet wired into rule execution as of v0.17.0.
- **ai-translation.md** — `optimize` response field is `estimated` (not `estimated_impact`); reference-genome discovery documented as fully deterministic (fixed search dirs + file existence).
- **diagnostics-engine.md** — cluster peak RSS sourced from the scheduler accounting store (SLURM `sacct` max MaxRSS; `None` for LSF/missing rows).
- **web-system-architecture.md** — license footer lives in the SPA (`frontend/src/components/Layout.tsx`), not in `infra/license.rs`.
- **workflow-format.md** — eight auto-derived indexes (incl. GATK dict); `[report].sections` = 15 built-in IDs; `[[pairs]]`.`control` is optional; residual `{meta.*}` placeholders log a **warning** (not an error); webhook `url` marked required with no default.

### gallery/ (verified against `examples/` + `report --list-sections`)
- wgs-germline built-in section-ID list completed (`software-versions` was missing); all other examples re-checked against their example files.

### tutorials/ + how-to/
- Installation prerequisites, deploy modes, desktop app, and collaboration flows aligned with current behavior.

## Verification

- [x] Every claim spot-checked against crate source with positive evidence (e.g. `format.rs` BLOCKING_PATTERNS + `scan_for_secrets`, `backend/mod.rs` trait, `report.rs` Report struct)
- [x] `mkdocs build --strict` passes clean (zero warnings, 1.15s)
- [x] Revert-watch on editor-volatile files (`contributing.md` Rust 1.98, `index.md` v0.17.0, `mkdocs.yml` nav) — all intact

## Test plan

- [x] `mkdocs build --strict`
- [ ] Docs-only change — no Rust behavior touched; CI should be green on arrival