### PR TITLE
feat(graph): production-ready graph subcommand — format matrix, metro polish

### DIFF
--- a/crates/oxo-flow-cli/src/commands/output.rs
+++ b/crates/oxo-flow-cli/src/commands/output.rs
@@ -3,19 +3,41 @@
 use crate::commands::{print_banner, resolve_workflow};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use clap::ValueEnum;
 use colored::Colorize;
 use oxo_flow_core::config::WorkflowConfig;
-use oxo_flow_core::dag::WorkflowDag;
+use oxo_flow_core::dag::{MetroGranularity, WorkflowDag};
 use oxo_flow_core::executor::CheckpointState;
 use oxo_flow_core::report::{Report, ReportContent, ReportSection, TemplateEngine};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+
+/// Station granularity for the `metro` graph format.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum MetroArg {
+    /// Every rule is one station (default).
+    Rule,
+    /// Rules chain-connected within a section and driven by the same tool
+    /// collapse into tool-named stations (the nf-core idiom:
+    /// `samtools sort`/`samtools index` → one "SAMtools" stop).
+    Process,
+}
+
+impl From<MetroArg> for MetroGranularity {
+    fn from(arg: MetroArg) -> Self {
+        match arg {
+            MetroArg::Rule => MetroGranularity::Rule,
+            MetroArg::Process => MetroGranularity::Process,
+        }
+    }
+}
 
 pub fn handle_graph(
     workflow: PathBuf,
     format: String,
     output: Option<PathBuf>,
     expanded: bool,
+    granularity: MetroArg,
 ) -> Result<()> {
     print_banner();
     let workflow = resolve_workflow(Some(workflow))?;
@@ -39,7 +61,13 @@ pub fn handle_graph(
         "dot-clustered" => dag.to_dot_clustered().map_err(|e| anyhow::anyhow!(e)),
         "tree" => dag.to_ascii_tree().map_err(|e| anyhow::anyhow!(e)),
         "mermaid" => Ok(dag.to_mermaid()),
-        "metro" => dag.to_metro(&config.rules).map_err(|e| anyhow::anyhow!(e)),
+        "metro" => dag
+            .to_metro(
+                &config.rules,
+                Some(&config.module_rules),
+                granularity.into(),
+            )
+            .map_err(|e| anyhow::anyhow!(e)),
         _ => Err(anyhow::anyhow!(
             "unsupported graph format '{}'. Supported formats: ascii, dot, dot-clustered, tree, mermaid, metro",
             format

--- a/crates/oxo-flow-cli/src/commands/output.rs
+++ b/crates/oxo-flow-cli/src/commands/output.rs
@@ -21,6 +21,10 @@ pub enum MetroArg {
     /// collapse into tool-named stations (the nf-core idiom:
     /// `samtools sort`/`samtools index` → one "SAMtools" stop).
     Process,
+    /// One station per module section: the publication/overview tier —
+    /// a compact module-level transit map (each section becomes a
+    /// station, colored by its dominant stage line).
+    Module,
 }
 
 impl From<MetroArg> for MetroGranularity {
@@ -28,6 +32,7 @@ impl From<MetroArg> for MetroGranularity {
         match arg {
             MetroArg::Rule => MetroGranularity::Rule,
             MetroArg::Process => MetroGranularity::Process,
+            MetroArg::Module => MetroGranularity::Module,
         }
     }
 }

--- a/crates/oxo-flow-cli/src/commands/output.rs
+++ b/crates/oxo-flow-cli/src/commands/output.rs
@@ -12,10 +12,31 @@ use oxo_flow_core::report::{Report, ReportContent, ReportSection, TemplateEngine
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+/// Output format for the `graph` subcommand.
+///
+/// `metro` additionally takes `--granularity`; every other format renders
+/// the template DAG as-is (use `--expanded` for the runtime DAG).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum GraphFormat {
+    /// Terminal ASCII DAG with level grouping and metrics box.
+    Ascii,
+    /// Graphviz digraph (machine-consumable).
+    Dot,
+    /// Graphviz digraph grouped into level clusters.
+    DotClustered,
+    /// Indented dependency tree.
+    Tree,
+    /// Standard Mermaid `graph LR` (GitHub/VS Code/MkDocs).
+    Mermaid,
+    /// nf-metro transit map (`%%metro` line/section directives).
+    Metro,
+}
+
 /// Station granularity for the `metro` graph format.
-#[derive(Clone, Copy, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
 pub enum MetroArg {
     /// Every rule is one station (default).
+    #[default]
     Rule,
     /// Rules chain-connected within a section and driven by the same tool
     /// collapse into tool-named stations (the nf-core idiom:
@@ -39,11 +60,24 @@ impl From<MetroArg> for MetroGranularity {
 
 pub fn handle_graph(
     workflow: PathBuf,
-    format: String,
+    format: GraphFormat,
     output: Option<PathBuf>,
     expanded: bool,
-    granularity: MetroArg,
+    granularity: Option<MetroArg>,
 ) -> Result<()> {
+    // `--granularity` is a metro-only zoom. A non-metro format silently
+    // ignoring it would look like the zoom applied, so fail fast before
+    // the workflow is even parsed. The value's spelling comes from clap
+    // itself (single source of truth for the allowed values).
+    if let Some(level) = granularity
+        && format != GraphFormat::Metro
+    {
+        let level = clap::ValueEnum::to_possible_value(&level).expect("ValueEnum value");
+        anyhow::bail!(
+            "--granularity '{}' only applies to the metro format; pass -f metro or drop the option",
+            level.get_name()
+        );
+    }
     print_banner();
     let workflow = resolve_workflow(Some(workflow))?;
     let mut config = WorkflowConfig::from_file(&workflow)
@@ -59,24 +93,25 @@ pub fn handle_graph(
     }
 
     let dag = WorkflowDag::from_rules(&config.rules).context("failed to build workflow DAG")?;
+    if dag.node_count() == 0 {
+        // An empty export (bare "graph LR") is indistinguishable from a
+        // successful render downstream — fail loudly instead.
+        anyhow::bail!("workflow '{}' has no rules to graph", workflow.display());
+    }
 
-    let result = match format.as_str() {
-        "ascii" => dag.to_ascii().map_err(|e| anyhow::anyhow!(e)),
-        "dot" => Ok(dag.to_dot()),
-        "dot-clustered" => dag.to_dot_clustered().map_err(|e| anyhow::anyhow!(e)),
-        "tree" => dag.to_ascii_tree().map_err(|e| anyhow::anyhow!(e)),
-        "mermaid" => Ok(dag.to_mermaid()),
-        "metro" => dag
+    let result = match format {
+        GraphFormat::Ascii => dag.to_ascii().map_err(|e| anyhow::anyhow!(e)),
+        GraphFormat::Dot => Ok(dag.to_dot()),
+        GraphFormat::DotClustered => dag.to_dot_clustered().map_err(|e| anyhow::anyhow!(e)),
+        GraphFormat::Tree => dag.to_ascii_tree().map_err(|e| anyhow::anyhow!(e)),
+        GraphFormat::Mermaid => Ok(dag.to_mermaid()),
+        GraphFormat::Metro => dag
             .to_metro(
                 &config.rules,
                 Some(&config.module_rules),
-                granularity.into(),
+                granularity.unwrap_or_default().into(),
             )
             .map_err(|e| anyhow::anyhow!(e)),
-        _ => Err(anyhow::anyhow!(
-            "unsupported graph format '{}'. Supported formats: ascii, dot, dot-clustered, tree, mermaid, metro",
-            format
-        )),
     }?;
 
     if let Some(path) = output {

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -435,7 +435,7 @@ pub enum Commands {
             long,
             value_enum,
             default_value_t = crate::commands::output::MetroArg::Rule,
-            help = "Station granularity for the metro format: 'rule' keeps one station per rule; 'process' collapses chain-connected same-tool rules into tool-named stations (nf-core idiom)"
+            help = "Station granularity for the metro format: 'rule' keeps one station per rule; 'process' collapses chain-connected same-tool rules into tool-named stations (nf-core idiom); 'module' emits one station per module section (publication/overview tier)"
         )]
         granularity: crate::commands::output::MetroArg,
     },

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -15,7 +15,9 @@ use crate::commands::cluster::cluster_command;
 use crate::commands::completions::handle_completions;
 use crate::commands::info::info_command;
 use crate::commands::infra::{env_command, handle_license};
-use crate::commands::output::{handle_diff, handle_export, handle_graph, handle_report};
+use crate::commands::output::{
+    GraphFormat, MetroArg, handle_diff, handle_export, handle_graph, handle_report,
+};
 use crate::commands::project::{init_command, template_command};
 use crate::commands::provenance::provenance_verify_command;
 use crate::commands::publish::publish_command;
@@ -420,10 +422,11 @@ pub enum Commands {
         #[arg(
             short = 'f',
             long,
-            default_value = "ascii",
+            value_enum,
+            default_value_t = GraphFormat::Ascii,
             help = "Output format: ascii, dot, dot-clustered, tree, mermaid, metro"
         )]
-        format: String,
+        format: GraphFormat,
         #[arg(short = 'o', long, help = "Output file path")]
         output: Option<PathBuf>,
         #[arg(
@@ -431,13 +434,13 @@ pub enum Commands {
             help = "Show the DAG after wildcard/sample/scatter expansion (the actual runtime DAG)"
         )]
         expanded: bool,
-        #[arg(
-            long,
-            value_enum,
-            default_value_t = crate::commands::output::MetroArg::Rule,
-            help = "Station granularity for the metro format: 'rule' keeps one station per rule; 'process' collapses chain-connected same-tool rules into tool-named stations (nf-core idiom); 'module' emits one station per module section (publication/overview tier)"
-        )]
-        granularity: crate::commands::output::MetroArg,
+        /// Station zoom for the metro format (default: rule): 'rule' keeps
+        /// one station per rule; 'process' collapses chain-connected
+        /// same-tool rules into tool-named stations (nf-core idiom);
+        /// 'module' emits one station per module section
+        /// (publication/overview tier).
+        #[arg(long, value_enum)]
+        granularity: Option<MetroArg>,
     },
     /// Show execution status and per-rule timings from a checkpoint file.
     Status {

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -431,6 +431,13 @@ pub enum Commands {
             help = "Show the DAG after wildcard/sample/scatter expansion (the actual runtime DAG)"
         )]
         expanded: bool,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = crate::commands::output::MetroArg::Rule,
+            help = "Station granularity for the metro format: 'rule' keeps one station per rule; 'process' collapses chain-connected same-tool rules into tool-named stations (nf-core idiom)"
+        )]
+        granularity: crate::commands::output::MetroArg,
     },
     /// Show execution status and per-rule timings from a checkpoint file.
     Status {
@@ -1461,7 +1468,8 @@ async fn main() -> Result<()> {
             format,
             output,
             expanded,
-        } => handle_graph(workflow, format, output, expanded)?,
+            granularity,
+        } => handle_graph(workflow, format, output, expanded, granularity)?,
         Commands::Status {
             checkpoint,
             timing,

--- a/crates/oxo-flow-cli/tests/graph.rs
+++ b/crates/oxo-flow-cli/tests/graph.rs
@@ -1,0 +1,315 @@
+//! Integration tests for the `graph` subcommand: the format matrix, the
+//! metro granularity ladder, `--expanded`, and the option constraints
+//! (`--granularity` is metro-only; unknown formats fail at the clap layer).
+
+use std::path::Path;
+use std::process::Command;
+
+fn oxo() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_oxo-flow"))
+}
+
+/// Write a workflow into `dir` and return its path string.
+fn write_workflow(dir: &Path, name: &str, content: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+/// Run `oxo-flow graph <args..>` in `dir`; return (status, stdout, stderr).
+fn run_graph(dir: &Path, workflow: &str, args: &[&str]) -> (bool, String, String) {
+    let out = oxo()
+        .args(["graph", "--quiet", workflow])
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+/// A two-rule chain `generate_data → transform` (the docs' canonical demo).
+fn two_step() -> &'static str {
+    r#"
+[workflow]
+name = "graph-demo"
+
+[[rules]]
+name = "generate_data"
+output = ["data/greeting.txt"]
+shell = "mkdir -p data && echo hello > data/greeting.txt"
+
+[[rules]]
+name = "transform"
+input = ["data/greeting.txt"]
+output = ["results/uppercase.txt"]
+shell = "mkdir -p results && tr a-z A-Z < data/greeting.txt > results/uppercase.txt"
+"#
+}
+
+/// A same-tool chain (`fastp` trim → `fastp` index) for the process tier.
+fn fastp_chain() -> &'static str {
+    r#"
+[workflow]
+name = "fastp-demo"
+
+[[rules]]
+name = "fastp_trim"
+output = ["out/trimmed.txt"]
+shell = "mkdir -p out && fastp -i in.fq -o out/trimmed.txt"
+
+[[rules]]
+name = "fastp_index"
+input = ["out/trimmed.txt"]
+output = ["final/idx.txt"]
+shell = "mkdir -p final && fastp -i out/trimmed.txt -o final/idx.txt"
+"#
+}
+
+/// A `module::`-prefixed pair for the module tier.
+fn two_modules() -> &'static str {
+    r#"
+[workflow]
+name = "module-demo"
+
+[[rules]]
+name = "qc::fastqc_raw"
+output = ["qc_raw/"]
+shell = "fastqc raw.fq"
+
+[[rules]]
+name = "align::bwa_mem"
+input = ["qc_raw/"]
+output = ["aln.bam"]
+shell = "bwa mem ref.fa raw.fq > aln.bam"
+"#
+}
+
+/// A workflow with a live `sample_pattern` (two real samples on disk).
+fn sampled() -> &'static str {
+    r#"
+[workflow]
+name = "expand-demo"
+sample_pattern = "raw/{sample}.txt"
+
+[[rules]]
+name = "step1"
+output = ["out/{sample}.txt"]
+shell = "mkdir -p out && cp raw/{sample}.txt out/{sample}.txt"
+
+[[rules]]
+name = "step2"
+input = ["out/{sample}.txt"]
+output = ["final/{sample}.txt"]
+shell = "mkdir -p final && cp out/{sample}.txt final/{sample}.txt"
+"#
+}
+
+/// Station emission lines — `n<digits>[...]` only, never subgraph
+/// declarations (whose sanitized section ids may contain an `n`).
+fn count_stations(mmd: &str) -> usize {
+    mmd.lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.starts_with('n')
+                && t.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
+                && t.contains('[')
+        })
+        .count()
+}
+
+#[test]
+fn ascii_is_the_default_format() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let (ok, stdout, _) = run_graph(dir.path(), &wf, &[]);
+    assert!(ok);
+    assert!(
+        stdout.contains("Workflow DAG"),
+        "metrics box missing:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Level 0"),
+        "level grouping missing:\n{stdout}"
+    );
+    assert!(stdout.contains("generate_data"));
+    assert!(stdout.contains("transform"));
+}
+
+#[test]
+fn dot_format_emits_graphviz_digraph() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let (ok, stdout, _) = run_graph(dir.path(), &wf, &["-f", "dot"]);
+    assert!(ok);
+    assert!(
+        stdout.starts_with("digraph"),
+        "digraph header missing:\n{stdout}"
+    );
+    assert!(stdout.contains("generate_data"));
+    assert!(stdout.contains(" -> "));
+}
+
+#[test]
+fn mermaid_format_emits_plain_graph_lr() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let (ok, stdout, _) = run_graph(dir.path(), &wf, &["-f", "mermaid"]);
+    assert!(ok);
+    assert!(
+        stdout.contains("graph LR"),
+        "graph LR header missing:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("%%metro"),
+        "mermaid must carry no metro directives:\n{stdout}"
+    );
+    assert!(stdout.contains("n0 --> n1"));
+}
+
+#[test]
+fn metro_rule_granularity_keeps_every_rule_a_station() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let (ok, stdout, _) = run_graph(dir.path(), &wf, &["-f", "metro"]);
+    assert!(ok);
+    assert!(
+        stdout.contains("%%metro line:"),
+        "line directives missing:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("n0[\"generate_data\"]"),
+        "station missing:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("n1[\"transform\"]"),
+        "station missing:\n{stdout}"
+    );
+    assert_eq!(count_stations(&stdout), 2);
+}
+
+#[test]
+fn metro_process_granularity_collapses_tool_chains() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", fastp_chain());
+    let (ok, stdout, _) = run_graph(
+        dir.path(),
+        &wf,
+        &["-f", "metro", "--granularity", "process"],
+    );
+    assert!(ok);
+    assert!(
+        stdout.contains("n0[\"fastp\"]"),
+        "tool chain must collapse into one station:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("n1["),
+        "merged rules keep no stations:\n{stdout}"
+    );
+    assert_eq!(count_stations(&stdout), 1);
+}
+
+#[test]
+fn metro_module_granularity_emits_one_station_per_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_modules());
+    let (ok, stdout, _) = run_graph(dir.path(), &wf, &["-f", "metro", "--granularity", "module"]);
+    assert!(ok);
+    assert!(
+        !stdout.contains("subgraph"),
+        "module tier is a flat graph:\n{stdout}"
+    );
+    assert_eq!(count_stations(&stdout), 2);
+    assert!(stdout.contains("n0["), "qc station missing:\n{stdout}");
+    assert!(stdout.contains("n1["), "align station missing:\n{stdout}");
+}
+
+#[test]
+fn granularity_is_rejected_outside_the_metro_format() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    for format in ["ascii", "dot", "mermaid"] {
+        let (ok, stdout, stderr) =
+            run_graph(dir.path(), &wf, &["-f", format, "--granularity", "module"]);
+        assert!(!ok, "granularity + {format} must fail");
+        assert!(
+            stdout.is_empty(),
+            "no graph output on a rejected combo:\n{stdout}"
+        );
+        assert!(
+            stderr.contains("only applies to the metro format"),
+            "explaining error expected:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn unknown_format_is_rejected_by_clap() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let (ok, stdout, stderr) = run_graph(dir.path(), &wf, &["-f", "svg"]);
+    assert!(!ok);
+    assert!(stdout.is_empty(), "no partial output on a clap error");
+    assert!(
+        stderr.contains("possible values"),
+        "clap must list the valid formats:\n{stderr}"
+    );
+}
+
+#[test]
+fn expanded_shows_per_sample_stations() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("raw")).unwrap();
+    std::fs::write(dir.path().join("raw/a.txt"), "a").unwrap();
+    std::fs::write(dir.path().join("raw/b.txt"), "b").unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", sampled());
+
+    let (ok, template, _) = run_graph(dir.path(), &wf, &["-f", "metro"]);
+    assert!(ok);
+    assert_eq!(
+        count_stations(&template),
+        2,
+        "template DAG has 2 stations:\n{template}"
+    );
+
+    let (ok, expanded, _) = run_graph(dir.path(), &wf, &["-f", "metro", "--expanded"]);
+    assert!(ok);
+    assert_eq!(
+        count_stations(&expanded),
+        4,
+        "expanded DAG has 4 stations:\n{expanded}"
+    );
+    assert!(
+        expanded.contains("step1_auto-discovered_a"),
+        "instance naming must follow the runtime DAG:\n{expanded}"
+    );
+}
+
+#[test]
+fn output_file_keeps_stdout_clean_for_pipes() {
+    let dir = tempfile::tempdir().unwrap();
+    let wf = write_workflow(dir.path(), "w.oxoflow", two_step());
+    let target = dir.path().join("graph.dot");
+    let (ok, stdout, stderr) = run_graph(
+        dir.path(),
+        &wf,
+        &["-f", "dot", "-o", target.to_str().unwrap()],
+    );
+    assert!(ok);
+    assert!(
+        stdout.is_empty(),
+        "stdout reserved for machine output:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("Graph saved to"),
+        "save notice expected:\n{stderr}"
+    );
+    let written = std::fs::read_to_string(&target).unwrap();
+    assert!(
+        written.starts_with("digraph"),
+        "file holds the DOT body:\n{written}"
+    );
+}

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -718,6 +718,14 @@ pub enum MetroGranularity {
     #[default]
     Rule,
     Process,
+    /// One station per section (the workflow's module namespaces, SCCs
+    /// contracted): the publication/overview tier. A compact module-level
+    /// transit map whose stations are the sections themselves, ordered by
+    /// the section DAG and colored by each section's dominant stage line.
+    /// Dense ported DAGs (live: community mag, 642 stations at rule
+    /// granularity) land in the ~10-20-station scale of published nf-core
+    /// maps without hand curation.
+    Module,
 }
 
 impl WorkflowDag {
@@ -841,7 +849,11 @@ impl WorkflowDag {
         // representative is its earliest rule (file order), keeping the
         // output deterministic.
         let station_of: HashMap<NodeIndex, NodeIndex> = match granularity {
-            MetroGranularity::Rule => nodes.iter().map(|&node| (node, node)).collect(),
+            // The module tier groups by section afterward, so no station
+            // collapsing happens here.
+            MetroGranularity::Rule | MetroGranularity::Module => {
+                nodes.iter().map(|&node| (node, node)).collect()
+            }
             MetroGranularity::Process => {
                 let mut parent: HashMap<NodeIndex, NodeIndex> =
                     nodes.iter().map(|&node| (node, node)).collect();
@@ -1053,7 +1065,11 @@ impl WorkflowDag {
         let mut label_counts: HashMap<(String, String), usize> = HashMap::new();
         for &rep in &station_nodes {
             let base = match granularity {
-                MetroGranularity::Rule => metro_station_label(&self.graph[rep].name).to_string(),
+                // Unused at module granularity (the early-returned module
+                // tier labels sections, not stations).
+                MetroGranularity::Rule | MetroGranularity::Module => {
+                    metro_station_label(&self.graph[rep].name).to_string()
+                }
                 MetroGranularity::Process => rules
                     .get(self.graph[rep].rule_index)
                     .and_then(crate::stage::detect_tool)
@@ -1160,11 +1176,8 @@ impl WorkflowDag {
                     .copied()
                     .filter(|n| &node_section[n] == section)
                     .collect();
-                let rank: HashMap<NodeIndex, usize> = members
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &n)| (n, i))
-                    .collect();
+                let rank: HashMap<NodeIndex, usize> =
+                    members.iter().enumerate().map(|(i, &n)| (n, i)).collect();
                 let mut ready: BTreeSet<(usize, NodeIndex)> = members
                     .iter()
                     .filter(|n| !intra_in_degree.contains_key(n))
@@ -1192,6 +1205,90 @@ impl WorkflowDag {
                 (section.clone(), ordered)
             })
             .collect();
+
+        if granularity == MetroGranularity::Module {
+            // Publication/overview tier: one station per contracted section,
+            // flat graph (the section IS the station — no nesting), edges
+            // are the deduplicated inter-section dataflow edges, and each
+            // station rides its section's dominant stage line (most member
+            // stations, ties by file order). Dense ported DAGs land in the
+            // ~10-20-station scale of published nf-core maps without any
+            // hand curation.
+            let rank: HashMap<&str, usize> = sections
+                .iter()
+                .enumerate()
+                .map(|(i, (section, _))| (section.as_str(), i))
+                .collect();
+            let mut dominant: HashMap<String, String> = HashMap::new();
+            for (section, _) in &sections {
+                let mut counts: HashMap<&str, usize> = HashMap::new();
+                for node in station_nodes.iter().filter(|n| &node_section[n] == section) {
+                    *counts.entry(node_stage[node].as_str()).or_insert(0) += 1;
+                }
+                let best = station_nodes
+                    .iter()
+                    .filter(|n| &node_section[n] == section)
+                    .map(|n| node_stage[n].as_str())
+                    .max_by_key(|s| counts[s])
+                    .unwrap_or("generic");
+                dominant.insert(section.clone(), best.to_string());
+            }
+            let mut seen: HashSet<(usize, usize)> = HashSet::new();
+            let mut module_edges: Vec<(usize, usize)> = Vec::new();
+            for &(src, dst) in &station_edges {
+                let (a, b) = (
+                    rank[node_section[&src].as_str()],
+                    rank[node_section[&dst].as_str()],
+                );
+                if a != b && seen.insert((a, b)) {
+                    module_edges.push((a, b));
+                }
+            }
+            let mut degree: HashMap<usize, usize> = HashMap::new();
+            for &(a, b) in &module_edges {
+                *degree.entry(a).or_default() += 1;
+                *degree.entry(b).or_default() += 1;
+            }
+            let isolated: Vec<String> = (0..sections.len())
+                .filter(|i| !degree.contains_key(i))
+                .map(|i| format!("n{i}"))
+                .collect();
+            let mut lines: Vec<String> = Vec::new();
+            for (section, _) in &sections {
+                let stage = &dominant[section];
+                if !lines.iter().any(|s| s == stage) {
+                    lines.push(stage.clone());
+                }
+            }
+            let mut out = String::new();
+            for stage in &lines {
+                out.push_str(&format!(
+                    "%%metro line: {} | {} | {}\n",
+                    sanitize_metro_id(stage),
+                    sanitize_mermaid_text(&crate::stage::stage_display(stage)),
+                    crate::stage::stage_color(stage),
+                ));
+            }
+            if !isolated.is_empty() && isolated.len() < sections.len() {
+                out.push_str(&format!("%%metro off_track: {}\n", isolated.join(", ")));
+            }
+            out.push('\n');
+            out.push_str("graph LR\n");
+            for (i, (_, display)) in sections.iter().enumerate() {
+                out.push_str(&format!(
+                    "    n{i}[\"{}\"]\n",
+                    sanitize_mermaid_label(display)
+                ));
+            }
+            for &(a, b) in &module_edges {
+                out.push_str(&format!(
+                    "    n{a} -->|{}| n{b}\n",
+                    sanitize_metro_id(&dominant[&sections[a].0])
+                ));
+            }
+            return Ok(out);
+        }
+
         let mut stages: Vec<String> = Vec::new();
         for node in &station_nodes {
             let stage = &node_stage[node];
@@ -3233,6 +3330,56 @@ mod tests {
         assert!(
             producer < consumer,
             "producer must sit left of its consumer within the section:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_module_granularity_emits_one_station_per_section() {
+        // Publication tier: stations are the sections themselves (flat
+        // graph, no subgraphs), edges are deduplicated section dataflow,
+        // each station colored by its section's dominant stage.
+        let mut rules = vec![
+            make_rule("qc_raw", vec!["raw.fq"], vec!["qc_raw/"]),
+            make_rule("align_reads", vec!["raw.fq"], vec!["aln.bam"]),
+            make_rule("qc_bam", vec!["aln.bam"], vec!["qc_bam/"]),
+            make_rule("report_all", vec!["qc_raw/", "qc_bam/"], vec!["report/"]),
+        ];
+        rules[0].shell = Some("fastqc raw.fq".into());
+        rules[1].shell = Some("bwa mem ref.fa raw.fq > aln.bam".into());
+        rules[2].shell = Some("fastqc aln.bam".into());
+        rules[3].shell = Some("multiqc .".into());
+        let mut modules: HashMap<String, Vec<String>> = HashMap::new();
+        modules.insert("fastq_qc".to_string(), vec!["qc_raw".to_string()]);
+        modules.insert("alignment".to_string(), vec!["align_reads".to_string()]);
+        modules.insert("bam_qc".to_string(), vec!["qc_bam".to_string()]);
+        modules.insert("report".to_string(), vec!["report_all".to_string()]);
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag
+            .to_metro(&rules, Some(&modules), MetroGranularity::Module)
+            .unwrap();
+        assert!(
+            !mmd.contains("subgraph"),
+            "module tier is flat — sections ARE the stations:\n{mmd}"
+        );
+        assert!(mmd.contains("n0[\"Read QC\"]"), "fastq_qc station:\n{mmd}");
+        assert!(
+            mmd.contains("n1[\"Alignment\"]"),
+            "alignment station:\n{mmd}"
+        );
+        assert!(mmd.contains("n2[\"BAM QC\"]"), "bam_qc station:\n{mmd}");
+        assert!(mmd.contains("n3[\"Reporting\"]"), "report station:\n{mmd}");
+        assert!(
+            mmd.contains("n1 -->|align| n2"),
+            "alignment -> bam_qc edge:\n{mmd}"
+        );
+        assert!(
+            mmd.contains("n2 -->|qc| n3"),
+            "bam_qc -> report edge:\n{mmd}"
+        );
+        assert!(
+            mmd.contains("n0 -->|qc| n3"),
+            "fastq_qc -> report edge:\n{mmd}"
         );
     }
 }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -1222,16 +1222,22 @@ impl WorkflowDag {
             let mut dominant: HashMap<String, String> = HashMap::new();
             for (section, _) in &sections {
                 let mut counts: HashMap<&str, usize> = HashMap::new();
+                // File order — station_nodes is rule-index ordered — so a
+                // count tie picks the FIRST stage (matching the tie
+                // convention elsewhere in the exporter; std's max_by_key
+                // would pick the last).
+                let mut best: Option<(usize, &str)> = None;
                 for node in station_nodes.iter().filter(|n| &node_section[n] == section) {
-                    *counts.entry(node_stage[node].as_str()).or_insert(0) += 1;
+                    let stage = node_stage[node].as_str();
+                    let count = counts.entry(stage).or_insert(0);
+                    *count += 1;
+                    let count = *count;
+                    if best.is_none_or(|(bc, _)| count > bc) {
+                        best = Some((count, stage));
+                    }
                 }
-                let best = station_nodes
-                    .iter()
-                    .filter(|n| &node_section[n] == section)
-                    .map(|n| node_stage[n].as_str())
-                    .max_by_key(|s| counts[s])
-                    .unwrap_or("generic");
-                dominant.insert(section.clone(), best.to_string());
+                let best_stage = best.map(|(_, stage)| stage).unwrap_or("generic");
+                dominant.insert(section.clone(), best_stage.to_string());
             }
             let mut seen: HashSet<(usize, usize)> = HashSet::new();
             let mut module_edges: Vec<(usize, usize)> = Vec::new();
@@ -1260,15 +1266,11 @@ impl WorkflowDag {
                     lines.push(stage.clone());
                 }
             }
+            let mut used_colors: HashSet<&'static str> = HashSet::new();
+            let mut taken_line_ids: HashSet<String> = HashSet::new();
             let mut out = String::new();
-            for stage in &lines {
-                out.push_str(&format!(
-                    "%%metro line: {} | {} | {}\n",
-                    sanitize_metro_id(stage),
-                    sanitize_mermaid_text(&crate::stage::stage_display(stage)),
-                    crate::stage::stage_color(stage),
-                ));
-            }
+            let line_ids =
+                emit_metro_line_defs(&mut out, &lines, &mut used_colors, &mut taken_line_ids);
             if !isolated.is_empty() && isolated.len() < sections.len() {
                 out.push_str(&format!("%%metro off_track: {}\n", isolated.join(", ")));
             }
@@ -1281,9 +1283,10 @@ impl WorkflowDag {
                 ));
             }
             for &(a, b) in &module_edges {
+                let stage = &dominant[&sections[a].0];
                 out.push_str(&format!(
                     "    n{a} -->|{}| n{b}\n",
-                    sanitize_metro_id(&dominant[&sections[a].0])
+                    line_ids[stage.as_str()]
                 ));
             }
             return Ok(out);
@@ -1297,17 +1300,13 @@ impl WorkflowDag {
             }
         }
 
+        // Line definitions (colors + ids shared with the module tier via
+        // emit_metro_line_defs).
+        let mut used_colors: HashSet<&'static str> = HashSet::new();
+        let mut taken_line_ids: HashSet<String> = HashSet::new();
         let mut out = String::new();
-
-        // Line definitions.
-        for stage in &stages {
-            out.push_str(&format!(
-                "%%metro line: {} | {} | {}\n",
-                sanitize_metro_id(stage),
-                sanitize_mermaid_text(&crate::stage::stage_display(stage)),
-                crate::stage::stage_color(stage),
-            ));
-        }
+        let line_ids =
+            emit_metro_line_defs(&mut out, &stages, &mut used_colors, &mut taken_line_ids);
         // Stations with no dataflow edges (terminal exports, side outputs)
         // are auxiliary to the main flow — nf-metro's off-track stops
         // render them without routing pressure, keeping the trunk wide
@@ -1336,12 +1335,13 @@ impl WorkflowDag {
         // inside their section, inter-section edges after every `end`
         // (nf-metro rule).
         let mut inter_section_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
+        let mut taken_section_ids: HashSet<String> = HashSet::new();
 
         for (section, display) in &sections {
             if multi_section {
                 out.push_str(&format!(
                     "    subgraph {} [{}]\n",
-                    sanitize_metro_id(section),
+                    unique_metro_id(&sanitize_metro_id(section), &mut taken_section_ids),
                     sanitize_mermaid_text(display)
                 ));
             }
@@ -1363,7 +1363,7 @@ impl WorkflowDag {
                     out.push_str(&format!(
                         "{inner_indent}n{} -->|{}| n{}\n",
                         src.index(),
-                        sanitize_metro_id(&node_stage[&src]),
+                        line_ids[node_stage[&src].as_str()],
                         dst.index()
                     ));
                 } else {
@@ -1382,7 +1382,7 @@ impl WorkflowDag {
             out.push_str(&format!(
                 "    n{} -->|{}| n{}\n",
                 src.index(),
-                sanitize_metro_id(&node_stage[&src]),
+                line_ids[node_stage[&src].as_str()],
                 dst.index()
             ));
         }
@@ -1571,6 +1571,51 @@ fn looks_like_directory(path: &str) -> bool {
 
 /// Sanitize a stage name into a safe nf-metro/Mermaid identifier (line ID or
 /// section ID): non-alphanumeric characters become underscores.
+/// Make a metro id unique within one export.
+///
+/// [`sanitize_metro_id`] is not injective — `de-analysis` and
+/// `de_analysis` both map to `de_analysis` — and nf-metro keeps the first
+/// declaration of an id, silently dropping the rest. Suffix collisions
+/// `_2`, `_3`, … so no line or section is lost (custom stage tags make
+/// punctuation-pair collisions reachable).
+fn unique_metro_id(base: &str, taken: &mut HashSet<String>) -> String {
+    let mut id = base.to_string();
+    let mut k = 2;
+    while !taken.insert(id.clone()) {
+        id = format!("{base}_{k}");
+        k += 1;
+    }
+    id
+}
+
+/// Emit one `%%metro line:` definition per stage, in order.
+///
+/// Shared by both metro tiers (their colour and id assignment must never
+/// diverge): colours go through [`crate::stage::metro_line_color`] so
+/// custom lanes never share a colour on one map; ids deduplicate as
+/// [`unique_metro_id`]. The returned `stage → id` map lets edge labels
+/// reuse exactly the declared ids.
+fn emit_metro_line_defs<'a>(
+    out: &mut String,
+    stages: &'a [String],
+    used_colors: &mut HashSet<&'static str>,
+    taken_ids: &mut HashSet<String>,
+) -> HashMap<&'a str, String> {
+    let mut line_ids: HashMap<&str, String> = HashMap::new();
+    for stage in stages {
+        let color = crate::stage::metro_line_color(stage, used_colors);
+        let id = unique_metro_id(&sanitize_metro_id(stage), taken_ids);
+        line_ids.insert(stage, id.clone());
+        out.push_str(&format!(
+            "%%metro line: {} | {} | {}\n",
+            id,
+            sanitize_mermaid_text(&crate::stage::stage_display(stage)),
+            color,
+        ));
+    }
+    line_ids
+}
+
 fn sanitize_metro_id(s: &str) -> String {
     let mut out: String = s
         .chars()
@@ -3142,6 +3187,31 @@ mod tests {
         assert!(
             mmd.contains("n1[\"rule(bracket)\"]"),
             "escaped bracket not found in:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_line_ids_survive_sanitize_collisions() {
+        // `de-analysis` and `de_analysis` both sanitize to `de_analysis`;
+        // nf-metro keeps the first declaration of an id, so the second
+        // line must be deduplicated (`_2`) or it silently disappears.
+        let mut a = make_rule("a", vec![], vec!["mid.txt"]);
+        a.tags = vec!["de-analysis".to_string()];
+        let mut b = make_rule("b", vec!["mid.txt"], vec!["out.txt"]);
+        b.tags = vec!["de_analysis".to_string()];
+        let rules = vec![a, b];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        assert!(
+            mmd.contains("%%metro line: de_analysis | de-analysis |")
+                && mmd.contains("%%metro line: de_analysis_2 | de_analysis |"),
+            "both colliding lines must be declared:\n{mmd}"
+        );
+        assert_eq!(
+            mmd.matches("%%metro line:").count(),
+            2,
+            "exactly the two lines:\n{mmd}"
         );
     }
 

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -7,13 +7,13 @@
 
 use crate::error::{OxoFlowError, Result};
 use crate::rule::{FilePatterns, Rule};
-use petgraph::algo::toposort;
+use petgraph::algo::{kosaraju_scc, toposort};
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::NodeRef;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 /// A node in the workflow DAG, representing a single rule.
 #[derive(Debug, Clone)]
@@ -698,7 +698,29 @@ impl WorkflowDag {
         }
         out
     }
+}
 
+/// Station granularity for [`WorkflowDag::to_metro`] metro-map exports.
+///
+/// `Rule` (the default) gives every rule its own station. `Process` collapses
+/// chains of rules that share a section and are driven by the same known tool
+/// (via the shell/script keyword table in [`crate::stage`]) into one station
+/// named after the tool — the nf-core transit-map idiom where `samtools
+/// sort`, `samtools index`, … are a single "SAMtools" stop. Only
+/// chain-connected rules merge (union-find over intra-group edges):
+/// independent uses of the same tool (raw- vs trimmed-read FastQC) keep
+/// separate stops, numbered `FastQC (2)` onward when labels repeat within a
+/// section. The coarser granularity keeps dense ported workflows (live:
+/// community rnaseq, 135 rules) within the ~40-60-station scale of the
+/// published nf-core maps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MetroGranularity {
+    #[default]
+    Rule,
+    Process,
+}
+
+impl WorkflowDag {
     /// Export the DAG as an nf-metro "metro map" definition.
     ///
     /// Output is a Mermaid `graph LR` subset extended with `%%metro`
@@ -711,61 +733,410 @@ impl WorkflowDag {
     /// nf-metro render workflow.mmd -o workflow.svg
     /// ```
     ///
-    /// Each rule becomes a station (its `module::` prefix stripped — the
-    /// section already names the group); each dependency becomes an edge
-    /// carrying the *source* rule's stage line. Stages are inferred per rule
-    /// (see [`crate::stage`]) and become colored lines that flow through
-    /// multiple sections — the nf-core transit-map structure — while sections
-    /// follow the workflow's module namespaces in data-flow order.
+    /// Each station's label is the rule name with its `module::` prefix
+    /// stripped (the section already names the group); each dependency
+    /// becomes an edge carrying the *source* station's stage line. Stages
+    /// are inferred per rule (see [`crate::stage`]) and become colored
+    /// lines that flow through multiple sections — the nf-core
+    /// transit-map structure — while sections group the workflow's module
+    /// namespaces, emitted in topological order with mutually-referencing
+    /// modules contracted into one merged section.
     ///
-    pub fn to_metro(&self, rules: &[Rule]) -> Result<String> {
+    /// `granularity` controls station collapsing: see [`MetroGranularity`].
+    /// Grouped rules keep the first member's stage for the line color and
+    /// never cross sections, so section placement is identical for both
+    /// granularities.
+    ///
+    /// `modules` maps a module name to its member rule names (the
+    /// `[[include]]` file stem by default) and places prefixless rules
+    /// into their workflow module. Without it, prefixless rules fall
+    /// back to their stage, which can merge distinct modules into one
+    /// section and make the section graph cyclic (live: community mag,
+    /// stage fallback aligned↔analysis).
+    pub fn to_metro(
+        &self,
+        rules: &[Rule],
+        modules: Option<&HashMap<String, Vec<String>>>,
+        granularity: MetroGranularity,
+    ) -> Result<String> {
         let nodes = self.nodes_by_rule_index();
         let edges = self.sorted_edges();
+
+        // Rule name → owning module, for includes without an explicit
+        // `namespace = "..."` (their rules keep unprefixed names). The
+        // module lists hold PARSE-TIME names; wildcard expansion does not
+        // rewrite them, so an expanded instance `fastqc_S1` is resolved by
+        // exact match first, then by the longest member prefix (`module_rules`
+        // members are original names — see expand.rs instance naming).
+        // Known limitation: a MAIN-file rule whose name extends a module
+        // member (`fastp` member, `fastp_extra` host rule) takes the prefix
+        // path and lands in that module's section. Exact member matches
+        // always win and stage fallback never regresses from the old
+        // export, so the cost is a misplaced section only — no lost edges.
+        let module_members: Vec<(&str, &str)> = modules
+            .into_iter()
+            .flat_map(|map| map.iter())
+            .flat_map(|(module, members)| {
+                members
+                    .iter()
+                    .map(move |member| (member.as_str(), module.as_str()))
+            })
+            .collect();
+        let find_module = |name: &str| -> Option<&str> {
+            let mut best: Option<(&str, &str)> = None;
+            for &(member, module) in &module_members {
+                if name == member {
+                    return Some(module);
+                }
+                let is_instance_prefix = name
+                    .as_bytes()
+                    .get(member.len())
+                    .is_some_and(|b| *b == b'_')
+                    && name.starts_with(member);
+                if is_instance_prefix && best.is_none_or(|(bm, _)| member.len() > bm.len()) {
+                    best = Some((member, module));
+                }
+            }
+            best.map(|(_, module)| module)
+        };
 
         // Two orthogonal groupings, mirroring nf-core's transit maps:
         // - the LINE is the rule's stage (tags → module prefix → shell
         //   keywords → generic) — the colored track an edge flows along;
         // - the SECTION is the workflow's own module namespace
-        //   (`module::rule`), falling back to the stage for prefixless
-        //   rules. Sections follow the workflow file's data-flow order, so
-        //   the section graph is acyclic by construction — no cycle
-        //   demotion (which previously flooded "generic" on real
-        //   pipelines, live: community rnaseq).
+        //   (`module::rule`, or the owning `[[include]]` module for
+        //   prefixless rules), falling back to the stage only for rules
+        //   defined directly in the main file. Real workflows cycle
+        //   between modules (live: community ampliseq — dada2 quality
+        //   checks sit in the qc module while dada2 results feed qc
+        //   plots), so the export contracts cyclic module groups into one
+        //   merged section rather than assuming an acyclic section graph.
         let mut node_stage: HashMap<NodeIndex, String> = HashMap::new();
         let mut node_section: HashMap<NodeIndex, String> = HashMap::new();
+        let mut node_section_is_module: HashMap<NodeIndex, bool> = HashMap::new();
         for node in &nodes {
             let stage = rules
                 .get(self.graph[*node].rule_index)
                 .map(crate::stage::detect_stage)
                 .unwrap_or_else(|| "generic".to_string());
-            let section = self.graph[*node]
-                .name
-                .split_once("::")
-                .map(|(prefix, _)| prefix.to_string())
-                .unwrap_or_else(|| stage.clone());
+            let name = &self.graph[*node].name;
+            let (section, is_module) = match name.split_once("::") {
+                Some((prefix, _)) => (prefix.to_string(), true),
+                None => match find_module(name.as_str()) {
+                    Some(module) => (module.to_string(), true),
+                    None => (stage.clone(), false),
+                },
+            };
             node_stage.insert(*node, stage);
             node_section.insert(*node, section);
+            node_section_is_module.insert(*node, is_module);
         }
 
-        // Sections and stages in first-appearance order (deterministic).
-        // A section's display comes from the module it groups, or from the
-        // stage itself for prefixless rules (custom stages keep their
-        // sanitized raw name).
-        let mut sections: Vec<(String, String)> = Vec::new();
-        for node in &nodes {
+        // Station collapsing: `Rule` keeps every rule as its own station;
+        // `Process` merges chains of same-section rules driven by the same
+        // known tool (union-find over intra-section edges) into one station
+        // named after the tool — see [`MetroGranularity`]. Merging never
+        // crosses sections, so every group lives in one section and section
+        // placement is identical for both granularities; a group's
+        // representative is its earliest rule (file order), keeping the
+        // output deterministic.
+        let station_of: HashMap<NodeIndex, NodeIndex> = match granularity {
+            MetroGranularity::Rule => nodes.iter().map(|&node| (node, node)).collect(),
+            MetroGranularity::Process => {
+                let mut parent: HashMap<NodeIndex, NodeIndex> =
+                    nodes.iter().map(|&node| (node, node)).collect();
+                let tool_of = |node: NodeIndex| {
+                    rules
+                        .get(self.graph[node].rule_index)
+                        .and_then(crate::stage::detect_tool)
+                };
+                let find = |mut node: NodeIndex, parent: &HashMap<NodeIndex, NodeIndex>| {
+                    while parent[&node] != node {
+                        node = parent[&node];
+                    }
+                    node
+                };
+                // Cycle-safe union: an acyclic rule DAG can still fold into
+                // a cyclic station graph when cross-connected same-tool
+                // pairs merge (live: clindet's `recal_link` symlink rule
+                // carries data from a GATK rule into another GATK rule, so
+                // the two GATK stations on either side would close a ring;
+                // nf-metro hard-aborts on any cycle). A union is applied
+                // only while the destination station stays unreachable from
+                // the source station once the direct station edge is
+                // removed — skipped unions keep both stations separate,
+                // which the duplicate-label numbering below renders as
+                // `GATK (2)` onward.
+                for &(src, dst) in &edges {
+                    if node_section[&src] != node_section[&dst] {
+                        continue;
+                    }
+                    if let (Some(a), Some(b)) = (tool_of(src), tool_of(dst))
+                        && a == b
+                    {
+                        let (root_src, root_dst) = (find(src, &parent), find(dst, &parent));
+                        if root_src == root_dst {
+                            continue;
+                        }
+                        // Station-level adjacency under the current
+                        // partition, with the direct station edge removed.
+                        let mut adjacent: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+                        for &(u, v) in &edges {
+                            let (ru, rv) = (find(u, &parent), find(v, &parent));
+                            if ru != rv && !(ru == root_src && rv == root_dst) {
+                                adjacent.entry(ru).or_default().push(rv);
+                            }
+                        }
+                        let mut visited: HashSet<NodeIndex> = HashSet::from([root_src]);
+                        let mut queue: VecDeque<NodeIndex> = VecDeque::from([root_src]);
+                        let mut reaches = false;
+                        while let Some(node) = queue.pop_front() {
+                            for &next in adjacent.get(&node).into_iter().flatten() {
+                                if next == root_dst {
+                                    reaches = true;
+                                    break;
+                                }
+                                if visited.insert(next) {
+                                    queue.push_back(next);
+                                }
+                            }
+                            if reaches {
+                                break;
+                            }
+                        }
+                        if !reaches {
+                            parent.insert(root_src, root_dst);
+                        }
+                    }
+                }
+                // Each group's representative is its earliest rule in file
+                // order (`nodes` is rule-index ordered).
+                let mut rep_of_root: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+                for &node in &nodes {
+                    let mut root = node;
+                    while parent[&root] != root {
+                        root = parent[&root];
+                    }
+                    rep_of_root.entry(root).or_insert(node);
+                }
+                nodes
+                    .iter()
+                    .map(|&node| {
+                        let mut root = node;
+                        while parent[&root] != root {
+                            root = parent[&root];
+                        }
+                        (node, rep_of_root[&root])
+                    })
+                    .collect()
+            }
+        };
+        // Stations in file order (a representative is its own station), and
+        // station-level edges: remapped through the collapse, with chain
+        // self-loops and parallel duplicates removed — nf-metro routes one
+        // edge per station pair.
+        let station_nodes: Vec<NodeIndex> = nodes
+            .iter()
+            .copied()
+            .filter(|&node| station_of[&node] == node)
+            .collect();
+        let mut seen_edges: HashSet<(NodeIndex, NodeIndex)> = HashSet::new();
+        let station_edges: Vec<(NodeIndex, NodeIndex)> = edges
+            .iter()
+            .filter_map(|&(src, dst)| {
+                let (src, dst) = (station_of[&src], station_of[&dst]);
+                (src != dst && seen_edges.insert((src, dst))).then_some((src, dst))
+            })
+            .collect();
+
+        // Sections in first-appearance order with their display names —
+        // module sections use the module's curated title, stage sections
+        // the stage display.
+        let mut section_order: Vec<String> = Vec::new();
+        let mut section_display: Vec<String> = Vec::new();
+        for node in &station_nodes {
             let section = &node_section[node];
-            if sections.iter().any(|(s, _)| s == section) {
+            if section_order.iter().any(|s| s == section) {
                 continue;
             }
-            let display = self.graph[*node]
-                .name
-                .split_once("::")
-                .map(|(prefix, _)| crate::stage::module_display(prefix))
-                .unwrap_or_else(|| crate::stage::stage_display(&node_stage[node]));
-            sections.push((section.clone(), display));
+            let display = if node_section_is_module[node] {
+                crate::stage::module_display(section)
+            } else {
+                crate::stage::stage_display(&node_stage[node])
+            };
+            section_order.push(section.clone());
+            section_display.push(display);
         }
+        let section_rank: HashMap<&str, usize> = section_order
+            .iter()
+            .enumerate()
+            .map(|(i, section)| (section.as_str(), i))
+            .collect();
+        let mut section_graph = DiGraph::new();
+        let section_nodes: Vec<NodeIndex> = section_order
+            .iter()
+            .map(|_| section_graph.add_node(()))
+            .collect();
+        let mut seen_section_edges: HashSet<(usize, usize)> = HashSet::new();
+        for &(src, dst) in &station_edges {
+            let (a, b) = (
+                section_rank[node_section[&src].as_str()],
+                section_rank[node_section[&dst].as_str()],
+            );
+            if a != b && seen_section_edges.insert((a, b)) {
+                section_graph.add_edge(section_nodes[a], section_nodes[b], ());
+            }
+        }
+
+        // Cyclic section groups (live: community ampliseq — dada2 quality
+        // checks sit in the qc module while dada2 results feed qc plots)
+        // have no acyclic subgraph order for nf-metro to lay out. Contract
+        // each strongly connected group into one merged section — the id
+        // joins the member ids, the display joins their titles with " + " —
+        // and remap its stations before labels and sections are built.
+        let mut section_of_scc: HashMap<usize, usize> = HashMap::new();
+        let mut merged_ids: Vec<String> = Vec::new();
+        let mut merged_displays: Vec<String> = Vec::new();
+        let mut taken_ids: HashSet<String> = section_order
+            .iter()
+            .map(|section| sanitize_metro_id(section))
+            .collect();
+        for scc in kosaraju_scc(&section_graph) {
+            if scc.len() < 2 {
+                continue;
+            }
+            // SCC members ascending = first-appearance order (section
+            // graph nodes were added in that order).
+            let mut members: Vec<usize> = scc.iter().map(|n| n.index()).collect();
+            members.sort_unstable();
+            let base_id = sanitize_metro_id(
+                &members
+                    .iter()
+                    .map(|&i| section_order[i].as_str())
+                    .collect::<Vec<_>>()
+                    .join("_"),
+            );
+            let mut merged_id = base_id.clone();
+            let mut suffix = 2;
+            while taken_ids.contains(&merged_id) {
+                merged_id = format!("{base_id}_{suffix}");
+                suffix += 1;
+            }
+            taken_ids.insert(merged_id.clone());
+            let slot = merged_ids.len();
+            for &member in &members {
+                section_of_scc.insert(member, slot);
+            }
+            merged_ids.push(merged_id);
+            merged_displays.push(
+                members
+                    .iter()
+                    .map(|&i| section_display[i].clone())
+                    .collect::<Vec<_>>()
+                    .join(" + "),
+            );
+        }
+        for node in &station_nodes {
+            if let Some(&slot) = section_of_scc.get(&section_rank[node_section[node].as_str()]) {
+                let merged = merged_ids[slot].clone();
+                node_section.insert(*node, merged);
+            }
+        }
+        let merged_display_by_id: HashMap<String, String> =
+            merged_ids.into_iter().zip(merged_displays).collect();
+
+        // Station labels: process-level stations carry the curated tool name
+        // (nf-core idiom — `samtools index` renders as "SAMtools"); rule
+        // names remain for tools outside the keyword table. Repeated labels
+        // within a section are numbered ` (2)`, ` (3)`, … onward.
+        let mut station_label: HashMap<NodeIndex, String> = HashMap::new();
+        let mut label_counts: HashMap<(String, String), usize> = HashMap::new();
+        for &rep in &station_nodes {
+            let base = match granularity {
+                MetroGranularity::Rule => metro_station_label(&self.graph[rep].name).to_string(),
+                MetroGranularity::Process => rules
+                    .get(self.graph[rep].rule_index)
+                    .and_then(crate::stage::detect_tool)
+                    .map_or_else(
+                        || metro_station_label(&self.graph[rep].name).to_string(),
+                        str::to_string,
+                    ),
+            };
+            let count = label_counts
+                .entry((node_section[&rep].clone(), base.clone()))
+                .or_insert(0);
+            *count += 1;
+            let label = if *count == 1 {
+                base
+            } else {
+                format!("{base} ({count})")
+            };
+            station_label.insert(rep, label);
+        }
+
+        // Sections in dataflow order and stages in first-appearance order
+        // (both deterministic). A section's display comes from the module
+        // it groups, from its contracted SCC merge, or from the stage
+        // itself for prefixless rules (custom stages keep their sanitized
+        // raw name).
+        let mut sections_first: Vec<(String, String)> = Vec::new();
+        for node in &station_nodes {
+            let section = &node_section[node];
+            if sections_first.iter().any(|(s, _)| s == section) {
+                continue;
+            }
+            let display = match merged_display_by_id.get(section) {
+                Some(display) => display.clone(),
+                None if node_section_is_module[node] => crate::stage::module_display(section),
+                None => crate::stage::stage_display(&node_stage[node]),
+            };
+            sections_first.push((section.clone(), display));
+        }
+        let final_rank: HashMap<&str, usize> = sections_first
+            .iter()
+            .enumerate()
+            .map(|(i, (section, _))| (section.as_str(), i))
+            .collect();
+        // Topological order over the contracted section graph (Kahn's,
+        // ties by first appearance): upstream modules sit left of their
+        // consumers regardless of rule file order (live: community
+        // ampliseq's reporting section collects from every earlier module
+        // yet first appears right after trim).
+        let mut in_degree: HashMap<usize, usize> = HashMap::new();
+        let mut successors: HashMap<usize, Vec<usize>> = HashMap::new();
+        let mut seen_final_edges: HashSet<(usize, usize)> = HashSet::new();
+        for &(src, dst) in &station_edges {
+            let (a, b) = (
+                final_rank[node_section[&src].as_str()],
+                final_rank[node_section[&dst].as_str()],
+            );
+            if a != b && seen_final_edges.insert((a, b)) {
+                *in_degree.entry(b).or_insert(0) += 1;
+                successors.entry(a).or_default().push(b);
+            }
+        }
+        let mut ready: BTreeSet<usize> = (0..sections_first.len())
+            .filter(|rank| !in_degree.contains_key(rank))
+            .collect();
+        let mut ordered: Vec<usize> = Vec::with_capacity(sections_first.len());
+        while let Some(&rank) = ready.first() {
+            ready.remove(&rank);
+            ordered.push(rank);
+            for &succ in successors.get(&rank).into_iter().flatten() {
+                let count = in_degree.get_mut(&succ).unwrap();
+                *count -= 1;
+                if *count == 0 {
+                    ready.insert(succ);
+                }
+            }
+        }
+        debug_assert_eq!(ordered.len(), sections_first.len());
+        let sections: Vec<(String, String)> = ordered
+            .into_iter()
+            .map(|rank| sections_first[rank].clone())
+            .collect();
         let mut stages: Vec<String> = Vec::new();
-        for node in &nodes {
+        for node in &station_nodes {
             let stage = &node_stage[node];
             if !stages.iter().any(|s| s == stage) {
                 stages.push(stage.clone());
@@ -782,6 +1153,24 @@ impl WorkflowDag {
                 sanitize_mermaid_text(&crate::stage::stage_display(stage)),
                 crate::stage::stage_color(stage),
             ));
+        }
+        // Stations with no dataflow edges (terminal exports, side outputs)
+        // are auxiliary to the main flow — nf-metro's off-track stops
+        // render them without routing pressure, keeping the trunk wide
+        // instead of stacking tall (live: 7-station community mixscape
+        // went from portrait 0.62 to landscape 4.2 with 4 off-track).
+        let mut degree: HashMap<NodeIndex, usize> = HashMap::new();
+        for &(src, dst) in &station_edges {
+            *degree.entry(src).or_default() += 1;
+            *degree.entry(dst).or_default() += 1;
+        }
+        let isolated: Vec<String> = station_nodes
+            .iter()
+            .filter(|node| !degree.contains_key(node))
+            .map(|node| format!("n{}", node.index()))
+            .collect();
+        if !isolated.is_empty() && isolated.len() < station_nodes.len() {
+            out.push_str(&format!("%%metro off_track: {}\n", isolated.join(", ")));
         }
         out.push('\n');
         out.push_str("graph LR\n");
@@ -803,15 +1192,15 @@ impl WorkflowDag {
                 ));
             }
 
-            for node in nodes.iter().filter(|n| &node_section[n] == section) {
+            for node in station_nodes.iter().filter(|n| &node_section[n] == section) {
                 out.push_str(&format!(
                     "{inner_indent}n{}[\"{}\"]\n",
                     node.index(),
-                    sanitize_mermaid_label(metro_station_label(&self.graph[*node].name))
+                    sanitize_mermaid_label(&station_label[node])
                 ));
             }
 
-            for &(src, dst) in &edges {
+            for &(src, dst) in &station_edges {
                 if node_section[&src] != *section {
                     continue;
                 }
@@ -1039,8 +1428,12 @@ fn sanitize_metro_id(s: &str) -> String {
             }
         })
         .collect();
+    // Mermaid ids must not start with a digit (module file stems like
+    // "01_preprocessing" do).
     if out.is_empty() {
         out = "stage".to_string();
+    } else if out.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        out = format!("s_{out}");
     }
     out
 }
@@ -2386,12 +2779,46 @@ mod tests {
             make_rule("b", vec!["mid.txt"], vec!["out.txt"]),
         ];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         assert!(mmd.contains("%%metro line: generic | Analysis | #79706E"));
         assert!(mmd.contains("graph LR"));
         assert!(mmd.contains("n0[\"a\"]"));
         assert!(mmd.contains("n0 -->|generic| n1"));
         assert!(!mmd.contains("subgraph"));
+        // No isolated nodes → no off-track directive.
+        assert!(!mmd.contains("off_track"));
+    }
+
+    #[test]
+    fn metro_export_isolated_rules_go_off_track() {
+        // Rules without dataflow edges (terminal exports) are auxiliary —
+        // nf-metro renders them off-track so the main trunk stays wide
+        // (live: 7-station mixscape went from portrait 0.62 to landscape
+        // 4.2 with 4 off-track stations). The directive is skipped when
+        // EVERY node is isolated (nothing to route).
+        let mut chain = make_rule("a", vec!["in.txt"], vec!["mid.txt"]);
+        chain.shell = Some("fastqc in.txt".to_string());
+        let sink = make_rule("b", vec!["mid.txt"], vec!["out.txt"]);
+        let export = make_rule("export_annot", vec![], vec![]);
+        let rules = vec![chain, sink, export];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        assert!(mmd.contains("%%metro off_track: n2"));
+    }
+
+    #[test]
+    fn metro_export_all_isolated_omits_off_track() {
+        // No edges at all (wildcard-only DAGs with no concrete matches):
+        // the directive would mark every station off-track with no trunk
+        // left to route — skipped entirely.
+        let a = make_rule("a", vec!["in.txt"], vec!["mid.txt"]);
+        let b = make_rule("b", vec![], vec![]);
+        let rules = vec![a, b];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        assert!(!mmd.contains("off_track"));
+        assert!(mmd.contains("n0[\"a\"]"));
+        assert!(mmd.contains("n1[\"b\"]"));
     }
 
     #[test]
@@ -2409,7 +2836,7 @@ mod tests {
         align.shell = Some("STAR --runThreadN 8".to_string());
         let rules = vec![trim, align];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         assert!(mmd.contains("subgraph fastq_qc [Read QC]"));
         assert!(mmd.contains("subgraph alignment [Alignment]"));
         // Station labels are the bare rule names (no `module::` prefix).
@@ -2420,6 +2847,79 @@ mod tests {
     }
 
     #[test]
+    fn metro_export_include_modules_place_prefixless_rules() {
+        // `[[include]]` without `namespace = "..."` keeps rule names
+        // prefixless; the module map must place them into their module
+        // section (not fall back to the stage — which can merge distinct
+        // modules and cycle the section graph, live: community mag).
+        // Digit-leading file stems are sanitized to valid mermaid ids.
+        let mut preprocess = make_rule("fastp", vec!["reads.fq"], vec!["trimmed.fq"]);
+        preprocess.shell = Some("fastp -i reads.fq".to_string());
+        let mut assemble = make_rule("spades_S1", vec!["trimmed.fq"], vec!["contigs.fa"]);
+        assemble.shell = Some("spades.py -o out".to_string());
+        let rules = vec![preprocess, assemble];
+        let modules: HashMap<String, Vec<String>> = HashMap::from([
+            ("01_preprocessing".to_string(), vec!["fastp".to_string()]),
+            ("02_assembly".to_string(), vec!["spades".to_string()]),
+        ]);
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag
+            .to_metro(&rules, Some(&modules), MetroGranularity::Rule)
+            .unwrap();
+        assert!(mmd.contains("subgraph s_01_preprocessing [01 Preprocessing]"));
+        assert!(mmd.contains("subgraph s_02_assembly [02 Assembly]"));
+        assert!(!mmd.contains("subgraph qc [Read QC]"));
+        // The inter-section edge is emitted with the source rule's stage line.
+        assert!(mmd.contains("n0 -->|trim| n1"));
+    }
+
+    #[test]
+    fn metro_export_cyclic_module_sections_contract_into_one() {
+        // Bidirectional module pair (live: community ampliseq — dada2
+        // trims reads that QC plots consume while dada2 quality reports
+        // sit in the qc module): the section condensation has a cycle,
+        // so both modules contract into one merged section instead of
+        // assuming an acyclic module order.
+        let mut fastqc = make_rule("qc::fastqc", vec!["reads.fq"], vec!["reads_fastqc.html"]);
+        fastqc.shell = Some("fastqc reads.fq".to_string());
+        let mut filtntrim = make_rule(
+            "dada2::filtntrim",
+            vec!["reads_fastqc.html"],
+            vec!["trimmed.fq"],
+        );
+        filtntrim.shell = Some("echo filterAndTrim".to_string());
+        let mut read_plot = make_rule("qc::read_plot", vec!["trimmed.fq"], vec!["qc_plot.pdf"]);
+        read_plot.shell = Some("echo plotQualityProfile".to_string());
+        let mut multiqc = make_rule("report::multiqc", vec!["qc_plot.pdf"], vec!["report.html"]);
+        multiqc.shell = Some("multiqc .".to_string());
+        let rules = vec![fastqc, filtntrim, read_plot, multiqc];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        // One merged section holds both modules (id joins the members,
+        // display joins their titles); no standalone sections remain.
+        assert!(
+            mmd.contains("subgraph qc_dada2 [Qc + Dada2]"),
+            "merged section missing:\n{mmd}"
+        );
+        assert!(!mmd.contains("subgraph qc ["));
+        assert!(!mmd.contains("subgraph dada2 ["));
+        // Both directions flow inside the merged section; the downstream
+        // reporting module keeps its own section after the merged one.
+        assert!(mmd.contains("n0 -->|qc| n1"));
+        assert!(mmd.contains("n1 -->|generic| n2"));
+        assert!(mmd.contains("subgraph report [Reporting]"));
+        let merged_end = mmd
+            .rfind("    end\n")
+            .expect("multi-section map has end blocks");
+        let merged_pos = mmd.find("subgraph qc_dada2").unwrap();
+        let report_pos = mmd.find("subgraph report").unwrap();
+        assert!(
+            merged_pos < report_pos && report_pos < merged_end,
+            "reporting section must follow the merged section:\n{mmd}"
+        );
+    }
+
+    #[test]
     fn metro_export_multi_stage_emits_sections() {
         let mut qc = make_rule("fastqc", vec!["reads.fq"], vec!["reads_fastqc.html"]);
         qc.shell = Some("fastqc reads.fq".to_string());
@@ -2427,7 +2927,7 @@ mod tests {
         align.shell = Some("bwa mem ref.fa reads.fq > mapped.sam".to_string());
         let rules = vec![qc, align];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         assert!(mmd.contains("%%metro line: qc | Read QC | #4C78A8"));
         assert!(mmd.contains("%%metro line: align | Alignment | #54A24B"));
         assert!(mmd.contains("subgraph qc [Read QC]"));
@@ -2444,7 +2944,7 @@ mod tests {
         trim.shell = Some("fastp -i reads.fastq.gz".to_string());
         let rules = vec![qc, trim];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         assert!(mmd.contains("n0 -->|qc| n1"));
         let last_end = mmd
             .rfind("    end\n")
@@ -2465,7 +2965,7 @@ mod tests {
         rule.tags = vec!["qc".to_string()];
         let rules = vec![rule];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         assert!(mmd.contains("%%metro line: qc | Read QC | #4C78A8"));
         assert!(!mmd.contains("%%metro line: align"));
     }
@@ -2501,7 +3001,7 @@ mod tests {
         b.tags = vec!["stage|pipe".to_string()];
         let rules = vec![a, b];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         // Line directive field separators must survive display names.
         assert!(
             mmd.contains("%%metro line: stage_bracket | stage bracket | "),
@@ -2538,7 +3038,7 @@ mod tests {
             make_rule("b", vec!["mid.txt"], vec!["out.txt"]),
         ];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
-        let mmd = dag.to_metro(&rules).unwrap();
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
         let lines: Vec<&str> = mmd.lines().collect();
         let station_line = lines
             .iter()
@@ -2552,6 +3052,106 @@ mod tests {
             station_line.len() - station_line.trim_start().len(),
             edge_line.len() - edge_line.trim_start().len(),
             "single-stage station and edge must share the same indentation:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_process_granularity_collapses_tool_chains() {
+        // `samtools sort` → `samtools index` → `samtools stats` is one tool
+        // chain; process granularity renders a single "SAMtools" stop.
+        let mut rules = vec![
+            make_rule("sort", vec!["reads.bam"], vec!["sorted.bam"]),
+            make_rule("index", vec!["sorted.bam"], vec!["sorted.bam.bai"]),
+            make_rule("stats", vec!["sorted.bam"], vec!["stats.txt"]),
+            make_rule("multiqc_report", vec!["stats.txt"], vec!["report.html"]),
+        ];
+        rules[0].shell = Some("samtools sort -o sorted.bam reads.bam".into());
+        rules[1].shell = Some("samtools index sorted.bam".into());
+        rules[2].shell = Some("samtools stats sorted.bam > stats.txt".into());
+        rules[3].shell = Some("multiqc .".into());
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag
+            .to_metro(&rules, None, MetroGranularity::Process)
+            .unwrap();
+        assert!(
+            mmd.contains("n0[\"SAMtools\"]"),
+            "chain collapses into one tool-named station:\n{mmd}"
+        );
+        assert!(
+            !mmd.contains("n1[") && !mmd.contains("n2["),
+            "merged rules no longer get their own stations:\n{mmd}"
+        );
+        assert!(
+            mmd.contains("n0 -->|align| n3"),
+            "collapsed station stays wired to downstream rules:\n{mmd}"
+        );
+
+        // Rule granularity keeps the same workflow expanded.
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        assert!(
+            mmd.contains("n1["),
+            "rule granularity keeps every stop:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_process_granularity_keeps_independent_uses_separate() {
+        // Two FastQC rules not chain-connected (raw vs trimmed reads) stay
+        // separate stops, numbered onward within their section.
+        let mut rules = vec![
+            make_rule("fastqc_raw", vec!["raw.fq"], vec!["raw_fastqc/"]),
+            make_rule("trim", vec!["raw.fq"], vec!["trimmed.fq"]),
+            make_rule(
+                "fastqc_trimmed",
+                vec!["trimmed.fq"],
+                vec!["trimmed_fastqc/"],
+            ),
+        ];
+        rules[0].shell = Some("fastqc raw.fq".into());
+        rules[1].shell = Some("fastp -i raw.fq -o trimmed.fq".into());
+        rules[2].shell = Some("fastqc trimmed.fq".into());
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag
+            .to_metro(&rules, None, MetroGranularity::Process)
+            .unwrap();
+        assert!(mmd.contains("n0[\"FastQC\"]"), "raw-read stop kept:\n{mmd}");
+        assert!(
+            mmd.contains("n2[\"FastQC (2)\"]"),
+            "independent same-tool use gets its own numbered stop:\n{mmd}"
+        );
+        assert!(
+            mmd.contains("n1[\"fastp\"]"),
+            "different-tool rule keeps its rule station:\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_process_granularity_merge_never_crosses_sections() {
+        // A tool chain bridging two module sections must not merge across
+        // the boundary: each section keeps its own station.
+        let mut rules = vec![
+            make_rule("align_reads", vec!["reads.fq"], vec!["aln.bam"]),
+            make_rule("qc_align", vec!["aln.bam"], vec!["qc/"]),
+        ];
+        rules[0].shell = Some("bwa mem ref.fa reads.fq > aln.bam".into());
+        rules[1].shell = Some("fastqc aln.bam".into());
+        let mut modules: HashMap<String, Vec<String>> = HashMap::new();
+        modules.insert("alignment".to_string(), vec!["align_reads".to_string()]);
+        modules.insert("bam_qc".to_string(), vec!["qc_align".to_string()]);
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag
+            .to_metro(&rules, Some(&modules), MetroGranularity::Process)
+            .unwrap();
+        assert!(
+            mmd.contains("subgraph alignment [Alignment]") && mmd.contains("n0[\"BWA\"]"),
+            "first section keeps its tool station:\n{mmd}"
+        );
+        assert!(
+            mmd.contains("subgraph bam_qc [BAM QC]") && mmd.contains("n1[\"FastQC\"]"),
+            "second section keeps its own station (no cross-section merge):\n{mmd}"
         );
     }
 }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -1135,6 +1135,63 @@ impl WorkflowDag {
             .into_iter()
             .map(|rank| sections_first[rank].clone())
             .collect();
+        // Topological station order within each section (Kahn over
+        // intra-section station edges, ties by file order): a left-to-right
+        // transit map needs producers left of consumers INSIDE a section —
+        // file order can violate dataflow (ported workflows group rules by
+        // module, live: community eager's kraken_merge precedes
+        // kraken_parse), and nf-metro rejects backward intra-section edges
+        // as collinear/bundle-order routing defects. Stations are acyclic
+        // (the collapse above is cycle-safe), but a residual cycle appends
+        // its members in file order rather than dropping any.
+        let mut intra_succ: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+        let mut intra_in_degree: HashMap<NodeIndex, usize> = HashMap::new();
+        for &(src, dst) in &station_edges {
+            if node_section[&src] == node_section[&dst] {
+                *intra_in_degree.entry(dst).or_insert(0) += 1;
+                intra_succ.entry(src).or_default().push(dst);
+            }
+        }
+        let section_station_order: HashMap<String, Vec<NodeIndex>> = sections
+            .iter()
+            .map(|(section, _)| {
+                let members: Vec<NodeIndex> = station_nodes
+                    .iter()
+                    .copied()
+                    .filter(|n| &node_section[n] == section)
+                    .collect();
+                let rank: HashMap<NodeIndex, usize> = members
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &n)| (n, i))
+                    .collect();
+                let mut ready: BTreeSet<(usize, NodeIndex)> = members
+                    .iter()
+                    .filter(|n| !intra_in_degree.contains_key(n))
+                    .map(|&n| (rank[&n], n))
+                    .collect();
+                let mut ordered: Vec<NodeIndex> = Vec::with_capacity(members.len());
+                while let Some(&(_, node)) = ready.first() {
+                    ready.remove(&(rank[&node], node));
+                    ordered.push(node);
+                    for &succ in intra_succ.get(&node).into_iter().flatten() {
+                        let count = intra_in_degree.get_mut(&succ).unwrap();
+                        *count -= 1;
+                        if *count == 0 {
+                            ready.insert((rank[&succ], succ));
+                        }
+                    }
+                }
+                if ordered.len() < members.len() {
+                    let leftover: Vec<NodeIndex> = members
+                        .into_iter()
+                        .filter(|n| !ordered.contains(n))
+                        .collect();
+                    ordered.extend(leftover);
+                }
+                (section.clone(), ordered)
+            })
+            .collect();
         let mut stages: Vec<String> = Vec::new();
         for node in &station_nodes {
             let stage = &node_stage[node];
@@ -1192,7 +1249,7 @@ impl WorkflowDag {
                 ));
             }
 
-            for node in station_nodes.iter().filter(|n| &node_section[n] == section) {
+            for node in &section_station_order[section] {
                 out.push_str(&format!(
                     "{inner_indent}n{}[\"{}\"]\n",
                     node.index(),
@@ -3152,6 +3209,30 @@ mod tests {
         assert!(
             mmd.contains("subgraph bam_qc [BAM QC]") && mmd.contains("n1[\"FastQC\"]"),
             "second section keeps its own station (no cross-section merge):\n{mmd}"
+        );
+    }
+
+    #[test]
+    fn metro_export_orders_stations_topologically_within_section() {
+        // A left-to-right transit map needs producers left of consumers
+        // INSIDE a section; file order can violate dataflow (ported
+        // workflows group rules by module — live: community eager's
+        // kraken_merge precedes kraken_parse in file order, which
+        // nf-metro rejects as collinear routing defects).
+        let mut rules = vec![
+            make_rule("qc_consumer", vec!["mid.txt"], vec!["out.txt"]),
+            make_rule("qc_producer", vec!["in.txt"], vec!["mid.txt"]),
+        ];
+        rules[0].shell = Some("fastqc mid.txt".into());
+        rules[1].shell = Some("fastqc in.txt".into());
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+
+        let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
+        let producer = mmd.find("n1[\"qc_producer\"]").expect("producer station");
+        let consumer = mmd.find("n0[\"qc_consumer\"]").expect("consumer station");
+        assert!(
+            producer < consumer,
+            "producer must sit left of its consumer within the section:\n{mmd}"
         );
     }
 }

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -14,6 +14,7 @@
 //! Rules that match nothing fall back to `"generic"`.
 
 use crate::rule::Rule;
+use std::collections::HashSet;
 
 /// Canonical stage names in the order the palette assigns colors.
 const PALETTE: &[(&str, &str, &str)] = &[
@@ -30,9 +31,14 @@ const PALETTE: &[(&str, &str, &str)] = &[
 ];
 
 /// Fallback colors for custom (non-canonical) stages, selected by stable hash.
+///
+/// Okabe-Ito (colour-blind safe) values plus two legacy light tones. The
+/// entries are mutually distinct so several custom-stage lines on one map
+/// stay separable (live: community enrichment has eight custom stage
+/// lines; the previous palette clustered them in the brown/pink family).
 const EXTRA_COLORS: &[&str] = &[
-    "#9C755F", "#BAB0AC", "#FF9DA7", "#D4A6C8", "#86BCB6", "#59A14F", "#EDC948", "#8CD17D",
-    "#B6992D", "#6E6E6E",
+    "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7", "#8CD17D",
+    "#B6992D", "#999999",
 ];
 
 /// `(rule-name prefix, canonical stage)` pairs for ported workflows whose
@@ -256,6 +262,41 @@ pub fn stage_color(stage: &str) -> &'static str {
     EXTRA_COLORS[stable_hash(stage) % EXTRA_COLORS.len()]
 }
 
+/// Whether `stage` is a canonical palette stage (stable, table-driven
+/// colour) rather than a workflow-specific custom stage.
+pub fn is_canonical_stage(stage: &str) -> bool {
+    PALETTE.iter().any(|(s, _, _)| *s == stage)
+}
+
+/// Colour for a stage line within one metro export.
+///
+/// Canonical stages keep their fixed palette entry. Custom stages start at
+/// their stable-hash offset in the fallback palette and walk forward to the
+/// first colour not yet used on this map, so a stage keeps its base colour
+/// wherever possible while several custom lines on one map never share a
+/// colour (live: community enrichment puts eight custom lines on one map,
+/// where a bare hash modulo painted several of them the same colour).
+pub fn metro_line_color(stage: &str, used: &mut HashSet<&'static str>) -> &'static str {
+    if let Some((_, _, color)) = PALETTE.iter().find(|(s, _, _)| *s == stage) {
+        // Canonical lanes keep their fixed colour and do not occupy slots in
+        // the fallback walk — dense maps may share a hue with a canonical
+        // lane (a problem of degree, never of correctness).
+        return color;
+    }
+    let offset = stable_hash(stage) % EXTRA_COLORS.len();
+    for k in 0..EXTRA_COLORS.len() {
+        let color = EXTRA_COLORS[(offset + k) % EXTRA_COLORS.len()];
+        if !used.contains(color) {
+            used.insert(color);
+            return color;
+        }
+    }
+    // More custom lanes than fallback colours (live: community bgcflow at
+    // rule granularity). Falling back to the stage's base colour is better
+    // than aborting an otherwise-valid export.
+    EXTRA_COLORS[offset % EXTRA_COLORS.len()]
+}
+
 /// DJB2-style hash — deterministic across runs, so diagram colors are stable.
 fn stable_hash(s: &str) -> usize {
     let mut h: usize = 5381;
@@ -269,7 +310,7 @@ fn stable_hash(s: &str) -> usize {
 mod tests {
     use super::*;
     use crate::rule::{EnvironmentSpec, Resources};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     fn rule(name: &str, shell: &str, tags: Vec<&str>) -> Rule {
         Rule {
@@ -377,5 +418,57 @@ mod tests {
     fn canonical_colors_are_stable() {
         assert_eq!(stage_color("qc"), "#4C78A8");
         assert_eq!(stage_color("custom_thing"), stage_color("custom_thing"));
+    }
+
+    #[test]
+    fn metro_line_colors_never_collide_on_one_map() {
+        // Eight custom stages on one export get eight distinct colours even
+        // when their hash offsets coincide (the live community enrichment
+        // case; a bare hash modulo painted several lines the same colour).
+        let mut used = HashSet::new();
+        let stages = [
+            "databases",
+            "great",
+            "pycistarget",
+            "gseapy",
+            "plots",
+            "aggregate",
+            "visualize",
+            "export",
+        ];
+        let colors: Vec<&str> = stages
+            .iter()
+            .map(|s| metro_line_color(s, &mut used))
+            .collect();
+        assert_eq!(colors.iter().collect::<HashSet<_>>().len(), colors.len());
+    }
+
+    #[test]
+    fn metro_line_canonical_stages_keep_their_color() {
+        let mut used = HashSet::new();
+        assert_eq!(metro_line_color("qc", &mut used), "#4C78A8");
+        assert_eq!(used.len(), 0, "canonical lanes take no fallback slot");
+    }
+
+    #[test]
+    fn custom_stage_colour_pin_stays_stable() {
+        // Pins the fallback walk's first assignment for one stage — a
+        // palette shuffle or offset change must fail here, not silently
+        // repaint regenerated maps.
+        let mut used = HashSet::new();
+        assert_eq!(metro_line_color("custom_tag", &mut used), "#8CD17D");
+    }
+
+    #[test]
+    fn metro_line_more_custom_lanes_than_palette_never_aborts() {
+        // A custom-stage-heavy map (live: community bgcflow, rule tier) must
+        // export even when the fallback palette is exhausted — the last lane
+        // repeats the stage's base colour instead of panicking.
+        let mut used = HashSet::new();
+        let mut colors = Vec::new();
+        for i in 0..24 {
+            colors.push(metro_line_color(&format!("custom_stage_{i}"), &mut used));
+        }
+        assert_eq!(colors.len(), 24);
     }
 }

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -58,67 +58,71 @@ const PREFIX_STAGES: &[(&str, &str)] = &[
     ("multiqc", "report"),
 ];
 
-/// `(stage, keyword)` pairs for shell/script inference, matched against the
-/// lowercased command text. Order matters: more specific signals (a variant
-/// caller) win over generic ones (an aligner), mirroring `WorkflowDomain`.
-const KEYWORDS: &[(&str, &str)] = &[
+/// `(stage, keyword, tool display)` pairs for shell/script inference, matched
+/// against the lowercased command text. Order matters: more specific signals
+/// (a variant caller) win over generic ones (an aligner), mirroring
+/// `WorkflowDomain`. The tool display is the curated process name used when
+/// the metro export groups rules into process-level stations (granularity
+/// `process`): several rules driven by the same tool collapse into one
+/// station named after the tool, the nf-core transit-map idiom
+/// (`samtools sort`/`samtools index`/… → one "SAMtools" stop).
+const KEYWORDS: &[(&str, &str, &str)] = &[
     // Reporting / aggregation — must precede QC so MultiQC is not misread as QC.
-    ("report", "multiqc"),
+    ("report", "multiqc", "MultiQC"),
     // Variant calling (specific callers before the broad "gatk").
-    ("variant", "haplotypecaller"),
-    ("variant", "mutect2"),
-    ("variant", "freebayes"),
-    ("variant", "strelka"),
-    ("variant", "vardict"),
-    ("variant", "bcftools call"),
-    ("variant", "bcftools mpileup"),
-    ("variant", "gatk"),
+    ("variant", "haplotypecaller", "HaplotypeCaller"),
+    ("variant", "mutect2", "Mutect2"),
+    ("variant", "freebayes", "freeBayes"),
+    ("variant", "strelka", "Strelka"),
+    ("variant", "vardict", "VarDict"),
+    ("variant", "bcftools call", "BCFtools"),
+    ("variant", "bcftools mpileup", "BCFtools"),
+    ("variant", "gatk", "GATK"),
     // Alignment-adjacent BAM processing (MarkDuplicates is the hub rule
     // most downstream stages consume — staging it as align keeps the
     // stage flow acyclic, live: community rnaseq).
-    ("align", "picard"),
+    ("align", "picard", "Picard"),
     // Annotation.
-    ("annotate", "snpeff"),
-    ("annotate", "snpsift"),
-    ("annotate", "annovar"),
-    ("annotate", "vep"),
+    ("annotate", "snpeff", "SnpEff"),
+    ("annotate", "snpsift", "SnpSift"),
+    ("annotate", "annovar", "ANNOVAR"),
+    ("annotate", "vep", "VEP"),
     // Quantification.
-    ("quantify", "featurecounts"),
-    ("quantify", "htseq"),
-    ("quantify", "salmon quant"),
-    ("quantify", "kallisto"),
-    ("quantify", "rsem"),
-    ("quantify", "stringtie"),
+    ("quantify", "featurecounts", "featureCounts"),
+    ("quantify", "htseq", "HTSeq"),
+    ("quantify", "salmon quant", "Salmon"),
+    ("quantify", "kallisto", "Kallisto"),
+    ("quantify", "rsem", "RSEM"),
+    ("quantify", "stringtie", "StringTie"),
     // Alignment.
-    ("align", "bwa"),
-    ("align", "star "),
-    ("align", "samtools sort"),
-    ("align", "samtools index"),
-    ("align", "samtools stats"),
-    ("align", "samtools flagstat"),
-    ("align", "samtools idxstats"),
-    ("align", "hisat2"),
-    ("align", "minimap2"),
-    ("align", "bowtie"),
-    ("align", "tophat"),
+    ("align", "bwa", "BWA"),
+    ("align", "star ", "STAR"),
+    ("align", "samtools sort", "SAMtools"),
+    ("align", "samtools index", "SAMtools"),
+    ("align", "samtools stats", "SAMtools"),
+    ("align", "samtools flagstat", "SAMtools"),
+    ("align", "samtools idxstats", "SAMtools"),
+    ("align", "hisat2", "HISAT2"),
+    ("align", "minimap2", "minimap2"),
+    ("align", "bowtie", "Bowtie2"),
+    ("align", "tophat", "TopHat"),
     // Trimming.
-    ("trim", "trimmomatic"),
-    ("trim", "trim_galore"),
-    ("trim", "cutadapt"),
-    ("trim", "fastp"),
+    ("trim", "trimmomatic", "Trimmomatic"),
+    ("trim", "trim_galore", "Trim Galore!"),
+    ("trim", "cutadapt", "cutadapt"),
+    ("trim", "fastp", "fastp"),
     // QC.
-    ("qc", "fastqc"),
-    ("qc", "fastq_screen"),
-    ("qc", "qualimap"),
-    ("qc", "fq_lint"),
-    ("qc", "fq lint"),
-    ("qc", "fqlint"),
+    ("qc", "fastqc", "FastQC"),
+    ("qc", "fastq_screen", "FastQ Screen"),
+    ("qc", "qualimap", "Qualimap"),
+    ("qc", "fq_lint", "fq lint"),
+    ("qc", "fqlint", "fq lint"),
     // Merge / concatenation (substring " cat"/" merge"/" concat" to avoid
     // matching "scatter" or "concatenate" noise).
-    ("merge", "samtools merge"),
-    ("merge", "bcftools merge"),
-    ("merge", "bcftools concat"),
-    ("merge", "picard merge"),
+    ("merge", "samtools merge", "SAMtools"),
+    ("merge", "bcftools merge", "BCFtools"),
+    ("merge", "bcftools concat", "BCFtools"),
+    ("merge", "picard merge", "Picard"),
 ];
 
 /// Normalize a user-supplied tag into a canonical stage name.
@@ -165,6 +169,24 @@ pub fn detect_stage(rule: &Rule) -> String {
     }
 
     // 3. Command keyword inference.
+    if let Some((stage, _, _)) = match_keyword(rule) {
+        return stage.to_string();
+    }
+
+    // 4. Fallback.
+    "generic".to_string()
+}
+
+/// The curated tool name for a rule, when its shell/script matches a known
+/// tool keyword (`samtools index` → `Some("SAMtools")`). Rules without a
+/// match stay individual stations in process-granularity metro exports.
+/// Same matching order as [`detect_stage`] step 3.
+pub fn detect_tool(rule: &Rule) -> Option<&'static str> {
+    match_keyword(rule).map(|(_, _, tool)| tool)
+}
+
+/// First `(stage, keyword, tool)` match over the rule's shell/script text.
+fn match_keyword(rule: &Rule) -> Option<(&'static str, &'static str, &'static str)> {
     let mut text = String::new();
     if let Some(shell) = &rule.shell {
         text.push_str(shell);
@@ -174,14 +196,10 @@ pub fn detect_stage(rule: &Rule) -> String {
         text.push_str(script);
     }
     let text = text.to_lowercase();
-    for (stage, keyword) in KEYWORDS {
-        if text.contains(keyword) {
-            return (*stage).to_string();
-        }
-    }
-
-    // 4. Fallback.
-    "generic".to_string()
+    KEYWORDS
+        .iter()
+        .find(|(_, keyword, _)| text.contains(keyword))
+        .copied()
 }
 
 /// Friendly section title for a module namespace (metro-map sections).
@@ -194,7 +212,7 @@ pub fn module_display(module: &str) -> String {
         "quantification" => "Quantification",
         "prepare_genome" => "Reference preparation",
         "bigwig" => "Coverage tracks",
-        "multiqc" => "Reporting",
+        "multiqc" | "report" => "Reporting",
         "trim" => "Trimming",
         "annotation" | "annotate" => "Annotation",
         "variant" => "Variant calling",
@@ -306,6 +324,9 @@ mod tests {
     fn module_display_curated_and_fallback() {
         assert_eq!(module_display("fastq_qc"), "Read QC");
         assert_eq!(module_display("prepare_genome"), "Reference preparation");
+        // Live: community ampliseq has a bare `report` module; the metro
+        // section must use the stage display, not a bare "Report".
+        assert_eq!(module_display("report"), "Reporting");
         assert_eq!(module_display("novel_module"), "Novel Module");
     }
 
@@ -331,6 +352,25 @@ mod tests {
     fn no_signal_falls_back_to_generic() {
         let r = rule("mystery", "echo hello", vec![]);
         assert_eq!(detect_stage(&r), "generic");
+    }
+
+    #[test]
+    fn detect_tool_returns_curated_display_name() {
+        assert_eq!(
+            detect_tool(&rule("a", "samtools sort in.bam", vec![])),
+            Some("SAMtools")
+        );
+        assert_eq!(
+            detect_tool(&rule("b", "STAR --genomeDir g", vec![])),
+            Some("STAR")
+        );
+        assert_eq!(
+            detect_tool(&rule("c", "multiqc .", vec![])),
+            Some("MultiQC")
+        );
+        assert_eq!(detect_tool(&rule("d", "echo nothing", vec![])), None);
+        // Tags/prefixes set the stage but are not tool identities.
+        assert_eq!(detect_tool(&rule("e", "echo x", vec!["qc"])), None);
     }
 
     #[test]

--- a/docs/guide/mkdocs.yml
+++ b/docs/guide/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
       - Workflow Versioning: reference/versioning.md
       - Wildcards: reference/wildcards.md
       - DAG Engine: reference/dag-engine.md
+      - Graph Subcommand Design: reference/graph-subcommand.md
       - DAG Edit API: reference/dag-edit-api.md
       - Environment System: reference/environment-system.md
       - China Network Mirrors: reference/china-mirrors.md

--- a/docs/guide/src/commands/graph.md
+++ b/docs/guide/src/commands/graph.md
@@ -27,6 +27,7 @@ oxo-flow graph [OPTIONS] <WORKFLOW>
 | `--format <FORMAT>` | `-f` | Output format: `ascii` (terminal), `dot` (Graphviz), `dot-clustered` (level-grouped), `tree` (indented tree), `mermaid` (Mermaid `graph LR`), `metro` (nf-metro metro map). Default: `ascii` |
 | `--output <FILE>` | `-o` | Save output to a file (useful for dot/svg generation) |
 | `--expanded` | | Show the DAG after wildcard/sample/scatter expansion (the actual runtime DAG) |
+| `--granularity <LEVEL>` | | `metro` station zoom: `rule` (one station per rule, default), `process` (chain-connected same-tool rules collapse into tool-named stations, the nf-core idiom), `module` (one station per module section — the publication/overview tier). See [Graph Subcommand Design](../reference/graph-subcommand.md) |
 | `--verbose` | `-v` | Enable debug-level logging |
 | `--quiet` | | Suppress non-essential output (errors only) |
 | `--no-color` | | Disable colored output |
@@ -87,6 +88,19 @@ oxo-flow graph pipeline.oxoflow -f metro -o pipeline.mmd
 # online playground at https://seqeralabs.github.io/nf-metro/latest/playground/
 pip install nf-metro
 nf-metro render pipeline.mmd -o pipeline.svg
+```
+
+`--granularity` zooms the metro map in three rungs (see [Graph Subcommand Design](../reference/graph-subcommand.md) for the persona rationale):
+
+- `rule` (default) — every rule is one station; the mechanical truth for operating and debugging a run.
+- `process` — chain-connected rules driven by the same tool collapse into tool-named stations (`samtools sort` → `samtools index` → one "SAMtools" stop).
+- `module` — one station per module section; the compact publication/overview tier that lands dense ports at the published-map scale.
+
+```bash
+# Publication-tier overview (compact module map)
+oxo-flow graph pipeline.oxoflow -f metro --granularity module -o overview.mmd
+# Tool-level map for reviewing a port against its upstream
+oxo-flow graph pipeline.oxoflow -f metro --granularity process -o tools.mmd
 ```
 
 ### View the expanded runtime DAG

--- a/docs/guide/src/commands/graph.md
+++ b/docs/guide/src/commands/graph.md
@@ -27,7 +27,7 @@ oxo-flow graph [OPTIONS] <WORKFLOW>
 | `--format <FORMAT>` | `-f` | Output format: `ascii` (terminal), `dot` (Graphviz), `dot-clustered` (level-grouped), `tree` (indented tree), `mermaid` (Mermaid `graph LR`), `metro` (nf-metro metro map). Default: `ascii` |
 | `--output <FILE>` | `-o` | Save output to a file (useful for dot/svg generation) |
 | `--expanded` | | Show the DAG after wildcard/sample/scatter expansion (the actual runtime DAG) |
-| `--granularity <LEVEL>` | | `metro` station zoom: `rule` (one station per rule, default), `process` (chain-connected same-tool rules collapse into tool-named stations, the nf-core idiom), `module` (one station per module section — the publication/overview tier). See [Graph Subcommand Design](../reference/graph-subcommand.md) |
+| `--granularity <LEVEL>` | | `metro` station zoom (metro only): `rule` (one station per rule, default), `process` (chain-connected same-tool rules collapse into tool-named stations, the nf-core idiom), `module` (one station per module section — the publication/overview tier). Passing it with any other format is an error. See [Graph Subcommand Design](../reference/graph-subcommand.md) |
 | `--verbose` | `-v` | Enable debug-level logging |
 | `--quiet` | | Suppress non-essential output (errors only) |
 | `--no-color` | | Disable colored output |
@@ -51,7 +51,14 @@ oxo-flow graph pipeline.oxoflow -f dot
 
 ### Render to PNG with Graphviz
 
-The graph command prints log output (e.g. resource warnings) to stdout before the DOT body, so piping stdout into `dot` does not work reliably. Write the DOT to a file first, then render it:
+Log output (the banner, resource warnings) goes to stderr; the workflow DAG
+is the only content on stdout, so piping into Graphviz works:
+
+```bash
+oxo-flow graph pipeline.oxoflow -f dot | dot -Tpng -o dag.png
+```
+
+For complex graphs, write the DOT to a file first and render from it:
 
 ```bash
 oxo-flow graph -f dot -o graph.dot pipeline.oxoflow
@@ -102,6 +109,11 @@ oxo-flow graph pipeline.oxoflow -f metro --granularity module -o overview.mmd
 # Tool-level map for reviewing a port against its upstream
 oxo-flow graph pipeline.oxoflow -f metro --granularity process -o tools.mmd
 ```
+
+`--granularity` is metro-only: it is rejected with any other `-f` value
+(before the workflow is parsed), so a zoom setting can never be silently
+ignored. Omit `-f` and use only `--granularity` and the latter fails with the
+same error — pass `-f metro` explicitly.
 
 ### View the expanded runtime DAG
 

--- a/docs/guide/src/reference/graph-subcommand.md
+++ b/docs/guide/src/reference/graph-subcommand.md
@@ -66,6 +66,13 @@ each persona actually uses:
 | `mermaid` | plain Mermaid `graph LR` for docs | — | documentation |
 | `metro` | nf-metro transit map (SVG/HTML) | `rule` / `process` / `module` | learner, reviewer, publication, site |
 
+**Constraint:** `--granularity` applies to `metro` only. With any other
+format the CLI rejects it before the workflow is parsed — a zoom setting is
+never silently ignored (the default is `rule`, so plain `-f metro` and
+`-f metro --granularity rule` are identical). The rejected-combination error
+names the option and the value, and tells the user to pass `-f metro` or drop
+the option.
+
 ## Engine design invariants
 
 The exporter is generic by construction — it knows nothing about any
@@ -116,3 +123,14 @@ curve-invariant fallback for process-tier maps whose density exceeds what
 nf-metro's router currently tables) live with the automation script, not
 in the engine: they are rendering policy, and the engine must stay a
 faithful, generic DAG exporter.
+
+## Known boundary
+
+The engine promises structurally valid, deterministic mmd — the ladder,
+the cycle-safety, and the topological ordering are engine-side invariants.
+Rendering success is nf-metro's concern, and its router has limits: for very
+dense `rule`- or `process`-tier maps (live: community enrichment,
+varlociraptor) nf-metro 1.1.0 aborts with a `CurveInvariantError` instead of
+producing a broken picture — a package upgrade or the project's render-fallback
+setup (above) is the fix. The `module` tier is the publication guarantee:
+it renders for the whole corpus.

--- a/docs/guide/src/reference/graph-subcommand.md
+++ b/docs/guide/src/reference/graph-subcommand.md
@@ -1,0 +1,118 @@
+# The `graph` Subcommand: Personas, Granularity Ladder, and Export Design
+
+This page documents the design behind `oxo-flow graph` — the scenario-driven
+rationale (who reads a workflow diagram, and why), the granularity ladder
+that serves those scenarios, the format matrix, and the engine-side design
+invariants that keep every export generic.
+
+## Personas
+
+Seven reader roles drive the design. Each reads a workflow DAG for a
+different purpose, at a different level of detail:
+
+| Persona | Scenario | Needs | Served by |
+|---|---|---|---|
+| **Learner** — first contact with a new workflow | learning | "What does this pipeline *do*?" — ~10-25 stops, plain-language section names, stage colors showing the read→align→quantify→report flow | `-f metro --granularity module`, gallery pages |
+| **Reviewer** — checking a port against its upstream | preview | Tool names per step (is `samtools index` present?), correspondence with the upstream nf-core/snakemake process list | `-f metro --granularity process`, fidelity tables |
+| **Operator** — running, rerunning, debugging a run | computation | Rule-level detail: which rules map to which checkpoint entries, files, and resource settings | `-f metro --granularity rule`, `-f ascii`, `-f tree`, `--expanded` |
+| **Publication author** — preparing a figure for a paper | publication | A compact, print-friendly, color-blind-safe transit map at figure scale (~2:1 landscape, ≤ ~1800 px wide) | `-f metro --granularity module`, `nf-metro render` recipes |
+| **Site maintainer** — regenerating diagrams for every community pipeline | documentation | Deterministic output, a repeatable automation script, pinned engine and renderer versions | `graph` + the site regeneration pipeline (issue #16) |
+| **Engine developer** — extending the exporter | development | A generic design: one mechanism serves every workflow; no per-pipeline special cases | granularity ladder, shared stage/tool knowledge tables |
+| **Auditor** — graph analysis with external tools | audit | Machine-readable DAGs for graphviz pipelines and custom analysis | `-f dot`, `-f dot-clustered`, `--expanded` |
+
+## The granularity ladder
+
+One DAG, three levels of abstraction — the same ladder the published
+nf-core transit maps climb implicitly (their stations are process-level,
+grouped into stage sections):
+
+- **`rule`** (default) — every rule is one station. Mechanical truth:
+  useful to map rules ↔ checkpoints ↔ files while operating a run, and as
+  the base truth the coarser tiers collapse. Dense ported workflows (live:
+  community mag, 600+ rules) produce very large maps here.
+
+- **`process`** — rules that are chain-connected within a section and
+  driven by the same tool collapse into one tool-named station (the
+  nf-core idiom: `samtools sort` → `samtools index` → one "SAMtools"
+  stop). The collapse is cycle-safe: a union applies only while the
+  destination stays unreachable from the source once the direct station
+  edge is removed, so cross-connected same-tool pairs keep separate
+  numbered stops (`GATK (2)` onward) and the station graph stays acyclic.
+
+- **`module`** — one station per module section: the publication/overview
+  tier. Stations are the workflow's own module namespaces (SCC-contracted
+  where they reference each other cyclically), ordered by the section DAG
+  and colored by each section's dominant stage line. This lands dense
+  ports in the published-map scale without any hand curation (live:
+  community mag, 642 stations at rule granularity → 10 at module
+  granularity, rendered at 760×362 px vs the upstream map's 413×260).
+
+Every tier comes out of the same `to_metro` pipeline (stage inference →
+section assignment → collapse → SCC contraction → topological ordering),
+so the tiers never disagree about structure — only about zoom.
+
+## The format matrix
+
+`-f` selects the output format; the granularity ladder selects the zoom.
+Not every combination is meaningful — the matrix below shows the pairs
+each persona actually uses:
+
+| Format | Purpose | Typical `--granularity` | Consumers |
+|---|---|---|---|
+| `ascii` | one-glance terminal DAG | — | operator |
+| `tree` | indented dependency tree | — | operator |
+| `dot` | graphviz input | `--expanded` for the runtime DAG | auditor, CI |
+| `dot-clustered` | graphviz input grouped by workflow modules | — | auditor |
+| `mermaid` | plain Mermaid `graph LR` for docs | — | documentation |
+| `metro` | nf-metro transit map (SVG/HTML) | `rule` / `process` / `module` | learner, reviewer, publication, site |
+
+## Engine design invariants
+
+The exporter is generic by construction — it knows nothing about any
+particular workflow:
+
+1. **Shared knowledge only.** Stage inference (shell keywords), tool
+   display names, curated module titles, and stage colors live in one
+   table (`stage.rs`) that every workflow consults. No rule name, module
+   name, or pipeline name is special-cased anywhere in `dag.rs`.
+2. **Deterministic output.** Stations follow the rule file order inside a
+   topological ordering; every tie-break is documented. The same workflow
+   file always produces byte-identical exports — a precondition for CI
+   regeneration and diffs.
+3. **Topological ordering everywhere.** Sections are Kahn-ordered over
+   the section graph; stations are Kahn-ordered over the intra-section
+   station subgraph (ties by file order). A left-to-right transit map
+   needs producers left of consumers; file order alone can violate
+   dataflow (ported workflows group rules by module), and nf-metro
+   rejects backward intra-section edges as routing defects.
+4. **Cycle-safe contraction.** Module sections that reference each other
+   cyclically merge into one section (deterministic id, `" + "`-joined
+   display) via Kosaraju SCCs — the contracted section graph is always
+   acyclic without dropping any station or edge.
+5. **Router-friendly shapes.** Edges are deduplicated per station pair;
+   isolated stations go off-track (`%%metro off_track`); labels are
+   sanitized for Mermaid and nf-metro alike.
+
+## Evaluation
+
+Every change to the exporter is evaluated against the full 24-pipeline
+community corpus, not against single examples:
+
+1. **Render matrix** — all 24 workflows are exported at all three
+   granularities and rendered with nf-metro; every export must be a valid
+   mmd and every module-tier export must render (the publication tier
+   must never abort).
+2. **Structural metrics** — canvas size, aspect ratio, station count, and
+   text-overlap count are compared against the upstream nf-core maps for
+   the seven pipelines that have one (atacseq, chipseq, mag, methylseq,
+   rnaseq, scrnaseq, viralrecon); the target is the same order of
+   magnitude at the module tier.
+3. **Visual QA** — rendered maps are inspected per persona (the gallery
+   QA page compares ours side-by-side with the upstream reference where
+   one exists).
+
+The render recipes (line-spread modes, spacing directives, and the
+curve-invariant fallback for process-tier maps whose density exceeds what
+nf-metro's router currently tables) live with the automation script, not
+in the engine: they are rendering policy, and the engine must stay a
+faithful, generic DAG exporter.


### PR DESCRIPTION
## Summary

Finishes the graph-overhaul story: the metro granularity ladder shipped in #325 now gets a production-grade CLI surface (strongly typed formats, metro-only zoom constraint, loud empty-workflow errors) and a publication-pass metro exporter (collision-free colour assignment, id deduplication, consistent tie-breaks), plus a 10-test integration suite and docs that match reality.

## What changed

### CLI (`oxo-flow graph`)
- **`-f` is a clap `ValueEnum`** (`GraphFormat`: ascii / dot / dot-clustered / tree / mermaid / metro). Invalid formats now fail at the clap layer (exit 2 + possible values) instead of after the workflow is parsed; zsh/bash completion auto-offers the six formats; the help text is self-maintaining.
- **`--granularity` is metro-only**: any non-metro format rejects it *before* the workflow is parsed (previously silently ignored). The reported value spelling comes from `clap::ValueEnum` itself (single source of truth).
- **Empty workflows fail loudly** instead of emitting a bare `graph LR` that a downstream renderer would silently accept.

### Metro exporter (core)
- **Custom (tag-driven) line colours** walk an Okabe-Ito fallback palette at their stable-hash offset to the first unused colour → several custom lines on one map never share a hue (live: community `enrichment`, 8 custom lines). Palette exhaustion repeats the base colour instead of panicking (this PR's review pass caught its own regression against `bgcflow` at rule granularity; covered by a dedup test).
- **Line/section id deduplication**: sanitized id collisions (`de-analysis` vs `de_analysis`) get a `_2` suffix, because nf-metro silently keeps the first declaration and drops the rest.
- **Dominant-stage ties** (module tier) resolve to the FIRST stage in file order, matching every other tie convention in the exporter (`max_by_key` picked the last).
- The two tiers' line-definition loops merge into one `emit_metro_line_defs` helper, so colour/id assignment can never diverge between the module and rule tiers.

### Tests
- `crates/oxo-flow-cli/tests/graph.rs` — 10 integration tests: format matrix, the granularity ladder (rule/process/module), `--expanded` per-sample instantiation, the rejection paths, clean-stdout pipe behaviour.
- `stage.rs` — colour-collision, canonical-stability and palette-exhaustion tests. Full workspace: **2657 passing**.

### Docs
- `graph.md`: the stdout/stderr claim was **inverted** (logs go to stderr; piping `-f dot` into `dot` works — verified), `--granularity` constraint documented.
- `graph-subcommand.md`: constraint matrix + "Known boundary" — nf-metro 1.1.0 aborts with `CurveInvariantError` on dense rule/process-tier maps (13/24 of the community corpus); the **module tier is the publication guarantee (24/24 render)**. Rendering policy stays with the site scripts.

## Test plan

- [x] `cargo test --workspace` — 2657 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 24-repo matrix (staging sources): module-tier metro renders **24/24**; dot 24/24; rule/process-tier render 11/24 (nf-metro router boundary, documented)
- [x] Persona spot-check with rendered SVGs (learner/reviewer/operator/publication) — visual QA passed