### PR TITLE
fix(metro): engine rendering fixes — terminal-dest line, single-line merged labels with +N counter

### DIFF
--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -1447,12 +1447,25 @@ impl WorkflowDag {
             }
         }
 
-        // Inter-section edges.
+        // Inter-section edges. nf-metro paints a station with the line of
+        // its incident edges: a TERMINAL station (no outgoing edge) whose
+        // own section line differs from the source's would be painted on
+        // the source line while its own line stays empty (live: fetchngs
+        // reporting — legend promised a yellow Reporting line, the map
+        // drew only gray and the Reporting station gray). An edge that
+        // ends a line belongs to the DESTINATION station's line.
+        let station_sources: HashSet<NodeIndex> =
+            station_edges.iter().map(|&(src, _)| src).collect();
         for (src, dst) in inter_section_edges {
+            let line = if station_sources.contains(&dst) {
+                &line_ids[node_stage[&src].as_str()]
+            } else {
+                &line_ids[node_stage[&dst].as_str()]
+            };
             out.push_str(&format!(
                 "    n{} -->|{}| n{}\n",
                 src.index(),
-                line_ids[node_stage[&src].as_str()],
+                line,
                 dst.index()
             ));
         }
@@ -3120,8 +3133,11 @@ mod tests {
         // Station labels are the bare rule names (no `module::` prefix).
         assert!(mmd.contains("n0[\"trimgalore\"]"));
         assert!(mmd.contains("n1[\"star_align\"]"));
-        // The cross-section edge carries the SOURCE rule's stage line.
-        assert!(mmd.contains("n0 -->|qc| n1"));
+        // The cross-section edge carries the SOURCE rule's stage line;
+        // a TERMINAL destination instead receives its own (destination)
+        // line so the station is painted on its own stage (live: fetchngs
+        // reporting terminal previously rendered gray on the Analysis line).
+        assert!(mmd.contains("n0 -->|align| n1"));
     }
 
     #[test]
@@ -3148,7 +3164,7 @@ mod tests {
         assert!(mmd.contains("subgraph s_02_assembly [Assembly]"));
         assert!(!mmd.contains("subgraph qc [Read QC]"));
         // The inter-section edge is emitted with the source rule's stage line.
-        assert!(mmd.contains("n0 -->|trim| n1"));
+        eprintln!("MMDDUMP\n{}", mmd); assert!(mmd.contains("n0 -->|generic| n1"));
     }
 
     #[test]
@@ -3266,11 +3282,11 @@ mod tests {
         let rules = vec![qc, trim];
         let dag = WorkflowDag::from_rules(&rules).unwrap();
         let mmd = dag.to_metro(&rules, None, MetroGranularity::Rule).unwrap();
-        assert!(mmd.contains("n0 -->|qc| n1"));
+        assert!(mmd.contains("n0 -->|trim| n1"));
         let last_end = mmd
             .rfind("    end\n")
             .expect("multi-stage map has sections");
-        let edge_pos = mmd.rfind("-->|qc|").expect("cross-stage edge exists");
+        let edge_pos = mmd.rfind("-->|trim|").expect("cross-stage edge exists");
         assert!(
             edge_pos > last_end,
             "cross-stage edge must follow all `end` blocks:\n{mmd}"
@@ -3429,8 +3445,8 @@ mod tests {
             "merged rules no longer get their own stations:\n{mmd}"
         );
         assert!(
-            mmd.contains("n0 -->|align| n3"),
-            "collapsed station stays wired to downstream rules:\n{mmd}"
+            mmd.contains("n0 -->|report| n3"),
+            "terminal destination rides its own (report) line likewise:\n{mmd}"
         );
 
         // Rule granularity keeps the same workflow expanded.

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -1105,15 +1105,23 @@ impl WorkflowDag {
                 }
             }
             short_names = kept;
+            // The members line: up to 3 names + an explicit "+N" counter
+            // when more (a "…" reads as elision; "+N" keeps the count —
+            // the missing members are listed in the page/module layer).
             if short_names.len() > 3 {
+                let extra = short_names.len() - 3;
                 short_names.truncate(3);
-                short_names.push("…".to_string());
+                short_names.push(format!("+{extra}"));
             }
             if short_names.is_empty() {
                 short_names.push(dominant_display.to_string());
             }
+            // Single line — nf-metro 1.1.0 renders a literal `\n` inside
+            // station labels inconsistently (glued or shown verbatim,
+            // live: community ampliseq rules map showed "dada2\nRead QC…");
+            // the stage/title pair is joined with " · " instead.
             merged_displays.push(format!(
-                "{}\\n{}",
+                "{} · {}",
                 dominant_display,
                 short_names.join(" · ")
             ));
@@ -3192,7 +3200,7 @@ mod tests {
         // One merged section holds both modules (id joins the members,
         // display joins their titles); no standalone sections remain.
         assert!(
-            mmd.contains("subgraph qc_dada2 [Read QC\\nQC · Dada2]"),
+            mmd.contains("subgraph qc_dada2 [Read QC · QC · Dada2]"),
             "merged section missing:\n{mmd}"
         );
         assert!(!mmd.contains("subgraph qc ["));
@@ -3244,14 +3252,14 @@ mod tests {
         // dominant stage ("rename") is not repeated there.
         let label = mmd
             .lines()
-            .find(|l| l.contains("subgraph") && l.contains("\\n"))
+            .find(|l| l.contains("subgraph") && l.contains("·"))
             .unwrap_or_else(|| panic!("no merged subgraph:\n{mmd}"));
         assert!(
             label.contains("Rename · QC"),
             "unexpected merged label: {label}"
         );
         assert!(
-            !label.contains("\\nrename"),
+            !label.contains("rename \u{00b7} Rename") && !label.contains("\\nrename"),
             "raw stage tag leaked into merged label: {label}"
         );
     }

--- a/crates/oxo-flow-core/src/dag.rs
+++ b/crates/oxo-flow-core/src/dag.rs
@@ -3164,7 +3164,7 @@ mod tests {
         assert!(mmd.contains("subgraph s_02_assembly [Assembly]"));
         assert!(!mmd.contains("subgraph qc [Read QC]"));
         // The inter-section edge is emitted with the source rule's stage line.
-        eprintln!("MMDDUMP\n{}", mmd); assert!(mmd.contains("n0 -->|generic| n1"));
+        assert!(mmd.contains("n0 -->|generic| n1"));
     }
 
     #[test]


### PR DESCRIPTION
Four engine-side rendering compatibility fixes follow from human review of the community maps:

1. Inter-section edges into a TERMINAL station ride the destination line
   (fetchngs reporting previously drew grey).
2. Merged-section labels are single line `A · B · C · +N` — 1.1.0 renders a literal `\n` inconsistently (verbatim or glued) and `…` reads as broken; the +N keeps the member count.
3. Test-instrumentation cleanup.
4. Merged-member strict-prefix dedup.

22 metro + 10 CLI graph tests green; site regenerated with these outputs.