### PR TITLE
fix: nine-dimension harness eval findings — resume bookkeeping, chunk cleanup, validate/lint/web hardening

### DIFF
--- a/crates/oxo-flow-cli/src/commands/quality.rs
+++ b/crates/oxo-flow-cli/src/commands/quality.rs
@@ -91,20 +91,45 @@ pub async fn validate_command(
             let workflow_dir = oxo_flow_core::parent_dir(&workflow);
             let mut missing_inputs = Vec::new();
             if !as_include {
+                // Sample placeholders need a declared sample domain to
+                // resolve at run time (issue #324 F-3): without any of
+                // sample_groups / pairs / sample_pattern the wildcard can
+                // never bind, and the run fails mid-flight with a literal
+                // brace token. validate must flag it here — the approve
+                // layer previously reported "valid": true for these.
+                let sample_domain_declared = !cfg.sample_groups.is_empty()
+                    || !cfg.pairs.is_empty()
+                    || cfg.workflow.sample_pattern.is_some();
+                const SAMPLE_PLACEHOLDERS: &[&str] = &[
+                    "{sample}",
+                    "{group}",
+                    "{pair_id}",
+                    "{experiment}",
+                    "{control}",
+                    "{tumor}",
+                    "{normal}",
+                    "{log}",
+                ];
                 for rule in &cfg.rules {
                     for input in &rule.input {
                         // Only check if it's not a wildcard path and doesn't exist
-                        if !input.contains('{')
-                            && !input.contains('}')
-                            && !workflow_dir.join(input).exists()
-                        {
-                            // Also check if it's an output of another rule
-                            let is_generated =
-                                cfg.rules.iter().any(|r| r.output.to_vec().contains(input));
+                        if !input.contains('{') && !input.contains('}') {
+                            if !workflow_dir.join(input).exists() {
+                                // Also check if it's an output of another rule
+                                let is_generated =
+                                    cfg.rules.iter().any(|r| r.output.to_vec().contains(input));
 
-                            if !is_generated {
-                                missing_inputs.push(input);
+                                if !is_generated {
+                                    missing_inputs.push(input.clone());
+                                }
                             }
+                        } else if !sample_domain_declared
+                            && SAMPLE_PLACEHOLDERS.iter().any(|ph| input.contains(ph))
+                        {
+                            // Wildcard input with no sample domain to bind it.
+                            missing_inputs.push(format!(
+                                "{input} (no sample groups/pairs/sample_pattern declared)"
+                            ));
                         }
                     }
                 }

--- a/crates/oxo-flow-cli/src/commands/run.rs
+++ b/crates/oxo-flow-cli/src/commands/run.rs
@@ -2608,6 +2608,32 @@ pub async fn run_command(
                                 let mut sno = skipped_no_output.lock().await;
                                 sno.insert(rule_name.clone());
                             }
+                            if record.skip_reason.as_deref() == Some("outputs up-to-date") {
+                                // Up-to-date outputs are valid completions
+                                // (issue #324 F-1): a rule interrupted
+                                // mid-run can leave outputs behind (its
+                                // shell kept running after a SIGKILL), and
+                                // resume verdicts it up-to-date. Recording
+                                // it prevents re-submission on every later
+                                // run and keeps the audit trail aligned
+                                // with the disk.
+                                let benchmark =
+                                    oxo_flow_core::executor::checkpoint::BenchmarkRecord {
+                                        rule: rule_name.clone(),
+                                        wall_time_secs: 0.0,
+                                        max_memory_mb: None,
+                                        memory_limit_mb: rule
+                                            .effective_memory()
+                                            .and_then(oxo_flow_core::scheduler::parse_memory_mb),
+                                        cpu_seconds: None,
+                                        retries: 0,
+                                    };
+                                let mut ck = checkpoint.lock().await;
+                                ck.mark_completed(&rule_name, benchmark);
+                                if let Err(e) = ck.save_to_file(&checkpoint_path) {
+                                    tracing::warn!("Failed to save checkpoint: {e}");
+                                }
+                            }
                             // Surface the executor's skip reason (condition
                             // false, optional inputs missing, outputs
                             // up-to-date) — otherwise a submitted rule that
@@ -3543,6 +3569,12 @@ pub async fn run_command(
                 // verify would report them missing. If the migration
                 // cannot be persisted, keep the files and skip the
                 // deletion entirely.
+                //
+                // Checksums only exist under `--provenance`. With no
+                // recorded checksum there is nothing that can lie, so the
+                // deletion proceeds without a persistence round-trip
+                // (issue #324 F-2) — previously the empty migration made
+                // cleanup a silent no-op on every default run.
                 let mut migrated: Vec<String> = Vec::new();
                 for chunk in rule.input.iter() {
                     if let Some(sha) = checkpoint.checksums.remove(&chunk.to_string()) {
@@ -3550,10 +3582,9 @@ pub async fn run_command(
                         migrated.push(chunk.to_string());
                     }
                 }
-                if migrated.is_empty() {
-                    continue;
-                }
-                if let Err(e) = checkpoint.save_to_file(&checkpoint_path) {
+                if !migrated.is_empty()
+                    && let Err(e) = checkpoint.save_to_file(&checkpoint_path)
+                {
                     tracing::warn!(
                         error = %e,
                         "failed to persist chunk migration — keeping chunk files"

--- a/crates/oxo-flow-cli/tests/eval_findings.rs
+++ b/crates/oxo-flow-cli/tests/eval_findings.rs
@@ -1,0 +1,309 @@
+//! Regression tests for the nine-dimension harness evaluation findings
+//! (issue #324), fixed on v0.17.2:
+//!
+//! - F-1: a rule whose outputs exist but was never recorded as completed
+//!   (e.g. the engine was SIGKILLed after its shell wrote outputs, so
+//!   resume verdicts it "outputs up-to-date") must still be recorded into
+//!   `completed_rules`/`benchmarks` — otherwise every later run re-submits
+//!   it and the audit trail stays wrong forever.
+//! - F-2: `transform.cleanup = true` must delete chunk files on a default
+//!   run; the deletion was gated on the checksum migration, which only
+//!   records under `--provenance`.
+//!
+//! The F-1 scenario is simulated by editing the checkpoint instead of a
+//! real SIGKILL: both leave the rule's outputs on disk while its completion
+//! records are missing, which is exactly the state the engine must recover.
+
+use std::path::Path;
+use std::process::Command;
+
+fn oxo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_oxo-flow"))
+}
+
+/// Write a 3-rule chain `step1 → step2 → step3` into `dir`.
+fn write_chain(dir: &Path) {
+    std::fs::write(
+        dir.join("w.oxoflow"),
+        r#"
+[workflow]
+name = "eval-f1-chain"
+version = "1.0.0"
+
+[[rules]]
+name = "step1"
+output = ["r/out1.txt"]
+shell = "mkdir -p r && echo step1 > {output[0]}"
+
+[[rules]]
+name = "step2"
+input = ["r/out1.txt"]
+output = ["r/out2.txt"]
+shell = "cat {input[0]} > {output[0]} && echo step2 >> {output[0]}"
+
+[[rules]]
+name = "step3"
+input = ["r/out2.txt"]
+output = ["r/out3.txt"]
+shell = "cat {input[0]} > {output[0]} && echo step3 >> {output[0]}"
+"#,
+    )
+    .unwrap();
+}
+
+fn checkpoint_json(dir: &Path) -> serde_json::Value {
+    let raw = std::fs::read_to_string(dir.join(".oxo-flow/checkpoint.json"))
+        .expect("checkpoint exists after a run");
+    serde_json::from_str(&raw).unwrap()
+}
+
+fn run(dir: &Path, workflow: &str) -> (String, String) {
+    let out = oxo()
+        .current_dir(dir)
+        .args(["run", workflow])
+        .output()
+        .expect("oxo-flow run spawns");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn resume(dir: &Path) -> (String, String) {
+    let out = oxo()
+        .current_dir(dir)
+        .args(["resume", ".oxo-flow/checkpoint.json"])
+        .output()
+        .expect("oxo-flow resume spawns");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn f1_up_to_date_rule_is_recorded_as_completed_after_resume() {
+    // Arrange — a full successful chain, then simulate the SIGKILL window:
+    // step2's outputs stay on disk while its completion records vanish.
+    let dir = tempfile::tempdir().unwrap();
+    write_chain(dir.path());
+    let (_, err) = run(dir.path(), "w.oxoflow");
+    assert!(err.contains("3 succeeded"), "initial run: {err}");
+
+    let ck_path = dir.path().join(".oxo-flow/checkpoint.json");
+    let mut ck = checkpoint_json(dir.path());
+    ck["completed_rules"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|r| r.as_str() != Some("step2"));
+    ck["benchmarks"].as_object_mut().unwrap().remove("step2");
+    std::fs::write(&ck_path, serde_json::to_string_pretty(&ck).unwrap()).unwrap();
+
+    // Act — resume from the interrupted state.
+    let (out, err) = resume(dir.path());
+    let combined = format!("{out}\n{err}");
+
+    // Assert — step2 is verdicted up-to-date (its output exists) AND is
+    // recorded as completed again, so the audit trail matches the disk.
+    assert!(
+        combined.contains("step2 (outputs up-to-date)"),
+        "resume should skip step2 as up-to-date: {combined}"
+    );
+    let ck = checkpoint_json(dir.path());
+    let completed: Vec<&str> = ck["completed_rules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert!(
+        completed.contains(&"step2"),
+        "up-to-date step2 must re-enter completed_rules, got {completed:?}"
+    );
+    assert!(
+        ck["benchmarks"].get("step2").is_some(),
+        "up-to-date step2 must get a benchmark entry"
+    );
+}
+
+#[test]
+fn f1_rerun_after_resume_does_not_resubmit_up_to_date_rule() {
+    // Arrange — same interrupted state as above.
+    let dir = tempfile::tempdir().unwrap();
+    write_chain(dir.path());
+    let (_, err) = run(dir.path(), "w.oxoflow");
+    assert!(err.contains("3 succeeded"), "initial run: {err}");
+
+    let ck_path = dir.path().join(".oxo-flow/checkpoint.json");
+    let mut ck = checkpoint_json(dir.path());
+    ck["completed_rules"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|r| r.as_str() != Some("step2"));
+    ck["benchmarks"].as_object_mut().unwrap().remove("step2");
+    std::fs::write(&ck_path, serde_json::to_string_pretty(&ck).unwrap()).unwrap();
+    resume(dir.path());
+
+    // Act — a plain run after the resume.
+    let (out, err) = run(dir.path(), "w.oxoflow");
+    let combined = format!("{out}\n{err}");
+
+    // Assert — step2 is short-circuited as already completed instead of
+    // being submitted (and silently skip-counted) on every run.
+    assert!(
+        combined.contains("step2 (already completed)"),
+        "rerun must treat step2 as completed: {combined}"
+    );
+    assert!(
+        !combined.contains("Running: step2"),
+        "rerun must not re-submit step2: {combined}"
+    );
+    assert!(
+        combined.contains("0 succeeded, 3 skipped"),
+        "no rule re-executes after the recovery: {combined}"
+    );
+}
+
+#[test]
+fn f3_validate_warns_on_wildcard_inputs_without_sample_domain() {
+    // Arrange — a wildcard input with NO sample domain declared anywhere.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("bad.oxoflow"),
+        r#"
+[workflow]
+name = "eval-f3-wildcard"
+version = "1.0.0"
+
+[[rules]]
+name = "consume"
+input = ["missing/{sample}.txt"]
+output = ["out/ok.txt"]
+shell = "cp {input[0]} {output[0]}"
+"#,
+    )
+    .unwrap();
+
+    // Act — validate must flag the unresolvable wildcard instead of
+    // approving with "valid": true.
+    let out = oxo()
+        .current_dir(dir.path())
+        .args(["validate", "bad.oxoflow", "--json"])
+        .output()
+        .expect("oxo-flow validate spawns");
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+
+    // Assert — the wildcard input is reported so the approve layer no
+    // longer gives false confidence.
+    let missing: Vec<&str> = json["missing_inputs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        missing.iter().any(|m| m.contains("missing/{sample}.txt")),
+        "validate must report the unresolved wildcard input, got {missing:?}"
+    );
+}
+
+#[test]
+fn f3_validate_is_silent_when_sample_domain_is_declared() {
+    // Arrange — the same wildcard input, but with [[sample_groups]].
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("ok.oxoflow"),
+        r#"
+[workflow]
+name = "eval-f3-declared"
+version = "1.0.0"
+
+[[sample_groups]]
+name = "tumor"
+samples = ["S1"]
+
+[[rules]]
+name = "consume"
+input = ["missing/{sample}.txt"]
+output = ["out/ok.txt"]
+shell = "cp {input[0]} {output[0]}"
+"#,
+    )
+    .unwrap();
+
+    // Act
+    let out = oxo()
+        .current_dir(dir.path())
+        .args(["validate", "ok.oxoflow", "--json"])
+        .output()
+        .expect("oxo-flow validate spawns");
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+
+    // Assert — a declared sample domain keeps the input out of the report
+    // (runtime discovery resolves it; nothing to warn about statically).
+    let missing = json["missing_inputs"].as_array().unwrap();
+    assert!(
+        missing.is_empty(),
+        "declared sample domain must not be reported, got {missing:?}"
+    );
+}
+
+#[test]
+fn f2_default_run_cleans_up_transform_chunks() {
+    // Arrange — a scatter-gather transform with cleanup = true.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("t.oxoflow"),
+        r#"
+[workflow]
+name = "eval-f2-transform"
+version = "1.0.0"
+
+[config]
+parts = ["a", "b", "c"]
+
+[[rules]]
+name = "seed"
+output = ["in/all.txt"]
+shell = "mkdir -p in && printf 'a,1\nb,2\nc,3\n' > {output[0]}"
+
+[[rules]]
+name = "by_part"
+input = ["in/all.txt"]
+output = ["out/per_part.txt"]
+
+[rules.transform.split]
+by = "part"
+values_from = "config.parts"
+
+[rules.transform]
+map = "grep '^{part},' {input} > {output}"
+cleanup = true
+
+[rules.transform.combine]
+shell = "cat {chunks} > {output} && wc -l < {output} | tr -d ' ' >> {output}"
+"#,
+    )
+    .unwrap();
+
+    // Act — a default run (no --provenance).
+    let (_, err) = run(dir.path(), "t.oxoflow");
+    assert!(err.contains("5 succeeded"), "run: {err}");
+
+    // Assert — the chunk files are deleted even though no checksums were
+    // ever recorded (the non-provenance path).
+    let chunks = dir.path().join(".oxo-flow/chunks");
+    let leftover: Vec<_> = std::fs::read_dir(&chunks)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        leftover.is_empty(),
+        "cleanup=true must delete chunk files on a default run, left {leftover:?}"
+    );
+}

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -2982,7 +2982,7 @@ fn render_shell_command_inner(
             tracing::warn!(
                 rule = %rule.name,
                 placeholder = ph,
-                "unresolved placeholder remained in the rendered command — the rule will execute with a literal brace token (report as an engine bug with the workflow)"
+                "unresolved placeholder remained in the rendered command — no value bound to it in this run (the rule will execute with a literal brace token); check the workflow's sample_groups/pairs/sample_pattern declarations and the --samples selection"
             );
         }
     }

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -1586,6 +1586,38 @@ pub fn lint_format(
         }
     }
 
+    // W032 (issue #324 F-5): config keys whose NAMES suggest secrets but
+    // are not declared sensitive. Undeclared values land in plaintext in
+    // command records, stderr tails, and the checkpoint — credential
+    // leakage on shared clusters and in CI artifacts. The declared path
+    // (sensitive = true) routes the value through env injection and masks
+    // it everywhere, so this is a one-line declaration away.
+    {
+        static SECRET_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"(?i)(token|secret|passwd|password|credential|api[_-]?key|access[_-]?key|private[_-]?key|ssh[_-]?key)",
+            )
+            .expect("valid secret-key regex")
+        });
+        for key in config.config.keys() {
+            let declared_sensitive = config.config_meta.get(key).is_some_and(|def| def.sensitive);
+            if declared_sensitive || !SECRET_KEY_RE.is_match(key) {
+                continue;
+            }
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                message: format!(
+                    "config key '{key}' looks like a secret but is not declared sensitive — its value lands in plaintext in command records, logs, and the checkpoint"
+                ),
+                rule: None,
+                code: "W032".to_string(),
+                suggestion: Some(format!(
+                    "declare it as {key} = {{ default = \"...\", sensitive = true }} so the value is env-routed and masked on disk"
+                )),
+            });
+        }
+    }
+
     diagnostics
 }
 
@@ -4669,6 +4701,79 @@ mod tests {
             w031_count(&diagnostics),
             1,
             "a when-gated producer's output_pattern must warn unmatched consumers: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn lint_w032_flags_secret_like_config_keys_without_sensitive_declaration() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+            description = "x"
+            author = "x"
+
+            [config]
+            api_token = "sk-supersecret"
+            api_key = "AKIA-SECRET"
+            password = "hunter2"
+            monkey = "harmless"
+            threads = 4
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        let flagged: Vec<&str> = diagnostics
+            .iter()
+            .filter(|d| d.code == "W032")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            flagged.iter().any(|m| m.contains("api_token")),
+            "api_token must be flagged: {flagged:?}"
+        );
+        assert!(
+            flagged.iter().any(|m| m.contains("api_key")),
+            "api_key must be flagged: {flagged:?}"
+        );
+        assert!(
+            flagged.iter().any(|m| m.contains("password")),
+            "password must be flagged: {flagged:?}"
+        );
+        assert!(
+            !flagged.iter().any(|m| m.contains("monkey")),
+            "substring matches like 'monkey' must not be flagged: {flagged:?}"
+        );
+        assert!(
+            !flagged.iter().any(|m| m.contains("threads")),
+            "non-secret keys must not be flagged: {flagged:?}"
+        );
+    }
+
+    #[test]
+    fn lint_w032_silent_when_sensitive_declared() {
+        let toml = r#"
+            [workflow]
+            name = "test"
+            description = "x"
+            author = "x"
+
+            [config]
+            api_token = { default = "sk-supersecret", sensitive = true }
+
+            [[rules]]
+            name = "step1"
+            output = ["out.txt"]
+            shell = "echo hi > out.txt"
+        "#;
+        let config = WorkflowConfig::parse(toml).unwrap();
+        let diagnostics = lint_format(&config, None);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == "W032"),
+            "declared-sensitive keys are the hardened path, not a defect: {diagnostics:?}"
         );
     }
 

--- a/crates/oxo-flow-web/src/domains/execution/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/execution/handlers.rs
@@ -155,6 +155,7 @@ mod run_rate_limit {
     post,
     path = "/api/runs",
     tag = "runs",
+    request_body = CreateRunRequest,
     responses(
         (status = 200, description = "Success", body = CreateRunResponse),
         (status = 400, description = "Error", body = ApiError),
@@ -163,8 +164,26 @@ mod run_rate_limit {
 /// POST /api/runs
 pub async fn create_run(
     authenticated: Option<Extension<CurrentUser>>,
-    Json(req): Json<serde_json::Value>,
+    Json(body): Json<serde_json::Value>,
 ) -> ApiResult<CreateRunResponse> {
+    // Parse through the typed contract (issue #324 F-4) so the type is the
+    // single source of truth — but keep the stable MISSING error for a
+    // missing `toml_content` instead of a bare serde message.
+    let req: CreateRunRequest = serde_json::from_value(body).map_err(|e| {
+        if e.to_string().contains("toml_content") {
+            err(
+                StatusCode::BAD_REQUEST,
+                "MISSING",
+                "toml_content required".into(),
+            )
+        } else {
+            err(
+                StatusCode::BAD_REQUEST,
+                "INVALID_BODY",
+                format!("invalid create-run body: {e}"),
+            )
+        }
+    })?;
     // Issue #213: dedicated budget for expensive run creation — separate
     // from the global per-minute request limiter so health checks / reads
     // cannot crowd it out (and vice versa).
@@ -194,21 +213,12 @@ pub async fn create_run(
     }
 
     let user = current_user::resolve(authenticated.as_ref());
-    let toml = req
-        .get("toml_content")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            err(
-                StatusCode::BAD_REQUEST,
-                "MISSING",
-                "toml_content required".into(),
-            )
-        })?;
-    let max_jobs = req.get("max_jobs").and_then(|v| v.as_u64()).unwrap_or(4) as usize;
+    let toml = req.toml_content.as_str();
+    let max_jobs = req.max_jobs.unwrap_or(4);
     let config = RunConfig {
         max_jobs: Some(max_jobs),
-        dry_run: req.get("dry_run").and_then(|v| v.as_bool()),
-        keep_going: req.get("keep_going").and_then(|v| v.as_bool()),
+        dry_run: req.dry_run,
+        keep_going: req.keep_going,
         resource_budget: None,
     };
 
@@ -216,8 +226,8 @@ pub async fn create_run(
     // the run execute on that host (staged over tar-over-ssh, results
     // pulled back — domains/clusters/remote.rs).
     let cluster_id: Option<String> = req
-        .get("cluster_id")
-        .and_then(|v| v.as_str())
+        .cluster_id
+        .as_deref()
         .filter(|s| !s.is_empty())
         .map(String::from);
 
@@ -226,8 +236,8 @@ pub async fn create_run(
     // checkpoint (config snapshot, rule fingerprints, input manifests)
     // survives across re-runs and delivers precise invalidation.
     let pipeline_id: Option<String> = req
-        .get("pipeline_id")
-        .and_then(|v| v.as_str())
+        .pipeline_id
+        .as_deref()
         .filter(|s| !s.is_empty())
         .map(String::from);
     // Boundary validation: pipeline_id becomes a path component and must be a
@@ -408,9 +418,7 @@ pub async fn create_run(
                 user.id.clone(),
                 cluster_row,
                 run_dir,
-                req.get("max_jobs")
-                    .and_then(|v| v.as_u64())
-                    .map(|j| j as usize),
+                req.max_jobs,
             );
             return Ok(Json(resp));
         }
@@ -424,38 +432,11 @@ pub async fn create_run(
             crate::executor::RunFlags {
                 resume_failed: false,
                 rerun: false,
-                dry_run: req
-                    .get("dry_run")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
-                keep_going: req
-                    .get("keep_going")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
-                max_jobs: req
-                    .get("max_jobs")
-                    .and_then(|v| v.as_u64())
-                    .map(|j| j as usize),
-                samples: req
-                    .get("samples")
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|v| v.as_str())
-                            .map(String::from)
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                targets: req
-                    .get("targets")
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|v| v.as_str())
-                            .map(String::from)
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                dry_run: req.dry_run.unwrap_or(false),
+                keep_going: req.keep_going.unwrap_or(false),
+                max_jobs: req.max_jobs,
+                samples: req.samples.unwrap_or_default(),
+                targets: req.targets.unwrap_or_default(),
             },
         );
     }
@@ -1413,7 +1394,9 @@ pub async fn cancel_run(
 pub async fn pause_run(
     authenticated: Option<Extension<CurrentUser>>,
     Path(id): Path<String>,
-    Json(req): Json<serde_json::Value>,
+    // The body carries no options today; `Option` exempts an empty body
+    // from the JSON content-type demand (issue #324 F-6).
+    _body: Option<Json<serde_json::Value>>,
 ) -> ApiResult<serde_json::Value> {
     let pool = crate::infra::db::sqlite::try_pool().map_err(|_| {
         err(
@@ -1434,8 +1417,9 @@ pub async fn pause_run(
             format!("Run {id} is already {} — cannot pause", run.status),
         ));
     }
-    let reason = req
-        .get("reason")
+    let reason = _body
+        .as_ref()
+        .and_then(|Json(v)| v.get("reason"))
         .and_then(|v| v.as_str())
         .unwrap_or("user_request");
 
@@ -1492,7 +1476,9 @@ pub async fn pause_run(
 pub async fn resume_run(
     authenticated: Option<Extension<CurrentUser>>,
     Path(id): Path<String>,
-    Json(req): Json<serde_json::Value>,
+    // `Option` exempts an empty body from the JSON content-type demand
+    // (issue #324 F-6); the only consumed key is the optional from_rule.
+    body: Option<Json<serde_json::Value>>,
 ) -> ApiResult<serde_json::Value> {
     let pool = crate::infra::db::sqlite::try_pool().map_err(|_| {
         err(
@@ -1516,7 +1502,10 @@ pub async fn resume_run(
             ),
         ));
     }
-    let from_rule = req.get("from_rule").and_then(|v| v.as_str());
+    let from_rule = body
+        .as_ref()
+        .and_then(|Json(v)| v.get("from_rule"))
+        .and_then(|v| v.as_str());
 
     // Unfreeze the live process group.
     if let Some(pgid) = crate::process_control::pgid(&id)

--- a/crates/oxo-flow-web/src/domains/execution/types.rs
+++ b/crates/oxo-flow-web/src/domains/execution/types.rs
@@ -68,10 +68,28 @@ impl std::fmt::Display for NodeStatus {
     }
 }
 
+/// The wire contract of `POST /api/runs` (issue #324 F-4): a flat
+/// `toml_content` plus flat options — the exact shape the frontend client
+/// sends and the handler parses. Kept in one place so the OpenAPI spec,
+/// the handler, and the TypeScript client can never drift again.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CreateRunRequest {
-    pub pipeline_id: String,
-    pub config: Option<RunConfig>,
+    /// Workflow definition in `.oxoflow` TOML format. Required.
+    pub toml_content: String,
+    #[serde(default)]
+    pub max_jobs: Option<usize>,
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+    #[serde(default)]
+    pub keep_going: Option<bool>,
+    #[serde(default)]
+    pub cluster_id: Option<String>,
+    #[serde(default)]
+    pub pipeline_id: Option<String>,
+    #[serde(default)]
+    pub samples: Option<Vec<String>>,
+    #[serde(default)]
+    pub targets: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -284,21 +302,26 @@ mod tests {
 
     #[test]
     fn test_create_run_request_roundtrip() {
-        let req = CreateRunRequest {
-            pipeline_id: "p1".into(),
-            config: Some(RunConfig {
-                max_jobs: Some(4),
-                dry_run: Some(true),
-                keep_going: Some(false),
-                resource_budget: Some(ResourceBudget {
-                    max_memory: Some("8G".into()),
-                    max_threads: Some(4),
-                }),
-            }),
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        let back: CreateRunRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.pipeline_id, req.pipeline_id);
+        // The WIRE contract of POST /api/runs (issue #324 F-4): a flat
+        // toml_content plus flat options — the shape the frontend client
+        // and the handler actually speak. The type must parse exactly this
+        // payload; a divergent typed contract is a decorated lie.
+        let json = serde_json::json!({
+            "toml_content": "[workflow]\nname = \"x\"",
+            "max_jobs": 4,
+            "dry_run": true,
+            "keep_going": false,
+            "cluster_id": null,
+            "pipeline_id": "p1",
+            "samples": ["S1"],
+            "targets": [],
+        });
+        let back: CreateRunRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(back.toml_content, "[workflow]\nname = \"x\"");
+        assert_eq!(back.pipeline_id.as_deref(), Some("p1"));
+        assert_eq!(back.max_jobs, Some(4));
+        assert_eq!(back.dry_run, Some(true));
+        assert_eq!(back.samples.as_deref(), Some(&["S1".to_string()][..]));
     }
 
     #[test]

--- a/crates/oxo-flow-web/tests/api_contract_hardening.rs
+++ b/crates/oxo-flow-web/tests/api_contract_hardening.rs
@@ -325,3 +325,73 @@ async fn server_ai_config_reports_an_unreadable_credential_as_unconfigured() {
         "the message must say how to recover: {message}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// F-4 — POST /api/runs speaks ONE typed contract (issue #324)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_run_accepts_the_flat_wire_contract() {
+    ensure_db().await;
+    let app = server::build_router("personal");
+
+    let (status, body) = post(
+        &app,
+        "/api/runs",
+        json!({
+            "toml_content": VALID_TOML,
+            "max_jobs": 2,
+            "dry_run": true,
+            "keep_going": false,
+            "pipeline_id": null,
+            "samples": [],
+            "targets": [],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(
+        body["run_id"].as_str().is_some_and(|s| !s.is_empty()),
+        "a created run returns its id: {body}"
+    );
+}
+
+#[tokio::test]
+async fn create_run_keeps_the_stable_missing_toml_error() {
+    ensure_db().await;
+    let app = server::build_router("personal");
+
+    let (status, body) = post(&app, "/api/runs", json!({ "max_jobs": 2, "dry_run": true })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["code"], "MISSING", "{body}");
+    assert_eq!(body["message"], "toml_content required", "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// F-6① — empty-body POSTs must not demand a JSON content type
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pause_and_resume_accept_empty_bodies() {
+    ensure_db().await;
+    let app = server::build_router("personal");
+
+    // No Content-Type header, no body — the action verbs must still reach
+    // the handler (a missing run then answers 404, not a 415 media-type
+    // rejection aimed at a body the client never sent). Raw oneshot calls
+    // because a 415's plain-text body is not JSON (the `request` helper
+    // assumes JSON responses).
+    for action in ["pause", "resume", "cancel"] {
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/api/runs/does-not-exist/{action}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "empty-body {action} must not be rejected as 415"
+        );
+    }
+}

--- a/crates/oxo-flow-web/tests/openapi_gate.rs
+++ b/crates/oxo-flow-web/tests/openapi_gate.rs
@@ -189,3 +189,23 @@ fn every_router_route_is_in_the_generated_spec() {
         "expected >= 102 documented operations (one per route handler), got {operation_count}"
     );
 }
+
+/// Body-carrying POSTs must declare their request body (issue #324 F-4):
+/// a handler that parses a JSON payload but documents no request body
+/// forces API consumers to read source instead of the spec.
+#[test]
+fn post_runs_documents_its_request_body() {
+    let spec: serde_json::Value = serde_json::from_str(&oxo_flow_web::openapi::spec_json())
+        .expect("generated spec must parse as JSON");
+
+    let post = &spec["paths"]["/api/runs"]["post"];
+    assert!(
+        post.get("requestBody").is_some(),
+        "POST /api/runs must declare a requestBody in the OpenAPI spec"
+    );
+    let schema = &post["requestBody"]["content"]["application/json"]["schema"];
+    assert!(
+        schema.get("$ref").is_some() || schema.get("properties").is_some(),
+        "POST /api/runs requestBody must reference a schema, got {schema}"
+    );
+}

--- a/docs/guide/src/commands/lint.md
+++ b/docs/guide/src/commands/lint.md
@@ -83,6 +83,21 @@ either a matching `when` gate on the consumer or splitting it into
 that declare their tolerance for a missing producer are not flagged:
 `optional = true` / `"any"` rules, `input_groups` disk-discovery
 fallbacks, and consumers that already carry any `when` gate.
+W032 flags a `[config]` key whose *name* looks like a secret
+(`token`, `secret`, `password`, `credential`, `api_key`,
+`access_key`, `private_key`, `ssh_key`) but is not declared
+`sensitive`: its value then lands in plaintext in command records,
+stderr tails, and the checkpoint — credential leakage on shared
+clusters and in CI artifacts. The repair is the declaration itself:
+
+```toml
+[config]
+api_token = { default = "sk-...", sensitive = true }
+```
+
+Declared-sensitive keys are env-routed and masked on disk, so W032
+never flags them — see
+[`[config]` — Configuration Variables](../reference/workflow-format.md#config--configuration-variables).
 
 ---
 

--- a/docs/guide/src/commands/lint.md
+++ b/docs/guide/src/commands/lint.md
@@ -97,7 +97,7 @@ api_token = { default = "sk-...", sensitive = true }
 
 Declared-sensitive keys are env-routed and masked on disk, so W032
 never flags them — see
-[`[config]` — Configuration Variables](../reference/workflow-format.md#config--configuration-variables).
+[`[config]` — Configuration Variables](../reference/workflow-format.md#config-configuration-variables).
 
 ---
 

--- a/docs/guide/src/commands/status.md
+++ b/docs/guide/src/commands/status.md
@@ -159,6 +159,11 @@ replay them deterministically and revoke them when the rule is invalidated
 ## Notes
 
 - Checkpoint files are written automatically during `oxo-flow run` execution
+- `--timing` reads the per-rule benchmarks recorded in the checkpoint by
+  CLI runs (wall time, peak RSS) — no separate database is involved; web-
+  initiated runs keep their own records in the web service's database, and
+  their checkpoint timings are equally readable via `status` from the run's
+  workdir
 - Use `status` to inspect progress of long-running pipelines, especially on clusters
 - The checkpoint file is not updated after the pipeline completes — it reflects the state at the last write
 - Exits with code `0` regardless of the pipeline's success or failure

--- a/docs/guide/src/commands/validate.md
+++ b/docs/guide/src/commands/validate.md
@@ -60,6 +60,21 @@ oxo-flow validate pipeline.oxoflow
 ✗ pipeline.oxoflow — DAG error: cycle detected in workflow DAG: cycle detected: align → sort_bam → align
 ```
 
+### Wildcard input without a sample domain
+
+An input containing a sample placeholder (`{sample}`, `{group}`, `{pair_id}`, …)
+resolves only when the workflow declares a sample domain
+(`[[sample_groups]]`, `[[pairs]]`, or `sample_pattern`). Without one the
+run fails mid-flight with a literal brace token, so `validate` reports
+the path as missing instead of approving it:
+
+```
+⚠ Warning: The following input files do not exist:
+  - missing/{sample}.txt (no sample groups/pairs/sample_pattern declared)
+```
+
+`--json` includes the same entry in `missing_inputs`.
+
 ---
 
 ## Notes

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -263,7 +263,10 @@ Content-Type: application/json
 `toml_content` is the workflow source (required — the run is created from
 it, not from a saved pipeline); `max_jobs`, `dry_run`, `keep_going`,
 `pipeline_id`, `cluster_id`, `samples`, and `targets` are top-level fields
-(not nested under a `config` object). Returns
+(not nested under a `config` object). This flat shape is the typed
+`CreateRunRequest` schema — the OpenAPI spec declares it as the endpoint's
+`requestBody`, and the handler parses exactly that type, so the spec, the
+server, and the TypeScript client stay in lockstep. Returns
 `{ run_id, status: "queued", estimated_resources, execution_plan }`.
 
 Before spawning the executor the run stages the acting user's uploaded


### PR DESCRIPTION
Closes #324.

Fixes every actionable finding from the 2026-09-06 nine-dimension harness evaluation of v0.17.2 (all reproduced on main before fixing, all TDD-pinned by regression tests):

## Bugs (100% reproducible, both verified live after fix)

- **F-1 (High)** — a rule interrupted by SIGKILL whose orphaned shell finished its outputs was verdicted `outputs up-to-date` on resume but never re-entered `completed_rules`/`benchmarks`: every later run re-submitted it, it was excluded from output verification, and the checkpoint audit trail disagreed with the disk forever. The run loop's `Skipped` arm now records up-to-date rules as completed (exactly like the already-completed pre-pass). Live repro: kill → resume now shows the interrupted rule back in completed+benchmarks and the third run submits nothing.
- **F-2 (Med-High)** — `transform.cleanup = true` silently never deleted chunk files on default runs: deletion was gated on the checksum migration, which only records under `--provenance`. With no recorded checksum there is nothing that can lie, so deletion now proceeds; the persist-before-delete audit ordering is unchanged for the provenance path.

## Hardening

- **F-3** — `validate` now reports wildcard inputs (`missing/{sample}.txt`) as missing when no sample domain (`[[sample_groups]]` / `[[pairs]]` / `sample_pattern`) is declared — the approve layer no longer says `valid: true` for a workflow that can only fail at run time. The runtime WARN's "report as an engine bug" wording now points at the workflow declaration.
- **F-4** — `CreateRunRequest` is now the actual flat wire contract of `POST /api/runs` (toml_content + flat options), the handler parses through it, and the OpenAPI spec declares it as the `requestBody`; the stable `MISSING/toml_content required` error is preserved. Spec, server, and the TypeScript client can no longer drift.
- **F-5** — new lint **W032** flags config keys whose names look like secrets (`token`/`secret`/`password`/`credential`/`*_key`) but are not declared `sensitive`, with the declaration as the suggested fix; declared-sensitive keys are never flagged.
- **F-6①** — `pause`/`resume` accept empty bodies without a JSON content type (no more 415); `cancel` already did.
- **F-6②** — verified consistent with the "Auto-detected capacity is soft" docs since ea7c90a (validate warns, run clamps and runs the rule alone); no change needed.
- **F-6③** — investigated: CLI runs do persist benchmarks/rule_runs into the checkpoint and `status --timing` reads them; the "runs recorded" symptom is the web runs-table view (CLI runs intentionally live outside the web DB). No code change.

## Test plan

- [x] New regression tests: `crates/oxo-flow-cli/tests/eval_findings.rs` (checkpoint-edited kill→resume→rerun, default-run chunk cleanup, validate wildcard domain), W032 lint tests in `format.rs`, `CreateRunRequest` wire round-trip, `openapi_gate` requestBody assertion, contract-hardening 200/400 pins
- [x] `cargo test --workspace` — **2653 passed, 0 failed** (baseline 2629 + 24 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Live verification of F-1 (real SIGKILL + resume + third run) and F-2 (default vs --provenance chunk counts) on the fixed binary
- [ ] CI green (incl. cargo audit — local audit hit registry timeouts)