### PR TITLE
fix(display): readable config descriptions and module map names

### DIFF
--- a/crates/oxo-flow-cli/src/commands/config_comments.rs
+++ b/crates/oxo-flow-cli/src/commands/config_comments.rs
@@ -264,7 +264,11 @@ fn join(lines: &[String]) -> Option<String> {
     } else {
         lines.iter().map(|line| strip_banner_dashes(line)).collect()
     };
-    let description = kept.join(" ");
+    // Keep the author's line structure: a multi-line comment block is
+    // prose (a reference_dir layout list, a stage walk-through), and a
+    // single-run paragraph is unreadable in sites that render the
+    // description (live: circrna reference_dir read as one run-on line).
+    let description = kept.join("\n");
     if description.is_empty() {
         None
     } else {
@@ -286,13 +290,29 @@ mod tests {
     }
 
     #[test]
-    fn multi_line_block_joins_with_spaces_and_skips_empty_lines() {
+    fn multi_line_block_keeps_structure_and_skips_empty_lines() {
+        // A blank # line is skipped (no leading/inner blank), the author's
+        // line structure survives so prose layouts render readably (live:
+        // circrna's reference_dir layout comment folded to one run-on line
+        // when joined with spaces).
         let text = "[config]\n# Optional: pre-trained classifier\n#\n# for the 16S region.\nclassifier = \"\"\n";
         assert_eq!(
             extract_config_descriptions(text),
             BTreeMap::from([(
                 "classifier".to_string(),
-                "Optional: pre-trained classifier for the 16S region.".to_string()
+                "Optional: pre-trained classifier\nfor the 16S region.".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn prose_layout_stays_multiline() {
+        let text = "[config]\n# reference_dir/ layout: genome.fa, genes.gtf\n# star/ index, bowtie2/ index.\nreference_dir = \"./reference\"\n";
+        assert_eq!(
+            extract_config_descriptions(text),
+            BTreeMap::from([(
+                "reference_dir".to_string(),
+                "reference_dir/ layout: genome.fa, genes.gtf\nstar/ index, bowtie2/ index.".to_string()
             )])
         );
     }

--- a/crates/oxo-flow-cli/src/commands/config_comments.rs
+++ b/crates/oxo-flow-cli/src/commands/config_comments.rs
@@ -312,7 +312,8 @@ mod tests {
             extract_config_descriptions(text),
             BTreeMap::from([(
                 "reference_dir".to_string(),
-                "reference_dir/ layout: genome.fa, genes.gtf\nstar/ index, bowtie2/ index.".to_string()
+                "reference_dir/ layout: genome.fa, genes.gtf\nstar/ index, bowtie2/ index."
+                    .to_string()
             )])
         );
     }

--- a/crates/oxo-flow-cli/src/commands/info.rs
+++ b/crates/oxo-flow-cli/src/commands/info.rs
@@ -860,8 +860,9 @@ mod tests {
             "../../examples/gallery/16_16s_qiime2_amplicon.oxoflow",
         );
 
-        // `classifier` carries a 4-line comment block (joined with spaces);
-        // uncommented keys omit the field entirely.
+        // `classifier` carries a 4-line comment block (newline-joined, so
+        // the author's line structure survives); uncommented keys omit the
+        // field entirely.
         let records = meta["config"].as_array().unwrap();
         let classifier = records
             .iter()
@@ -869,9 +870,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             classifier["description"],
-            "Optional: pre-trained classifier for the target 16S region \
-             (e.g. silva-138-99-515-806-nb-classifier.qza). Set via \
-             `oxo-flow run wf.oxoflow classifier=/path/to/classifier.qza`; \
+            "Optional: pre-trained classifier for the target 16S region\n\
+             (e.g. silva-138-99-515-806-nb-classifier.qza). Set via\n\
+             `oxo-flow run wf.oxoflow classifier=/path/to/classifier.qza`;\n\
              without it, skip the classify step or train a classifier first."
         );
         let trim_left_f = records

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -3065,8 +3065,8 @@ mod tests {
         let mmd = dag
             .to_metro(&rules, Some(&modules), MetroGranularity::Rule)
             .unwrap();
-        assert!(mmd.contains("subgraph s_01_preprocessing [01 Preprocessing]"));
-        assert!(mmd.contains("subgraph s_02_assembly [02 Assembly]"));
+        assert!(mmd.contains("subgraph s_01_preprocessing [Preprocessing]"));
+        assert!(mmd.contains("subgraph s_02_assembly [Assembly]"));
         assert!(!mmd.contains("subgraph qc [Read QC]"));
         // The inter-section edge is emitted with the source rule's stage line.
         assert!(mmd.contains("n0 -->|trim| n1"));
@@ -3097,7 +3097,7 @@ mod tests {
         // One merged section holds both modules (id joins the members,
         // display joins their titles); no standalone sections remain.
         assert!(
-            mmd.contains("subgraph qc_dada2 [Qc + Dada2]"),
+            mmd.contains("subgraph qc_dada2 [QC + Dada2]"),
             "merged section missing:\n{mmd}"
         );
         assert!(!mmd.contains("subgraph qc ["));

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -240,8 +240,8 @@ pub fn module_display(module: &str) -> String {
 /// `Somatic Callers + Germline + WGS Callers` instead of
 /// `10 Somatic Callers + 20 Germline + 91 Wgs Callers`.
 fn title_case(module: &str) -> String {
-    let stripped = module
-        .trim_start_matches(|c: char| c.is_ascii_digit() || c == '_' || c == '-' || c == '.');
+    let stripped =
+        module.trim_start_matches(|c: char| c.is_ascii_digit() || c == '_' || c == '-' || c == '.');
     let word_case = stripped
         .split(['_', ' ', '-'])
         .filter(|w| !w.is_empty())

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -228,10 +228,23 @@ pub fn module_display(module: &str) -> String {
     curated.to_string()
 }
 
-/// `fastq_qc` → `Fastq qc` (fallback for unknown module names).
+/// `fastq_qc` → `Fastq QC`, `91_wgs_callers` → `WGS Callers` (fallback for
+/// unknown module names).
+///
+/// Leading numeric stage prefixes are dropped (`01_preprocessing` →
+/// `Preprocessing`): they are file-organization noise on the map, not
+/// flow meaning, and stay on the page's module table if the author wants
+/// them. Known abbreviations normalize for readability — `qc` → `QC`,
+/// `wgs` → `WGS`, `snv` → `SNV`, `cnv` → `CNV`, `vcf`/`maf` → `VCF`/`MAF`,
+/// `rna`/`dna` → `RNA`/`DNA`, `sv` → `SV` — so a ported clindet map reads
+/// `Somatic Callers + Germline + WGS Callers` instead of
+/// `10 Somatic Callers + 20 Germline + 91 Wgs Callers`.
 fn title_case(module: &str) -> String {
-    module
-        .split('_')
+    let stripped = module
+        .trim_start_matches(|c: char| c.is_ascii_digit() || c == '_' || c == '-' || c == '.');
+    let word_case = stripped
+        .split(['_', ' ', '-'])
+        .filter(|w| !w.is_empty())
         .map(|w| {
             let mut chars = w.chars();
             match chars.next() {
@@ -239,8 +252,28 @@ fn title_case(module: &str) -> String {
                 None => String::new(),
             }
         })
-        .collect::<Vec<_>>()
-        .join(" ")
+        .collect::<Vec<_>>();
+    let normalized = word_case
+        .iter()
+        .map(|w| match w.to_ascii_lowercase().as_str() {
+            "qc" => "QC",
+            "wgs" => "WGS",
+            "snv" => "SNV",
+            "cnv" => "CNV",
+            "vcf" => "VCF",
+            "maf" => "MAF",
+            "vcf2maf" => "VCF2MAF",
+            "rna" => "RNA",
+            "dna" => "DNA",
+            "sv" => "SV",
+            _ => w.as_str(),
+        })
+        .collect::<Vec<_>>();
+    if normalized.is_empty() {
+        module.to_string()
+    } else {
+        normalized.join(" ")
+    }
 }
 
 /// Human-readable display name for a stage.
@@ -418,6 +451,24 @@ mod tests {
     fn canonical_colors_are_stable() {
         assert_eq!(stage_color("qc"), "#4C78A8");
         assert_eq!(stage_color("custom_thing"), stage_color("custom_thing"));
+    }
+
+    #[test]
+    fn module_display_reads_unknown_module_names_fluently() {
+        // Ported workflows number their module files; the map must read
+        // `91_wgs_callers` as `WGS Callers`, not raw file noise (live:
+        // community clindet's overview map read "10 Somatic Callers +
+        // 20 Germline + 91 Wgs Callers").
+        assert_eq!(module_display("01_preprocessing"), "Preprocessing");
+        assert_eq!(module_display("91_wgs_callers"), "WGS Callers");
+        assert_eq!(module_display("80_cnv"), "CNV");
+        assert_eq!(module_display("30_vcf_norm"), "VCF Norm");
+        assert_eq!(module_display("60_vcf2maf"), "VCF2MAF");
+        assert_eq!(module_display("00_common"), "Common");
+        assert_eq!(module_display("70_unpaired"), "Unpaired");
+        // Curated names and bare acronym modules still win.
+        assert_eq!(module_display("fastq_qc"), "Read QC");
+        assert_eq!(module_display("wgs"), "WGS");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #328 from the site audit: two metadata-surface fixes surfaced
by checking every `oxo-flow-community.github.io/pipelines` page against
its staged workflow.

### config descriptions keep the author's line structure
`extract_config_descriptions` joined multi-line comment blocks with
spaces, folding prose layouts into one run-on line — circrna's
`reference_dir` description read "=== The only path you need to set ===
reference_dir/ layout: genome.fa … star/" as a single paragraph. Comment
lines are newline-joined now (blank `#` lines still skipped, banners
stripped), so renderers break the description per line. Existing test
updated; prose-layout regression test added.

### module map names read like the flow, not the file stem
`module_display` strips leading numeric stage prefixes and normalizes
abbreviations (`qc`→`QC`, `wgs`→`WGS`, `snv`→`SNV`, `cnv`→`CNV`,
`vcf`/`maf`/`vcf2maf`, `rna`/`dna`, `sv`): a ported clindet overview now
reads "Somatic Callers + Germline + WGS Callers" instead of "10 Somatic
Callers + 20 Germline + 91 Wgs Callers", and "01 Preprocessing" renders
as "Preprocessing" instead of the raw file stem. Unknown-cleanup fallback
kept (`fastq_qc` → "Read QC" and similar curated names unchanged).

## Test plan
- [x] config_comments suite: 20 passed
- [x] stage suite: 30 passed (incl. new module_display_* tests)