### PR TITLE
ci(release): fix artifact download pattern to single wildcard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,15 +708,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          # Skip docker buildx build records (*.dockerbuild): the v4 download
-          # action has repeatedly stalled runner-side on these two artifacts
-          # and aborted the whole release (attempts 1-4 of the v0.17.2
-          # release, identical failure each time), while every binaries-*/
-          # and frontend-static artifact downloads fine. The release job
-          # consumes none of them (its `files:` globs only stage
-          # tar.gz/zip/dmg/deb/rpm/AppImage + SHA256SUMS.txt), so excluding
-          # them loses nothing and unblocks the release.
-          pattern: "binaries-*\nfrontend-static"
+          # Only binaries-* artifacts are consumed by the validation/staging
+          # steps below; frontend-static is restored separately by the
+          # "Restore built frontend assets" step. Skipping the buildx
+          # *.dockerbuild records also sidesteps a runner-side download stall
+          # in download-artifact@v4 that aborted the v0.17.2 release 4/4
+          # times (direct API download of those artifacts succeeds).
+          pattern: "binaries-*"
 
       - name: Validate required release artifacts
         shell: bash


### PR DESCRIPTION
## What

PR #322 set `pattern: "binaries-*\nfrontend-static"` on the release job's `Download all artifacts` step. YAML turns that double-quoted escape into **one scalar with an embedded newline**; download-artifact@v4 treats it as a single glob, matched **0 of 11** artifacts, and still reported the step successful — so release validation failed with `Missing required release artifact: .../oxo-flow-v0.17.2-x86_64-unknown-linux-gnu.tar.gz`.

## Fix

Single documented wildcard: `pattern: "binaries-*"`.

- `frontend-static` is restored independently by the release job's `Restore built frontend assets` step (deb/rpm/AppImage packaging).
- `*.dockerbuild` buildx records remain excluded (nothing consumes them; they caused the original runner-side stall that aborted the release 4/4 times).

## Verification

Fresh dispatch of ci.yml with `tag=v0.17.2` after merge must download 8 binaries-* artifacts and publish the GitHub Release with `oxo-flow-latest-*` tarballs + SHA256SUMS.