### PR TITLE
docs(graph): reading semantics for the metro exports

### DIFF
--- a/docs/guide/src/reference/graph-subcommand.md
+++ b/docs/guide/src/reference/graph-subcommand.md
@@ -134,3 +134,29 @@ varlociraptor) nf-metro 1.1.0 aborts with a `CurveInvariantError` instead of
 producing a broken picture — a package upgrade or the project's render-fallback
 setup (above) is the fix. The `module` tier is the publication guarantee:
 it renders for the whole corpus.
+
+## Reading semantics
+
+Every export draws the *template* DAG: one node per rule (or per collapsed
+station at coarser granularity), one edge per data dependency. Three shapes
+that can look like broken rendering are structural reality — worth knowing
+before editing the exporter:
+
+1. **Off-track stations.** A rule with no dataflow edge (an external input
+   consumed as a path, a terminal export) appears outside the main flow —
+   nf-metro renders the `%%metro off_track` list in its own band. The
+   engine emits the directive only when a subset of stations is isolated;
+   a fully isolated workflow intentionally stays on one line.
+2. **Independent chains.** A DAG can be weakly disconnected: a quantifier
+   reading the same raw reads the alignment chain reads (live: tcasia's
+   `salmon_quant`) draws as a separate group ending in the shared report.
+   Correct connectivity, not a missing edge.
+3. **Merged-cyclic stations.** Mutually-referencing modules contract into
+   one merged section (the SCC pass) with a `" + "`-joined title; the
+   site's overview pass keeps those as separate per-stage stations, so a
+   cyclic multi-module pipeline reads as one station per analysis stage
+   instead of one repeated merged name (live: sarek).
+
+The runtime view — one node per (rule × sample/pair) task — is
+`oxo-flow graph --expanded`; exported figures stay template-level for the
+stable overview.


### PR DESCRIPTION
## Summary

Follow-up to #328/#329: the site audit taught the reader-facing truths of
the metro exports, and three shapes that render fine look like broken
rendering unless documented:

- **off-track stations** — a rule with no dataflow edge (external input
  path, terminal export) belongs outside the flow; the engine emits
  `%%metro off_track` only when a subset is isolated.
- **independent chains** — a weakly disconnected DAG is real
  connectivity (live: tcasia `salmon_quant` reads the same raw reads the
  alignment chain reads and draws as a separate group).
- **merged-cyclic stations** — mutually-referencing modules contract via
  the SCC pass; the site's overview pass keeps the stage split, so a
  cyclic pipeline reads one station per stage, not one repeated merged
  name (live: sarek).

Also notes that every export is the template DAG and points at
`--expanded` for the runtime view.