### PR TITLE
feat(metro): two-line merged-section displays + canonical-hue avoidance

### DIFF
--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -1040,13 +1040,49 @@ impl WorkflowDag {
                 section_of_scc.insert(member, slot);
             }
             merged_ids.push(merged_id);
-            merged_displays.push(
-                members
-                    .iter()
-                    .map(|&i| section_display[i].clone())
-                    .collect::<Vec<_>>()
-                    .join(" + "),
-            );
+            // Two-line merged display: the group's DOMINANT stage reads
+            // first (what the section DOES — "Analysis") and the member
+            // module short-names after ("Read · Dada2 · …"). A 34-char
+            // one-liner ("Read QC + dada2 + Analysis + its", live:
+            // ampliseq) obscured reading in every consumer; the literal
+            // `\n` survives label sanitizing and wraps in nf-metro.
+            let member_sections: Vec<&str> =
+                members.iter().map(|&i| section_order[i].as_str()).collect();
+            let mut stage_counts: HashMap<&str, usize> = HashMap::new();
+            let mut best_stage: Option<(usize, &str)> = None;
+            for node in station_nodes.iter() {
+                let sec = node_section[node].as_str();
+                if !member_sections.contains(&sec) {
+                    continue;
+                }
+                let stage = node_stage[node].as_str();
+                let count = stage_counts.entry(stage).or_insert(0);
+                *count += 1;
+                if best_stage.is_none_or(|(bc, _)| *count > bc) {
+                    best_stage = Some((*count, stage));
+                }
+            }
+            let dominant = best_stage.map(|(_, s)| s).unwrap_or("generic");
+            let mut short_names: Vec<String> = members
+                .iter()
+                .map(|&i| {
+                    section_display[i]
+                        .split(' ')
+                        .next()
+                        .unwrap_or(section_display[i].as_str())
+                })
+                .map(str::to_string)
+                .collect();
+            short_names.dedup();
+            if short_names.len() > 3 {
+                short_names.truncate(3);
+                short_names.push("…".to_string());
+            }
+            merged_displays.push(format!(
+                "{}\\n{}",
+                crate::stage::stage_display(dominant),
+                short_names.join(" · ")
+            ));
         }
         for node in &station_nodes {
             if let Some(&slot) = section_of_scc.get(&section_rank[node_section[node].as_str()]) {
@@ -1601,9 +1637,18 @@ fn emit_metro_line_defs<'a>(
     used_colors: &mut HashSet<&'static str>,
     taken_ids: &mut HashSet<String>,
 ) -> HashMap<&'a str, String> {
+    // Custom lanes avoid the canonical palette hues on this map: a custom
+    // "rename" line next to canonical "Reporting" yellow was near
+    // indistinguishable (live: community ampliseq).
+    let avoid: HashSet<&'static str> = stages
+        .iter()
+        .filter(|s| crate::stage::is_canonical_stage(s))
+        .map(|s| crate::stage::stage_color(s))
+        .chain(crate::stage::EXTRA_NEAR_CANONICAL.iter().copied())
+        .collect();
     let mut line_ids: HashMap<&str, String> = HashMap::new();
     for stage in stages {
-        let color = crate::stage::metro_line_color(stage, used_colors);
+        let color = crate::stage::metro_line_color(stage, used_colors, &avoid);
         let id = unique_metro_id(&sanitize_metro_id(stage), taken_ids);
         line_ids.insert(stage, id.clone());
         out.push_str(&format!(
@@ -3097,7 +3142,7 @@ mod tests {
         // One merged section holds both modules (id joins the members,
         // display joins their titles); no standalone sections remain.
         assert!(
-            mmd.contains("subgraph qc_dada2 [QC + Dada2]"),
+            mmd.contains("subgraph qc_dada2 [Read QC\\nQC · Dada2]"),
             "merged section missing:\n{mmd}"
         );
         assert!(!mmd.contains("subgraph qc ["));

--- a/crates/oxo-flow-core/src/stage.rs
+++ b/crates/oxo-flow-core/src/stage.rs
@@ -30,6 +30,13 @@ const PALETTE: &[(&str, &str, &str)] = &[
     ("generic", "Analysis", "#79706E"),
 ];
 
+/// Extra-colour hues that sit in the same FAMILY as canonical palette
+/// entries (#E69F00/#F0E442/#B6992D are orange/yellow/mustard shades close
+/// to canonical #F58518/#F2CF5B). Custom lanes avoid both the canonical
+/// colours and these hues (live: community ampliseq — the custom "rename"
+/// lane looked like the canonical "Reporting" yellow).
+pub const EXTRA_NEAR_CANONICAL: &[&str] = &["#E69F00", "#F0E442", "#B6992D"];
+
 /// Fallback colors for custom (non-canonical) stages, selected by stable hash.
 ///
 /// Okabe-Ito (colour-blind safe) values plus two legacy light tones. The
@@ -309,14 +316,29 @@ pub fn is_canonical_stage(stage: &str) -> bool {
 /// wherever possible while several custom lines on one map never share a
 /// colour (live: community enrichment puts eight custom lines on one map,
 /// where a bare hash modulo painted several of them the same colour).
-pub fn metro_line_color(stage: &str, used: &mut HashSet<&'static str>) -> &'static str {
+pub fn metro_line_color(
+    stage: &str,
+    used: &mut HashSet<&'static str>,
+    avoid: &HashSet<&'static str>,
+) -> &'static str {
     if let Some((_, _, color)) = PALETTE.iter().find(|(s, _, _)| *s == stage) {
-        // Canonical lanes keep their fixed colour and do not occupy slots in
-        // the fallback walk — dense maps may share a hue with a canonical
-        // lane (a problem of degree, never of correctness).
+        // Canonical lanes keep their fixed colour; the fallback walk below
+        // avoids them so a custom lane never trips a canonical hue (live:
+        // ampliseq's custom "rename" yellow next to the Reporting yellow).
         return color;
     }
     let offset = stable_hash(stage) % EXTRA_COLORS.len();
+    for k in 0..EXTRA_COLORS.len() {
+        let color = EXTRA_COLORS[(offset + k) % EXTRA_COLORS.len()];
+        if !used.contains(color) && !avoid.contains(color) {
+            used.insert(color);
+            return color;
+        }
+    }
+    // Fallback colours exhausted (canonical hues plus dense custom lanes —
+    // live: community bgcflow at rule granularity). First retry ignoring
+    // the avoid set; only then accept the stage's base colour rather than
+    // aborting an otherwise-valid export.
     for k in 0..EXTRA_COLORS.len() {
         let color = EXTRA_COLORS[(offset + k) % EXTRA_COLORS.len()];
         if !used.contains(color) {
@@ -324,9 +346,6 @@ pub fn metro_line_color(stage: &str, used: &mut HashSet<&'static str>) -> &'stat
             return color;
         }
     }
-    // More custom lanes than fallback colours (live: community bgcflow at
-    // rule granularity). Falling back to the stage's base colour is better
-    // than aborting an otherwise-valid export.
     EXTRA_COLORS[offset % EXTRA_COLORS.len()]
 }
 
@@ -489,7 +508,7 @@ mod tests {
         ];
         let colors: Vec<&str> = stages
             .iter()
-            .map(|s| metro_line_color(s, &mut used))
+            .map(|s| metro_line_color(s, &mut used, &HashSet::new()))
             .collect();
         assert_eq!(colors.iter().collect::<HashSet<_>>().len(), colors.len());
     }
@@ -497,8 +516,22 @@ mod tests {
     #[test]
     fn metro_line_canonical_stages_keep_their_color() {
         let mut used = HashSet::new();
-        assert_eq!(metro_line_color("qc", &mut used), "#4C78A8");
+        assert_eq!(
+            metro_line_color("qc", &mut used, &HashSet::new()),
+            "#4C78A8"
+        );
         assert_eq!(used.len(), 0, "canonical lanes take no fallback slot");
+    }
+
+    #[test]
+    fn metro_line_custom_lanes_avoid_canonical_hues() {
+        // live: community ampliseq — a custom "rename" lane next to the
+        // canonical "Reporting" yellow was indistinguishable; the walk
+        // must skip hues the map's canonical lanes already use.
+        let avoid = HashSet::from(["#F2CF5B"]);
+        let mut used = HashSet::new();
+        let color = metro_line_color("rename", &mut used, &avoid);
+        assert_ne!(color, "#F2CF5B", "custom lane must avoid the canonical hue");
     }
 
     #[test]
@@ -507,7 +540,10 @@ mod tests {
         // palette shuffle or offset change must fail here, not silently
         // repaint regenerated maps.
         let mut used = HashSet::new();
-        assert_eq!(metro_line_color("custom_tag", &mut used), "#8CD17D");
+        assert_eq!(
+            metro_line_color("custom_tag", &mut used, &HashSet::new()),
+            "#8CD17D"
+        );
     }
 
     #[test]
@@ -518,7 +554,11 @@ mod tests {
         let mut used = HashSet::new();
         let mut colors = Vec::new();
         for i in 0..24 {
-            colors.push(metro_line_color(&format!("custom_stage_{i}"), &mut used));
+            colors.push(metro_line_color(
+                &format!("custom_stage_{i}"),
+                &mut used,
+                &HashSet::new(),
+            ));
         }
         assert_eq!(colors.len(), 24);
     }


### PR DESCRIPTION
## Summary

Per-pipeline readability audit (#1 ampliseq): two GENERIC export problems,
fixed in the engine so every workflow benefits.

- **Two-line merged-section displays.** An SCC-merged section's display
  was a single joined line ("Read QC + dada2 + Analysis + its", 34 chars)
  that obscured reading in every consumer. Now: dominant stage on line
  one (what the section DOES), member module short-names on line two
  (`dada2` / `Read · Dada2 · Analysis · …`). The literal `\n` survives
  label sanitizing and wraps in nf-metro. Applies to the module tier and
  to the rule tier's merged subgraph titles alike.
- **Canonical-hue avoidance for custom lanes.** Custom lanes avoided
  other custom lanes but could sit next to a canonical hue (live:
  ampliseq custom `rename` yellow next to canonical `Reporting` yellow).
  New `EXTRA_NEAR_CANONICAL` const lists the extra hues in canonical
  orange/yellow/mustard families; the fallback walk skips them. The
  exhaustion fallback still never aborts (bgcflow guard).

## Test plan
- [x] core lib: 1415 passed (merged-title expectation updated, canonical-hue
  regression test added)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] Site corpus regenerated: 24/24 QA PASS; ampliseq before/after
  reviewed visually (merged title wraps to two lines; rename lane now
  blue, clearly separable)