### PR TITLE
feat: metro maps — module sections in flow order, stage lines, prefix-free labels

### DIFF
--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -281,8 +281,9 @@ fn declared_default(def: &oxo_flow_core::config::ConfigDef) -> Value {
     }
 }
 
-/// Does the rule reference the config key in its shell, script, I/O patterns
-/// (`{config.<key>}`), or `when` condition (brace-less `config.<key>`)?
+/// Does the rule reference the config key in its shell, script, I/O or
+/// expansion patterns (`{config.<key>}`), or `when` condition (brace-less
+/// `config.<key>`)?
 fn rule_uses_config(rule: &Rule, key: &str) -> bool {
     let braced = format!("{{config.{key}}}");
     let paths_use = |paths: &[String]| paths.iter().any(|path| path.contains(&braced));
@@ -290,6 +291,18 @@ fn rule_uses_config(rule: &Rule, key: &str) -> bool {
         || rule.script.as_deref().is_some_and(|s| s.contains(&braced))
         || paths_use(&rule.input.to_vec())
         || paths_use(&rule.output.to_vec())
+        || rule
+            .expand_inputs
+            .iter()
+            .any(|e| e.pattern.contains(&braced))
+        || rule
+            .input_groups
+            .iter()
+            .any(|g| g.pattern.contains(&braced))
+        || rule
+            .expand_inputs
+            .iter()
+            .any(|e| e.variables.values().any(|v| v.contains(&braced)))
     {
         return true;
     }
@@ -873,5 +886,80 @@ mod tests {
                 },
             ])
         );
+    }
+
+    #[test]
+    fn derive_meta_config_used_by_expand_inputs_and_groups() {
+        // {config.<key>} inside expand_inputs patterns / variables and
+        // input_groups patterns must count as usage too — community
+        // workflows (rnaseq cat_reads) feed config keys exclusively
+        // through these channels: reads_dir appears ONLY in the
+        // input_groups pattern, parts_dir ONLY in the expand_inputs
+        // pattern.
+        let dir = std::env::temp_dir().join(format!("oxo-info-expand-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wf = dir.join("wf.oxoflow");
+        std::fs::write(
+            &wf,
+            r#"
+[workflow]
+name = "n"
+version = "1.0.0"
+
+[config]
+reads_dir = "raw"
+parts_dir = "parts"
+unused_key = "x"
+[[rules]]
+name = "cat_reads"
+input_groups = [
+    { pattern = "{config.reads_dir}/{sample}_R{read}.fastq.gz", group_by = "sample" },
+]
+output = ["merged/{sample}.fastq.gz"]
+shell = "cat {input} > {output[0]}"
+
+[[rules]]
+name = "aggregate"
+input = []
+expand_inputs = [
+    { pattern = "{config.parts_dir}/*.txt", variables = {} },
+]
+output = ["all.txt"]
+shell = "cat {input} > {output[0]}"
+
+[[rules]]
+name = "unused_user"
+input = []
+output = ["u.txt"]
+shell = "echo done > {output[0]}"
+"#,
+        )
+        .unwrap();
+        let meta = meta(wf.to_str().unwrap(), wf.to_str().unwrap());
+        let records = meta["config"].as_array().unwrap();
+        let used_by = |key: &str| -> Vec<String> {
+            records
+                .iter()
+                .find(|record| record["key"] == key)
+                .unwrap_or_else(|| panic!("{key} must appear in config records"))["used_by"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap().to_string())
+                .collect()
+        };
+        assert_eq!(
+            used_by("reads_dir"),
+            vec!["cat_reads"],
+            "input_groups pattern is a usage site"
+        );
+        assert_eq!(
+            used_by("parts_dir"),
+            vec!["aggregate"],
+            "expand_inputs pattern is a usage site"
+        );
+        assert_eq!(used_by("unused_key"), Vec::<String>::new());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -711,179 +711,59 @@ impl WorkflowDag {
     /// nf-metro render workflow.mmd -o workflow.svg
     /// ```
     ///
-    /// Each rule becomes a station; each dependency becomes an edge carrying
-    /// the *source* rule's stage line. Stages are inferred per rule (see
-    /// [`crate::stage`]); distinct stages become distinct sections.
-    /// Break stage-level cycles by demoting inferred stages to "generic".
+    /// Each rule becomes a station (its `module::` prefix stripped — the
+    /// section already names the group); each dependency becomes an edge
+    /// carrying the *source* rule's stage line. Stages are inferred per rule
+    /// (see [`crate::stage`]) and become colored lines that flow through
+    /// multiple sections — the nf-core transit-map structure — while sections
+    /// follow the workflow's module namespaces in data-flow order.
     ///
-    /// The rule DAG is acyclic by construction, but the coarse stage labels can
-    /// make the stage flow circular (e.g. a mark-duplicates hub rule staged
-    /// differently from its consumers). Rules carrying an explicit `tags` stage
-    /// keep it (user intent wins); everything else may be demoted until the
-    /// stage graph is acyclic. Deterministic: each iteration removes one rule
-    /// from a non-generic stage, so the loop terminates.
-    fn break_stage_cycles(
-        graph: &DiGraph<DagNode, ()>,
-        rules: &[Rule],
-        node_stage: &mut HashMap<NodeIndex, String>,
-    ) {
-        loop {
-            // Stage-level edges, deduplicated.
-            let mut stage_edges: std::collections::HashSet<(String, String)> =
-                std::collections::HashSet::new();
-            for edge in graph.edge_indices() {
-                let (src, dst) = graph.edge_endpoints(edge).unwrap();
-                let s = node_stage[&src].clone();
-                let d = node_stage[&dst].clone();
-                if s != d {
-                    stage_edges.insert((s, d));
-                }
-            }
-
-            // Find one cycle in the stage graph (DFS with a path stack).
-            fn dfs(
-                current: &str,
-                edges: &std::collections::HashSet<(String, String)>,
-                stack: &mut Vec<String>,
-                on_stack: &mut std::collections::HashSet<String>,
-                visited: &mut std::collections::HashSet<String>,
-            ) -> Option<Vec<(String, String)>> {
-                if !on_stack.insert(current.to_string()) {
-                    // Cycle found: the segment from current..end of stack.
-                    let start = stack.iter().position(|s| s == current).unwrap_or(0);
-                    let cycle: Vec<(String, String)> = stack[start..]
-                        .windows(2)
-                        .map(|w| (w[0].clone(), w[1].clone()))
-                        .collect();
-                    let cycle = if cycle.is_empty() {
-                        vec![(current.to_string(), current.to_string())]
-                    } else {
-                        cycle
-                    };
-                    // Close the loop back to current.
-                    let mut cycle = cycle;
-                    if let Some(last) = stack.last()
-                        && *last != current
-                    {
-                        cycle.push((last.clone(), current.to_string()));
-                    }
-                    return Some(cycle);
-                }
-                if !visited.insert(current.to_string()) {
-                    on_stack.remove(current);
-                    return None;
-                }
-                stack.push(current.to_string());
-                for (s, d) in edges {
-                    if s == current
-                        && let Some(found) = dfs(d, edges, stack, on_stack, visited)
-                    {
-                        return Some(found);
-                    }
-                }
-                stack.pop();
-                on_stack.remove(current);
-                None
-            }
-
-            let mut cycle: Option<Vec<(String, String)>> = None;
-            let mut visited = std::collections::HashSet::new();
-            let all_stages: std::collections::HashSet<String> = stage_edges
-                .iter()
-                .flat_map(|(s, d)| [s.clone(), d.clone()])
-                .collect();
-            for start in all_stages {
-                let mut stack = Vec::new();
-                let mut on_stack = std::collections::HashSet::new();
-                if let Some(found) = dfs(
-                    &start,
-                    &stage_edges,
-                    &mut stack,
-                    &mut on_stack,
-                    &mut visited,
-                ) {
-                    cycle = Some(found);
-                    break;
-                }
-            }
-
-            let Some(cycle) = cycle else {
-                return; // acyclic — done
-            };
-
-            // Demote one inferred rule participating in the cycle: the source
-            // rule of the first cycle edge whose stage is not "generic".
-            let mut demoted = false;
-            for (s, d) in &cycle {
-                if *s == "generic" {
-                    continue;
-                }
-                for edge in graph.edge_indices() {
-                    let (a, b) = graph.edge_endpoints(edge).unwrap();
-                    if node_stage[&a] != *s || node_stage[&b] != *d {
-                        continue;
-                    }
-                    let rule_idx = graph[a].rule_index;
-                    let explicitly_tagged = rules.get(rule_idx).is_some_and(|r| !r.tags.is_empty());
-                    if !explicitly_tagged {
-                        node_stage.insert(a, "generic".to_string());
-                        demoted = true;
-                        break;
-                    }
-                }
-                if demoted {
-                    break;
-                }
-            }
-            if !demoted {
-                // Every participant is explicitly tagged or already generic —
-                // renderability beats stage fidelity: demote the first
-                // non-generic participant regardless.
-                for (s, _d) in &cycle {
-                    if *s == "generic" {
-                        continue;
-                    }
-                    for edge in graph.edge_indices() {
-                        let (a, _b) = graph.edge_endpoints(edge).unwrap();
-                        if node_stage[&a] == *s {
-                            node_stage.insert(a, "generic".to_string());
-                            demoted = true;
-                            break;
-                        }
-                    }
-                    if demoted {
-                        break;
-                    }
-                }
-            }
-            if !demoted {
-                return; // unreachable in practice; avoid an infinite loop
-            }
-        }
-    }
-
     pub fn to_metro(&self, rules: &[Rule]) -> Result<String> {
-        // Stage per node (fallback "generic" when `rule_index` is out of
-        // range — cannot happen for a DAG built from `rules`, but stay total).
-        let mut node_stage: HashMap<NodeIndex, String> = HashMap::new();
-        for node in self.graph.node_indices() {
-            let stage = rules
-                .get(self.graph[node].rule_index)
-                .map(crate::stage::detect_stage)
-                .unwrap_or_else(|| "generic".to_string());
-            node_stage.insert(node, stage);
-        }
-
-        // nf-metro rejects cyclic layouts: a hub rule staged differently
-        // from its consumers can make the STAGE flow circular even though
-        // the rule DAG is acyclic (live: community rnaseq). Demote inferred
-        // stages until the stage graph admits a topological order.
-        Self::break_stage_cycles(&self.graph, rules, &mut node_stage);
-
         let nodes = self.nodes_by_rule_index();
         let edges = self.sorted_edges();
 
-        // Stages in first-appearance order (deterministic).
+        // Two orthogonal groupings, mirroring nf-core's transit maps:
+        // - the LINE is the rule's stage (tags → module prefix → shell
+        //   keywords → generic) — the colored track an edge flows along;
+        // - the SECTION is the workflow's own module namespace
+        //   (`module::rule`), falling back to the stage for prefixless
+        //   rules. Sections follow the workflow file's data-flow order, so
+        //   the section graph is acyclic by construction — no cycle
+        //   demotion (which previously flooded "generic" on real
+        //   pipelines, live: community rnaseq).
+        let mut node_stage: HashMap<NodeIndex, String> = HashMap::new();
+        let mut node_section: HashMap<NodeIndex, String> = HashMap::new();
+        for node in &nodes {
+            let stage = rules
+                .get(self.graph[*node].rule_index)
+                .map(crate::stage::detect_stage)
+                .unwrap_or_else(|| "generic".to_string());
+            let section = self.graph[*node]
+                .name
+                .split_once("::")
+                .map(|(prefix, _)| prefix.to_string())
+                .unwrap_or_else(|| stage.clone());
+            node_stage.insert(*node, stage);
+            node_section.insert(*node, section);
+        }
+
+        // Sections and stages in first-appearance order (deterministic).
+        // A section's display comes from the module it groups, or from the
+        // stage itself for prefixless rules (custom stages keep their
+        // sanitized raw name).
+        let mut sections: Vec<(String, String)> = Vec::new();
+        for node in &nodes {
+            let section = &node_section[node];
+            if sections.iter().any(|(s, _)| s == section) {
+                continue;
+            }
+            let display = self.graph[*node]
+                .name
+                .split_once("::")
+                .map(|(prefix, _)| crate::stage::module_display(prefix))
+                .unwrap_or_else(|| crate::stage::stage_display(&node_stage[node]));
+            sections.push((section.clone(), display));
+        }
         let mut stages: Vec<String> = Vec::new();
         for node in &nodes {
             let stage = &node_stage[node];
@@ -906,38 +786,37 @@ impl WorkflowDag {
         out.push('\n');
         out.push_str("graph LR\n");
 
-        let multi_stage = stages.len() > 1;
-        let inner_indent = if multi_stage { "        " } else { "    " };
+        let multi_section = sections.len() > 1;
+        let inner_indent = if multi_section { "        " } else { "    " };
 
-        // Stations. With multiple stages, wrap each stage's stations in a
-        // section (`subgraph`) and place intra-stage edges inside it. Edges
-        // that cross sections must follow every `end` block (nf-metro rule),
-        // so we collect those and emit them last.
-        let mut inter_stage_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
+        // Stations grouped into flow-ordered sections; intra-section edges
+        // inside their section, inter-section edges after every `end`
+        // (nf-metro rule).
+        let mut inter_section_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
 
-        for stage in &stages {
-            if multi_stage {
+        for (section, display) in &sections {
+            if multi_section {
                 out.push_str(&format!(
                     "    subgraph {} [{}]\n",
-                    sanitize_metro_id(stage),
-                    sanitize_mermaid_text(&crate::stage::stage_display(stage))
+                    sanitize_metro_id(section),
+                    sanitize_mermaid_text(display)
                 ));
             }
 
-            for node in nodes.iter().filter(|n| &node_stage[n] == stage) {
+            for node in nodes.iter().filter(|n| &node_section[n] == section) {
                 out.push_str(&format!(
                     "{inner_indent}n{}[\"{}\"]\n",
                     node.index(),
-                    sanitize_mermaid_label(&self.graph[*node].name)
+                    sanitize_mermaid_label(metro_station_label(&self.graph[*node].name))
                 ));
             }
 
             for &(src, dst) in &edges {
-                if node_stage[&src] != *stage {
+                if node_section[&src] != *section {
                     continue;
                 }
-                if node_stage[&dst] == *stage {
-                    // Intra-stage edge — inside this section.
+                if node_section[&dst] == *section {
+                    // Intra-section edge — inside this section.
                     out.push_str(&format!(
                         "{inner_indent}n{} -->|{}| n{}\n",
                         src.index(),
@@ -945,18 +824,18 @@ impl WorkflowDag {
                         dst.index()
                     ));
                 } else {
-                    // Edge leaving this stage — emit after all sections.
-                    inter_stage_edges.push((src, dst));
+                    // Edge leaving this section — emit after all sections.
+                    inter_section_edges.push((src, dst));
                 }
             }
 
-            if multi_stage {
+            if multi_section {
                 out.push_str("    end\n");
             }
         }
 
-        // Inter-stage edges.
-        for (src, dst) in inter_stage_edges {
+        // Inter-section edges.
+        for (src, dst) in inter_section_edges {
             out.push_str(&format!(
                 "    n{} -->|{}| n{}\n",
                 src.index(),
@@ -1181,6 +1060,13 @@ fn sanitize_mermaid_label(s: &str) -> String {
             c => c,
         })
         .collect()
+}
+
+/// Station label for the metro map: strip the `module::` namespace prefix —
+/// the section already names the group, so "alignment::star_align" reads
+/// "star_align" (nf-core transit-map labels are short process names).
+fn metro_station_label(name: &str) -> &str {
+    name.split_once("::").map_or(name, |(_, rest)| rest)
 }
 
 /// Sanitize text that appears in metro `%%metro line` directives or
@@ -2506,6 +2392,31 @@ mod tests {
         assert!(mmd.contains("n0[\"a\"]"));
         assert!(mmd.contains("n0 -->|generic| n1"));
         assert!(!mmd.contains("subgraph"));
+    }
+
+    #[test]
+    fn metro_export_module_namespaces_become_sections() {
+        // `module::rule` namespaces form flow-ordered sections (the nf-core
+        // structure), while the stage line flows through them; station
+        // labels drop the redundant module prefix.
+        let mut trim = make_rule("fastq_qc::trimgalore", vec!["reads.fq"], vec!["trimmed.fq"]);
+        trim.shell = Some("trim_galore reads.fq".to_string());
+        let mut align = make_rule(
+            "alignment::star_align",
+            vec!["trimmed.fq"],
+            vec!["mapped.bam"],
+        );
+        align.shell = Some("STAR --runThreadN 8".to_string());
+        let rules = vec![trim, align];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules).unwrap();
+        assert!(mmd.contains("subgraph fastq_qc [Read QC]"));
+        assert!(mmd.contains("subgraph alignment [Alignment]"));
+        // Station labels are the bare rule names (no `module::` prefix).
+        assert!(mmd.contains("n0[\"trimgalore\"]"));
+        assert!(mmd.contains("n1[\"star_align\"]"));
+        // The cross-section edge carries the SOURCE rule's stage line.
+        assert!(mmd.contains("n0 -->|qc| n1"));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -35,6 +35,29 @@ const EXTRA_COLORS: &[&str] = &[
     "#B6992D", "#6E6E6E",
 ];
 
+/// `(rule-name prefix, canonical stage)` pairs for ported workflows whose
+/// rules are namespaced as `module::rule` (e.g. `alignment::star_align`).
+/// The module is the workflow author's own grouping — the strongest signal
+/// after an explicit tag. Unknown prefixes fall through to keyword
+/// inference rather than becoming custom stages (module names are
+/// workflow-internal; the palette should stay canonical).
+const PREFIX_STAGES: &[(&str, &str)] = &[
+    ("fastq_qc", "qc"),
+    ("bam_qc", "qc"),
+    ("qc", "qc"),
+    ("alignment", "align"),
+    ("align", "align"),
+    ("trim", "trim"),
+    ("quantification", "quantify"),
+    ("quant", "quantify"),
+    ("variant", "variant"),
+    ("annotate", "annotate"),
+    ("annotation", "annotate"),
+    ("merge", "merge"),
+    ("report", "report"),
+    ("multiqc", "report"),
+];
+
 /// `(stage, keyword)` pairs for shell/script inference, matched against the
 /// lowercased command text. Order matters: more specific signals (a variant
 /// caller) win over generic ones (an aligner), mirroring `WorkflowDomain`.
@@ -134,7 +157,14 @@ pub fn detect_stage(rule: &Rule) -> String {
         }
     }
 
-    // 2. Command keyword inference.
+    // 2. Rule-name prefix (module namespace, e.g. `alignment::star_align`).
+    if let Some((prefix, _)) = rule.name.split_once("::")
+        && let Some((_, stage)) = PREFIX_STAGES.iter().find(|(p, _)| *p == prefix)
+    {
+        return (*stage).to_string();
+    }
+
+    // 3. Command keyword inference.
     let mut text = String::new();
     if let Some(shell) = &rule.shell {
         text.push_str(shell);
@@ -150,8 +180,43 @@ pub fn detect_stage(rule: &Rule) -> String {
         }
     }
 
-    // 3. Fallback.
+    // 4. Fallback.
     "generic".to_string()
+}
+
+/// Friendly section title for a module namespace (metro-map sections).
+/// Known modules get curated titles; unknown ones are title-cased.
+pub fn module_display(module: &str) -> String {
+    let curated = match module {
+        "fastq_qc" => "Read QC",
+        "bam_qc" => "BAM QC",
+        "alignment" => "Alignment",
+        "quantification" => "Quantification",
+        "prepare_genome" => "Reference preparation",
+        "bigwig" => "Coverage tracks",
+        "multiqc" => "Reporting",
+        "trim" => "Trimming",
+        "annotation" | "annotate" => "Annotation",
+        "variant" => "Variant calling",
+        "merge" => "Merge",
+        _ => return title_case(module),
+    };
+    curated.to_string()
+}
+
+/// `fastq_qc` → `Fastq qc` (fallback for unknown module names).
+fn title_case(module: &str) -> String {
+    module
+        .split('_')
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Human-readable display name for a stage.
@@ -216,6 +281,29 @@ mod tests {
     fn unknown_tag_kept_as_custom_stage() {
         let r = rule("impute_step", "impute2", vec!["imputation"]);
         assert_eq!(detect_stage(&r), "imputation");
+    }
+
+    #[test]
+    fn rule_name_prefix_inference() {
+        // Module namespaces map to canonical stages; the module is the
+        // workflow author's own grouping (stronger than shell keywords).
+        let r = rule("alignment::star_align", "echo unused", vec![]);
+        assert_eq!(detect_stage(&r), "align");
+        assert_eq!(detect_stage(&rule("fastq_qc::fq_lint", "echo", vec![])), "qc");
+        assert_eq!(
+            detect_stage(&rule("quantification::salmon_quant", "echo", vec![])),
+            "quantify"
+        );
+        // Unknown prefixes fall through to keyword inference, then generic.
+        let r2 = rule("mystery::step", "echo nothing matches", vec![]);
+        assert_eq!(detect_stage(&r2), "generic");
+    }
+
+    #[test]
+    fn module_display_curated_and_fallback() {
+        assert_eq!(module_display("fastq_qc"), "Read QC");
+        assert_eq!(module_display("prepare_genome"), "Reference preparation");
+        assert_eq!(module_display("novel_module"), "Novel Module");
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -289,7 +289,10 @@ mod tests {
         // workflow author's own grouping (stronger than shell keywords).
         let r = rule("alignment::star_align", "echo unused", vec![]);
         assert_eq!(detect_stage(&r), "align");
-        assert_eq!(detect_stage(&rule("fastq_qc::fq_lint", "echo", vec![])), "qc");
+        assert_eq!(
+            detect_stage(&rule("fastq_qc::fq_lint", "echo", vec![])),
+            "qc"
+        );
         assert_eq!(
             detect_stage(&rule("quantification::salmon_quant", "echo", vec![])),
             "quantify"


### PR DESCRIPTION
## Metro 地铁图美观重构（站点 #16 视觉反馈）

社区站 17 张地铁图全部"很丑"的根因在导出模型，三处修复：

1. **阶段推断加前缀信号**：`detect_stage` 在显式 tag 与 shell 关键词之间插入规则名模块前缀推断（`alignment::star_align` → align）— 关键词漏匹配是灰图主因之一
2. **section≠stage**：旧模型 section=stage + 环打破降级，真实管线的 qc↔align 双向边让降级雪崩（社区 rnaseq 一半规则被降成灰色 Analysis）。新模型对齐 nf-core 地铁图结构：**section = 工作流自己的模块命名空间**（按数据流序，天然无环，删除 break_stage_cycles），**线 = 阶段**（颜色贯穿多个 section）— rnaseq 呈现为 Reporting / Read QC / Reference preparation / Alignment / BAM QC / Coverage tracks / Quantification 7 段 5 线
3. **站名去冗余**：剥掉 `module::` 前缀（section 已表明分组），站名 = 裸规则名

**实测**：rnaseq 148 站/414 边/5 线渲染宽度 16284px→8257px；varlociraptor 17479px→3683px；snparcher 3417x7760→4975x3882。17/24 站点工作流全部渲染通过。

**测试**：+3 测试（前缀推断、module_display、模块 section + 跨段边线标注），core 全量 1376 通过。

（站点侧依赖此 PR 合入后重跑 regen 即可；站点 PR 随后。）
