### PR TITLE
docs: add transform cleanup caveat to skill QC stage

### DIFF
--- a/docs/guide/src/SKILL.md
+++ b/docs/guide/src/SKILL.md
@@ -95,7 +95,9 @@ Seven stages, three approval gates. Every stage ends with a
   .oxo-flow/checkpoint.json` passes; spot-check logs for silent errors.
   (On releases ≤ 0.14, verify mis-resolves relative output paths and reports
   existing files as missing — fall back to direct checksum comparison against
-  the checkpoint, or upgrade oxo-flow.)
+  the checkpoint, or upgrade oxo-flow. Chunk intermediates deleted by a
+  transform rule's `cleanup = true` are expected to be reported missing —
+  they were cleaned by design, not lost.)
 - Judge against the Stage 0 success criteria. Performed by an evaluator
   role — **never the author of the workflow**.
 - Fail → back to Stage 2 with written findings.


### PR DESCRIPTION
Follow-up from the v0.17.1 live test on tx-ubuntu: transform rules with `cleanup = true` delete chunk intermediates at workflow end, so `provenance verify` reports them missing. The skill's Stage 5 now marks this as expected-by-design so agents don't misread it as data loss.