### PR TITLE
ci(release): skip dockerbuild build records in artifact download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,6 +708,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          # Skip docker buildx build records (*.dockerbuild): the v4 download
+          # action has repeatedly stalled runner-side on these two artifacts
+          # and aborted the whole release (attempts 1-4 of the v0.17.2
+          # release, identical failure each time), while every binaries-*/
+          # and frontend-static artifact downloads fine. The release job
+          # consumes none of them (its `files:` globs only stage
+          # tar.gz/zip/dmg/deb/rpm/AppImage + SHA256SUMS.txt), so excluding
+          # them loses nothing and unblocks the release.
+          pattern: "binaries-*\nfrontend-static"
 
       - name: Validate required release artifacts
         shell: bash


### PR DESCRIPTION
## What

The `release` job's `Download all artifacts` step (actions/download-artifact@v4) has been aborting the whole release 4/4 attempts on the two buildx `*.dockerbuild` build-record artifacts:

- `Traitome~oxo-flow~47QGZ6.dockerbuild` (95.6 KB)
- `Traitome~oxo-flow~JPXY20.dockerbuild` (92.7 KB)

with `Unable to download and extract artifact: Artifact download failed after 5 retries` — while the other 9 artifacts (all `binaries-*` + `frontend-static`) download fine, and direct API download of both dockerbuild artifacts returns HTTP 200 with correct bytes (artifacts are healthy; the stall is runner-side inside the action).

## Fix

Restrict the download to what the release actually consumes: `pattern: "binaries-*\nfrontend-static"`. The release `files:` globs only stage `tar.gz/zip/dmg/deb/rpm/AppImage` + `SHA256SUMS.txt` — no step touches `.dockerbuild` records, so nothing is lost.

## Verification

- v0.17.2 release re-dispatch after merge must reach `Create GitHub Release` and publish the `oxo-flow-latest-*` tarballs that oxo-flow-community CI installs from `releases/latest/download/`.