### PR TITLE
fix(cluster): harden SLURM lifecycle and streamline cluster CLI

### DIFF
--- a/crates/oxo-flow-cli/src/commands/cluster.rs
+++ b/crates/oxo-flow-cli/src/commands/cluster.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use oxo_flow_core::backend::BackendJobStatus;
 use oxo_flow_core::backend::ExecutorBackend;
-use oxo_flow_core::cluster::ClusterBackend;
+use oxo_flow_core::cluster::{ClusterBackend, ClusterJobConfig};
 use oxo_flow_core::config::WorkflowConfig;
 use oxo_flow_core::dag::WorkflowDag;
 use std::collections::HashMap;
@@ -20,6 +20,29 @@ fn parse_backend(name: &str) -> Result<ClusterBackend> {
     ClusterBackend::from_str(name).map_err(|_| {
         anyhow::anyhow!("unknown cluster backend '{name}' — expected slurm, pbs, sge, or lsf")
     })
+}
+
+/// Resolve the backend for a cluster action: the `--backend` flag wins,
+/// then `$OXO_FLOW_CLUSTER_BACKEND`, then SLURM — the overwhelmingly
+/// common scheduler, and the one `-b` used to be required for. An EXPLICIT
+/// value keeps [`parse_backend`]'s strict error, so a typo can never
+/// silently route to SLURM; only an omitted flag falls back.
+fn resolve_backend(flag: Option<&str>) -> Result<ClusterBackend> {
+    let env = std::env::var("OXO_FLOW_CLUSTER_BACKEND").ok();
+    resolve_backend_with(flag, env.as_deref())
+}
+
+/// The pure decision behind [`resolve_backend`], with the environment value
+/// injected — the test crate forbids `unsafe`, which rules out the
+/// `set_var` dance, and a pure function pins the precedence table anyway.
+fn resolve_backend_with(flag: Option<&str>, env: Option<&str>) -> Result<ClusterBackend> {
+    if let Some(name) = flag {
+        return parse_backend(name);
+    }
+    match env.map(str::trim).filter(|name| !name.is_empty()) {
+        Some(name) => parse_backend(name),
+        None => Ok(ClusterBackend::Slurm),
+    }
 }
 
 /// Human one-liner for the parsed status of one job.
@@ -62,6 +85,37 @@ fn query_status(
         }
     }
     Ok(report)
+}
+
+/// Ask the scheduler for the current user's live jobs and answer one
+/// `(id, status)` per listed row — the no-arguments `cluster status` view.
+/// Same execution seam as [`query_status`].
+fn query_my_jobs(
+    backend: &ClusterBackend,
+    run: impl Fn(&str, &[String]) -> Result<String>,
+) -> Result<Vec<(String, BackendJobStatus)>> {
+    // Every backend currently yields exactly one listing invocation, so
+    // this is a plain single call — the first answer is the answer.
+    let Some((program, args)) = oxo_flow_core::backend::cluster::my_jobs_invocations(backend)
+        .into_iter()
+        .next()
+    else {
+        return Ok(Vec::new());
+    };
+    eprintln!(
+        "{} Executing '{} {}'...",
+        "Cluster:".bold().cyan(),
+        program,
+        args.join(" ")
+    );
+    // A user listing has no per-requested-id contract: the rows the
+    // scheduler returns ARE the answer, so run the invocations inline
+    // rather than threading through the overwrite-only-non-Unknown
+    // machinery of query_status.
+    let listing = run(program, &args)?;
+    Ok(oxo_flow_core::backend::cluster::parse_job_listing(
+        backend, &listing,
+    ))
 }
 
 /// Emit the `oxo_submit` shell helper: submits a script and echoes the bare
@@ -237,7 +291,7 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
         } => {
             // The backend is validated before any workflow is read: a typo
             // must not cost a parse, let alone reach a queue.
-            let cluster_backend = parse_backend(&backend)?;
+            let cluster_backend = resolve_backend(backend.as_deref())?;
 
             let mut config = WorkflowConfig::from_file(&workflow)
                 .with_context(|| format!("failed to parse {}", workflow.display()))?;
@@ -352,14 +406,14 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
                 eprintln!(
                     "{} (dry-run) generating {} job scripts for {} rule instances — nothing is submitted",
                     "Cluster:".bold().yellow(),
-                    backend,
+                    cluster_backend,
                     order.len()
                 );
             } else {
                 eprintln!(
                     "{} Generating {} job scripts for {} rule instances",
                     "Cluster:".bold().cyan(),
-                    backend,
+                    cluster_backend,
                     order.len()
                 );
             }
@@ -481,13 +535,51 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
         }
 
         ClusterAction::Status { backend, job_ids } => {
-            let cluster_backend = parse_backend(&backend)?;
+            let cluster_backend = resolve_backend(backend.as_deref())?;
 
             if job_ids.is_empty() {
-                anyhow::bail!(
-                    "cluster status requires at least one job ID from a submit/run output — '{}' with an empty job list is not useful",
-                    oxo_flow_core::cluster::status_command(&cluster_backend)
+                // No ids: answer "what of MINE is in the queue right now" —
+                // the natural first question after a submit, and the one the
+                // old hard error left unanswered (the command used to bail
+                // with "requires at least one job ID").
+                let listing = query_my_jobs(&cluster_backend, |program, args| {
+                    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                    let output = match std::process::Command::new(program).args(&arg_refs).output()
+                    {
+                        Ok(out) => out,
+                        Err(e) => {
+                            eprintln!("  Is {program} installed on this system?");
+                            anyhow::bail!("Failed to execute status command: {e}");
+                        }
+                    };
+                    if !output.status.success() {
+                        // bjobs exits non-zero when the queue is empty;
+                        // treat that as an empty answer, not a failure.
+                        eprintln!(
+                            "{} exited {} (no jobs listed)",
+                            program,
+                            output.status.code().unwrap_or(-1)
+                        );
+                        return Ok(String::new());
+                    }
+                    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+                })?;
+
+                eprintln!(
+                    "{} {} queued job(s)",
+                    "Cluster:".bold().cyan(),
+                    listing.len()
                 );
+                for (id, status) in &listing {
+                    eprintln!("{}", status_line(id, *status));
+                }
+                // Machine-readable form on stdout, one `<id>\t<state>` per
+                // job — human output stays on stderr, the codebase-wide
+                // convention.
+                for (id, status) in &listing {
+                    println!("{id}\t{}", status.label());
+                }
+                return Ok(());
             }
             for (program, args) in
                 oxo_flow_core::backend::cluster::status_invocations(&cluster_backend, &job_ids)
@@ -500,7 +592,7 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
                 );
             }
 
-            let report = query_status(&cluster_backend, &job_ids, |program, args| {
+            let mut report = query_status(&cluster_backend, &job_ids, |program, args| {
                 let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
                 let output = match std::process::Command::new(program).args(&arg_refs).output() {
                     Ok(out) => out,
@@ -519,6 +611,39 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
             })?;
 
             eprintln!("{} {} job(s):", "Cluster:".bold().cyan(), report.len());
+            // The live queue only answers for jobs still in it. A finished
+            // job is invisible to squeue/qstat, yet that is exactly the
+            // state a user asks about most — layer the accounting store
+            // over the Unknown verdicts, the same way the run driver does
+            // (see the executor's terminal_status and issue #244's
+            // no-slurmdbd story). A job with no accounting record either
+            // keeps its Unknown ("finished, or an unknown id") below.
+            let unknown: Vec<String> = report
+                .iter()
+                .filter(|(_, s)| *s == BackendJobStatus::Unknown)
+                .map(|(id, _)| id.clone())
+                .collect();
+            if !unknown.is_empty() {
+                let executor = oxo_flow_core::backend::cluster::ClusterExecutor::new(
+                    cluster_backend,
+                    ClusterJobConfig {
+                        backend: cluster_backend,
+                        queue: None,
+                        account: None,
+                        walltime: None,
+                        extra_args: Vec::new(),
+                    },
+                );
+                for id in &unknown {
+                    if let Some(record) = executor.terminal_status(id).await {
+                        let entry = report
+                            .iter_mut()
+                            .find(|(rid, _)| rid == id)
+                            .expect("report came from the same id list");
+                        entry.1 = record.status;
+                    }
+                }
+            }
             for (id, status) in &report {
                 eprintln!("{}", status_line(id, *status));
             }
@@ -530,8 +655,9 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
         }
 
         ClusterAction::Cancel { backend, job_ids } => {
-            let cancel_cmd =
-                oxo_flow_core::backend::cluster::cancel_command(&parse_backend(&backend)?);
+            let cancel_cmd = oxo_flow_core::backend::cluster::cancel_command(&resolve_backend(
+                backend.as_deref(),
+            )?);
 
             if job_ids.is_empty() {
                 eprintln!(
@@ -573,7 +699,7 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
             // Elapsed,MaxRSS`); PBS/SGE/LSF stay best-effort (qstat -f /
             // qacct / bacct) — the same per-scheduler contract the
             // BackendDriver uses.
-            let cluster_backend = parse_backend(&backend)?;
+            let cluster_backend = resolve_backend(backend.as_deref())?;
             let executor = oxo_flow_core::backend::cluster::ClusterExecutor::new(
                 cluster_backend,
                 oxo_flow_core::cluster::ClusterJobConfig {
@@ -604,9 +730,10 @@ pub async fn cluster_command(action: ClusterAction) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{cluster_command, parse_backend, query_status, status_line};
+    use super::{cluster_command, query_my_jobs, query_status, resolve_backend_with, status_line};
     use crate::ClusterAction;
     use oxo_flow_core::backend::BackendJobStatus;
+    use oxo_flow_core::cluster::ClusterBackend;
     use std::path::PathBuf;
 
     fn run(action: ClusterAction) -> anyhow::Result<()> {
@@ -634,7 +761,7 @@ mod tests {
     ) -> ClusterAction {
         ClusterAction::Submit {
             workflow,
-            backend: backend.to_string(),
+            backend: Some(backend.to_string()),
             queue: None,
             account: None,
             walltime: None,
@@ -650,18 +777,20 @@ mod tests {
     #[test]
     fn unknown_backend_is_rejected_for_every_action() {
         // A typo used to fall back to SLURM silently — submit scripts for the
-        // wrong scheduler, scancel where the user asked for qdel.
+        // wrong scheduler, scancel where the user asked for qdel. An EXPLICIT
+        // bad value must still be rejected even though an omitted flag now
+        // defaults to slurm.
         let cases = vec![
             ClusterAction::Status {
-                backend: "slrm".to_string(),
+                backend: Some("slrm".to_string()),
                 job_ids: vec!["1".to_string()],
             },
             ClusterAction::Cancel {
-                backend: "torque".to_string(),
+                backend: Some("torque".to_string()),
                 job_ids: vec!["1".to_string()],
             },
             ClusterAction::Logs {
-                backend: "ge".to_string(),
+                backend: Some("ge".to_string()),
                 job_id: "1".to_string(),
             },
         ];
@@ -698,8 +827,93 @@ mod tests {
     #[test]
     fn parse_backend_accepts_every_documented_name() {
         for name in ["slurm", "SLURM", "pbs", "sge", "lsf"] {
-            assert!(parse_backend(name).is_ok(), "{name} must resolve");
+            assert!(
+                resolve_backend_with(Some(name), None).is_ok(),
+                "{name} must resolve"
+            );
         }
+    }
+
+    #[test]
+    fn resolve_backend_falls_back_to_slurm_when_the_flag_is_omitted() {
+        // The -b flag used to be required on every cluster action; typing it
+        // on a SLURM site is pure ceremony. Omitted = slurm, unless the
+        // environment names another scheduler.
+        assert_eq!(
+            resolve_backend_with(None, None).unwrap(),
+            ClusterBackend::Slurm
+        );
+        assert_eq!(
+            resolve_backend_with(Some("sge"), Some("pbs")).unwrap(),
+            ClusterBackend::Sge
+        );
+    }
+
+    #[test]
+    fn resolve_backend_honors_the_environment_default() {
+        // A PBS-site user sets OXO_FLOW_CLUSTER_BACKEND once and never types
+        // -b again. Whitespace around the value is tolerated (export typos),
+        // an empty value falls through to the slurm default, and an explicit
+        // flag still wins over the environment.
+        assert_eq!(
+            resolve_backend_with(None, Some("pbs")).unwrap(),
+            ClusterBackend::Pbs
+        );
+        assert_eq!(
+            resolve_backend_with(Some("lsf"), Some("pbs")).unwrap(),
+            ClusterBackend::Lsf
+        );
+        assert_eq!(
+            resolve_backend_with(None, Some("  sge  ")).unwrap(),
+            ClusterBackend::Sge
+        );
+        assert_eq!(
+            resolve_backend_with(None, Some("")).unwrap(),
+            ClusterBackend::Slurm
+        );
+        assert_eq!(
+            resolve_backend_with(None, Some("   ")).unwrap(),
+            ClusterBackend::Slurm
+        );
+
+        // And a garbage environment value is an error naming the value —
+        // never a silent slurm fallback.
+        let msg = resolve_backend_with(None, Some("torque"))
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("unknown cluster backend 'torque'"), "{msg}");
+    }
+
+    #[test]
+    fn query_my_jobs_parses_the_listing() {
+        // The seam question: exactly the user-listing invocation, and the
+        // returned rows are parsed (id, status) — header lines skipped.
+        let listing = query_my_jobs(&ClusterBackend::Slurm, |program, args| {
+            assert_eq!(program, "squeue");
+            assert_eq!(args[0], "-u");
+            assert_eq!(args[2], "--noheader");
+            Ok("101|PENDING\n202|RUNNING\n".to_string())
+        })
+        .unwrap();
+        assert_eq!(
+            listing,
+            vec![
+                ("101".to_string(), BackendJobStatus::Pending),
+                ("202".to_string(), BackendJobStatus::Running),
+            ]
+        );
+    }
+
+    #[test]
+    fn query_my_jobs_surfaces_scheduler_failures() {
+        let err = query_my_jobs(&ClusterBackend::Slurm, |_, _| {
+            Err(anyhow::anyhow!("squeue: slurm_load_jobs error"))
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("slurm_load_jobs"),
+            "the scheduler's own words must reach the user: {err}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -897,8 +897,12 @@ pub enum ClusterAction {
     Submit {
         #[arg(value_name = "WORKFLOW", help = "Path to the .oxoflow workflow file")]
         workflow: PathBuf,
-        #[arg(short = 'b', long, help = "Cluster backend: slurm, pbs, sge, or lsf")]
-        backend: String,
+        #[arg(
+            short = 'b',
+            long,
+            help = "Cluster backend: slurm, pbs, sge, or lsf (defaults to $OXO_FLOW_CLUSTER_BACKEND, then slurm)"
+        )]
+        backend: Option<String>,
         #[arg(short = 'q', long, help = "Cluster queue or partition name")]
         queue: Option<String>,
         #[arg(short = 'a', long, help = "Cluster billing account")]
@@ -940,24 +944,37 @@ pub enum ClusterAction {
         #[arg(long, help = "Generate job scripts with dependency support")]
         with_dependencies: bool,
     },
-    /// Show the status of submitted cluster jobs.
+    /// Show the status of submitted cluster jobs. Without job IDs, list the
+    /// user's jobs the scheduler currently reports.
     Status {
-        #[arg(short = 'b', long, help = "Cluster backend: slurm, pbs, sge, or lsf")]
-        backend: String,
+        #[arg(
+            short = 'b',
+            long,
+            help = "Cluster backend: slurm, pbs, sge, or lsf (defaults to $OXO_FLOW_CLUSTER_BACKEND, then slurm)"
+        )]
+        backend: Option<String>,
         #[arg(value_name = "JOB_IDS", help = "Job ID(s)")]
         job_ids: Vec<String>,
     },
     /// Cancel submitted cluster jobs.
     Cancel {
-        #[arg(short = 'b', long, help = "Cluster backend: slurm, pbs, sge, or lsf")]
-        backend: String,
+        #[arg(
+            short = 'b',
+            long,
+            help = "Cluster backend: slurm, pbs, sge, or lsf (defaults to $OXO_FLOW_CLUSTER_BACKEND, then slurm)"
+        )]
+        backend: Option<String>,
         #[arg(value_name = "JOB_IDS", help = "Job ID(s)")]
         job_ids: Vec<String>,
     },
     /// Fetch logs for a submitted cluster job.
     Logs {
-        #[arg(short = 'b', long, help = "Cluster backend: slurm, pbs, sge, or lsf")]
-        backend: String,
+        #[arg(
+            short = 'b',
+            long,
+            help = "Cluster backend: slurm, pbs, sge, or lsf (defaults to $OXO_FLOW_CLUSTER_BACKEND, then slurm)"
+        )]
+        backend: Option<String>,
         #[arg(value_name = "JOB_ID", help = "Cluster job ID")]
         job_id: String,
     },

--- a/crates/oxo-flow-core/src/backend/cluster.rs
+++ b/crates/oxo-flow-core/src/backend/cluster.rs
@@ -102,6 +102,20 @@ pub fn parse_status_line(
             Some((id, status))
         }
         ClusterBackend::Sge => {
+            // The bare `qstat` table has whitespace columns with the state in
+            // field 4 ("job-ID prior qname ... state"), matching the shape
+            // PBS/LSF rows take above.
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() > 4 && fields[0].chars().all(|c| c.is_ascii_digit()) {
+                let status = match *fields.get(4)? {
+                    "r" | "t" => BackendJobStatus::Running,
+                    "qw" | "hqw" | "h" | "Rq" | "P" => BackendJobStatus::Pending,
+                    "d" | "dr" | "dt" | "dR" => BackendJobStatus::Completed,
+                    "Eqw" | "E" => BackendJobStatus::Failed,
+                    _ => BackendJobStatus::Unknown,
+                };
+                return Some((fields[0].to_string(), status));
+            }
             // qstat -j output pairs "job_number: N" with "state: r"; the
             // executor collects both lines — here we extract the number only.
             Some((
@@ -143,6 +157,52 @@ pub fn status_invocations(
             .map(|id| ("qstat", vec!["-j".to_string(), id.clone()]))
             .collect(),
     }
+}
+
+/// The invocations that list the CURRENT USER's jobs — the no-arguments
+/// `cluster status` view. `std::process::Command` performs no shell
+/// expansion, so the conventional `-u $USER` is resolved from the
+/// environment here; SGE and LSF scope a bare call to the invoking user on
+/// their own.
+pub fn my_jobs_invocations(backend: &ClusterBackend) -> Vec<(&'static str, Vec<String>)> {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_default();
+    match backend {
+        ClusterBackend::Slurm => vec![(
+            "squeue",
+            vec![
+                "-u".to_string(),
+                user,
+                "--noheader".to_string(),
+                "-o".to_string(),
+                "%i|%t".to_string(),
+            ],
+        )],
+        ClusterBackend::Pbs => vec![("qstat", vec!["-u".to_string(), user])],
+        ClusterBackend::Sge => vec![("qstat", Vec::new())],
+        ClusterBackend::Lsf => vec![("bjobs", Vec::new())],
+    }
+}
+
+/// Parse listing output — the scheduler's per-user table — into one
+/// `(job id, status)` per LIVE row.
+///
+/// Unlike [`status_report`] this answers per parsed row: the question here
+/// is "what is in my queue right now", so header lines are skipped (a PBS
+/// header's first field is the literal `Job id`, not a numeric id) and there
+/// is no requested-id list to anchor unknowns against.
+pub fn parse_job_listing(
+    backend: &ClusterBackend,
+    stdout: &str,
+) -> Vec<(String, BackendJobStatus)> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter_map(|line| parse_status_line(backend, line))
+        .filter(|(id, _)| id.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .collect()
 }
 
 /// The command that cancels a job, matching [`ClusterExecutor::cancel`] so
@@ -219,6 +279,80 @@ fn absolute_workdir(path: &Path) -> PathBuf {
         path.to_path_buf()
     } else {
         std::env::current_dir().unwrap_or_default().join(path)
+    }
+}
+
+/// Log paths a rendered script directs its scheduler to open, in directive
+/// order: `(output, error)` — either may be absent.
+///
+/// Parsed from the script TEXT rather than re-derived from the rule: array
+/// scripts rewrite the directives to per-element patterns (`%A_%a`, `%I`)
+/// and `--extra-arg` lines can add more, so the script itself is the only
+/// source of truth for what the scheduler will open.
+fn script_log_paths(script: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for line in script.lines() {
+        let line = line.trim_start();
+        // The four directive prefixes, with the log path either after '='
+        // (SLURM `--output=`) or after a space (PBS/SGE/LSF `-o `/`-e `).
+        for (prefix, sep) in [
+            ("#SBATCH --output=", '='),
+            ("#SBATCH --error=", '='),
+            ("#PBS -o ", ' '),
+            ("#PBS -e ", ' '),
+            ("#$ -o ", ' '),
+            ("#$ -e ", ' '),
+            ("#BSUB -o ", ' '),
+            ("#BSUB -e ", ' '),
+        ] {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                // The path runs to the next separator (or end of line) —
+                // LSF appends nothing, but extra args on the same directive
+                // line must not become part of the path.
+                let raw = match rest.find(sep) {
+                    Some(idx) => &rest[..idx],
+                    None => rest,
+                };
+                // LSF's `-o` accepts %J-style patterns; whitespace never
+                // belongs in the path itself.
+                let raw = raw.split_whitespace().next().unwrap_or(raw);
+                if !raw.is_empty() {
+                    paths.push(PathBuf::from(raw));
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// Pre-create the directories a scheduler will open log files in.
+///
+/// Every backend opens the `--output`/`-o`/`-e` files at job LAUNCH, before
+/// the script body runs — the body's `mkdir -p logs` is too late (proven on
+/// a live SLURM cluster: a job into a fresh run dir failed instantly with
+/// "error: can't open ... logs/align.out"; the same job into a pre-made
+/// `logs/` completed). Resolve each directive path relative to the pinned
+/// working directory — the same resolution the scheduler does for
+/// `--chdir`/`-d`/`-wd`/`-cwd` — and create its parent.
+fn ensure_log_dirs(script: &str, workdir: &Path) {
+    let base = absolute_workdir(workdir);
+    for path in script_log_paths(script) {
+        let full = if path.is_absolute() {
+            path
+        } else {
+            base.join(path)
+        };
+        if let Some(parent) = full.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            // Never block submission on housekeeping: the scheduler may
+            // itself create the directory, and the old behavior was to
+            // create nothing at all.
+            eprintln!(
+                "warning: could not pre-create log dir {}: {e}",
+                parent.display()
+            );
+        }
     }
 }
 
@@ -379,6 +513,12 @@ impl super::ExecutorBackend for ClusterExecutor {
     }
 
     async fn submit(&self, script_path: &Path) -> Result<String> {
+        // The scheduler opens the script's log files before the body runs —
+        // pre-create their directories or a fresh run dir fails on launch
+        // (issue: engine never created `logs/`, sbatch jobs died instantly).
+        if let Ok(script) = std::fs::read_to_string(script_path) {
+            ensure_log_dirs(&script, &self.workdir);
+        }
         let mut args: Vec<&str> = Vec::new();
         if matches!(self.backend, ClusterBackend::Slurm) {
             args.push("--parsable");
@@ -928,6 +1068,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_status_line_sge() {
+        // The bare `qstat` table row (state in field 4) — what the
+        // no-arguments `cluster status` listing reads.
+        assert_eq!(
+            parse_status_line(&ClusterBackend::Sge, "77  0.55500  align  me  r  batch"),
+            Some(("77".into(), BackendJobStatus::Running))
+        );
+        assert_eq!(
+            parse_status_line(&ClusterBackend::Sge, "78  0.55500  call  me  qw  batch"),
+            Some(("78".into(), BackendJobStatus::Pending))
+        );
+        // A `qstat -j` job_number line stays (id, unknown); the state pairs
+        // up in status_report's positional handling.
+        assert_eq!(
+            parse_status_line(&ClusterBackend::Sge, "job_number: 99"),
+            Some(("99".into(), BackendJobStatus::Unknown))
+        );
+        // Neither shape.
+        assert_eq!(parse_status_line(&ClusterBackend::Sge, "garbage"), None);
+    }
+
+    #[test]
     fn parse_status_line_lsf() {
         let line = "12345  me  RUN  batch  1  1  8  Aug 14 12:00";
         assert_eq!(
@@ -976,6 +1138,89 @@ mod tests {
                 ("qstat", vec!["-j".to_string(), "101".to_string()]),
                 ("qstat", vec!["-j".to_string(), "202".to_string()]),
             ]
+        );
+    }
+
+    #[test]
+    fn my_jobs_invocations_scope_to_the_current_user() {
+        // std::process::Command does no shell expansion, so `-u $USER` is
+        // resolved from the environment at invocation-build time; SGE and
+        // LSF answer a bare call for the invoking user.
+        let user = std::env::var("USER")
+            .or_else(|_| std::env::var("LOGNAME"))
+            .unwrap_or_default();
+        assert!(!user.is_empty(), "test environment must have USER/LOGNAME");
+        assert_eq!(
+            my_jobs_invocations(&ClusterBackend::Slurm),
+            vec![(
+                "squeue",
+                vec![
+                    "-u".to_string(),
+                    user.clone(),
+                    "--noheader".to_string(),
+                    "-o".to_string(),
+                    "%i|%t".to_string(),
+                ]
+            )]
+        );
+        assert_eq!(
+            my_jobs_invocations(&ClusterBackend::Pbs),
+            vec![("qstat", vec!["-u".to_string(), user])]
+        );
+        assert_eq!(
+            my_jobs_invocations(&ClusterBackend::Sge),
+            vec![("qstat", Vec::new())]
+        );
+        assert_eq!(
+            my_jobs_invocations(&ClusterBackend::Lsf),
+            vec![("bjobs", Vec::new())]
+        );
+    }
+
+    #[test]
+    fn parse_job_listing_reads_rows_and_skips_headers() {
+        let squeue = "101|PENDING\n202|RUNNING\n";
+        assert_eq!(
+            parse_job_listing(&ClusterBackend::Slurm, squeue),
+            vec![
+                ("101".to_string(), BackendJobStatus::Pending),
+                ("202".to_string(), BackendJobStatus::Running),
+            ]
+        );
+        // The qstat header's first field is the literal "Job id" — a
+        // non-numeric id, so the header never becomes a job row.
+        let qstat = "Job id      Name    User  Time Use S Queue\n\
+                      404.queue   align   me    0:00   R batch\n\
+                      405.queue   call    me    0:00   Q batch\n";
+        assert_eq!(
+            parse_job_listing(&ClusterBackend::Pbs, qstat),
+            vec![
+                ("404.queue".to_string(), BackendJobStatus::Running),
+                ("405.queue".to_string(), BackendJobStatus::Pending),
+            ]
+        );
+        // SGE's bare `qstat` table puts the state in field 4, like PBS.
+        let qstat_sge = "job-ID  prior   name       user         state\n\
+                         77      0.55500 align      me           r\n\
+                         78      0.55500 call       me           qw\n";
+        assert_eq!(
+            parse_job_listing(&ClusterBackend::Sge, qstat_sge),
+            vec![
+                ("77".to_string(), BackendJobStatus::Running),
+                ("78".to_string(), BackendJobStatus::Pending),
+            ]
+        );
+        // And a `qstat -j` pairing stays unknown-per-number as before — the
+        // table arm must not swallow it.
+        assert_eq!(
+            parse_job_listing(&ClusterBackend::Sge, "job_number: 99\n"),
+            vec![("99".to_string(), BackendJobStatus::Unknown)]
+        );
+        let bjobs = "JOBID   USER    STAT  QUEUE\n\
+                     12345   me      RUN   normal\n";
+        assert_eq!(
+            parse_job_listing(&ClusterBackend::Lsf, bjobs),
+            vec![("12345".to_string(), BackendJobStatus::Running)]
         );
     }
 
@@ -1074,6 +1319,74 @@ mod tests {
             script.starts_with("#!/bin/bash\n#SBATCH --chdir=/wf\n#SBATCH --array=1-2\n"),
             "the array range stays right after the new chdir directive: {script}"
         );
+    }
+
+    #[test]
+    fn script_log_paths_reads_every_backend_directive() {
+        let slurm = "#!/bin/bash\n\
+                     #SBATCH --output=logs/align.out\n\
+                     #SBATCH --error=logs/align.err\n";
+        assert_eq!(
+            script_log_paths(slurm),
+            vec![
+                PathBuf::from("logs/align.out"),
+                PathBuf::from("logs/align.err")
+            ]
+        );
+        // Array forms: the per-element pattern is one shared parent dir.
+        let array = "#SBATCH --output=logs/align.%A_%a.out\n#SBATCH --error=logs/align.%A_%a.err\n";
+        assert_eq!(script_log_paths(array).len(), 2);
+
+        let pbs = "#PBS -o logs/fastqc.out\n#PBS -e logs/fastqc.err\n";
+        assert_eq!(script_log_paths(pbs).len(), 2);
+        let sge = "#$ -o logs/align.out\n#$ -e logs/align.err\n";
+        assert_eq!(script_log_paths(sge).len(), 2);
+        let lsf = "#BSUB -o logs/sort.%I.out\n#BSUB -e logs/sort.%I.err\n";
+        assert_eq!(script_log_paths(lsf).len(), 2);
+
+        // Body lines that merely mention the directives stay untouched.
+        assert!(script_log_paths("# echo #SBATCH --output=x\ntrue\n").is_empty());
+    }
+
+    #[test]
+    fn ensure_log_dirs_creates_the_referenced_directory_before_submit() {
+        // Regression: a fresh run dir with no `logs/` made every backend's
+        // job die at launch — the scheduler opens the output file before the
+        // script body's `mkdir -p logs` runs.
+        let dir = tempfile::tempdir().unwrap();
+        let run_dir = dir.path().join("fresh-run");
+        std::fs::create_dir(&run_dir).unwrap();
+        let script =
+            "#!/bin/bash\n#SBATCH --output=logs/align.out\n#SBATCH --error=logs/align.err\n";
+        ensure_log_dirs(script, &run_dir);
+        assert!(
+            run_dir.join("logs").is_dir(),
+            "logs/ must exist before the scheduler opens the file"
+        );
+
+        // Relative workdir resolves against the process cwd, matching the
+        // scheduler's --chdir handling.
+        ensure_log_dirs(script, Path::new("."));
+        // no return value; must not panic on a relative workdir
+    }
+
+    #[test]
+    fn ensure_log_dirs_tolerates_an_unreadable_or_missing_script() {
+        // submit() reads the script best-effort: a missing file must not
+        // block submission (the scheduler's own error is the truthful one).
+        let dir = tempfile::tempdir().unwrap();
+        ensure_log_dirs("", dir.path()); // empty script → no dirs
+        std::fs::set_permissions(
+            dir.path(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o555),
+        )
+        .unwrap();
+        ensure_log_dirs("#SBATCH --output=logs/x.out\n", dir.path()); // read-only base
+        std::fs::set_permissions(
+            dir.path(),
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )
+        .unwrap();
     }
 }
 

--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -934,6 +934,31 @@ impl BackendDriver {
                                 Some((f.submitted_at, observed_at)),
                                 acct,
                             )?;
+                            // Fail fast, mirroring the local executor's
+                            // abort-on-first-failure default (run.rs): the
+                            // remaining inflight entries are exactly this
+                            // failure's live siblings, and a run that can no
+                            // longer succeed must not keep billing for them.
+                            // Non-required failures leave the run salvageable
+                            // (record_outcome counts them separately), so
+                            // only a required rule's failure cancels.
+                            if plan.rules[&f.rule].rule.required {
+                                let siblings: Vec<(String, String, Option<String>)> = inflight
+                                    .iter()
+                                    .map(|(id, f)| {
+                                        (id.clone(), f.rule.clone(), f.array_base.clone())
+                                    })
+                                    .collect();
+                                if !siblings.is_empty() {
+                                    tracing::warn!(
+                                        rule = %f.rule,
+                                        job = %job_id,
+                                        cancelling = siblings.len(),
+                                        "required rule failed — cancelling remaining in-flight jobs"
+                                    );
+                                    self.cancel_inflight(&siblings).await?;
+                                }
+                            }
                             JobRecord {
                                 rule: f.rule.clone(),
                                 status: JobStatus::Failed,

--- a/crates/oxo-flow-core/src/cluster.rs
+++ b/crates/oxo-flow-core/src/cluster.rs
@@ -319,6 +319,13 @@ fn slurm_gpu_directive(spec: &crate::rule::GpuSpec) -> String {
     }
 }
 
+/// A zero GPU count means "no GPUs" — every scheduler rejects or
+/// mis-accounts a request for 0 of a consumable (SLURM: `--gres=gpu:0`
+/// fails with Invalid generic resource; PBS/SGE/LSF take it literally).
+fn gpu_count_requested(count: u32) -> bool {
+    count > 0
+}
+
 fn generate_slurm_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig) -> String {
     let mut lines = vec!["#!/bin/bash".to_string()];
     lines.push(format!("#SBATCH --job-name={}", rule.name));
@@ -334,7 +341,9 @@ fn generate_slurm_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig
     // GPU handling - translate from resources.gpu or gpu_spec
     if let Some(ref spec) = rule.resources.gpu_spec {
         // Use detailed GPU spec (preferred)
-        lines.push(format!("#SBATCH --gres={}", slurm_gpu_directive(spec)));
+        if gpu_count_requested(spec.count) {
+            lines.push(format!("#SBATCH --gres={}", slurm_gpu_directive(spec)));
+        }
         // Add GPU memory constraint if specified
         if let Some(mem_gb) = spec.memory_gb {
             // Some SLURM configs support --mem-per-gpu
@@ -342,7 +351,9 @@ fn generate_slurm_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig
         }
     } else if let Some(gpu_count) = rule.resources.gpu {
         // Simple GPU count
-        lines.push(format!("#SBATCH --gres=gpu:{}", gpu_count));
+        if gpu_count_requested(gpu_count) {
+            lines.push(format!("#SBATCH --gres=gpu:{}", gpu_count));
+        }
     }
 
     // Per-rule walltime (override config walltime)
@@ -422,15 +433,19 @@ fn generate_pbs_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig) 
 
     // GPU for PBS (site-specific format)
     if let Some(ref spec) = rule.resources.gpu_spec {
-        for directive in pbs_gpu_directive(spec) {
-            if directive.starts_with('#') {
-                // Comments go directly into the script
-                lines.push(directive);
-            } else {
-                resource_parts.push(directive);
+        if gpu_count_requested(spec.count) {
+            for directive in pbs_gpu_directive(spec) {
+                if directive.starts_with('#') {
+                    // Comments go directly into the script
+                    lines.push(directive);
+                } else {
+                    resource_parts.push(directive);
+                }
             }
         }
-    } else if let Some(gpu_count) = rule.resources.gpu {
+    } else if let Some(gpu_count) = rule.resources.gpu
+        && gpu_count_requested(gpu_count)
+    {
         resource_parts.push(format!("gpu={}", gpu_count));
     }
 
@@ -491,9 +506,13 @@ fn generate_sge_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig) 
 
     // GPU handling for SGE (site-specific)
     if let Some(ref spec) = rule.resources.gpu_spec {
-        resource_parts.push(format!("gpu={}", spec.count));
+        if gpu_count_requested(spec.count) {
+            resource_parts.push(format!("gpu={}", spec.count));
+        }
         // Model selection requires site-specific complex resource definition
-    } else if let Some(gpu_count) = rule.resources.gpu {
+    } else if let Some(gpu_count) = rule.resources.gpu
+        && gpu_count_requested(gpu_count)
+    {
         resource_parts.push(format!("gpu={}", gpu_count));
     }
 
@@ -554,7 +573,9 @@ fn generate_lsf_script(rule: &Rule, shell_cmd: &str, config: &ClusterJobConfig) 
     }
 
     // GPU handling for LSF
-    if let Some(gpu_count) = rule.resources.gpu {
+    if let Some(gpu_count) = rule.resources.gpu
+        && gpu_count_requested(gpu_count)
+    {
         lines.push(format!("#BSUB -gpu {}", gpu_count));
     }
 
@@ -1075,6 +1096,92 @@ mod tests {
             generate_submit_script(&ClusterBackend::Lsf, &rule, "python train.py", &config);
 
         assert!(script.contains("#BSUB -gpu 2"));
+    }
+
+    #[test]
+    fn zero_gpu_requests_omit_the_directive_on_every_backend() {
+        // gpu = 0 means "no GPUs" — emitting `--gres=gpu:0` / `gpu=0`
+        // makes schedulers reject or mis-account the job (SLURM: Invalid
+        // generic resource). The directive must simply disappear.
+        let cases = [
+            (ClusterBackend::Slurm, "#SBATCH --gres=gpu:0"),
+            (ClusterBackend::Pbs, "gpu=0"),
+            (ClusterBackend::Sge, "gpu=0"),
+            (ClusterBackend::Lsf, "#BSUB -gpu 0"),
+        ];
+        for (backend, forbidden) in cases {
+            let rule = Rule {
+                name: "no_gpu".to_string(),
+                input: vec![].into(),
+                output: vec![].into(),
+                shell: Some("echo hello".to_string()),
+                script: None,
+                threads: Some(1),
+                memory: None,
+                resources: Resources {
+                    gpu: Some(0),
+                    ..Resources::default()
+                },
+                environment: EnvironmentSpec::default(),
+                log: None,
+                benchmark: None,
+                params: HashMap::new(),
+                priority: 0,
+                target: false,
+                group: None,
+                description: None,
+                ..Default::default()
+            };
+            let config = ClusterJobConfig {
+                backend,
+                queue: None,
+                account: None,
+                walltime: None,
+                extra_args: vec![],
+            };
+            let script = generate_submit_script(&backend, &rule, "echo hello", &config);
+            assert!(
+                !script.contains(forbidden),
+                "{backend:?} script must not contain '{forbidden}':\n{script}"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_count_gpu_spec_omits_the_directive_but_keeps_memory() {
+        // A spec with count = 0 and a memory floor still constrains GPU
+        // memory (mem-per-gpu applies to any GPU the site assigns).
+        let rule = Rule {
+            name: "mem_only".to_string(),
+            input: vec![].into(),
+            output: vec![].into(),
+            shell: Some("echo hello".to_string()),
+            script: None,
+            threads: Some(1),
+            memory: None,
+            resources: Resources {
+                gpu_spec: Some(crate::rule::GpuSpec {
+                    count: 0,
+                    model: Some("a100".to_string()),
+                    memory_gb: Some(40),
+                    ..Default::default()
+                }),
+                ..Resources::default()
+            },
+            environment: EnvironmentSpec::default(),
+            log: None,
+            benchmark: None,
+            params: HashMap::new(),
+            priority: 0,
+            target: false,
+            group: None,
+            description: None,
+            ..Default::default()
+        };
+        let config = make_config();
+        let script = generate_submit_script(&ClusterBackend::Slurm, &rule, "echo hello", &config);
+        assert!(!script.contains("gres=gpu:0"), "\n{script}");
+        assert!(script.contains("#SBATCH --mem-per-gpu=40G"), "\n{script}");
     }
 
     // -- Per-rule walltime tests --------------------------------------------

--- a/docs/guide/src/commands/cluster.md
+++ b/docs/guide/src/commands/cluster.md
@@ -34,8 +34,28 @@ oxo-flow cluster <ACTION> [OPTIONS]
 | Argument | Description |
 |---|---|
 | `<WORKFLOW>` | Path to the `.oxoflow` workflow file (for `submit`) |
-| `[JOB_IDS]...` | Cluster job IDs from a submit/run output — required for `status` (an empty job list is rejected); optional for `cancel` |
+| `[JOB_IDS]...` | Cluster job IDs from a submit/run output — for `status`: omitted, the command lists your queued jobs; given, it answers exactly those ids. Optional for `cancel` |
 | `<JOB_ID>` | Job ID (for `logs`) |
+
+---
+
+## Options
+
+Every action accepts `--backend` / `-b`:
+
+| Option | Short | Default | Description |
+|---|---|---|---|
+| `--backend` | `-b` | `$OXO_FLOW_CLUSTER_BACKEND`, then `slurm` | Cluster backend (`slurm`, `pbs`, `sge`, `lsf`) — on a SLURM site you never need to type it |
+
+An **explicit** value is always validated — `-b slrm` fails with
+`unknown cluster backend 'slrm' — expected slurm, pbs, sge, or lsf` rather
+than silently querying SLURM. The default applies only when the flag is
+omitted entirely. On a non-SLURM site set the default once in your shell
+profile:
+
+```bash
+export OXO_FLOW_CLUSTER_BACKEND=pbs   # or sge / lsf
+```
 
 ---
 
@@ -43,7 +63,6 @@ oxo-flow cluster <ACTION> [OPTIONS]
 
 | Option | Short | Default | Description |
 |---|---|---|---|
-| `--backend` | `-b` | *(required)* | Cluster backend (`slurm`, `pbs`, `sge`, `lsf`) |
 | `--queue` | `-q` | — | Partition / queue name |
 | `--account` | `-a` | — | Account / project name |
 | `--walltime` | — | — | Wall-time limit for every job (`24h`, `2d`, or `24:00:00`) |
@@ -148,16 +167,23 @@ submission line to review, e.g. `sbatch cluster_scripts/*.sh`.
 
 ### Check job status
 
-`status` needs at least one job id — an empty list is rejected, because
-querying a scheduler for "everything" is not what this command is for:
+With no ids, `status` lists **your** queued jobs (all jobs the scheduler
+reports for your user) — the natural first question after a submit:
 
 ```bash
-oxo-flow cluster status -b slurm 12345 12346
+$ oxo-flow cluster status
+Cluster: Executing 'squeue -u alice --noheader -o %i|%t'...
+Cluster: 2 queued job(s)
+  12345: running
+  12346: pending
 ```
 
-Unknown backends are rejected rather than guessed: `-b slrm` fails with
-`unknown cluster backend 'slrm' — expected slurm, pbs, sge, or lsf` instead of
-silently querying SLURM.
+Pass the ids the submit/run step printed to answer exactly those — including
+finished ones, which are settled from the scheduler's accounting store:
+
+```bash
+oxo-flow cluster status 12345 12346
+```
 
 ### Cancel specific jobs
 
@@ -360,10 +386,20 @@ Different backends use different dependency syntax:
   render layer the live submission path uses, so generated scripts and
   submitted scripts can never drift apart
 - The `logs/` directory referenced by the scripts' `--output` directives is
-  created before the scripts are written (slurmd opens that file at job
-  launch, before the script body runs)
+  created at submit time (both by `oxo-flow run --profile` and by the
+  engine's live submission path): schedulers open the script's `--output`
+  file at job launch, before the script body runs, so a missing directory
+  fails the job instantly. When you submit generated scripts yourself
+  (`cluster submit --dry-run` output), create the directory first.
 - Resource requirements (threads, memory, gpu) from the workflow are automatically translated to cluster directives
 - **Environment wrapping is applied automatically** — conda, docker, singularity, pixi, venv, and module environments are properly wrapped in the generated scripts
-- `status` and `cancel` actively execute native cluster commands (like `squeue`, `scancel`) and print their outputs directly
+- `status`, `cancel`, and `logs` actively execute native cluster commands
+  (`squeue`, `scancel`, …). `status` captures the scheduler's output and
+  parses it into one normalized state per job (pending / running /
+  completed / failed / cancelled / unknown); for ids you request explicitly,
+  jobs no longer in the queue fall back to the scheduler's accounting store
+  (`sacct`, `qstat -x`, `qacct`, `bacct`) so finished jobs report their real
+  final state instead of "not in the queue". The no-ids listing shows only
+  live (queued or running) jobs — that is what the scheduler itself reports.
 - Ensure the required environments (conda envs, docker images, etc.) are available on cluster nodes before submitting
 - Use `--with-dependencies` for workflows where rules depend on each other — this ensures proper execution order

--- a/docs/guide/src/commands/run.md
+++ b/docs/guide/src/commands/run.md
@@ -442,7 +442,9 @@ shared between the submitting host and the compute nodes.
 > **Not yet implemented.** The driver polls until every job reaches a
 > terminal state; it does not yet re-attach to jobs still in flight if the
 > driver exits, and Ctrl-C does not yet cancel submitted jobs. Until then,
-> use `oxo-flow cluster cancel <JOB_ID>...` to clean up an interrupted run.
+> use `oxo-flow cluster status` (no ids: lists your queued jobs) and
+> `oxo-flow cluster cancel <JOB_ID>...` to inspect or clean up an
+> interrupted run.
 
 Cluster scheduler submission (SLURM, PBS, SGE, LSF) is configured
 separately — see the [`cluster`](cluster.md) command.

--- a/docs/guide/src/how-to/run-on-cluster.md
+++ b/docs/guide/src/how-to/run-on-cluster.md
@@ -50,9 +50,9 @@ memory = "32G"
 time_limit = "24h"
 ```
 
-> **Note on `gpu`:** declare `gpu = 1` or higher. `gpu = 0` is treated as a
-> present-but-zero value and generates directives like `#SBATCH --gres=gpu:0`
-> — omit the field instead.
+> **Note on `gpu`:** `gpu = 0` means "no GPUs" — the engine omits the GPU
+> directive entirely, exactly as if the field were absent. Only declare it
+> when you need at least one GPU (`gpu = 1` or higher).
 
 ### Resource fields
 
@@ -366,14 +366,32 @@ Or use oxo-flow's status command with a checkpoint file:
 oxo-flow status .oxo-flow/checkpoint.json
 ```
 
-`oxo-flow cluster status` and `cluster cancel` take the **backend and the
-scheduler job ids** — there is no "show all my submissions" mode, so keep the
-ids the submit/run step printed:
+`oxo-flow cluster status` answers two questions. **With no ids** it lists
+every job the scheduler currently reports for your user — the natural check
+right after a submit:
 
 ```bash
-oxo-flow cluster status -b slurm 12345 12346
-oxo-flow cluster cancel -b slurm 12345
+$ oxo-flow cluster status
+Cluster: Executing 'squeue -u alice --noheader -o %i|%t'...
+Cluster: 2 queued job(s)
+  12345: running
+  12346: pending
 ```
+
+**With ids** (the ones submit/run printed) it answers exactly those,
+settling finished jobs from the scheduler's accounting store:
+
+```bash
+oxo-flow cluster status 12345 12346
+oxo-flow cluster cancel 12345
+```
+
+Every cluster action resolves its backend the same way: the `--backend` /
+`-b` flag if given, then `$OXO_FLOW_CLUSTER_BACKEND`, then `slurm`. On a
+SLURM site you never type `-b`; on a PBS site set the environment variable
+once (`export OXO_FLOW_CLUSTER_BACKEND=pbs`). An explicit-but-typoed value
+is still rejected outright (`unknown cluster backend '…' — expected slurm,
+pbs, sge, or lsf`) — the default never swallows a bad name.
 
 ---
 
@@ -404,10 +422,10 @@ extra_args    = ["--exclusive", "--constraint=haswell"]  # verbatim scheduler ar
 
 `extra_args` entries are emitted as scheduler directives **verbatim and
 unvalidated** — a typo reaches the scheduler as written (the same applies to
-`cluster submit --extra-arg`). An unknown `--backend` value is rejected
-outright (`unknown cluster backend '…' — expected slurm, pbs, sge, or lsf`);
-nothing falls back to SLURM, so a typo cannot submit into the wrong
-scheduler.
+`cluster submit --extra-arg`). Cluster CLI actions resolve `--backend` as
+flag > `$OXO_FLOW_CLUSTER_BACKEND` > `slurm` (see
+[Monitoring Jobs](#monitoring-jobs)); the profile block's `backend` key
+remains required and is validated the same strict way.
 
 ---
 

--- a/tests/cluster_backend.rs
+++ b/tests/cluster_backend.rs
@@ -391,6 +391,9 @@ fn dry_run_will_run_set_equals_driver_submitted_set() {
 
 #[test]
 fn poll_timeout_cancels_inflight_jobs() {
+    // A rule that outlives the poll deadline (no failure involved — a
+    // failing required rule now cancels its siblings itself and settles
+    // the run before the deadline fires).
     let dir = tempfile::tempdir().unwrap();
     let workflow = r#"
 [workflow]
@@ -400,18 +403,11 @@ name = "timeout"
 name = "slow"
 shell = "sleep 30"
 output = ["slow.done"]
-
-[[rules]]
-name = "fail"
-shell = "exit 3"
-output = ["fail.done"]
 "#;
     std::fs::write(dir.path().join("wf.oxoflow"), workflow).unwrap();
     let state = tempfile::tempdir().unwrap();
     let run_dir = tempfile::tempdir().unwrap();
-    let to_run: HashSet<String> = ["slow".to_string(), "fail".to_string()]
-        .into_iter()
-        .collect();
+    let to_run: HashSet<String> = ["slow".to_string()].into_iter().collect();
     let err = run_driver(
         dir.path(),
         run_dir.path(),

--- a/tests/dispatch_fairness.rs
+++ b/tests/dispatch_fairness.rs
@@ -845,14 +845,29 @@ fn cli_samples_subset_does_not_overwrite_gather_output() {
     );
 }
 
-/// `cluster status` with no job IDs must fail with a clear message instead
-/// of invoking the scheduler's status command with an empty list
-/// (issue #142 LOW).
+/// `cluster status` with no job IDs lists the user's scheduler jobs instead
+/// of erroring (issue #142 LOW follow-up): the listing asks `squeue -u $USER`,
+/// so it must never fall back to `squeue -j` with an empty id list. Wired to
+/// the mock scheduler so every returned row is `<id>\t<state>`.
 #[test]
-fn cli_cluster_status_requires_job_ids() {
+fn cli_cluster_status_without_ids_lists_users_jobs() {
+    let dir = tempfile::tempdir().unwrap();
+    let jobs = dir.path().join("jobs").join("424242");
+    fs::create_dir_all(&jobs).unwrap();
+    fs::write(jobs.join("state"), "RUNNING").unwrap();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock-scheduler");
     oxo_flow_cmd()
-        .args(["cluster", "status", "-b", "slurm"])
+        .env("MOCK_SCHEDULER_DIR", dir.path())
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                fixtures.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .args(["cluster", "status"])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("requires at least one job ID"));
+        .success()
+        .stdout(predicate::str::starts_with("424242\trunning\n"));
 }

--- a/tests/fixtures/mock-scheduler/squeue
+++ b/tests/fixtures/mock-scheduler/squeue
@@ -1,20 +1,30 @@
 #!/bin/bash
-# Mock squeue — answers `squeue -j <ids> --noheader -o "%i|%t"`.
-# With MOCK_SQUEUE_HIDE_TERMINAL=1, terminal jobs are omitted — real
-# squeue only lists live jobs, and the driver must settle vanished ids
+# Mock squeue — answers `squeue -j <ids> --noheader -o "%i|%t"` and
+# `squeue -u <user> --noheader -o "%i|%t"` (the no-ids `cluster status`
+# listing). With MOCK_SQUEUE_HIDE_TERMINAL=1, terminal jobs are omitted —
+# real squeue only lists live jobs, and the driver must settle vanished ids
 # from sacct (issue: short jobs never settled).
 set -eu
 dir="${MOCK_SCHEDULER_DIR:?MOCK_SCHEDULER_DIR not set}"
 ids=""
+user=""
 fmt="%i|%t"
 while [ $# -gt 0 ]; do
   case "$1" in
     -j) ids="$2"; shift 2;;
+    -u) user="$2"; shift 2;;
     -o) fmt="$2"; shift 2;;
     --noheader) shift;;
     *) shift;;
   esac
 done
+# A user listing: every job dir is "mine" for the test user.
+if [ -n "$user" ]; then
+  for d in "$dir"/jobs/*/; do
+    [ -d "$d" ] || continue
+    ids="$ids $(basename "$d")"
+  done
+fi
 for id in $(echo "$ids" | tr ',' ' '); do
   [ -d "$dir/jobs/$id" ] || continue
   state=$(cat "$dir/jobs/$id/state" 2>/dev/null || echo "PENDING")


### PR DESCRIPTION
## Summary

Four issues found by live SLURM testing on a paid HPC cluster (`fr`), plus a CLI usability overhaul. Full test evidence in the on-cluster test report (12-row original matrix + V2 re-verification, every job audited via `sacct`).

### Fixes (each re-verified live on the cluster)

1. **Engine pre-creates `logs/` before sbatch** — schedulers open `--output`/`--error` at launch, before the script body runs, so a missing `logs/` dir failed every job instantly (evidence: jobs 45787919 vs 45787920). V2 re-test: fresh run dir, 4/4 jobs COMPLETED, logs landed.
2. **Required-rule failure cancels in-flight siblings** (`scancel`/`qdel`/`qdel`/`bkill`) instead of letting them burn paid machine time. V2 re-test: fail_fast (3 s) + slow (60 s) siblings → slow jobs `CANCELLED by 3+` after 5 s (previously ran to completion, 91 s). Non-required failures deliberately do **not** cancel — the run stays salvageable.
3. **`cluster status` settles finished jobs from the accounting store** (`sacct` / `qstat -x -f` / `qacct` / `bacct`, plus SLURM `scontrol` fallback) instead of reporting `unknown`. V2 re-test: 3 real finished jobs resolved to completed/failed/completed.
4. **`gpu = 0` emits no GPU directive** (some sites reject `--gres=gpu:0`). Gate applied across all four script generators (SLURM/PBS/SGE/LSF), for both `gpu` and `gpu_spec.count`. V2 re-test: dry-run shows no `gres` line for `gpu = 0`, `--gres=gpu:1` preserved for `gpu = 1`.

### CLI usability

- All cluster actions resolve the backend as `--backend` flag > `$OXO_FLOW_CLUSTER_BACKEND` > `slurm` (explicit values strictly validated; empty env value skipped).
- `cluster status` with no job IDs lists the user's scheduler jobs (`squeue -u` / `qstat -u` / bare `qstat` / bare `bjobs`) instead of erroring — machine lines (`<id>\t<state>`) on stdout, human lines on stderr.
- Docs rewritten: `run --profile <name>` is the everyday submission path; `cluster` commands are the lifecycle escape hatch (submit/status/cancel/logs).

## Generality

PBS/SGE/LSF get the same accounting-settlement, listing, cancellation and gpu-gating treatment via the shared helpers; correctness rests on unit tests (no live PBS/SGE/LSF site available — the test cluster is SLURM-only, where `qstat` is a Torque wrapper that exits 153 silently for finished ids).

## Test plan

- [x] `cargo fmt --check`, `clippy` clean
- [x] Full workspace tests green (2606 passed) pre-commit; touched crates re-run post-commit (core 1377, cli 194, cluster_backend 8, dispatch_fairness 23)
- [x] Live SLURM re-verification of all four fixes + CLI paths (V2 section of the test report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
