### PR TITLE
feat(cli): config comment group propagation + include-tree description merge

### DIFF
--- a/crates/oxo-flow-cli/src/commands/config_comments.rs
+++ b/crates/oxo-flow-cli/src/commands/config_comments.rs
@@ -9,8 +9,20 @@
 //! - a contiguous block of `#` lines immediately above a key line (no blank
 //!   line in between) is that key's description;
 //! - a trailing `#` comment on the key line itself is the fallback;
+//! - a BLOCK description also describes the group it heads: bare keys that
+//!   follow on consecutive lines inherit it (workflows write one comment
+//!   block above a group of related params, e.g. "Binning options" above a
+//!   dozen keys — live: mag/ampliseq). Trailing comments never propagate
+//!   (they are key-specific), and a blank line or new section ends the
+//!   group;
 //! - comments inside multi-line values or outside `[config]` never associate;
 //! - comments above `[config.<name>]` subtable headers describe the table key.
+//!
+//! Known limitation: bracket tracking covers `[...]`/`{...}` but not
+//! triple-quoted `"""..."""` values — a blank line or `#`-prefixed line
+//! INSIDE a `[config]` multi-line string can sever a group or seed the next
+//! key's description. Rare in practice (multi-line `[config]` strings are
+//! uncommon); descriptions are prose, never a correctness matter.
 
 use std::collections::BTreeMap;
 
@@ -23,6 +35,11 @@ pub fn extract_config_descriptions(text: &str) -> BTreeMap<String, String> {
     let mut section: Option<String> = None;
     let mut pending: Vec<String> = Vec::new();
     let mut value_depth = 0usize;
+    // Group propagation state: the most recent BLOCK description and
+    // whether the previous significant line was a key (a group continues
+    // over consecutive key lines only).
+    let mut last_block_desc: Option<String> = None;
+    let mut last_line_was_key = false;
 
     for line in text.lines() {
         let line = line.trim();
@@ -49,6 +66,8 @@ pub fn extract_config_descriptions(text: &str) -> BTreeMap<String, String> {
                 pending.clear();
             }
             value_depth = 0;
+            last_block_desc = None;
+            last_line_was_key = false;
             continue;
         }
         if section.as_deref() != Some("config") {
@@ -60,12 +79,15 @@ pub fn extract_config_descriptions(text: &str) -> BTreeMap<String, String> {
             if !comment.is_empty() && !is_decorator(&comment) {
                 pending.push(comment);
             }
+            last_line_was_key = false;
             continue;
         }
 
         if line.is_empty() {
             // A blank line severs the comment block from any following key.
             pending.clear();
+            last_block_desc = None;
+            last_line_was_key = false;
             continue;
         }
 
@@ -76,10 +98,19 @@ pub fn extract_config_descriptions(text: &str) -> BTreeMap<String, String> {
         if pending.is_empty() {
             if let Some(trailing) = trailing_comment(value) {
                 descriptions.insert(key, trailing);
+                last_block_desc = None;
+            } else if last_line_was_key && let Some(desc) = last_block_desc.clone() {
+                // Bare key directly under a block-described key: part of the
+                // same group, inherits the group's description.
+                descriptions.insert(key, desc);
+            } else {
+                last_block_desc = None;
             }
         } else {
             attach(&mut descriptions, &mut pending, &key);
+            last_block_desc = descriptions.get(&key).cloned();
         }
+        last_line_was_key = true;
     }
     descriptions
 }
@@ -298,6 +329,51 @@ mod tests {
         // The comment reads as a section note, not a key description.
         let text = "[config]\n# Section-level note.\n\nrmats_cstat = 0.0001\n";
         assert_eq!(extract_config_descriptions(text), BTreeMap::new());
+    }
+
+    #[test]
+    fn group_block_propagates_to_consecutive_bare_keys() {
+        // One block above a group of related params describes them all
+        // (live: mag "Binning options" above a dozen keys).
+        let text = "[config]\n# Clipping (upstream params with the same defaults)\nclip_tool = \"fastp\"\nreads_minlength = 15\nfastp_qualified_quality = 15\n\n# Next group.\nnext = 1\n";
+        let desc = "Clipping (upstream params with the same defaults)";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([
+                ("clip_tool".to_string(), desc.to_string()),
+                ("reads_minlength".to_string(), desc.to_string()),
+                ("fastp_qualified_quality".to_string(), desc.to_string()),
+                ("next".to_string(), "Next group.".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn trailing_comment_does_not_propagate_to_next_key() {
+        // Trailing comments are key-specific — a bare key after them
+        // inherits nothing (live: save_align_intermeds' trailing note
+        // must not leak onto out_dir).
+        let text =
+            "[config]\nsave_align_intermeds = true   # --create-bam flag\nout_dir = \"results\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([(
+                "save_align_intermeds".to_string(),
+                "--create-bam flag".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn blank_line_ends_group_propagation() {
+        let text = "[config]\n# Group note.\na = 1\nb = 2\n\nc = 3\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([
+                ("a".to_string(), "Group note.".to_string()),
+                ("b".to_string(), "Group note.".to_string()),
+            ])
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -8,7 +8,7 @@
 use crate::commands::config_comments::extract_config_descriptions;
 use anyhow::{Context, Result};
 use colored::Colorize;
-use oxo_flow_core::config::WorkflowConfig;
+use oxo_flow_core::config::{IncludeDirective, WorkflowConfig};
 use oxo_flow_core::config_impact::is_engine_injected_key;
 use oxo_flow_core::rule::{EnvironmentSpec, Rule};
 use oxo_flow_core::scheduler::parse_memory_mb;
@@ -25,9 +25,18 @@ pub fn info_command(workflow: PathBuf, format: Option<String>) -> Result<()> {
     // surfaces the `[config]` section comments as parameter descriptions.
     let text = std::fs::read_to_string(&workflow)
         .with_context(|| format!("failed to read workflow {}", workflow.display()))?;
-    let descriptions = extract_config_descriptions(&text);
     let cfg = WorkflowConfig::from_file(&workflow)
         .with_context(|| format!("failed to parse workflow {}", workflow.display()))?;
+    let mut descriptions = extract_config_descriptions(&text);
+    // Included files merge their own `[config]` keys into the workflow —
+    // their comments describe those keys too, and nested includes merge
+    // just the same (parse.rs resolves them recursively), so walk the
+    // local include tree. The main file's text wins (`or_insert` follows
+    // parse.rs's merge order: earlier inserts keep priority); git-pinned
+    // (issue #112) and URL includes are skipped (best-effort prose, never
+    // a correctness matter).
+    let mut visited: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    collect_include_descriptions(&workflow, &cfg.includes, &mut visited, &mut descriptions);
 
     let meta = derive_meta(&workflow, &cfg, &descriptions);
 
@@ -41,6 +50,42 @@ pub fn info_command(workflow: PathBuf, format: Option<String>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Recursively merge `[config]` comment descriptions from local include
+/// files (URL and git-pinned includes are skipped). Unreadable files are
+/// silently skipped — descriptions are prose, never a correctness matter.
+fn collect_include_descriptions(
+    workflow: &Path,
+    includes: &[IncludeDirective],
+    visited: &mut std::collections::HashSet<PathBuf>,
+    descriptions: &mut BTreeMap<String, String>,
+) {
+    for inc in includes {
+        if inc.repo.is_some() || inc.path.starts_with("http://") || inc.path.starts_with("https://")
+        {
+            continue;
+        }
+        let inc_path = workflow
+            .parent()
+            .map(|dir| dir.join(&inc.path))
+            .unwrap_or_else(|| PathBuf::from(&inc.path));
+        if !visited.insert(inc_path.clone()) {
+            continue;
+        }
+        let Ok(inc_text) = std::fs::read_to_string(&inc_path) else {
+            continue;
+        };
+        for (key, description) in extract_config_descriptions(&inc_text) {
+            descriptions.entry(key).or_insert(description);
+        }
+        // Nested includes: parse the included file to find its own
+        // `[[include]]` directives (their paths resolve against the
+        // included file's directory).
+        if let Ok(inc_cfg) = WorkflowConfig::from_file(&inc_path) {
+            collect_include_descriptions(&inc_path, &inc_cfg.includes, visited, descriptions);
+        }
+    }
 }
 
 /// Derive the machine-checkable catalog metadata from a parsed workflow.


### PR DESCRIPTION
Companion to the site parameter-documentation work (oxo-flow-community.github.io PR #98).

- `extract_config_descriptions`: a block description above a group of consecutive bare keys now describes each key (workflows write one comment block above related params, e.g. mag "Binning options" above a dozen keys); trailing comments stay key-specific; blank line or a new section ends the group.
- `info --json`: merge `[config]` comment descriptions from the local include tree (URL and git-pinned includes skipped, main file wins per parse.rs merge order). Unreadable files are skipped — descriptions are prose, never a correctness matter.
- 3 new group-propagation tests.

## Verification

- [x] `cargo test --workspace` green
- [x] clippy 0 warnings
- [x] live: mag "Binning options" group, scrnaseq gtf_filtered description regenerated on the site side
