### PR TITLE
feat: add regex_extract(path, pattern, group?) runtime when-fn

### DIFF
--- a/crates/oxo-flow-core/src/config_impact.rs
+++ b/crates/oxo-flow-core/src/config_impact.rs
@@ -472,8 +472,9 @@ pub fn detect_config_changes(
 /// [`detect_config_changes`] with runtime-gate replay (issue #282).
 ///
 /// `workdir` is the run's working directory: runtime file functions in
-/// `when` strings (`reads_count` / `wc_lines` / `file_size`) resolve their
-/// relative paths against it, so a *threshold* change (e.g.
+/// `when` strings (`reads_count` / `wc_lines` / `file_size` /
+/// `regex_extract`) resolve their relative paths against it, so a
+/// *threshold* change (e.g.
 /// `config.min_reads`) re-evaluates each instance's gate on the files the
 /// previous run produced and flips/keeps the verdict like any other gate —
 /// instead of being vacuously true and needing `--force`. `config` supplies

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -1249,7 +1249,8 @@ impl LocalExecutor {
             // kept instance's veto.
             //
             // The workdir-aware entry (issue #282) lets runtime file
-            // functions (`reads_count` / `wc_lines` / `file_size`) resolve
+            // functions (`reads_count` / `wc_lines` / `file_size` /
+            // `regex_extract`) resolve
             // relative paths against the run's workdir and decide on real
             // file contents; missing files fail closed here instead of
             // deferring like they do at plan time.
@@ -3193,7 +3194,8 @@ pub fn evaluate_condition_with_wildcards_base_dir_and_pending_outputs(
 
 /// Condition evaluation in the **execution-time phase** (issue #282):
 /// runtime file-reading functions (`reads_count` / `wc_lines` /
-/// `file_size`) resolve relative paths against `workdir` — the run's
+/// `file_size` / `regex_extract`) resolve relative paths against
+/// `workdir` — the run's
 /// working directory, the same root every shell command runs in — and a
 /// referenced file that does not exist evaluates **false**: the gate
 /// decides the instance here (its producer already ran, so a missing file
@@ -3415,11 +3417,73 @@ fn evaluate_condition_inner(
             _ => Path::new(path).exists(),
         });
     }
+    // Runtime regex extraction (issue #312): `regex_extract(path, pattern,
+    // group?)` parses an integer out of a text report — the flagstat
+    // mapped-count and bcftools-stats record-count gates no counting fn
+    // can express. The captured text must parse as an integer (when-
+    // language comparisons are numeric); the group defaults to 0 (the
+    // whole match). Line-oriented (`(?m)`) so `^`/`$` anchor per line.
+    // Malformed CALLS defer at plan time like every other gate that
+    // cannot yet be established (the instance survives to the execution
+    // re-check) and fail closed at execution time.
+    if let Some(rest) = s.strip_prefix("regex_extract(")
+        && let Some(close) = find_matching_paren(rest)
+    {
+        let after = rest[close + 1..].trim();
+        let args = split_top_level_commas(&rest[..close]);
+        let parsed: Option<(&str, &str, usize)> = match args.as_slice() {
+            [p, pat] => Some((
+                strip_matching_quotes(p.trim()),
+                strip_matching_quotes(pat.trim()),
+                0,
+            )),
+            [p, pat, g] => {
+                let group = strip_matching_quotes(g.trim()).trim().parse::<usize>().ok();
+                group.map(|group| {
+                    (
+                        strip_matching_quotes(p.trim()),
+                        strip_matching_quotes(pat.trim()),
+                        group,
+                    )
+                })
+            }
+            _ => None,
+        };
+        let Some((raw_path, pattern, group)) = parsed else {
+            return if workdir.is_none() {
+                ConditionVerdict::Deferred
+            } else {
+                ConditionVerdict::No
+            };
+        };
+        // Compile FIRST — a malformed pattern fails before any file I/O.
+        let re = match regex::Regex::new(&format!("(?m){pattern}")) {
+            Ok(re) => re,
+            Err(_) => {
+                return if workdir.is_none() {
+                    ConditionVerdict::Deferred
+                } else {
+                    ConditionVerdict::No
+                };
+            }
+        };
+        let candidate =
+            match resolve_runtime_path(raw_path, wildcard_values, workdir, pending_outputs) {
+                Ok(candidate) => candidate,
+                Err(verdict) => return verdict,
+            };
+        let n = read_text_report(&candidate).and_then(|content| {
+            let caps = re.captures(&content)?;
+            caps.get(group)?.as_str().trim().parse::<i64>().ok()
+        });
+        return compare_runtime_count(n, after, config_values);
+    }
     // Runtime file-reading functions (issue #282): `reads_count(path)`,
     // `wc_lines(path)`, `file_size(path)` — a small pure-read stdlib so
     // `when` can gate on runtime-produced values, e.g.
     // `reads_count('{sample}/trimmed/{sample}.fq.gz') > config.min_reads`.
-    // Only these three names are recognized, only `when` strings reach this
+    // Only these three names are recognized by THIS loop (`regex_extract`
+    // above has its own multi-arg parser), only `when` strings reach this
     // evaluator, and each function just opens a file and counts — no shell,
     // no arbitrary code. `{wildcard}` tokens in the path expand against the
     // caller's wildcard context (unbound tokens cannot exist on disk and
@@ -3448,72 +3512,17 @@ fn evaluate_condition_inner(
         let arg = rest[1..1 + close].trim();
         let after = rest[close + 2..].trim();
         let raw_path = arg.trim_matches('"').trim_matches('\'');
-        let expanded = crate::wildcard::expand_pattern(raw_path, wildcard_values)
-            .unwrap_or_else(|_| raw_path.to_string());
-        let candidate = if Path::new(&expanded).is_absolute() {
-            PathBuf::from(&expanded)
-        } else {
-            workdir.map_or_else(|| PathBuf::from(&expanded), |root| root.join(&expanded))
-        };
-        // Plan-time deferral: the referenced output cannot exist yet, or it
-        // exists only as a previous run's leftover that this run's producer
-        // will overwrite (`pending_outputs`).
-        let exists = candidate.exists();
-        if workdir.is_none()
-            && (!exists
-                || pending_outputs.is_some_and(|pending| {
-                    pending.iter().any(|p| path_matches_output(p, &expanded))
-                }))
-        {
-            return ConditionVerdict::Deferred;
-        }
+        let candidate =
+            match resolve_runtime_path(raw_path, wildcard_values, workdir, pending_outputs) {
+                Ok(candidate) => candidate,
+                Err(verdict) => return verdict,
+            };
         let n = match name {
             "file_size" => std::fs::metadata(&candidate).ok().map(|md| md.len() as i64),
             "reads_count" => count_fastq_records(&candidate),
             _ => count_text_lines(&candidate),
         };
-        let Some(n) = n else {
-            // Missing or unreadable at the deciding phase: the producer has
-            // not delivered the file — fail closed.
-            return ConditionVerdict::No;
-        };
-        if after.is_empty() {
-            // Bare `reads_count('x')` — true when a non-empty value was
-            // read (consistent with bare `len(config.x)`).
-            return ConditionVerdict::decided(n > 0);
-        }
-        for op in &["==", "!=", ">=", "<=", ">", "<"] {
-            if let Some(rhs_text) = after.strip_prefix(op) {
-                let rhs_text = rhs_text.trim();
-                // The threshold is a number literal or a `config.*`
-                // reference (`> config.min_reads`) — typed config values
-                // are read directly, string values (e.g. merged from
-                // wildcard bindings) parse.
-                let rhs_num = if let Some(key) = rhs_text.strip_prefix("config.") {
-                    config_values
-                        .get(key.trim())
-                        .and_then(runtime_threshold_as_i64)
-                } else {
-                    rhs_text.parse::<i64>().ok()
-                };
-                let Some(rhs_num) = rhs_num else {
-                    // Unresolvable threshold (absent config key,
-                    // non-numeric): the gate cannot be established — the
-                    // same absent-key behavior as `compare_config_value`.
-                    return ConditionVerdict::No;
-                };
-                return ConditionVerdict::decided(match *op {
-                    "==" => n == rhs_num,
-                    "!=" => n != rhs_num,
-                    ">=" => n >= rhs_num,
-                    "<=" => n <= rhs_num,
-                    ">" => n > rhs_num,
-                    "<" => n < rhs_num,
-                    _ => false,
-                });
-            }
-        }
-        return ConditionVerdict::No;
+        return compare_runtime_count(n, after, config_values);
     }
     for op in &["==", "!=", ">=", "<=", ">", "<"] {
         if let Some(idx) = find_top_level_op(s, op) {
@@ -3647,30 +3656,238 @@ fn runtime_threshold_as_i64(value: &toml::Value) -> Option<i64> {
 /// Byte index of the `)` that balances the `(` implied by the caller's
 /// `strip_prefix("len(")` — i.e., relative to the string starting just
 /// after that `(`. Respects nesting and quoted strings.
-fn find_matching_paren(s: &str) -> Option<usize> {
+/// Quote-state tracking shared by the when-string scanners. A quote
+/// toggles its state only when NOT backslash-escaped: regex patterns
+/// legitimately contain escaped quotes (`\"mapped\"`), and treating them
+/// as delimiters desyncs the scanner (issue #312 review).
+#[derive(Default)]
+pub(crate) struct QuoteState {
+    in_double: bool,
+    in_single: bool,
+}
+
+impl QuoteState {
+    pub(crate) fn advance(&mut self, bytes: &[u8], i: usize) {
+        let b = bytes[i];
+        let escaped = i > 0 && bytes[i - 1] == b'\\';
+        match b {
+            b'"' if !escaped && !self.in_single => self.in_double = !self.in_double,
+            b'\'' if !escaped && !self.in_double => self.in_single = !self.in_single,
+            _ => {}
+        }
+    }
+    pub(crate) fn in_quote(&self) -> bool {
+        self.in_double || self.in_single
+    }
+}
+
+pub(crate) fn find_matching_paren(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut depth = 1i32;
-    let mut in_double = false;
-    let mut in_single = false;
+    let mut quotes = QuoteState::default();
     let n = bytes.len();
     let mut i = 0usize;
     while i < n {
+        quotes.advance(bytes, i);
         let b = bytes[i];
-        match b {
-            b'"' if !in_single => in_double = !in_double,
-            b'\'' if !in_double => in_single = !in_single,
-            b'(' if !in_double && !in_single => depth += 1,
-            b')' if !in_double && !in_single => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
+        if !quotes.in_quote() {
+            match b {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
         i += 1;
     }
     None
+}
+
+/// Split function arguments on top-level commas. Commas inside `()` groups,
+/// `{}` regex quantifiers (`\d{2,3}`), `[]` character classes, or quoted
+/// arguments do not split — the delimiter only counts at nesting depth
+/// zero, outside quotes (issue #312 review: `'AC=(\d+),AN=(\d+)'` is ONE
+/// argument).
+pub(crate) fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let bytes = s.as_bytes();
+    let mut quotes = QuoteState::default();
+    for (i, c) in s.char_indices() {
+        quotes.advance(bytes, i);
+        if quotes.in_quote() {
+            continue;
+        }
+        match c {
+            '(' | '{' | '[' => depth += 1,
+            ')' | '}' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
+/// Strip an argument's wrapping quote pair — only a MATCHING pair of the
+/// same quote character is removed. A regex pattern whose first and last
+/// characters are the OTHER quote style keeps them (they are content:
+/// `"(\\d+)"` matches quoted numbers, and `'(\\d+)'` stays intact when
+/// authored under double quotes) (issue #312 review).
+pub(crate) fn strip_matching_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let (first, last) = (bytes[0], bytes[bytes.len() - 1]);
+        if (first == b'\'' || first == b'"') && last == first {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+/// The when-string content OUTSIDE quoted arguments, one string per
+/// unquoted span (delimiter quotes and quoted content excluded). Used by
+/// the lint layer (issue #312): `config.<key>` text inside a
+/// `regex_extract` pattern argument is a string literal, not a variable
+/// reference.
+pub(crate) fn unquoted_spans(s: &str) -> Vec<String> {
+    let bytes = s.as_bytes();
+    let mut quotes = QuoteState::default();
+    let mut prev_in_quote = false;
+    let mut spans = Vec::new();
+    let mut current = String::new();
+    for (i, c) in s.char_indices() {
+        quotes.advance(bytes, i);
+        let in_quote = quotes.in_quote();
+        if in_quote && !prev_in_quote {
+            spans.push(std::mem::take(&mut current));
+        } else if !in_quote {
+            current.push(c);
+        }
+        prev_in_quote = in_quote;
+    }
+    spans.push(current);
+    spans.retain(|s| !s.is_empty());
+    spans
+}
+
+/// Shared preamble of the runtime file-reading atoms (issues #282/#312):
+/// expand wildcards, resolve the path against the workdir, and apply the
+/// plan-time deferral rule (missing file, or a previous run's leftover
+/// this run's producer will overwrite). `Err(Deferred)` tells the caller
+/// to defer; otherwise the candidate path is returned.
+fn resolve_runtime_path(
+    raw_path: &str,
+    wildcard_values: &HashMap<String, String>,
+    workdir: Option<&std::path::Path>,
+    pending_outputs: Option<&[String]>,
+) -> std::result::Result<PathBuf, ConditionVerdict> {
+    let expanded = crate::wildcard::expand_pattern(raw_path, wildcard_values)
+        .unwrap_or_else(|_| raw_path.to_string());
+    let candidate = if Path::new(&expanded).is_absolute() {
+        PathBuf::from(&expanded)
+    } else {
+        workdir.map_or_else(|| PathBuf::from(&expanded), |root| root.join(&expanded))
+    };
+    // Plan-time deferral: the referenced output cannot exist yet, or it
+    // exists only as a previous run's leftover that this run's producer
+    // will overwrite (`pending_outputs`).
+    let exists = candidate.exists();
+    if workdir.is_none()
+        && (!exists
+            || pending_outputs
+                .is_some_and(|pending| pending.iter().any(|p| path_matches_output(p, &expanded))))
+    {
+        return Err(ConditionVerdict::Deferred);
+    }
+    Ok(candidate)
+}
+
+/// Read a text report for `regex_extract` (issue #312): transparent `.gz`
+/// decompression like the counting fns, bounded at 16 MiB (reports are
+/// small; the cap keeps every phase's read cheap and predictable).
+fn read_text_report(path: &Path) -> Option<String> {
+    const MAX_REPORT_BYTES: u64 = 16 * 1024 * 1024;
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > MAX_REPORT_BYTES {
+        return None;
+    }
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf = String::new();
+    let read = if path.to_string_lossy().ends_with(".gz") {
+        use std::io::Read;
+        flate2::read::MultiGzDecoder::new(file)
+            .take(MAX_REPORT_BYTES + 1)
+            .read_to_string(&mut buf)
+    } else {
+        use std::io::Read;
+        file.take(MAX_REPORT_BYTES + 1).read_to_string(&mut buf)
+    };
+    read.ok()?;
+    if buf.len() as u64 > MAX_REPORT_BYTES {
+        return None;
+    }
+    Some(buf)
+}
+
+/// Shared comparison tail of the runtime file-reading atoms (issues #282
+/// and #312): compare a read value against number literals or `config.*`
+/// thresholds, fail-closed on missing/unparseable values.
+fn compare_runtime_count(
+    n: Option<i64>,
+    after: &str,
+    config_values: &HashMap<String, toml::Value>,
+) -> ConditionVerdict {
+    let Some(n) = n else {
+        // Missing or unreadable at the deciding phase: the producer has
+        // not delivered the file — fail closed.
+        return ConditionVerdict::No;
+    };
+    if after.is_empty() {
+        // Bare `reads_count('x')` — true when a non-empty value was read
+        // (consistent with bare `len(config.x)`).
+        return ConditionVerdict::decided(n > 0);
+    }
+    for op in &["==", "!=", ">=", "<=", ">", "<"] {
+        if let Some(rhs_text) = after.strip_prefix(op) {
+            let rhs_text = rhs_text.trim();
+            // The threshold is a number literal or a `config.*`
+            // reference (`> config.min_reads`) — typed config values are
+            // read directly, string values (e.g. merged from wildcard
+            // bindings) parse.
+            let rhs_num = if let Some(key) = rhs_text.strip_prefix("config.") {
+                config_values
+                    .get(key.trim())
+                    .and_then(runtime_threshold_as_i64)
+            } else {
+                rhs_text.parse::<i64>().ok()
+            };
+            let Some(rhs_num) = rhs_num else {
+                // Unresolvable threshold (absent config key, non-numeric):
+                // the gate cannot be established — the same absent-key
+                // behavior as `compare_config_value`.
+                return ConditionVerdict::No;
+            };
+            return ConditionVerdict::decided(match *op {
+                "==" => n == rhs_num,
+                "!=" => n != rhs_num,
+                ">=" => n >= rhs_num,
+                "<=" => n <= rhs_num,
+                ">" => n > rhs_num,
+                "<" => n < rhs_num,
+                _ => false,
+            });
+        }
+    }
+    ConditionVerdict::No
 }
 
 fn find_top_level_op(s: &str, op: &str) -> Option<usize> {
@@ -3678,24 +3895,20 @@ fn find_top_level_op(s: &str, op: &str) -> Option<usize> {
     let op_len = op_bytes.len();
     let bytes = s.as_bytes();
     let mut depth: i32 = 0;
-    let mut in_double = false;
-    let mut in_single = false;
+    let mut quotes = QuoteState::default();
     let n = bytes.len();
     let mut i = 0usize;
     while i < n {
+        quotes.advance(bytes, i);
         let b = bytes[i];
-        match b {
-            b'"' if !in_single => in_double = !in_double,
-            b'\'' if !in_double => in_single = !in_single,
-            b'(' if !in_double && !in_single => depth += 1,
-            b')' if !in_double && !in_single => depth -= 1,
-            _ => {}
+        if !quotes.in_quote() {
+            match b {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
         }
-        if !in_double
-            && !in_single
-            && depth == 0
-            && i + op_len <= n
-            && &bytes[i..i + op_len] == op_bytes
+        if !quotes.in_quote() && depth == 0 && i + op_len <= n && &bytes[i..i + op_len] == op_bytes
         {
             return Some(i);
         }

--- a/crates/oxo-flow-core/src/executor/tests.rs
+++ b/crates/oxo-flow-core/src/executor/tests.rs
@@ -1090,6 +1090,149 @@ fn runtime_when_functions_count_real_files() {
 }
 
 #[test]
+fn regex_extract_reads_counts_from_text_reports() {
+    // Issue #312: `regex_extract(path, pattern, group?)` extracts an
+    // integer from a text report line — the flagstat mapped-count and
+    // bcftools-stats record-count gates that no 0.17 runtime fn could
+    // express.
+    use super::process::evaluate_condition_with_workdir_and_base_dir;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = HashMap::new();
+    let empty = HashMap::new();
+
+    // samtools flagstat: "100 + 0 mapped (100% : N/A)".
+    std::fs::write(
+        dir.path().join("flagstat.txt"),
+        "100 + 0 in total (QC-passed reads + QC-failed reads)\n\
+         100 + 0 mapped (100% : N/A)\n\
+         0 + 0 properly paired (0% : N/A)\n",
+    )
+    .unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('flagstat.txt', '(\\d+) \\+ 0 mapped', 1) == 100",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('flagstat.txt', '(\\d+) \\+ 0 mapped', 1) > 100",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // bcftools stats: "SN\t0\tnumber of records:\t42".
+    std::fs::write(
+        dir.path().join("stats.txt"),
+        "SN\t0\tnumber of samples:\t1\nSN\t0\tnumber of records:\t42\n",
+    )
+    .unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('stats.txt', 'number of records:\\s+(\\d+)', 1) == 42",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Group defaults to 0 (the whole match) — a pattern that matches a
+    // pure number needs no explicit group.
+    std::fs::write(dir.path().join("pure.txt"), "answer: 7\n").unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('pure.txt', '\\d+') == 7",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    // Explicit group 1 extracts the same value out of surrounding text.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('pure.txt', 'answer: (\\d+)', 1) == 7",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Bare call: truthiness = extracted value > 0.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('stats.txt', 'number of records:\\s+(\\d+)', 1)",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Config thresholds work like the other runtime fns.
+    let mut typed = HashMap::new();
+    typed.insert("min_mapped".to_string(), toml::Value::Integer(50));
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('flagstat.txt', '(\\d+) \\+ 0 mapped', 1) >= config.min_mapped",
+        &typed,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // Fail-closed at execution time: missing file, no match, non-numeric
+    // capture, and out-of-range group are all false.
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('missing.txt', '(\\d+)') > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('flagstat.txt', 'properly paired', 1) > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    std::fs::write(dir.path().join("words.txt"), "just words here\n").unwrap();
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('words.txt', '(\\w+)', 1) > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+    assert!(!evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('flagstat.txt', '(\\d+)', 9) > 0",
+        &config,
+        &empty,
+        Some(dir.path()),
+        None
+    ));
+
+    // The same missing file at PLAN time defers — the producer has not
+    // run yet.
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('missing.txt', '(\\d+)') > 0",
+        &config,
+        &empty,
+        None,
+        None
+    ));
+
+    // `{wildcard}` tokens expand like the other runtime fns.
+    let mut wildcards = HashMap::new();
+    wildcards.insert("sample".to_string(), "sample".to_string());
+    std::fs::write(dir.path().join("sample.flagstat.txt"), "9 + 0 mapped\n").unwrap();
+    assert!(evaluate_condition_with_workdir_and_base_dir(
+        "regex_extract('{sample}.flagstat.txt', '(\\d+) \\+ 0 mapped', 1) == 9",
+        &config,
+        &wildcards,
+        Some(dir.path()),
+        None
+    ));
+}
+
+#[test]
 fn wc_lines_decompresses_gzip_like_reads_count() {
     // Issue #282 review: `wc_lines` must decompress `.gz` inputs the same
     // way `reads_count` does — the count is of the decompressed content.
@@ -2692,5 +2835,134 @@ async fn meta_when_gate_runs_se_and_skips_pe_instances() {
             .iter()
             .all(|r| r.name != "trim_control_PE1" && r.name != "trim_control_X1"),
         "gated instances must not survive planning"
+    );
+}
+
+#[test]
+fn regex_extract_review_hardening_cases() {
+    // Issue #312 review regressions: quotes, commas and anchors inside
+    // pattern arguments; group-0 strictness; quoted numeric group; gz;
+    // zero-value truthiness; malformed-call phase semantics.
+    use super::process::evaluate_condition_with_workdir_and_base_dir;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = HashMap::new();
+    let empty = HashMap::new();
+    let ev = |expr: &str, wd: Option<&std::path::Path>| {
+        evaluate_condition_with_workdir_and_base_dir(expr, &config, &empty, wd, None)
+    };
+
+    // Escaped quotes inside the pattern do not desync the paren scanner
+    // (they are regex content, not when-string delimiters).
+    std::fs::write(dir.path().join("qc.txt"), "{\"mapped\": 80}\n").unwrap();
+    assert!(ev(
+        r#"regex_extract('qc.txt', '\"mapped\": (\d+)', 1) == 80"#,
+        Some(dir.path())
+    ));
+
+    // A comma at depth 0 INSIDE the quoted pattern is one argument.
+    std::fs::write(dir.path().join("f.txt"), "mapped: 80, total\n").unwrap();
+    assert!(ev(
+        r#"regex_extract('f.txt', 'mapped: (\d+), total', 1) == 80"#,
+        Some(dir.path())
+    ));
+
+    // Group 0 is the WHOLE match — embedded text does not silently fall
+    // back to capture group 1.
+    std::fs::write(dir.path().join("pure.txt"), "answer: 7\n").unwrap();
+    assert!(!ev(
+        r#"regex_extract('pure.txt', 'answer: (\d+)') == 7"#,
+        Some(dir.path())
+    ));
+
+    // A quoted numeric group parses (doc style).
+    assert!(ev(
+        r#"regex_extract('pure.txt', 'answer: (\d+)', '1') == 7"#,
+        Some(dir.path())
+    ));
+
+    // Zero-value bare call is falsy (n > 0 boundary pinned).
+    std::fs::write(dir.path().join("zero.txt"), "count: 0\n").unwrap();
+    assert!(!ev(
+        r#"regex_extract('zero.txt', 'count: (\d+)', 1)"#,
+        Some(dir.path())
+    ));
+
+    // Line-oriented matching: `^` anchors each line under (?m).
+    std::fs::write(
+        dir.path().join("anchor.txt"),
+        "total reads: 100\nmapped: 42\n",
+    )
+    .unwrap();
+    assert!(ev(
+        r#"regex_extract('anchor.txt', '^mapped: (\d+)', 1) == 42"#,
+        Some(dir.path())
+    ));
+
+    // Gzip reports decode like the sibling counting fns.
+    let gz_path = dir.path().join("stats.txt.gz");
+    let gz_file = std::fs::File::create(&gz_path).unwrap();
+    let mut enc = flate2::write::GzEncoder::new(gz_file, flate2::Compression::default());
+    std::io::Write::write_all(&mut enc, b"number of records:\t42\n").unwrap();
+    enc.finish().unwrap();
+    assert!(ev(
+        r#"regex_extract('stats.txt.gz', 'number of records:\s+(\d+)', 1) == 42"#,
+        Some(dir.path())
+    ));
+
+    // Malformed calls defer at plan time (the instance must survive for
+    // the execution re-check, never silently pruned) and fail closed at
+    // execution time.
+    for expr in [
+        r#"regex_extract('f.txt', 'p', 1, 'extra') > 0"#, // wrong arity
+        r#"regex_extract('f.txt', '(\d+', 1) > 0"#,       // uncompilable pattern
+        r#"regex_extract('f.txt', '(\d+)', 'x') > 0"#,    // non-numeric group
+    ] {
+        assert!(ev(expr, None), "plan time must defer: {expr}");
+        assert!(
+            !ev(expr, Some(dir.path())),
+            "execution must fail closed: {expr}"
+        );
+    }
+}
+
+#[test]
+fn unquoted_spans_exclude_quoted_arguments() {
+    // The lint layer's E005/W030 scans run on unquoted spans only.
+    let spans = super::process::unquoted_spans(
+        "config.a > 1 && regex_extract('x.txt', 'config.b = (\\d+)', 1) > 2",
+    );
+    // One span per unquoted stretch: before the path, between the args,
+    // and after the call.
+    assert_eq!(spans.len(), 3);
+    assert!(spans[0].contains("config.a"));
+    assert!(spans[2].contains("> 2"));
+    assert!(
+        !spans.iter().any(|s| s.contains("config.b")),
+        "quoted pattern text stays quoted"
+    );
+}
+
+#[test]
+fn strip_matching_quotes_keeps_cross_style_edge_quotes() {
+    // A pattern whose edge characters are the OTHER quote style keeps
+    // them — they are regex content.
+    assert_eq!(
+        super::process::strip_matching_quotes("'regex_content'"),
+        "regex_content"
+    );
+    assert_eq!(
+        super::process::strip_matching_quotes("\"(\\d+)\""),
+        "(\\d+)"
+    );
+    // Cross-style: single-quoted arg matching apostrophes, and a
+    // double-quoted arg wrapping single-quote content.
+    assert_eq!(
+        super::process::strip_matching_quotes("\"'(\\d+)'\""),
+        "'(\\d+)'"
+    );
+    assert_eq!(
+        super::process::strip_matching_quotes("unquoted"),
+        "unquoted"
     );
 }

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -145,6 +145,67 @@ fn environment_field_value(env: &EnvironmentSpec, field: &str) -> String {
     value.unwrap_or_default().to_string()
 }
 
+/// W030: `regex_extract(path, pattern, group?)` call-shape checks for
+/// `when` strings (issue #312) — wrong arity, non-numeric group, or an
+/// uncompilable pattern is a silent always-false gate at execution time,
+/// so the authoring error must be loud at validate/lint time.
+fn lint_regex_extract_calls(when: &str, rule: &Rule, diagnostics: &mut Vec<Diagnostic>) {
+    let bytes = when.as_bytes();
+    let needle = b"regex_extract(";
+    let mut quotes = crate::executor::process::QuoteState::default();
+    let mut i = 0usize;
+    while i + needle.len() <= bytes.len() {
+        quotes.advance(bytes, i);
+        if !quotes.in_quote() && &bytes[i..i + needle.len()] == needle {
+            // The call spans multiple quoted arguments — parse the parens
+            // and args from the FULL string (the scanners are quote-aware).
+            // `find_matching_paren` scans text AFTER the opening paren.
+            let open = i + needle.len() - 1;
+            let Some(close) = crate::executor::process::find_matching_paren(&when[open + 1..])
+            else {
+                i += needle.len();
+                continue;
+            };
+            let parts =
+                crate::executor::process::split_top_level_commas(&when[open + 1..open + 1 + close]);
+            let mut reason: Option<String> = None;
+            if parts.len() != 2 && parts.len() != 3 {
+                reason = Some(format!("{} arguments (expected 2 or 3)", parts.len()));
+            }
+            if reason.is_none() && parts.len() == 3 {
+                let group = crate::executor::process::strip_matching_quotes(parts[2].trim()).trim();
+                if group.parse::<usize>().is_err() {
+                    reason = Some(format!("group '{}' is not a number", parts[2].trim()));
+                }
+            }
+            if reason.is_none() && parts.len() >= 2 {
+                let pattern = crate::executor::process::strip_matching_quotes(parts[1].trim());
+                if regex::Regex::new(&format!("(?m){pattern}")).is_err() {
+                    reason = Some("pattern does not compile".to_string());
+                }
+            }
+            if let Some(reason) = reason {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    message: format!(
+                        "when condition has a malformed regex_extract call: {reason} — the gate silently evaluates false at execution time"
+                    ),
+                    rule: Some(rule.name.clone()),
+                    code: "W030".to_string(),
+                    suggestion: Some(
+                        "use regex_extract('path', 'pattern', group?) with a numeric group \
+                         (default 0 = whole match)"
+                            .to_string(),
+                    ),
+                });
+            }
+            i = open + 1 + close + 1;
+        } else {
+            i += 1;
+        }
+    }
+}
+
 pub fn undefined_config_refs(rule: &Rule, config: &WorkflowConfig) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     let config_ref_re = regex::Regex::new(r"\{config\.(\w+)\}").expect("valid regex");
@@ -178,18 +239,29 @@ pub fn undefined_config_refs(rule: &Rule, config: &WorkflowConfig) -> Vec<Diagno
         check("input path", input, &mut diagnostics);
     }
     if let Some(ref when) = rule.when {
-        for cap in when_ref_re.captures_iter(when) {
-            let key = &cap[1];
-            if config.get_config_value(key).is_none() {
-                diagnostics.push(Diagnostic {
-                    severity: Severity::Error,
-                    message: format!("when condition references undefined config variable '{key}'"),
-                    rule: Some(rule.name.clone()),
-                    code: "E005".to_string(),
-                    suggestion: Some(format!("define '{key}' in the [config] section")),
-                });
+        // Quote-aware scan (issue #312): `config.<key>` text inside a
+        // quoted argument — e.g. a `regex_extract` pattern matching a
+        // settings dump — is a string literal, not a variable reference.
+        for span in crate::executor::process::unquoted_spans(when) {
+            for cap in when_ref_re.captures_iter(&span) {
+                let key = &cap[1];
+                if config.get_config_value(key).is_none() {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Error,
+                        message: format!(
+                            "when condition references undefined config variable '{key}'"
+                        ),
+                        rule: Some(rule.name.clone()),
+                        code: "E005".to_string(),
+                        suggestion: Some(format!("define '{key}' in the [config] section")),
+                    });
+                }
             }
         }
+        // W030 (issue #312): a malformed `regex_extract(...)` call is a
+        // silent always-false gate at execution time — authoring errors
+        // must be loud at validate/lint time.
+        lint_regex_extract_calls(when, rule, &mut diagnostics);
         // `len(config.<key>)` (issue #252): a length comparison against a
         // non-numeric literal is a silent always-false — flag it.
         let len_ref_re = regex::Regex::new(
@@ -2058,6 +2130,72 @@ mod tests {
         let result = validate_format(&config);
         assert!(!result.valid);
         assert!(result.errors().iter().any(|d| d.code == "E005"));
+    }
+
+    #[test]
+    fn e005_skips_config_text_inside_regex_extract_pattern() {
+        // Issue #312: `config.<key>` text inside a quoted regex pattern is
+        // a string literal (matching a settings dump), not a reference.
+        let toml = r#"
+            [workflow]
+            name = "test"
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            when = "regex_extract('settings.log', 'config.min_reads = (\\d+)', 1) > 0"
+            shell = "echo hi"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let result = validate_format(&config);
+        assert!(
+            result.errors().iter().all(|d| d.code != "E005"),
+            "quoted pattern text must not trigger E005: {:?}",
+            result.errors()
+        );
+    }
+
+    #[test]
+    fn w030_flags_malformed_regex_extract_calls() {
+        // Issue #312: silent always-false gates must be loud authoring
+        // errors — wrong arity, non-numeric group, uncompilable pattern.
+        let base = r#"
+            [workflow]
+            name = "test"
+
+            [config]
+            min_reads = 5
+
+            [[rules]]
+            name = "{name}"
+            output = ["out.txt"]
+            when = "{when}"
+            shell = "echo hi"
+        "#;
+        for (name, when, expect_w030) in [
+            (
+                "ok",
+                r#"regex_extract('f.txt', '(\\d+) \\+ \\d+ mapped', 1) > config.min_reads"#,
+                false,
+            ),
+            ("arity", r#"regex_extract('f.txt', 'p', 1, 'x') > 0"#, true),
+            (
+                "bad_group",
+                r#"regex_extract('f.txt', '(\\d+)', 'x') > 0"#,
+                true,
+            ),
+            (
+                "bad_pattern",
+                r#"regex_extract('f.txt', '(\\d+', 1) > 0"#,
+                true,
+            ),
+        ] {
+            let toml = base.replace("{name}", name).replace("{when}", when);
+            let config = WorkflowConfig::parse(&toml).unwrap();
+            let result = validate_format(&config);
+            let has_w030 = result.warnings().iter().any(|d| d.code == "W030");
+            assert_eq!(has_w030, expect_w030, "{name}: {when}");
+        }
     }
 
     #[test]

--- a/docs/guide/src/how-to/conditional-rules.md
+++ b/docs/guide/src/how-to/conditional-rules.md
@@ -58,7 +58,7 @@ paths pass through unchanged.
 ### Data-dependent gates (runtime functions)
 
 `when` can also inspect files produced earlier in the same run — the gate
-becomes data-dependent (issue #282). Three read-only functions are
+becomes data-dependent (issue #282). Five read-only functions are
 available in `when` strings:
 
 | Function | Reads | Returns |
@@ -66,6 +66,7 @@ available in `when` strings:
 | `reads_count(path)` | FASTQ (plain or `.gz`) | record count (lines ÷ 4, truncated) |
 | `wc_lines(path)` | any text file (plain or `.gz`) | line count of the decompressed content |
 | `file_size(path)` | any file | size in bytes |
+| `regex_extract(path, pattern, group?)` | any text file | integer parsed from the first regex match (group defaults to 0 = whole match; the captured text must be a number) |
 | `file_exists(path)` | — | 1/0 existence probe |
 
 ```toml

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -595,7 +595,7 @@ memory = "32G"
 | `resources` | Table | No | Full resource specification (threads, memory, gpu, disk, time_limit, partition, groups) |
 | `environment` | Table | No | Environment specification |
 | `transform` | Table | No | Unified scatter-gather operator (split → map → combine) |
-| `when` | String | No | Conditional expression — skip rule when `false`. May call read-only runtime functions (`reads_count`, `wc_lines`, `file_size`, `file_exists`) that inspect files in the run workdir; see [Data-Dependent `when` Gates](#data-dependent-when-gates) |
+| `when` | String | No | Conditional expression — skip rule when `false`. May call read-only runtime functions (`reads_count`, `wc_lines`, `file_size`, `file_exists`, `regex_extract`) that inspect files in the run workdir; see [Data-Dependent `when` Gates](#data-dependent-when-gates) |
 | `envvars` | Table | No | Dictionary of environment variables to inject |
 | `params` | Table | No | User-defined parameters for shell templates |
 | `pre_exec` | String | No | Command to run *before* the main shell command |
@@ -2055,6 +2055,7 @@ shell = "fastqc {input[0]} -o qc/"
 | `len(config.<key>)` | `len(config.gene_sets) > 0` | Element count comparison: array items, string characters, or table keys, compared against a whole number (`==`, `!=`, `>=`, `<=`, `>`, `<`). A missing key counts as 0. Bare `len(config.<key>)` is truthy when non-empty. Note a bare `config.<key>` array is truthy even when empty — `len(...) > 0` is the "list is non-empty" gate. Comparing against a non-numeric literal is a lint warning (W029) and always evaluates false |
 | `file_exists("path")` | `file_exists("panel.bed")` | File existence test. Relative paths resolve against the **workflow root** (the workflow file's directory), not the process working directory, and every evaluation site (plan time, execution re-check, config-change analysis) resolves the same way. In per-instance predicates (`wildcard.<key>` / `{meta.<column>}`) it is evaluated at **plan time** — the instance set is fixed when the DAG is built, so files produced mid-run cannot gate instances; express those with `{meta.*}` (plan-time bakeable) or an execution-time `config` gate instead |
 | `reads_count("path")` / `wc_lines("path")` / `file_size("path")` | `reads_count('trimmed/{sample}.fq.gz') > config.min_reads` | Data-dependent gates — count FASTQ records (4-line records, plain or `.gz`), text lines of the decompressed content (plain or `.gz`), or file bytes in the **run workdir** at execution time. See [Data-Dependent `when` Gates](#data-dependent-when-gates) |
+| `regex_extract("path", "pattern", group?)` | `regex_extract('alignment/{sample}.flagstat', '(\\d+) \\+ \\d+ mapped', 1) > config.min_mapped_reads` | Data-dependent gate — parse an integer out of a text report's first regex match (issue #312). `group` defaults to 0 (the whole match — the pattern must then match a bare number); use group 1+ to extract a number embedded in surrounding text (samtools flagstat's mapped count, bcftools-stats record counts). The captured text must parse as an integer; missing file / no match / non-numeric capture fail closed at execution time. Malformed calls (wrong arity, non-numeric group, uncompilable pattern) are flagged as W030 |
 | `wildcard.<key> == "value"` | `wildcard.control != ""` | Per-instance pair/group wildcard comparison (`pair_id`, `experiment`, `control`, `tumor`, `normal`, `experiment_type`, `tumor_type`, `group`, `sample`, plus any `metadata` keys declared on `[[pairs]]` / `[[sample_groups]]` and `[[values]]` table names) — evaluated per expansion combo at DAG build time; non-matching instances never enter the DAG (snakemake-style morphing) |
 | `{meta.<column>} == "value"` | `{meta.endedness} == 'SE'` | Per-instance sample-metadata comparison (see [Sample Metadata](#sample-metadata-metadata_file)) — baked and evaluated per instance at plan time; instances whose gate evaluates false never enter the DAG. A missing row or column renders `''` in a comparison (a closed gate) |
 | `!<expr>` | `!config.skip` | Logical NOT |
@@ -2064,10 +2065,11 @@ shell = "fastqc {input[0]} -o qc/"
 
 ### Data-Dependent `when` Gates
 
-The runtime functions `reads_count(path)`, `wc_lines(path)`, and
-`file_size(path)` let a `when` gate inspect files produced earlier in the
-same run (issue #282) — e.g. skip a variant caller on samples whose
-trimmed FASTQ has too few records:
+The runtime functions `reads_count(path)`, `wc_lines(path)`,
+`file_size(path)`, and `regex_extract(path, pattern, group?)` let a `when`
+gate inspect files produced earlier in the same run (issues #282/#312) —
+e.g. skip a variant caller on samples whose trimmed FASTQ has too few
+records:
 
 ```toml
 [[rules]]
@@ -2097,6 +2099,15 @@ shell = "caller --input {input[0]} --output {output[0]}"
   content for plain or gzip files (same `.gz` detection as `reads_count`);
   `file_size` returns the byte length. BAM/BGZF indexing is planned for
   a future release.
+- **Regex extraction** — `regex_extract(path, pattern, group?)` reads the
+  whole file (plain or `.gz`, up to 16 MiB) and takes the **first** regex
+  match; the captured text (group `0` = whole match by default, or an
+  explicit capture group) must parse as an integer. Matching is
+  line-oriented (`(?m)` is applied automatically), so `^` and `$` anchor
+  per line. Commas inside the pattern's `{}` quantifiers, `[]` character
+  classes, or quoted arguments do not split arguments. The extracted
+  value compares against literals and `config.*` thresholds exactly like
+  the counting functions.
 - **Change tracking** — recorded verdicts participate in config-change
   replay: changing a threshold referenced by such a gate (e.g.
   `config.min_reads`) re-evaluates only the instances whose verdict


### PR DESCRIPTION
Fixes #312 — the runtime-fn gap that blocked viralrecon's `min_mapped_reads` flagstat gate and the bcftools-stats zero-variant filter.

## What

`regex_extract(path, pattern, group?)` parses an integer out of a text report's first regex match. Group defaults to 0 (whole match); use group 1+ to extract a number embedded in surrounding text. The captured text must parse as an integer — when-language comparisons are numeric, so the String-coercion question the issue raised dissolves.

Semantics shared with the counting fns: plan-time deferral (the instance survives until its producer ran), execution-time fail-closed, `{wildcard}` expansion, config-threshold comparison, gz transparency, and a 16 MiB read cap. Line-oriented matching (`(?m)`) so `^`/`$` anchor per line.

## Review hardening (forked high-level review, 14 findings — all addressed)

- **Scanner correctness**: quote-aware + backslash-escape-aware paren/comma/operator scanning — patterns containing `\mapped\` or commas (`'AC=(\\d+),AN=(\\d+)'`) no longer desync into permanently-true/false gates; argument quotes stripped only as MATCHING pairs
- **Plan-time semantics**: malformed calls (arity/group/pattern) defer at plan time instead of silently pruning instances; fail closed at execution
- **Loud authoring errors**: new **W030** lint — wrong arity, non-numeric group, uncompilable pattern are warnings at validate/lint, not silent always-false gates
- **E005 hardening**: quote-aware when-scan — `config.<key>` text inside a quoted regex pattern is a string literal, not an undefined-variable error
- **Docs/fixture traps fixed**: flagstat example pattern now tolerates nonzero QC-failed term (`\\d+ \\+ \\d+ mapped`); doc/fixture semantics pinned by tests

## Tests

13+ new tests: both issue scenarios, group-0 strictness, zero-value truthiness, quoted numeric group, gz, `(?m)` anchors, quote/comma patterns, malformed-call phase semantics, unquoted_spans, strip_matching_quotes, W030, E005 quote-skip. `make ci` green locally.

## Test plan

- [x] make ci (fmt + clippy -D warnings + full suite + audit)
- [x] tx-ubuntu live: flagstat gate workflow — plan-time deferral (4 planned), execution-time per-sample drop (s1 80-mapped kept / s2 10-mapped skipped), verify 3 matched
- [ ] tx-ubuntu live re-verify on the review-fixed commit (in progress)
- [ ] CI green on main after merge

## Follow-ups (out of scope)

- viralrecon port adoption once the engine ships (`min_mapped_reads` + zero-variant gates)
- Pre-existing #282-class staleness: content-only changes to gate files don't re-trigger verdict replay without a config-key change — documented, tracked for a follow-up issue