### PR TITLE
fix(bench): comparative harness actually runs all three engines (#67)

### DIFF
--- a/benches/comparative/README.md
+++ b/benches/comparative/README.md
@@ -1,7 +1,8 @@
 # Comparative Benchmarks (Phase 4)
 
 This directory contains pipeline definitions equivalent to the oxo-flow
-micro-benchmarks, written for Nextflow and Snakemake.
+macro-benchmarks, written for Nextflow and Snakemake, plus a runner that
+times all three engines on the same workload.
 
 ## Purpose
 
@@ -20,26 +21,74 @@ workflow engines on equivalent workloads.  The metrics of interest are:
 Requires: [Nextflow](https://www.nextflow.io/),
 [Snakemake](https://snakemake.readthedocs.io/),
 [hyperfine](https://github.com/sharkdp/hyperfine).
+Missing engines are skipped with a warning (oxo-flow binary and hyperfine
+are mandatory).
 
 ```bash
-# Run all comparisons
+# Run all comparisons (default N=100 steps)
 ./benches/comparative/run_comparison.sh
 
+# Custom chain length and oxo-flow binary
+./benches/comparative/run_comparison.sh 1000 target/release/oxo-flow
+
 # Individual runs
-# Generate a 100-rule workflow with:
-#   python3 -c "from benches.macro.suite import generate_hello; open('/tmp/wf.oxoflow', 'w').write(generate_hello(100))"
-# hyperfine -n "oxo-flow" "oxo-flow validate /tmp/wf.oxoflow"
-hyperfine -n "nextflow" "nextflow run hello.nf"
-hyperfine -n "snakemake" "snakemake --cores 1"
+python3 -c "from benches.macro.suite import generate_hello; open('/tmp/wf.oxoflow', 'w').write(generate_hello(100))"
+oxo-flow dry-run /tmp/wf.oxoflow
+cd benches/comparative/nextflow   && nextflow run hello.nf --count 100
+cd benches/comparative/snakemake  && snakemake --cores 1 --config count=100
 ```
 
 ## Pipeline Equivalence
 
-| Engine | File | Description |
-|---|---|---|
-| oxo-flow | `benches/macro/suite.py:generate_hello(N)` | N-rule chain |
-| Nextflow | `nextflow/hello.nf --count N` | N-process chain |
-| Snakemake | `snakemake/Snakefile` | N-rule chain (configurable via COUNT) |
+All three pipelines produce an identical DAG: a sequential dependency
+chain `step_0 -> step_1 -> ... -> step_{N-1}` where each step writes a
+one-line file derived from its index (`echo {i} > step_{i}_output.txt`).
 
-All three pipelines produce an identical DAG: sequential dependency chain
-where each step copies its input to an output file.
+| Engine | File | Depth control |
+|---|---|---|
+| oxo-flow | `benches/macro/suite.py:generate_hello(N)` | generated N `[[rules]]` |
+| Nextflow | `nextflow/hello.nf --count N` | 1000 static include aliases (see below) |
+| Snakemake | `snakemake/Snakefile --config count=N` | wildcard rule + input function (dynamic) |
+
+## Engine semantic differences (measured, 2026-09)
+
+The three engines do **not** express this chain with equal ease — this is a
+real, benchmarkable difference:
+
+- **oxo-flow / Snakemake**: dynamic chains of any depth via wildcards
+  (Snakemake: `rule step_i` with an input function; oxo-flow: generated
+  rules). No per-step definition cost.
+- **Nextflow (DSL2)**: *"A given process or workflow can only be called
+  once in a given workflow"* (docs.seqera.io/nextflow/dsl2). A serial
+  chain must reuse one process N times, so `hello.nf` pre-expands **1000
+  static include aliases** (`include { echo_step as step_i }`) plus 1000
+  one-line guards. `--count` beyond 1000 fails; the alias block dominates
+  the file (2041 lines vs. 34 for the Snakefile).
+- **Snakemake depth ceiling**: the DAG builder is recursive; chains
+  deeper than ~484 steps hit `RecursionError` on Python's default
+  recursionlimit (measured on Snakemake 9.19.0: 484 OK, 485 fails).
+  The runner skips snakemake above 484 and says so.
+
+## Measurement semantics
+
+`run_comparison.sh` times:
+
+- `oxo-flow dry-run` / `validate`: parse + DAG construction + simulated
+  execution (**no process spawn**)
+- `nextflow run` / `snakemake run`: **full real execution** of the echo
+  chain (spawns one `echo` process per step)
+
+Since each step is a microsecond-scale `echo`, wall time is dominated by
+each engine's scheduling overhead, which is the quantity of interest.
+Cross-engine comparisons are therefore *order-of-magnitude scheduling*
+comparisons, not identical-semantics timings; the JSON export
+(`results/macro_comparison.json`) preserves per-engine labels so the
+difference is always visible.
+
+## Reference numbers (bioinfo-wsx, 25.10.4 nextflow / 9.19.0 snakemake / oxo-flow 0.17.2, 2026-09-08)
+
+| N | oxo-flow dry-run | nextflow run | snakemake run |
+|---|---|---|---|
+| 10 | ~27 ms | ~6.6 s | ~1.04 s |
+| 100 | ~161 ms | ~8.1 s | ~1.09 s |
+| 1000 | ~1.27 s | ~25.7 s | skipped (> 484) |

--- a/benches/comparative/nextflow/echo_step.nf
+++ b/benches/comparative/nextflow/echo_step.nf
@@ -1,0 +1,14 @@
+process echo_step {
+    tag "step_${idx}"
+
+    input:
+    path input_file
+    val idx
+
+    output:
+    path "step_${idx}_output.txt"
+
+    """
+    echo "${idx}" > "step_${idx}_output.txt"
+    """
+}

--- a/benches/comparative/nextflow/hello.nf
+++ b/benches/comparative/nextflow/hello.nf
@@ -1,43 +1,2041 @@
 #!/usr/bin/env nextflow
-nextflow.enable.dsl=2
+// oxo-flow 对比基准 — Nextflow 等效管线
+//
+// 生成 count+1 个文件的串行依赖链（step_0 -> step_1 -> ... -> step_{N-1}），
+// 与 benches/macro/suite.py 的 generate_hello(N) 等效。
+//
+// 用法:
+//     nextflow run hello.nf                # 默认 count=10
+//     nextflow run hello.nf --count 100
+//
+// ── 引擎语义差异（DSL2 单调用限制）──────────────────────────────────
+// DSL2 规定: "A given process or workflow can only be called once in a
+// given workflow"（docs.seqera.io/nextflow/dsl2）。oxo-flow 与 Snakemake
+// 都能用通配符表达任意深度的动态链（Snakemake 用 input 函数 + 通配符，
+// 见同目录 Snakefile），而 Nextflow 的链式复用只能通过 include 别名
+// 静态展开 —— 每个额外步骤需要一行 include + 一行 if。
+// 本文件预展开 1000 个别名（与 macro 基准的 1000 规模上限一致）；
+// --count 超过 1000 时会因越界别名而失败，属已知边界。
+// nextflow run 前需要 echo_step.nf 与本文件同目录。
+// ────────────────────────────────────────────────────────────────────
 
-/*
- * oxo-flow 对比基准 — Nextflow 等效管线
- *
- * 与 benches/macro/suite.py 中 generate_hello(N) 生成的 oxo-flow
- * 管线在功能上等价：N 步顺序链，每步将输入拷贝到输出。
- *
- * 用法:
- *   nextflow run hello.nf --count 10
- */
+nextflow.enable.dsl = 2
 
-params.count = 10
 
-// 各步骤顺序执行，每步依赖上一步的输出
-process step {
-    tag "step_${task.index - 1}"
-
+process echo_step {
     input:
     path input_file
+    val idx
 
     output:
-    path "step_${task.index - 1}_output.txt"
+    path "step_${idx}_output.txt"
 
-    exec """
-    if [ -f "${input_file}" ]; then
-        cp "${input_file}" "step_${task.index - 1}_output.txt"
-    else
-        echo "${task.index - 1}" > "step_${task.index - 1}_output.txt"
-    fi
-    """
+    """ echo "${idx}" > "step_${idx}_output.txt" """
 }
 
-workflow {
-    // 第一个规则使用输入文件或创建初始文件
-    step( file("input.txt") )
+include { echo_step as step_0 } from './echo_step'
+include { echo_step as step_1 } from './echo_step'
+include { echo_step as step_2 } from './echo_step'
+include { echo_step as step_3 } from './echo_step'
+include { echo_step as step_4 } from './echo_step'
+include { echo_step as step_5 } from './echo_step'
+include { echo_step as step_6 } from './echo_step'
+include { echo_step as step_7 } from './echo_step'
+include { echo_step as step_8 } from './echo_step'
+include { echo_step as step_9 } from './echo_step'
+include { echo_step as step_10 } from './echo_step'
+include { echo_step as step_11 } from './echo_step'
+include { echo_step as step_12 } from './echo_step'
+include { echo_step as step_13 } from './echo_step'
+include { echo_step as step_14 } from './echo_step'
+include { echo_step as step_15 } from './echo_step'
+include { echo_step as step_16 } from './echo_step'
+include { echo_step as step_17 } from './echo_step'
+include { echo_step as step_18 } from './echo_step'
+include { echo_step as step_19 } from './echo_step'
+include { echo_step as step_20 } from './echo_step'
+include { echo_step as step_21 } from './echo_step'
+include { echo_step as step_22 } from './echo_step'
+include { echo_step as step_23 } from './echo_step'
+include { echo_step as step_24 } from './echo_step'
+include { echo_step as step_25 } from './echo_step'
+include { echo_step as step_26 } from './echo_step'
+include { echo_step as step_27 } from './echo_step'
+include { echo_step as step_28 } from './echo_step'
+include { echo_step as step_29 } from './echo_step'
+include { echo_step as step_30 } from './echo_step'
+include { echo_step as step_31 } from './echo_step'
+include { echo_step as step_32 } from './echo_step'
+include { echo_step as step_33 } from './echo_step'
+include { echo_step as step_34 } from './echo_step'
+include { echo_step as step_35 } from './echo_step'
+include { echo_step as step_36 } from './echo_step'
+include { echo_step as step_37 } from './echo_step'
+include { echo_step as step_38 } from './echo_step'
+include { echo_step as step_39 } from './echo_step'
+include { echo_step as step_40 } from './echo_step'
+include { echo_step as step_41 } from './echo_step'
+include { echo_step as step_42 } from './echo_step'
+include { echo_step as step_43 } from './echo_step'
+include { echo_step as step_44 } from './echo_step'
+include { echo_step as step_45 } from './echo_step'
+include { echo_step as step_46 } from './echo_step'
+include { echo_step as step_47 } from './echo_step'
+include { echo_step as step_48 } from './echo_step'
+include { echo_step as step_49 } from './echo_step'
+include { echo_step as step_50 } from './echo_step'
+include { echo_step as step_51 } from './echo_step'
+include { echo_step as step_52 } from './echo_step'
+include { echo_step as step_53 } from './echo_step'
+include { echo_step as step_54 } from './echo_step'
+include { echo_step as step_55 } from './echo_step'
+include { echo_step as step_56 } from './echo_step'
+include { echo_step as step_57 } from './echo_step'
+include { echo_step as step_58 } from './echo_step'
+include { echo_step as step_59 } from './echo_step'
+include { echo_step as step_60 } from './echo_step'
+include { echo_step as step_61 } from './echo_step'
+include { echo_step as step_62 } from './echo_step'
+include { echo_step as step_63 } from './echo_step'
+include { echo_step as step_64 } from './echo_step'
+include { echo_step as step_65 } from './echo_step'
+include { echo_step as step_66 } from './echo_step'
+include { echo_step as step_67 } from './echo_step'
+include { echo_step as step_68 } from './echo_step'
+include { echo_step as step_69 } from './echo_step'
+include { echo_step as step_70 } from './echo_step'
+include { echo_step as step_71 } from './echo_step'
+include { echo_step as step_72 } from './echo_step'
+include { echo_step as step_73 } from './echo_step'
+include { echo_step as step_74 } from './echo_step'
+include { echo_step as step_75 } from './echo_step'
+include { echo_step as step_76 } from './echo_step'
+include { echo_step as step_77 } from './echo_step'
+include { echo_step as step_78 } from './echo_step'
+include { echo_step as step_79 } from './echo_step'
+include { echo_step as step_80 } from './echo_step'
+include { echo_step as step_81 } from './echo_step'
+include { echo_step as step_82 } from './echo_step'
+include { echo_step as step_83 } from './echo_step'
+include { echo_step as step_84 } from './echo_step'
+include { echo_step as step_85 } from './echo_step'
+include { echo_step as step_86 } from './echo_step'
+include { echo_step as step_87 } from './echo_step'
+include { echo_step as step_88 } from './echo_step'
+include { echo_step as step_89 } from './echo_step'
+include { echo_step as step_90 } from './echo_step'
+include { echo_step as step_91 } from './echo_step'
+include { echo_step as step_92 } from './echo_step'
+include { echo_step as step_93 } from './echo_step'
+include { echo_step as step_94 } from './echo_step'
+include { echo_step as step_95 } from './echo_step'
+include { echo_step as step_96 } from './echo_step'
+include { echo_step as step_97 } from './echo_step'
+include { echo_step as step_98 } from './echo_step'
+include { echo_step as step_99 } from './echo_step'
+include { echo_step as step_100 } from './echo_step'
+include { echo_step as step_101 } from './echo_step'
+include { echo_step as step_102 } from './echo_step'
+include { echo_step as step_103 } from './echo_step'
+include { echo_step as step_104 } from './echo_step'
+include { echo_step as step_105 } from './echo_step'
+include { echo_step as step_106 } from './echo_step'
+include { echo_step as step_107 } from './echo_step'
+include { echo_step as step_108 } from './echo_step'
+include { echo_step as step_109 } from './echo_step'
+include { echo_step as step_110 } from './echo_step'
+include { echo_step as step_111 } from './echo_step'
+include { echo_step as step_112 } from './echo_step'
+include { echo_step as step_113 } from './echo_step'
+include { echo_step as step_114 } from './echo_step'
+include { echo_step as step_115 } from './echo_step'
+include { echo_step as step_116 } from './echo_step'
+include { echo_step as step_117 } from './echo_step'
+include { echo_step as step_118 } from './echo_step'
+include { echo_step as step_119 } from './echo_step'
+include { echo_step as step_120 } from './echo_step'
+include { echo_step as step_121 } from './echo_step'
+include { echo_step as step_122 } from './echo_step'
+include { echo_step as step_123 } from './echo_step'
+include { echo_step as step_124 } from './echo_step'
+include { echo_step as step_125 } from './echo_step'
+include { echo_step as step_126 } from './echo_step'
+include { echo_step as step_127 } from './echo_step'
+include { echo_step as step_128 } from './echo_step'
+include { echo_step as step_129 } from './echo_step'
+include { echo_step as step_130 } from './echo_step'
+include { echo_step as step_131 } from './echo_step'
+include { echo_step as step_132 } from './echo_step'
+include { echo_step as step_133 } from './echo_step'
+include { echo_step as step_134 } from './echo_step'
+include { echo_step as step_135 } from './echo_step'
+include { echo_step as step_136 } from './echo_step'
+include { echo_step as step_137 } from './echo_step'
+include { echo_step as step_138 } from './echo_step'
+include { echo_step as step_139 } from './echo_step'
+include { echo_step as step_140 } from './echo_step'
+include { echo_step as step_141 } from './echo_step'
+include { echo_step as step_142 } from './echo_step'
+include { echo_step as step_143 } from './echo_step'
+include { echo_step as step_144 } from './echo_step'
+include { echo_step as step_145 } from './echo_step'
+include { echo_step as step_146 } from './echo_step'
+include { echo_step as step_147 } from './echo_step'
+include { echo_step as step_148 } from './echo_step'
+include { echo_step as step_149 } from './echo_step'
+include { echo_step as step_150 } from './echo_step'
+include { echo_step as step_151 } from './echo_step'
+include { echo_step as step_152 } from './echo_step'
+include { echo_step as step_153 } from './echo_step'
+include { echo_step as step_154 } from './echo_step'
+include { echo_step as step_155 } from './echo_step'
+include { echo_step as step_156 } from './echo_step'
+include { echo_step as step_157 } from './echo_step'
+include { echo_step as step_158 } from './echo_step'
+include { echo_step as step_159 } from './echo_step'
+include { echo_step as step_160 } from './echo_step'
+include { echo_step as step_161 } from './echo_step'
+include { echo_step as step_162 } from './echo_step'
+include { echo_step as step_163 } from './echo_step'
+include { echo_step as step_164 } from './echo_step'
+include { echo_step as step_165 } from './echo_step'
+include { echo_step as step_166 } from './echo_step'
+include { echo_step as step_167 } from './echo_step'
+include { echo_step as step_168 } from './echo_step'
+include { echo_step as step_169 } from './echo_step'
+include { echo_step as step_170 } from './echo_step'
+include { echo_step as step_171 } from './echo_step'
+include { echo_step as step_172 } from './echo_step'
+include { echo_step as step_173 } from './echo_step'
+include { echo_step as step_174 } from './echo_step'
+include { echo_step as step_175 } from './echo_step'
+include { echo_step as step_176 } from './echo_step'
+include { echo_step as step_177 } from './echo_step'
+include { echo_step as step_178 } from './echo_step'
+include { echo_step as step_179 } from './echo_step'
+include { echo_step as step_180 } from './echo_step'
+include { echo_step as step_181 } from './echo_step'
+include { echo_step as step_182 } from './echo_step'
+include { echo_step as step_183 } from './echo_step'
+include { echo_step as step_184 } from './echo_step'
+include { echo_step as step_185 } from './echo_step'
+include { echo_step as step_186 } from './echo_step'
+include { echo_step as step_187 } from './echo_step'
+include { echo_step as step_188 } from './echo_step'
+include { echo_step as step_189 } from './echo_step'
+include { echo_step as step_190 } from './echo_step'
+include { echo_step as step_191 } from './echo_step'
+include { echo_step as step_192 } from './echo_step'
+include { echo_step as step_193 } from './echo_step'
+include { echo_step as step_194 } from './echo_step'
+include { echo_step as step_195 } from './echo_step'
+include { echo_step as step_196 } from './echo_step'
+include { echo_step as step_197 } from './echo_step'
+include { echo_step as step_198 } from './echo_step'
+include { echo_step as step_199 } from './echo_step'
+include { echo_step as step_200 } from './echo_step'
+include { echo_step as step_201 } from './echo_step'
+include { echo_step as step_202 } from './echo_step'
+include { echo_step as step_203 } from './echo_step'
+include { echo_step as step_204 } from './echo_step'
+include { echo_step as step_205 } from './echo_step'
+include { echo_step as step_206 } from './echo_step'
+include { echo_step as step_207 } from './echo_step'
+include { echo_step as step_208 } from './echo_step'
+include { echo_step as step_209 } from './echo_step'
+include { echo_step as step_210 } from './echo_step'
+include { echo_step as step_211 } from './echo_step'
+include { echo_step as step_212 } from './echo_step'
+include { echo_step as step_213 } from './echo_step'
+include { echo_step as step_214 } from './echo_step'
+include { echo_step as step_215 } from './echo_step'
+include { echo_step as step_216 } from './echo_step'
+include { echo_step as step_217 } from './echo_step'
+include { echo_step as step_218 } from './echo_step'
+include { echo_step as step_219 } from './echo_step'
+include { echo_step as step_220 } from './echo_step'
+include { echo_step as step_221 } from './echo_step'
+include { echo_step as step_222 } from './echo_step'
+include { echo_step as step_223 } from './echo_step'
+include { echo_step as step_224 } from './echo_step'
+include { echo_step as step_225 } from './echo_step'
+include { echo_step as step_226 } from './echo_step'
+include { echo_step as step_227 } from './echo_step'
+include { echo_step as step_228 } from './echo_step'
+include { echo_step as step_229 } from './echo_step'
+include { echo_step as step_230 } from './echo_step'
+include { echo_step as step_231 } from './echo_step'
+include { echo_step as step_232 } from './echo_step'
+include { echo_step as step_233 } from './echo_step'
+include { echo_step as step_234 } from './echo_step'
+include { echo_step as step_235 } from './echo_step'
+include { echo_step as step_236 } from './echo_step'
+include { echo_step as step_237 } from './echo_step'
+include { echo_step as step_238 } from './echo_step'
+include { echo_step as step_239 } from './echo_step'
+include { echo_step as step_240 } from './echo_step'
+include { echo_step as step_241 } from './echo_step'
+include { echo_step as step_242 } from './echo_step'
+include { echo_step as step_243 } from './echo_step'
+include { echo_step as step_244 } from './echo_step'
+include { echo_step as step_245 } from './echo_step'
+include { echo_step as step_246 } from './echo_step'
+include { echo_step as step_247 } from './echo_step'
+include { echo_step as step_248 } from './echo_step'
+include { echo_step as step_249 } from './echo_step'
+include { echo_step as step_250 } from './echo_step'
+include { echo_step as step_251 } from './echo_step'
+include { echo_step as step_252 } from './echo_step'
+include { echo_step as step_253 } from './echo_step'
+include { echo_step as step_254 } from './echo_step'
+include { echo_step as step_255 } from './echo_step'
+include { echo_step as step_256 } from './echo_step'
+include { echo_step as step_257 } from './echo_step'
+include { echo_step as step_258 } from './echo_step'
+include { echo_step as step_259 } from './echo_step'
+include { echo_step as step_260 } from './echo_step'
+include { echo_step as step_261 } from './echo_step'
+include { echo_step as step_262 } from './echo_step'
+include { echo_step as step_263 } from './echo_step'
+include { echo_step as step_264 } from './echo_step'
+include { echo_step as step_265 } from './echo_step'
+include { echo_step as step_266 } from './echo_step'
+include { echo_step as step_267 } from './echo_step'
+include { echo_step as step_268 } from './echo_step'
+include { echo_step as step_269 } from './echo_step'
+include { echo_step as step_270 } from './echo_step'
+include { echo_step as step_271 } from './echo_step'
+include { echo_step as step_272 } from './echo_step'
+include { echo_step as step_273 } from './echo_step'
+include { echo_step as step_274 } from './echo_step'
+include { echo_step as step_275 } from './echo_step'
+include { echo_step as step_276 } from './echo_step'
+include { echo_step as step_277 } from './echo_step'
+include { echo_step as step_278 } from './echo_step'
+include { echo_step as step_279 } from './echo_step'
+include { echo_step as step_280 } from './echo_step'
+include { echo_step as step_281 } from './echo_step'
+include { echo_step as step_282 } from './echo_step'
+include { echo_step as step_283 } from './echo_step'
+include { echo_step as step_284 } from './echo_step'
+include { echo_step as step_285 } from './echo_step'
+include { echo_step as step_286 } from './echo_step'
+include { echo_step as step_287 } from './echo_step'
+include { echo_step as step_288 } from './echo_step'
+include { echo_step as step_289 } from './echo_step'
+include { echo_step as step_290 } from './echo_step'
+include { echo_step as step_291 } from './echo_step'
+include { echo_step as step_292 } from './echo_step'
+include { echo_step as step_293 } from './echo_step'
+include { echo_step as step_294 } from './echo_step'
+include { echo_step as step_295 } from './echo_step'
+include { echo_step as step_296 } from './echo_step'
+include { echo_step as step_297 } from './echo_step'
+include { echo_step as step_298 } from './echo_step'
+include { echo_step as step_299 } from './echo_step'
+include { echo_step as step_300 } from './echo_step'
+include { echo_step as step_301 } from './echo_step'
+include { echo_step as step_302 } from './echo_step'
+include { echo_step as step_303 } from './echo_step'
+include { echo_step as step_304 } from './echo_step'
+include { echo_step as step_305 } from './echo_step'
+include { echo_step as step_306 } from './echo_step'
+include { echo_step as step_307 } from './echo_step'
+include { echo_step as step_308 } from './echo_step'
+include { echo_step as step_309 } from './echo_step'
+include { echo_step as step_310 } from './echo_step'
+include { echo_step as step_311 } from './echo_step'
+include { echo_step as step_312 } from './echo_step'
+include { echo_step as step_313 } from './echo_step'
+include { echo_step as step_314 } from './echo_step'
+include { echo_step as step_315 } from './echo_step'
+include { echo_step as step_316 } from './echo_step'
+include { echo_step as step_317 } from './echo_step'
+include { echo_step as step_318 } from './echo_step'
+include { echo_step as step_319 } from './echo_step'
+include { echo_step as step_320 } from './echo_step'
+include { echo_step as step_321 } from './echo_step'
+include { echo_step as step_322 } from './echo_step'
+include { echo_step as step_323 } from './echo_step'
+include { echo_step as step_324 } from './echo_step'
+include { echo_step as step_325 } from './echo_step'
+include { echo_step as step_326 } from './echo_step'
+include { echo_step as step_327 } from './echo_step'
+include { echo_step as step_328 } from './echo_step'
+include { echo_step as step_329 } from './echo_step'
+include { echo_step as step_330 } from './echo_step'
+include { echo_step as step_331 } from './echo_step'
+include { echo_step as step_332 } from './echo_step'
+include { echo_step as step_333 } from './echo_step'
+include { echo_step as step_334 } from './echo_step'
+include { echo_step as step_335 } from './echo_step'
+include { echo_step as step_336 } from './echo_step'
+include { echo_step as step_337 } from './echo_step'
+include { echo_step as step_338 } from './echo_step'
+include { echo_step as step_339 } from './echo_step'
+include { echo_step as step_340 } from './echo_step'
+include { echo_step as step_341 } from './echo_step'
+include { echo_step as step_342 } from './echo_step'
+include { echo_step as step_343 } from './echo_step'
+include { echo_step as step_344 } from './echo_step'
+include { echo_step as step_345 } from './echo_step'
+include { echo_step as step_346 } from './echo_step'
+include { echo_step as step_347 } from './echo_step'
+include { echo_step as step_348 } from './echo_step'
+include { echo_step as step_349 } from './echo_step'
+include { echo_step as step_350 } from './echo_step'
+include { echo_step as step_351 } from './echo_step'
+include { echo_step as step_352 } from './echo_step'
+include { echo_step as step_353 } from './echo_step'
+include { echo_step as step_354 } from './echo_step'
+include { echo_step as step_355 } from './echo_step'
+include { echo_step as step_356 } from './echo_step'
+include { echo_step as step_357 } from './echo_step'
+include { echo_step as step_358 } from './echo_step'
+include { echo_step as step_359 } from './echo_step'
+include { echo_step as step_360 } from './echo_step'
+include { echo_step as step_361 } from './echo_step'
+include { echo_step as step_362 } from './echo_step'
+include { echo_step as step_363 } from './echo_step'
+include { echo_step as step_364 } from './echo_step'
+include { echo_step as step_365 } from './echo_step'
+include { echo_step as step_366 } from './echo_step'
+include { echo_step as step_367 } from './echo_step'
+include { echo_step as step_368 } from './echo_step'
+include { echo_step as step_369 } from './echo_step'
+include { echo_step as step_370 } from './echo_step'
+include { echo_step as step_371 } from './echo_step'
+include { echo_step as step_372 } from './echo_step'
+include { echo_step as step_373 } from './echo_step'
+include { echo_step as step_374 } from './echo_step'
+include { echo_step as step_375 } from './echo_step'
+include { echo_step as step_376 } from './echo_step'
+include { echo_step as step_377 } from './echo_step'
+include { echo_step as step_378 } from './echo_step'
+include { echo_step as step_379 } from './echo_step'
+include { echo_step as step_380 } from './echo_step'
+include { echo_step as step_381 } from './echo_step'
+include { echo_step as step_382 } from './echo_step'
+include { echo_step as step_383 } from './echo_step'
+include { echo_step as step_384 } from './echo_step'
+include { echo_step as step_385 } from './echo_step'
+include { echo_step as step_386 } from './echo_step'
+include { echo_step as step_387 } from './echo_step'
+include { echo_step as step_388 } from './echo_step'
+include { echo_step as step_389 } from './echo_step'
+include { echo_step as step_390 } from './echo_step'
+include { echo_step as step_391 } from './echo_step'
+include { echo_step as step_392 } from './echo_step'
+include { echo_step as step_393 } from './echo_step'
+include { echo_step as step_394 } from './echo_step'
+include { echo_step as step_395 } from './echo_step'
+include { echo_step as step_396 } from './echo_step'
+include { echo_step as step_397 } from './echo_step'
+include { echo_step as step_398 } from './echo_step'
+include { echo_step as step_399 } from './echo_step'
+include { echo_step as step_400 } from './echo_step'
+include { echo_step as step_401 } from './echo_step'
+include { echo_step as step_402 } from './echo_step'
+include { echo_step as step_403 } from './echo_step'
+include { echo_step as step_404 } from './echo_step'
+include { echo_step as step_405 } from './echo_step'
+include { echo_step as step_406 } from './echo_step'
+include { echo_step as step_407 } from './echo_step'
+include { echo_step as step_408 } from './echo_step'
+include { echo_step as step_409 } from './echo_step'
+include { echo_step as step_410 } from './echo_step'
+include { echo_step as step_411 } from './echo_step'
+include { echo_step as step_412 } from './echo_step'
+include { echo_step as step_413 } from './echo_step'
+include { echo_step as step_414 } from './echo_step'
+include { echo_step as step_415 } from './echo_step'
+include { echo_step as step_416 } from './echo_step'
+include { echo_step as step_417 } from './echo_step'
+include { echo_step as step_418 } from './echo_step'
+include { echo_step as step_419 } from './echo_step'
+include { echo_step as step_420 } from './echo_step'
+include { echo_step as step_421 } from './echo_step'
+include { echo_step as step_422 } from './echo_step'
+include { echo_step as step_423 } from './echo_step'
+include { echo_step as step_424 } from './echo_step'
+include { echo_step as step_425 } from './echo_step'
+include { echo_step as step_426 } from './echo_step'
+include { echo_step as step_427 } from './echo_step'
+include { echo_step as step_428 } from './echo_step'
+include { echo_step as step_429 } from './echo_step'
+include { echo_step as step_430 } from './echo_step'
+include { echo_step as step_431 } from './echo_step'
+include { echo_step as step_432 } from './echo_step'
+include { echo_step as step_433 } from './echo_step'
+include { echo_step as step_434 } from './echo_step'
+include { echo_step as step_435 } from './echo_step'
+include { echo_step as step_436 } from './echo_step'
+include { echo_step as step_437 } from './echo_step'
+include { echo_step as step_438 } from './echo_step'
+include { echo_step as step_439 } from './echo_step'
+include { echo_step as step_440 } from './echo_step'
+include { echo_step as step_441 } from './echo_step'
+include { echo_step as step_442 } from './echo_step'
+include { echo_step as step_443 } from './echo_step'
+include { echo_step as step_444 } from './echo_step'
+include { echo_step as step_445 } from './echo_step'
+include { echo_step as step_446 } from './echo_step'
+include { echo_step as step_447 } from './echo_step'
+include { echo_step as step_448 } from './echo_step'
+include { echo_step as step_449 } from './echo_step'
+include { echo_step as step_450 } from './echo_step'
+include { echo_step as step_451 } from './echo_step'
+include { echo_step as step_452 } from './echo_step'
+include { echo_step as step_453 } from './echo_step'
+include { echo_step as step_454 } from './echo_step'
+include { echo_step as step_455 } from './echo_step'
+include { echo_step as step_456 } from './echo_step'
+include { echo_step as step_457 } from './echo_step'
+include { echo_step as step_458 } from './echo_step'
+include { echo_step as step_459 } from './echo_step'
+include { echo_step as step_460 } from './echo_step'
+include { echo_step as step_461 } from './echo_step'
+include { echo_step as step_462 } from './echo_step'
+include { echo_step as step_463 } from './echo_step'
+include { echo_step as step_464 } from './echo_step'
+include { echo_step as step_465 } from './echo_step'
+include { echo_step as step_466 } from './echo_step'
+include { echo_step as step_467 } from './echo_step'
+include { echo_step as step_468 } from './echo_step'
+include { echo_step as step_469 } from './echo_step'
+include { echo_step as step_470 } from './echo_step'
+include { echo_step as step_471 } from './echo_step'
+include { echo_step as step_472 } from './echo_step'
+include { echo_step as step_473 } from './echo_step'
+include { echo_step as step_474 } from './echo_step'
+include { echo_step as step_475 } from './echo_step'
+include { echo_step as step_476 } from './echo_step'
+include { echo_step as step_477 } from './echo_step'
+include { echo_step as step_478 } from './echo_step'
+include { echo_step as step_479 } from './echo_step'
+include { echo_step as step_480 } from './echo_step'
+include { echo_step as step_481 } from './echo_step'
+include { echo_step as step_482 } from './echo_step'
+include { echo_step as step_483 } from './echo_step'
+include { echo_step as step_484 } from './echo_step'
+include { echo_step as step_485 } from './echo_step'
+include { echo_step as step_486 } from './echo_step'
+include { echo_step as step_487 } from './echo_step'
+include { echo_step as step_488 } from './echo_step'
+include { echo_step as step_489 } from './echo_step'
+include { echo_step as step_490 } from './echo_step'
+include { echo_step as step_491 } from './echo_step'
+include { echo_step as step_492 } from './echo_step'
+include { echo_step as step_493 } from './echo_step'
+include { echo_step as step_494 } from './echo_step'
+include { echo_step as step_495 } from './echo_step'
+include { echo_step as step_496 } from './echo_step'
+include { echo_step as step_497 } from './echo_step'
+include { echo_step as step_498 } from './echo_step'
+include { echo_step as step_499 } from './echo_step'
+include { echo_step as step_500 } from './echo_step'
+include { echo_step as step_501 } from './echo_step'
+include { echo_step as step_502 } from './echo_step'
+include { echo_step as step_503 } from './echo_step'
+include { echo_step as step_504 } from './echo_step'
+include { echo_step as step_505 } from './echo_step'
+include { echo_step as step_506 } from './echo_step'
+include { echo_step as step_507 } from './echo_step'
+include { echo_step as step_508 } from './echo_step'
+include { echo_step as step_509 } from './echo_step'
+include { echo_step as step_510 } from './echo_step'
+include { echo_step as step_511 } from './echo_step'
+include { echo_step as step_512 } from './echo_step'
+include { echo_step as step_513 } from './echo_step'
+include { echo_step as step_514 } from './echo_step'
+include { echo_step as step_515 } from './echo_step'
+include { echo_step as step_516 } from './echo_step'
+include { echo_step as step_517 } from './echo_step'
+include { echo_step as step_518 } from './echo_step'
+include { echo_step as step_519 } from './echo_step'
+include { echo_step as step_520 } from './echo_step'
+include { echo_step as step_521 } from './echo_step'
+include { echo_step as step_522 } from './echo_step'
+include { echo_step as step_523 } from './echo_step'
+include { echo_step as step_524 } from './echo_step'
+include { echo_step as step_525 } from './echo_step'
+include { echo_step as step_526 } from './echo_step'
+include { echo_step as step_527 } from './echo_step'
+include { echo_step as step_528 } from './echo_step'
+include { echo_step as step_529 } from './echo_step'
+include { echo_step as step_530 } from './echo_step'
+include { echo_step as step_531 } from './echo_step'
+include { echo_step as step_532 } from './echo_step'
+include { echo_step as step_533 } from './echo_step'
+include { echo_step as step_534 } from './echo_step'
+include { echo_step as step_535 } from './echo_step'
+include { echo_step as step_536 } from './echo_step'
+include { echo_step as step_537 } from './echo_step'
+include { echo_step as step_538 } from './echo_step'
+include { echo_step as step_539 } from './echo_step'
+include { echo_step as step_540 } from './echo_step'
+include { echo_step as step_541 } from './echo_step'
+include { echo_step as step_542 } from './echo_step'
+include { echo_step as step_543 } from './echo_step'
+include { echo_step as step_544 } from './echo_step'
+include { echo_step as step_545 } from './echo_step'
+include { echo_step as step_546 } from './echo_step'
+include { echo_step as step_547 } from './echo_step'
+include { echo_step as step_548 } from './echo_step'
+include { echo_step as step_549 } from './echo_step'
+include { echo_step as step_550 } from './echo_step'
+include { echo_step as step_551 } from './echo_step'
+include { echo_step as step_552 } from './echo_step'
+include { echo_step as step_553 } from './echo_step'
+include { echo_step as step_554 } from './echo_step'
+include { echo_step as step_555 } from './echo_step'
+include { echo_step as step_556 } from './echo_step'
+include { echo_step as step_557 } from './echo_step'
+include { echo_step as step_558 } from './echo_step'
+include { echo_step as step_559 } from './echo_step'
+include { echo_step as step_560 } from './echo_step'
+include { echo_step as step_561 } from './echo_step'
+include { echo_step as step_562 } from './echo_step'
+include { echo_step as step_563 } from './echo_step'
+include { echo_step as step_564 } from './echo_step'
+include { echo_step as step_565 } from './echo_step'
+include { echo_step as step_566 } from './echo_step'
+include { echo_step as step_567 } from './echo_step'
+include { echo_step as step_568 } from './echo_step'
+include { echo_step as step_569 } from './echo_step'
+include { echo_step as step_570 } from './echo_step'
+include { echo_step as step_571 } from './echo_step'
+include { echo_step as step_572 } from './echo_step'
+include { echo_step as step_573 } from './echo_step'
+include { echo_step as step_574 } from './echo_step'
+include { echo_step as step_575 } from './echo_step'
+include { echo_step as step_576 } from './echo_step'
+include { echo_step as step_577 } from './echo_step'
+include { echo_step as step_578 } from './echo_step'
+include { echo_step as step_579 } from './echo_step'
+include { echo_step as step_580 } from './echo_step'
+include { echo_step as step_581 } from './echo_step'
+include { echo_step as step_582 } from './echo_step'
+include { echo_step as step_583 } from './echo_step'
+include { echo_step as step_584 } from './echo_step'
+include { echo_step as step_585 } from './echo_step'
+include { echo_step as step_586 } from './echo_step'
+include { echo_step as step_587 } from './echo_step'
+include { echo_step as step_588 } from './echo_step'
+include { echo_step as step_589 } from './echo_step'
+include { echo_step as step_590 } from './echo_step'
+include { echo_step as step_591 } from './echo_step'
+include { echo_step as step_592 } from './echo_step'
+include { echo_step as step_593 } from './echo_step'
+include { echo_step as step_594 } from './echo_step'
+include { echo_step as step_595 } from './echo_step'
+include { echo_step as step_596 } from './echo_step'
+include { echo_step as step_597 } from './echo_step'
+include { echo_step as step_598 } from './echo_step'
+include { echo_step as step_599 } from './echo_step'
+include { echo_step as step_600 } from './echo_step'
+include { echo_step as step_601 } from './echo_step'
+include { echo_step as step_602 } from './echo_step'
+include { echo_step as step_603 } from './echo_step'
+include { echo_step as step_604 } from './echo_step'
+include { echo_step as step_605 } from './echo_step'
+include { echo_step as step_606 } from './echo_step'
+include { echo_step as step_607 } from './echo_step'
+include { echo_step as step_608 } from './echo_step'
+include { echo_step as step_609 } from './echo_step'
+include { echo_step as step_610 } from './echo_step'
+include { echo_step as step_611 } from './echo_step'
+include { echo_step as step_612 } from './echo_step'
+include { echo_step as step_613 } from './echo_step'
+include { echo_step as step_614 } from './echo_step'
+include { echo_step as step_615 } from './echo_step'
+include { echo_step as step_616 } from './echo_step'
+include { echo_step as step_617 } from './echo_step'
+include { echo_step as step_618 } from './echo_step'
+include { echo_step as step_619 } from './echo_step'
+include { echo_step as step_620 } from './echo_step'
+include { echo_step as step_621 } from './echo_step'
+include { echo_step as step_622 } from './echo_step'
+include { echo_step as step_623 } from './echo_step'
+include { echo_step as step_624 } from './echo_step'
+include { echo_step as step_625 } from './echo_step'
+include { echo_step as step_626 } from './echo_step'
+include { echo_step as step_627 } from './echo_step'
+include { echo_step as step_628 } from './echo_step'
+include { echo_step as step_629 } from './echo_step'
+include { echo_step as step_630 } from './echo_step'
+include { echo_step as step_631 } from './echo_step'
+include { echo_step as step_632 } from './echo_step'
+include { echo_step as step_633 } from './echo_step'
+include { echo_step as step_634 } from './echo_step'
+include { echo_step as step_635 } from './echo_step'
+include { echo_step as step_636 } from './echo_step'
+include { echo_step as step_637 } from './echo_step'
+include { echo_step as step_638 } from './echo_step'
+include { echo_step as step_639 } from './echo_step'
+include { echo_step as step_640 } from './echo_step'
+include { echo_step as step_641 } from './echo_step'
+include { echo_step as step_642 } from './echo_step'
+include { echo_step as step_643 } from './echo_step'
+include { echo_step as step_644 } from './echo_step'
+include { echo_step as step_645 } from './echo_step'
+include { echo_step as step_646 } from './echo_step'
+include { echo_step as step_647 } from './echo_step'
+include { echo_step as step_648 } from './echo_step'
+include { echo_step as step_649 } from './echo_step'
+include { echo_step as step_650 } from './echo_step'
+include { echo_step as step_651 } from './echo_step'
+include { echo_step as step_652 } from './echo_step'
+include { echo_step as step_653 } from './echo_step'
+include { echo_step as step_654 } from './echo_step'
+include { echo_step as step_655 } from './echo_step'
+include { echo_step as step_656 } from './echo_step'
+include { echo_step as step_657 } from './echo_step'
+include { echo_step as step_658 } from './echo_step'
+include { echo_step as step_659 } from './echo_step'
+include { echo_step as step_660 } from './echo_step'
+include { echo_step as step_661 } from './echo_step'
+include { echo_step as step_662 } from './echo_step'
+include { echo_step as step_663 } from './echo_step'
+include { echo_step as step_664 } from './echo_step'
+include { echo_step as step_665 } from './echo_step'
+include { echo_step as step_666 } from './echo_step'
+include { echo_step as step_667 } from './echo_step'
+include { echo_step as step_668 } from './echo_step'
+include { echo_step as step_669 } from './echo_step'
+include { echo_step as step_670 } from './echo_step'
+include { echo_step as step_671 } from './echo_step'
+include { echo_step as step_672 } from './echo_step'
+include { echo_step as step_673 } from './echo_step'
+include { echo_step as step_674 } from './echo_step'
+include { echo_step as step_675 } from './echo_step'
+include { echo_step as step_676 } from './echo_step'
+include { echo_step as step_677 } from './echo_step'
+include { echo_step as step_678 } from './echo_step'
+include { echo_step as step_679 } from './echo_step'
+include { echo_step as step_680 } from './echo_step'
+include { echo_step as step_681 } from './echo_step'
+include { echo_step as step_682 } from './echo_step'
+include { echo_step as step_683 } from './echo_step'
+include { echo_step as step_684 } from './echo_step'
+include { echo_step as step_685 } from './echo_step'
+include { echo_step as step_686 } from './echo_step'
+include { echo_step as step_687 } from './echo_step'
+include { echo_step as step_688 } from './echo_step'
+include { echo_step as step_689 } from './echo_step'
+include { echo_step as step_690 } from './echo_step'
+include { echo_step as step_691 } from './echo_step'
+include { echo_step as step_692 } from './echo_step'
+include { echo_step as step_693 } from './echo_step'
+include { echo_step as step_694 } from './echo_step'
+include { echo_step as step_695 } from './echo_step'
+include { echo_step as step_696 } from './echo_step'
+include { echo_step as step_697 } from './echo_step'
+include { echo_step as step_698 } from './echo_step'
+include { echo_step as step_699 } from './echo_step'
+include { echo_step as step_700 } from './echo_step'
+include { echo_step as step_701 } from './echo_step'
+include { echo_step as step_702 } from './echo_step'
+include { echo_step as step_703 } from './echo_step'
+include { echo_step as step_704 } from './echo_step'
+include { echo_step as step_705 } from './echo_step'
+include { echo_step as step_706 } from './echo_step'
+include { echo_step as step_707 } from './echo_step'
+include { echo_step as step_708 } from './echo_step'
+include { echo_step as step_709 } from './echo_step'
+include { echo_step as step_710 } from './echo_step'
+include { echo_step as step_711 } from './echo_step'
+include { echo_step as step_712 } from './echo_step'
+include { echo_step as step_713 } from './echo_step'
+include { echo_step as step_714 } from './echo_step'
+include { echo_step as step_715 } from './echo_step'
+include { echo_step as step_716 } from './echo_step'
+include { echo_step as step_717 } from './echo_step'
+include { echo_step as step_718 } from './echo_step'
+include { echo_step as step_719 } from './echo_step'
+include { echo_step as step_720 } from './echo_step'
+include { echo_step as step_721 } from './echo_step'
+include { echo_step as step_722 } from './echo_step'
+include { echo_step as step_723 } from './echo_step'
+include { echo_step as step_724 } from './echo_step'
+include { echo_step as step_725 } from './echo_step'
+include { echo_step as step_726 } from './echo_step'
+include { echo_step as step_727 } from './echo_step'
+include { echo_step as step_728 } from './echo_step'
+include { echo_step as step_729 } from './echo_step'
+include { echo_step as step_730 } from './echo_step'
+include { echo_step as step_731 } from './echo_step'
+include { echo_step as step_732 } from './echo_step'
+include { echo_step as step_733 } from './echo_step'
+include { echo_step as step_734 } from './echo_step'
+include { echo_step as step_735 } from './echo_step'
+include { echo_step as step_736 } from './echo_step'
+include { echo_step as step_737 } from './echo_step'
+include { echo_step as step_738 } from './echo_step'
+include { echo_step as step_739 } from './echo_step'
+include { echo_step as step_740 } from './echo_step'
+include { echo_step as step_741 } from './echo_step'
+include { echo_step as step_742 } from './echo_step'
+include { echo_step as step_743 } from './echo_step'
+include { echo_step as step_744 } from './echo_step'
+include { echo_step as step_745 } from './echo_step'
+include { echo_step as step_746 } from './echo_step'
+include { echo_step as step_747 } from './echo_step'
+include { echo_step as step_748 } from './echo_step'
+include { echo_step as step_749 } from './echo_step'
+include { echo_step as step_750 } from './echo_step'
+include { echo_step as step_751 } from './echo_step'
+include { echo_step as step_752 } from './echo_step'
+include { echo_step as step_753 } from './echo_step'
+include { echo_step as step_754 } from './echo_step'
+include { echo_step as step_755 } from './echo_step'
+include { echo_step as step_756 } from './echo_step'
+include { echo_step as step_757 } from './echo_step'
+include { echo_step as step_758 } from './echo_step'
+include { echo_step as step_759 } from './echo_step'
+include { echo_step as step_760 } from './echo_step'
+include { echo_step as step_761 } from './echo_step'
+include { echo_step as step_762 } from './echo_step'
+include { echo_step as step_763 } from './echo_step'
+include { echo_step as step_764 } from './echo_step'
+include { echo_step as step_765 } from './echo_step'
+include { echo_step as step_766 } from './echo_step'
+include { echo_step as step_767 } from './echo_step'
+include { echo_step as step_768 } from './echo_step'
+include { echo_step as step_769 } from './echo_step'
+include { echo_step as step_770 } from './echo_step'
+include { echo_step as step_771 } from './echo_step'
+include { echo_step as step_772 } from './echo_step'
+include { echo_step as step_773 } from './echo_step'
+include { echo_step as step_774 } from './echo_step'
+include { echo_step as step_775 } from './echo_step'
+include { echo_step as step_776 } from './echo_step'
+include { echo_step as step_777 } from './echo_step'
+include { echo_step as step_778 } from './echo_step'
+include { echo_step as step_779 } from './echo_step'
+include { echo_step as step_780 } from './echo_step'
+include { echo_step as step_781 } from './echo_step'
+include { echo_step as step_782 } from './echo_step'
+include { echo_step as step_783 } from './echo_step'
+include { echo_step as step_784 } from './echo_step'
+include { echo_step as step_785 } from './echo_step'
+include { echo_step as step_786 } from './echo_step'
+include { echo_step as step_787 } from './echo_step'
+include { echo_step as step_788 } from './echo_step'
+include { echo_step as step_789 } from './echo_step'
+include { echo_step as step_790 } from './echo_step'
+include { echo_step as step_791 } from './echo_step'
+include { echo_step as step_792 } from './echo_step'
+include { echo_step as step_793 } from './echo_step'
+include { echo_step as step_794 } from './echo_step'
+include { echo_step as step_795 } from './echo_step'
+include { echo_step as step_796 } from './echo_step'
+include { echo_step as step_797 } from './echo_step'
+include { echo_step as step_798 } from './echo_step'
+include { echo_step as step_799 } from './echo_step'
+include { echo_step as step_800 } from './echo_step'
+include { echo_step as step_801 } from './echo_step'
+include { echo_step as step_802 } from './echo_step'
+include { echo_step as step_803 } from './echo_step'
+include { echo_step as step_804 } from './echo_step'
+include { echo_step as step_805 } from './echo_step'
+include { echo_step as step_806 } from './echo_step'
+include { echo_step as step_807 } from './echo_step'
+include { echo_step as step_808 } from './echo_step'
+include { echo_step as step_809 } from './echo_step'
+include { echo_step as step_810 } from './echo_step'
+include { echo_step as step_811 } from './echo_step'
+include { echo_step as step_812 } from './echo_step'
+include { echo_step as step_813 } from './echo_step'
+include { echo_step as step_814 } from './echo_step'
+include { echo_step as step_815 } from './echo_step'
+include { echo_step as step_816 } from './echo_step'
+include { echo_step as step_817 } from './echo_step'
+include { echo_step as step_818 } from './echo_step'
+include { echo_step as step_819 } from './echo_step'
+include { echo_step as step_820 } from './echo_step'
+include { echo_step as step_821 } from './echo_step'
+include { echo_step as step_822 } from './echo_step'
+include { echo_step as step_823 } from './echo_step'
+include { echo_step as step_824 } from './echo_step'
+include { echo_step as step_825 } from './echo_step'
+include { echo_step as step_826 } from './echo_step'
+include { echo_step as step_827 } from './echo_step'
+include { echo_step as step_828 } from './echo_step'
+include { echo_step as step_829 } from './echo_step'
+include { echo_step as step_830 } from './echo_step'
+include { echo_step as step_831 } from './echo_step'
+include { echo_step as step_832 } from './echo_step'
+include { echo_step as step_833 } from './echo_step'
+include { echo_step as step_834 } from './echo_step'
+include { echo_step as step_835 } from './echo_step'
+include { echo_step as step_836 } from './echo_step'
+include { echo_step as step_837 } from './echo_step'
+include { echo_step as step_838 } from './echo_step'
+include { echo_step as step_839 } from './echo_step'
+include { echo_step as step_840 } from './echo_step'
+include { echo_step as step_841 } from './echo_step'
+include { echo_step as step_842 } from './echo_step'
+include { echo_step as step_843 } from './echo_step'
+include { echo_step as step_844 } from './echo_step'
+include { echo_step as step_845 } from './echo_step'
+include { echo_step as step_846 } from './echo_step'
+include { echo_step as step_847 } from './echo_step'
+include { echo_step as step_848 } from './echo_step'
+include { echo_step as step_849 } from './echo_step'
+include { echo_step as step_850 } from './echo_step'
+include { echo_step as step_851 } from './echo_step'
+include { echo_step as step_852 } from './echo_step'
+include { echo_step as step_853 } from './echo_step'
+include { echo_step as step_854 } from './echo_step'
+include { echo_step as step_855 } from './echo_step'
+include { echo_step as step_856 } from './echo_step'
+include { echo_step as step_857 } from './echo_step'
+include { echo_step as step_858 } from './echo_step'
+include { echo_step as step_859 } from './echo_step'
+include { echo_step as step_860 } from './echo_step'
+include { echo_step as step_861 } from './echo_step'
+include { echo_step as step_862 } from './echo_step'
+include { echo_step as step_863 } from './echo_step'
+include { echo_step as step_864 } from './echo_step'
+include { echo_step as step_865 } from './echo_step'
+include { echo_step as step_866 } from './echo_step'
+include { echo_step as step_867 } from './echo_step'
+include { echo_step as step_868 } from './echo_step'
+include { echo_step as step_869 } from './echo_step'
+include { echo_step as step_870 } from './echo_step'
+include { echo_step as step_871 } from './echo_step'
+include { echo_step as step_872 } from './echo_step'
+include { echo_step as step_873 } from './echo_step'
+include { echo_step as step_874 } from './echo_step'
+include { echo_step as step_875 } from './echo_step'
+include { echo_step as step_876 } from './echo_step'
+include { echo_step as step_877 } from './echo_step'
+include { echo_step as step_878 } from './echo_step'
+include { echo_step as step_879 } from './echo_step'
+include { echo_step as step_880 } from './echo_step'
+include { echo_step as step_881 } from './echo_step'
+include { echo_step as step_882 } from './echo_step'
+include { echo_step as step_883 } from './echo_step'
+include { echo_step as step_884 } from './echo_step'
+include { echo_step as step_885 } from './echo_step'
+include { echo_step as step_886 } from './echo_step'
+include { echo_step as step_887 } from './echo_step'
+include { echo_step as step_888 } from './echo_step'
+include { echo_step as step_889 } from './echo_step'
+include { echo_step as step_890 } from './echo_step'
+include { echo_step as step_891 } from './echo_step'
+include { echo_step as step_892 } from './echo_step'
+include { echo_step as step_893 } from './echo_step'
+include { echo_step as step_894 } from './echo_step'
+include { echo_step as step_895 } from './echo_step'
+include { echo_step as step_896 } from './echo_step'
+include { echo_step as step_897 } from './echo_step'
+include { echo_step as step_898 } from './echo_step'
+include { echo_step as step_899 } from './echo_step'
+include { echo_step as step_900 } from './echo_step'
+include { echo_step as step_901 } from './echo_step'
+include { echo_step as step_902 } from './echo_step'
+include { echo_step as step_903 } from './echo_step'
+include { echo_step as step_904 } from './echo_step'
+include { echo_step as step_905 } from './echo_step'
+include { echo_step as step_906 } from './echo_step'
+include { echo_step as step_907 } from './echo_step'
+include { echo_step as step_908 } from './echo_step'
+include { echo_step as step_909 } from './echo_step'
+include { echo_step as step_910 } from './echo_step'
+include { echo_step as step_911 } from './echo_step'
+include { echo_step as step_912 } from './echo_step'
+include { echo_step as step_913 } from './echo_step'
+include { echo_step as step_914 } from './echo_step'
+include { echo_step as step_915 } from './echo_step'
+include { echo_step as step_916 } from './echo_step'
+include { echo_step as step_917 } from './echo_step'
+include { echo_step as step_918 } from './echo_step'
+include { echo_step as step_919 } from './echo_step'
+include { echo_step as step_920 } from './echo_step'
+include { echo_step as step_921 } from './echo_step'
+include { echo_step as step_922 } from './echo_step'
+include { echo_step as step_923 } from './echo_step'
+include { echo_step as step_924 } from './echo_step'
+include { echo_step as step_925 } from './echo_step'
+include { echo_step as step_926 } from './echo_step'
+include { echo_step as step_927 } from './echo_step'
+include { echo_step as step_928 } from './echo_step'
+include { echo_step as step_929 } from './echo_step'
+include { echo_step as step_930 } from './echo_step'
+include { echo_step as step_931 } from './echo_step'
+include { echo_step as step_932 } from './echo_step'
+include { echo_step as step_933 } from './echo_step'
+include { echo_step as step_934 } from './echo_step'
+include { echo_step as step_935 } from './echo_step'
+include { echo_step as step_936 } from './echo_step'
+include { echo_step as step_937 } from './echo_step'
+include { echo_step as step_938 } from './echo_step'
+include { echo_step as step_939 } from './echo_step'
+include { echo_step as step_940 } from './echo_step'
+include { echo_step as step_941 } from './echo_step'
+include { echo_step as step_942 } from './echo_step'
+include { echo_step as step_943 } from './echo_step'
+include { echo_step as step_944 } from './echo_step'
+include { echo_step as step_945 } from './echo_step'
+include { echo_step as step_946 } from './echo_step'
+include { echo_step as step_947 } from './echo_step'
+include { echo_step as step_948 } from './echo_step'
+include { echo_step as step_949 } from './echo_step'
+include { echo_step as step_950 } from './echo_step'
+include { echo_step as step_951 } from './echo_step'
+include { echo_step as step_952 } from './echo_step'
+include { echo_step as step_953 } from './echo_step'
+include { echo_step as step_954 } from './echo_step'
+include { echo_step as step_955 } from './echo_step'
+include { echo_step as step_956 } from './echo_step'
+include { echo_step as step_957 } from './echo_step'
+include { echo_step as step_958 } from './echo_step'
+include { echo_step as step_959 } from './echo_step'
+include { echo_step as step_960 } from './echo_step'
+include { echo_step as step_961 } from './echo_step'
+include { echo_step as step_962 } from './echo_step'
+include { echo_step as step_963 } from './echo_step'
+include { echo_step as step_964 } from './echo_step'
+include { echo_step as step_965 } from './echo_step'
+include { echo_step as step_966 } from './echo_step'
+include { echo_step as step_967 } from './echo_step'
+include { echo_step as step_968 } from './echo_step'
+include { echo_step as step_969 } from './echo_step'
+include { echo_step as step_970 } from './echo_step'
+include { echo_step as step_971 } from './echo_step'
+include { echo_step as step_972 } from './echo_step'
+include { echo_step as step_973 } from './echo_step'
+include { echo_step as step_974 } from './echo_step'
+include { echo_step as step_975 } from './echo_step'
+include { echo_step as step_976 } from './echo_step'
+include { echo_step as step_977 } from './echo_step'
+include { echo_step as step_978 } from './echo_step'
+include { echo_step as step_979 } from './echo_step'
+include { echo_step as step_980 } from './echo_step'
+include { echo_step as step_981 } from './echo_step'
+include { echo_step as step_982 } from './echo_step'
+include { echo_step as step_983 } from './echo_step'
+include { echo_step as step_984 } from './echo_step'
+include { echo_step as step_985 } from './echo_step'
+include { echo_step as step_986 } from './echo_step'
+include { echo_step as step_987 } from './echo_step'
+include { echo_step as step_988 } from './echo_step'
+include { echo_step as step_989 } from './echo_step'
+include { echo_step as step_990 } from './echo_step'
+include { echo_step as step_991 } from './echo_step'
+include { echo_step as step_992 } from './echo_step'
+include { echo_step as step_993 } from './echo_step'
+include { echo_step as step_994 } from './echo_step'
+include { echo_step as step_995 } from './echo_step'
+include { echo_step as step_996 } from './echo_step'
+include { echo_step as step_997 } from './echo_step'
+include { echo_step as step_998 } from './echo_step'
+include { echo_step as step_999 } from './echo_step'
 
-    // 后续 N-1 个规则
-    for (int i = 1; i < params.count; i++) {
-        step( file("step_${i - 1}_output.txt") )
-    }
+workflow {
+    def seed = file('input.txt', checkIfExists: false)
+    if (!seed.exists()) { seed.write('') }
+    def count = (params.count as Integer) ?: 10
+    def ch = step_0(seed, 0)
+    if (count > 1) { ch = step_1(ch, 1) }
+    if (count > 2) { ch = step_2(ch, 2) }
+    if (count > 3) { ch = step_3(ch, 3) }
+    if (count > 4) { ch = step_4(ch, 4) }
+    if (count > 5) { ch = step_5(ch, 5) }
+    if (count > 6) { ch = step_6(ch, 6) }
+    if (count > 7) { ch = step_7(ch, 7) }
+    if (count > 8) { ch = step_8(ch, 8) }
+    if (count > 9) { ch = step_9(ch, 9) }
+    if (count > 10) { ch = step_10(ch, 10) }
+    if (count > 11) { ch = step_11(ch, 11) }
+    if (count > 12) { ch = step_12(ch, 12) }
+    if (count > 13) { ch = step_13(ch, 13) }
+    if (count > 14) { ch = step_14(ch, 14) }
+    if (count > 15) { ch = step_15(ch, 15) }
+    if (count > 16) { ch = step_16(ch, 16) }
+    if (count > 17) { ch = step_17(ch, 17) }
+    if (count > 18) { ch = step_18(ch, 18) }
+    if (count > 19) { ch = step_19(ch, 19) }
+    if (count > 20) { ch = step_20(ch, 20) }
+    if (count > 21) { ch = step_21(ch, 21) }
+    if (count > 22) { ch = step_22(ch, 22) }
+    if (count > 23) { ch = step_23(ch, 23) }
+    if (count > 24) { ch = step_24(ch, 24) }
+    if (count > 25) { ch = step_25(ch, 25) }
+    if (count > 26) { ch = step_26(ch, 26) }
+    if (count > 27) { ch = step_27(ch, 27) }
+    if (count > 28) { ch = step_28(ch, 28) }
+    if (count > 29) { ch = step_29(ch, 29) }
+    if (count > 30) { ch = step_30(ch, 30) }
+    if (count > 31) { ch = step_31(ch, 31) }
+    if (count > 32) { ch = step_32(ch, 32) }
+    if (count > 33) { ch = step_33(ch, 33) }
+    if (count > 34) { ch = step_34(ch, 34) }
+    if (count > 35) { ch = step_35(ch, 35) }
+    if (count > 36) { ch = step_36(ch, 36) }
+    if (count > 37) { ch = step_37(ch, 37) }
+    if (count > 38) { ch = step_38(ch, 38) }
+    if (count > 39) { ch = step_39(ch, 39) }
+    if (count > 40) { ch = step_40(ch, 40) }
+    if (count > 41) { ch = step_41(ch, 41) }
+    if (count > 42) { ch = step_42(ch, 42) }
+    if (count > 43) { ch = step_43(ch, 43) }
+    if (count > 44) { ch = step_44(ch, 44) }
+    if (count > 45) { ch = step_45(ch, 45) }
+    if (count > 46) { ch = step_46(ch, 46) }
+    if (count > 47) { ch = step_47(ch, 47) }
+    if (count > 48) { ch = step_48(ch, 48) }
+    if (count > 49) { ch = step_49(ch, 49) }
+    if (count > 50) { ch = step_50(ch, 50) }
+    if (count > 51) { ch = step_51(ch, 51) }
+    if (count > 52) { ch = step_52(ch, 52) }
+    if (count > 53) { ch = step_53(ch, 53) }
+    if (count > 54) { ch = step_54(ch, 54) }
+    if (count > 55) { ch = step_55(ch, 55) }
+    if (count > 56) { ch = step_56(ch, 56) }
+    if (count > 57) { ch = step_57(ch, 57) }
+    if (count > 58) { ch = step_58(ch, 58) }
+    if (count > 59) { ch = step_59(ch, 59) }
+    if (count > 60) { ch = step_60(ch, 60) }
+    if (count > 61) { ch = step_61(ch, 61) }
+    if (count > 62) { ch = step_62(ch, 62) }
+    if (count > 63) { ch = step_63(ch, 63) }
+    if (count > 64) { ch = step_64(ch, 64) }
+    if (count > 65) { ch = step_65(ch, 65) }
+    if (count > 66) { ch = step_66(ch, 66) }
+    if (count > 67) { ch = step_67(ch, 67) }
+    if (count > 68) { ch = step_68(ch, 68) }
+    if (count > 69) { ch = step_69(ch, 69) }
+    if (count > 70) { ch = step_70(ch, 70) }
+    if (count > 71) { ch = step_71(ch, 71) }
+    if (count > 72) { ch = step_72(ch, 72) }
+    if (count > 73) { ch = step_73(ch, 73) }
+    if (count > 74) { ch = step_74(ch, 74) }
+    if (count > 75) { ch = step_75(ch, 75) }
+    if (count > 76) { ch = step_76(ch, 76) }
+    if (count > 77) { ch = step_77(ch, 77) }
+    if (count > 78) { ch = step_78(ch, 78) }
+    if (count > 79) { ch = step_79(ch, 79) }
+    if (count > 80) { ch = step_80(ch, 80) }
+    if (count > 81) { ch = step_81(ch, 81) }
+    if (count > 82) { ch = step_82(ch, 82) }
+    if (count > 83) { ch = step_83(ch, 83) }
+    if (count > 84) { ch = step_84(ch, 84) }
+    if (count > 85) { ch = step_85(ch, 85) }
+    if (count > 86) { ch = step_86(ch, 86) }
+    if (count > 87) { ch = step_87(ch, 87) }
+    if (count > 88) { ch = step_88(ch, 88) }
+    if (count > 89) { ch = step_89(ch, 89) }
+    if (count > 90) { ch = step_90(ch, 90) }
+    if (count > 91) { ch = step_91(ch, 91) }
+    if (count > 92) { ch = step_92(ch, 92) }
+    if (count > 93) { ch = step_93(ch, 93) }
+    if (count > 94) { ch = step_94(ch, 94) }
+    if (count > 95) { ch = step_95(ch, 95) }
+    if (count > 96) { ch = step_96(ch, 96) }
+    if (count > 97) { ch = step_97(ch, 97) }
+    if (count > 98) { ch = step_98(ch, 98) }
+    if (count > 99) { ch = step_99(ch, 99) }
+    if (count > 100) { ch = step_100(ch, 100) }
+    if (count > 101) { ch = step_101(ch, 101) }
+    if (count > 102) { ch = step_102(ch, 102) }
+    if (count > 103) { ch = step_103(ch, 103) }
+    if (count > 104) { ch = step_104(ch, 104) }
+    if (count > 105) { ch = step_105(ch, 105) }
+    if (count > 106) { ch = step_106(ch, 106) }
+    if (count > 107) { ch = step_107(ch, 107) }
+    if (count > 108) { ch = step_108(ch, 108) }
+    if (count > 109) { ch = step_109(ch, 109) }
+    if (count > 110) { ch = step_110(ch, 110) }
+    if (count > 111) { ch = step_111(ch, 111) }
+    if (count > 112) { ch = step_112(ch, 112) }
+    if (count > 113) { ch = step_113(ch, 113) }
+    if (count > 114) { ch = step_114(ch, 114) }
+    if (count > 115) { ch = step_115(ch, 115) }
+    if (count > 116) { ch = step_116(ch, 116) }
+    if (count > 117) { ch = step_117(ch, 117) }
+    if (count > 118) { ch = step_118(ch, 118) }
+    if (count > 119) { ch = step_119(ch, 119) }
+    if (count > 120) { ch = step_120(ch, 120) }
+    if (count > 121) { ch = step_121(ch, 121) }
+    if (count > 122) { ch = step_122(ch, 122) }
+    if (count > 123) { ch = step_123(ch, 123) }
+    if (count > 124) { ch = step_124(ch, 124) }
+    if (count > 125) { ch = step_125(ch, 125) }
+    if (count > 126) { ch = step_126(ch, 126) }
+    if (count > 127) { ch = step_127(ch, 127) }
+    if (count > 128) { ch = step_128(ch, 128) }
+    if (count > 129) { ch = step_129(ch, 129) }
+    if (count > 130) { ch = step_130(ch, 130) }
+    if (count > 131) { ch = step_131(ch, 131) }
+    if (count > 132) { ch = step_132(ch, 132) }
+    if (count > 133) { ch = step_133(ch, 133) }
+    if (count > 134) { ch = step_134(ch, 134) }
+    if (count > 135) { ch = step_135(ch, 135) }
+    if (count > 136) { ch = step_136(ch, 136) }
+    if (count > 137) { ch = step_137(ch, 137) }
+    if (count > 138) { ch = step_138(ch, 138) }
+    if (count > 139) { ch = step_139(ch, 139) }
+    if (count > 140) { ch = step_140(ch, 140) }
+    if (count > 141) { ch = step_141(ch, 141) }
+    if (count > 142) { ch = step_142(ch, 142) }
+    if (count > 143) { ch = step_143(ch, 143) }
+    if (count > 144) { ch = step_144(ch, 144) }
+    if (count > 145) { ch = step_145(ch, 145) }
+    if (count > 146) { ch = step_146(ch, 146) }
+    if (count > 147) { ch = step_147(ch, 147) }
+    if (count > 148) { ch = step_148(ch, 148) }
+    if (count > 149) { ch = step_149(ch, 149) }
+    if (count > 150) { ch = step_150(ch, 150) }
+    if (count > 151) { ch = step_151(ch, 151) }
+    if (count > 152) { ch = step_152(ch, 152) }
+    if (count > 153) { ch = step_153(ch, 153) }
+    if (count > 154) { ch = step_154(ch, 154) }
+    if (count > 155) { ch = step_155(ch, 155) }
+    if (count > 156) { ch = step_156(ch, 156) }
+    if (count > 157) { ch = step_157(ch, 157) }
+    if (count > 158) { ch = step_158(ch, 158) }
+    if (count > 159) { ch = step_159(ch, 159) }
+    if (count > 160) { ch = step_160(ch, 160) }
+    if (count > 161) { ch = step_161(ch, 161) }
+    if (count > 162) { ch = step_162(ch, 162) }
+    if (count > 163) { ch = step_163(ch, 163) }
+    if (count > 164) { ch = step_164(ch, 164) }
+    if (count > 165) { ch = step_165(ch, 165) }
+    if (count > 166) { ch = step_166(ch, 166) }
+    if (count > 167) { ch = step_167(ch, 167) }
+    if (count > 168) { ch = step_168(ch, 168) }
+    if (count > 169) { ch = step_169(ch, 169) }
+    if (count > 170) { ch = step_170(ch, 170) }
+    if (count > 171) { ch = step_171(ch, 171) }
+    if (count > 172) { ch = step_172(ch, 172) }
+    if (count > 173) { ch = step_173(ch, 173) }
+    if (count > 174) { ch = step_174(ch, 174) }
+    if (count > 175) { ch = step_175(ch, 175) }
+    if (count > 176) { ch = step_176(ch, 176) }
+    if (count > 177) { ch = step_177(ch, 177) }
+    if (count > 178) { ch = step_178(ch, 178) }
+    if (count > 179) { ch = step_179(ch, 179) }
+    if (count > 180) { ch = step_180(ch, 180) }
+    if (count > 181) { ch = step_181(ch, 181) }
+    if (count > 182) { ch = step_182(ch, 182) }
+    if (count > 183) { ch = step_183(ch, 183) }
+    if (count > 184) { ch = step_184(ch, 184) }
+    if (count > 185) { ch = step_185(ch, 185) }
+    if (count > 186) { ch = step_186(ch, 186) }
+    if (count > 187) { ch = step_187(ch, 187) }
+    if (count > 188) { ch = step_188(ch, 188) }
+    if (count > 189) { ch = step_189(ch, 189) }
+    if (count > 190) { ch = step_190(ch, 190) }
+    if (count > 191) { ch = step_191(ch, 191) }
+    if (count > 192) { ch = step_192(ch, 192) }
+    if (count > 193) { ch = step_193(ch, 193) }
+    if (count > 194) { ch = step_194(ch, 194) }
+    if (count > 195) { ch = step_195(ch, 195) }
+    if (count > 196) { ch = step_196(ch, 196) }
+    if (count > 197) { ch = step_197(ch, 197) }
+    if (count > 198) { ch = step_198(ch, 198) }
+    if (count > 199) { ch = step_199(ch, 199) }
+    if (count > 200) { ch = step_200(ch, 200) }
+    if (count > 201) { ch = step_201(ch, 201) }
+    if (count > 202) { ch = step_202(ch, 202) }
+    if (count > 203) { ch = step_203(ch, 203) }
+    if (count > 204) { ch = step_204(ch, 204) }
+    if (count > 205) { ch = step_205(ch, 205) }
+    if (count > 206) { ch = step_206(ch, 206) }
+    if (count > 207) { ch = step_207(ch, 207) }
+    if (count > 208) { ch = step_208(ch, 208) }
+    if (count > 209) { ch = step_209(ch, 209) }
+    if (count > 210) { ch = step_210(ch, 210) }
+    if (count > 211) { ch = step_211(ch, 211) }
+    if (count > 212) { ch = step_212(ch, 212) }
+    if (count > 213) { ch = step_213(ch, 213) }
+    if (count > 214) { ch = step_214(ch, 214) }
+    if (count > 215) { ch = step_215(ch, 215) }
+    if (count > 216) { ch = step_216(ch, 216) }
+    if (count > 217) { ch = step_217(ch, 217) }
+    if (count > 218) { ch = step_218(ch, 218) }
+    if (count > 219) { ch = step_219(ch, 219) }
+    if (count > 220) { ch = step_220(ch, 220) }
+    if (count > 221) { ch = step_221(ch, 221) }
+    if (count > 222) { ch = step_222(ch, 222) }
+    if (count > 223) { ch = step_223(ch, 223) }
+    if (count > 224) { ch = step_224(ch, 224) }
+    if (count > 225) { ch = step_225(ch, 225) }
+    if (count > 226) { ch = step_226(ch, 226) }
+    if (count > 227) { ch = step_227(ch, 227) }
+    if (count > 228) { ch = step_228(ch, 228) }
+    if (count > 229) { ch = step_229(ch, 229) }
+    if (count > 230) { ch = step_230(ch, 230) }
+    if (count > 231) { ch = step_231(ch, 231) }
+    if (count > 232) { ch = step_232(ch, 232) }
+    if (count > 233) { ch = step_233(ch, 233) }
+    if (count > 234) { ch = step_234(ch, 234) }
+    if (count > 235) { ch = step_235(ch, 235) }
+    if (count > 236) { ch = step_236(ch, 236) }
+    if (count > 237) { ch = step_237(ch, 237) }
+    if (count > 238) { ch = step_238(ch, 238) }
+    if (count > 239) { ch = step_239(ch, 239) }
+    if (count > 240) { ch = step_240(ch, 240) }
+    if (count > 241) { ch = step_241(ch, 241) }
+    if (count > 242) { ch = step_242(ch, 242) }
+    if (count > 243) { ch = step_243(ch, 243) }
+    if (count > 244) { ch = step_244(ch, 244) }
+    if (count > 245) { ch = step_245(ch, 245) }
+    if (count > 246) { ch = step_246(ch, 246) }
+    if (count > 247) { ch = step_247(ch, 247) }
+    if (count > 248) { ch = step_248(ch, 248) }
+    if (count > 249) { ch = step_249(ch, 249) }
+    if (count > 250) { ch = step_250(ch, 250) }
+    if (count > 251) { ch = step_251(ch, 251) }
+    if (count > 252) { ch = step_252(ch, 252) }
+    if (count > 253) { ch = step_253(ch, 253) }
+    if (count > 254) { ch = step_254(ch, 254) }
+    if (count > 255) { ch = step_255(ch, 255) }
+    if (count > 256) { ch = step_256(ch, 256) }
+    if (count > 257) { ch = step_257(ch, 257) }
+    if (count > 258) { ch = step_258(ch, 258) }
+    if (count > 259) { ch = step_259(ch, 259) }
+    if (count > 260) { ch = step_260(ch, 260) }
+    if (count > 261) { ch = step_261(ch, 261) }
+    if (count > 262) { ch = step_262(ch, 262) }
+    if (count > 263) { ch = step_263(ch, 263) }
+    if (count > 264) { ch = step_264(ch, 264) }
+    if (count > 265) { ch = step_265(ch, 265) }
+    if (count > 266) { ch = step_266(ch, 266) }
+    if (count > 267) { ch = step_267(ch, 267) }
+    if (count > 268) { ch = step_268(ch, 268) }
+    if (count > 269) { ch = step_269(ch, 269) }
+    if (count > 270) { ch = step_270(ch, 270) }
+    if (count > 271) { ch = step_271(ch, 271) }
+    if (count > 272) { ch = step_272(ch, 272) }
+    if (count > 273) { ch = step_273(ch, 273) }
+    if (count > 274) { ch = step_274(ch, 274) }
+    if (count > 275) { ch = step_275(ch, 275) }
+    if (count > 276) { ch = step_276(ch, 276) }
+    if (count > 277) { ch = step_277(ch, 277) }
+    if (count > 278) { ch = step_278(ch, 278) }
+    if (count > 279) { ch = step_279(ch, 279) }
+    if (count > 280) { ch = step_280(ch, 280) }
+    if (count > 281) { ch = step_281(ch, 281) }
+    if (count > 282) { ch = step_282(ch, 282) }
+    if (count > 283) { ch = step_283(ch, 283) }
+    if (count > 284) { ch = step_284(ch, 284) }
+    if (count > 285) { ch = step_285(ch, 285) }
+    if (count > 286) { ch = step_286(ch, 286) }
+    if (count > 287) { ch = step_287(ch, 287) }
+    if (count > 288) { ch = step_288(ch, 288) }
+    if (count > 289) { ch = step_289(ch, 289) }
+    if (count > 290) { ch = step_290(ch, 290) }
+    if (count > 291) { ch = step_291(ch, 291) }
+    if (count > 292) { ch = step_292(ch, 292) }
+    if (count > 293) { ch = step_293(ch, 293) }
+    if (count > 294) { ch = step_294(ch, 294) }
+    if (count > 295) { ch = step_295(ch, 295) }
+    if (count > 296) { ch = step_296(ch, 296) }
+    if (count > 297) { ch = step_297(ch, 297) }
+    if (count > 298) { ch = step_298(ch, 298) }
+    if (count > 299) { ch = step_299(ch, 299) }
+    if (count > 300) { ch = step_300(ch, 300) }
+    if (count > 301) { ch = step_301(ch, 301) }
+    if (count > 302) { ch = step_302(ch, 302) }
+    if (count > 303) { ch = step_303(ch, 303) }
+    if (count > 304) { ch = step_304(ch, 304) }
+    if (count > 305) { ch = step_305(ch, 305) }
+    if (count > 306) { ch = step_306(ch, 306) }
+    if (count > 307) { ch = step_307(ch, 307) }
+    if (count > 308) { ch = step_308(ch, 308) }
+    if (count > 309) { ch = step_309(ch, 309) }
+    if (count > 310) { ch = step_310(ch, 310) }
+    if (count > 311) { ch = step_311(ch, 311) }
+    if (count > 312) { ch = step_312(ch, 312) }
+    if (count > 313) { ch = step_313(ch, 313) }
+    if (count > 314) { ch = step_314(ch, 314) }
+    if (count > 315) { ch = step_315(ch, 315) }
+    if (count > 316) { ch = step_316(ch, 316) }
+    if (count > 317) { ch = step_317(ch, 317) }
+    if (count > 318) { ch = step_318(ch, 318) }
+    if (count > 319) { ch = step_319(ch, 319) }
+    if (count > 320) { ch = step_320(ch, 320) }
+    if (count > 321) { ch = step_321(ch, 321) }
+    if (count > 322) { ch = step_322(ch, 322) }
+    if (count > 323) { ch = step_323(ch, 323) }
+    if (count > 324) { ch = step_324(ch, 324) }
+    if (count > 325) { ch = step_325(ch, 325) }
+    if (count > 326) { ch = step_326(ch, 326) }
+    if (count > 327) { ch = step_327(ch, 327) }
+    if (count > 328) { ch = step_328(ch, 328) }
+    if (count > 329) { ch = step_329(ch, 329) }
+    if (count > 330) { ch = step_330(ch, 330) }
+    if (count > 331) { ch = step_331(ch, 331) }
+    if (count > 332) { ch = step_332(ch, 332) }
+    if (count > 333) { ch = step_333(ch, 333) }
+    if (count > 334) { ch = step_334(ch, 334) }
+    if (count > 335) { ch = step_335(ch, 335) }
+    if (count > 336) { ch = step_336(ch, 336) }
+    if (count > 337) { ch = step_337(ch, 337) }
+    if (count > 338) { ch = step_338(ch, 338) }
+    if (count > 339) { ch = step_339(ch, 339) }
+    if (count > 340) { ch = step_340(ch, 340) }
+    if (count > 341) { ch = step_341(ch, 341) }
+    if (count > 342) { ch = step_342(ch, 342) }
+    if (count > 343) { ch = step_343(ch, 343) }
+    if (count > 344) { ch = step_344(ch, 344) }
+    if (count > 345) { ch = step_345(ch, 345) }
+    if (count > 346) { ch = step_346(ch, 346) }
+    if (count > 347) { ch = step_347(ch, 347) }
+    if (count > 348) { ch = step_348(ch, 348) }
+    if (count > 349) { ch = step_349(ch, 349) }
+    if (count > 350) { ch = step_350(ch, 350) }
+    if (count > 351) { ch = step_351(ch, 351) }
+    if (count > 352) { ch = step_352(ch, 352) }
+    if (count > 353) { ch = step_353(ch, 353) }
+    if (count > 354) { ch = step_354(ch, 354) }
+    if (count > 355) { ch = step_355(ch, 355) }
+    if (count > 356) { ch = step_356(ch, 356) }
+    if (count > 357) { ch = step_357(ch, 357) }
+    if (count > 358) { ch = step_358(ch, 358) }
+    if (count > 359) { ch = step_359(ch, 359) }
+    if (count > 360) { ch = step_360(ch, 360) }
+    if (count > 361) { ch = step_361(ch, 361) }
+    if (count > 362) { ch = step_362(ch, 362) }
+    if (count > 363) { ch = step_363(ch, 363) }
+    if (count > 364) { ch = step_364(ch, 364) }
+    if (count > 365) { ch = step_365(ch, 365) }
+    if (count > 366) { ch = step_366(ch, 366) }
+    if (count > 367) { ch = step_367(ch, 367) }
+    if (count > 368) { ch = step_368(ch, 368) }
+    if (count > 369) { ch = step_369(ch, 369) }
+    if (count > 370) { ch = step_370(ch, 370) }
+    if (count > 371) { ch = step_371(ch, 371) }
+    if (count > 372) { ch = step_372(ch, 372) }
+    if (count > 373) { ch = step_373(ch, 373) }
+    if (count > 374) { ch = step_374(ch, 374) }
+    if (count > 375) { ch = step_375(ch, 375) }
+    if (count > 376) { ch = step_376(ch, 376) }
+    if (count > 377) { ch = step_377(ch, 377) }
+    if (count > 378) { ch = step_378(ch, 378) }
+    if (count > 379) { ch = step_379(ch, 379) }
+    if (count > 380) { ch = step_380(ch, 380) }
+    if (count > 381) { ch = step_381(ch, 381) }
+    if (count > 382) { ch = step_382(ch, 382) }
+    if (count > 383) { ch = step_383(ch, 383) }
+    if (count > 384) { ch = step_384(ch, 384) }
+    if (count > 385) { ch = step_385(ch, 385) }
+    if (count > 386) { ch = step_386(ch, 386) }
+    if (count > 387) { ch = step_387(ch, 387) }
+    if (count > 388) { ch = step_388(ch, 388) }
+    if (count > 389) { ch = step_389(ch, 389) }
+    if (count > 390) { ch = step_390(ch, 390) }
+    if (count > 391) { ch = step_391(ch, 391) }
+    if (count > 392) { ch = step_392(ch, 392) }
+    if (count > 393) { ch = step_393(ch, 393) }
+    if (count > 394) { ch = step_394(ch, 394) }
+    if (count > 395) { ch = step_395(ch, 395) }
+    if (count > 396) { ch = step_396(ch, 396) }
+    if (count > 397) { ch = step_397(ch, 397) }
+    if (count > 398) { ch = step_398(ch, 398) }
+    if (count > 399) { ch = step_399(ch, 399) }
+    if (count > 400) { ch = step_400(ch, 400) }
+    if (count > 401) { ch = step_401(ch, 401) }
+    if (count > 402) { ch = step_402(ch, 402) }
+    if (count > 403) { ch = step_403(ch, 403) }
+    if (count > 404) { ch = step_404(ch, 404) }
+    if (count > 405) { ch = step_405(ch, 405) }
+    if (count > 406) { ch = step_406(ch, 406) }
+    if (count > 407) { ch = step_407(ch, 407) }
+    if (count > 408) { ch = step_408(ch, 408) }
+    if (count > 409) { ch = step_409(ch, 409) }
+    if (count > 410) { ch = step_410(ch, 410) }
+    if (count > 411) { ch = step_411(ch, 411) }
+    if (count > 412) { ch = step_412(ch, 412) }
+    if (count > 413) { ch = step_413(ch, 413) }
+    if (count > 414) { ch = step_414(ch, 414) }
+    if (count > 415) { ch = step_415(ch, 415) }
+    if (count > 416) { ch = step_416(ch, 416) }
+    if (count > 417) { ch = step_417(ch, 417) }
+    if (count > 418) { ch = step_418(ch, 418) }
+    if (count > 419) { ch = step_419(ch, 419) }
+    if (count > 420) { ch = step_420(ch, 420) }
+    if (count > 421) { ch = step_421(ch, 421) }
+    if (count > 422) { ch = step_422(ch, 422) }
+    if (count > 423) { ch = step_423(ch, 423) }
+    if (count > 424) { ch = step_424(ch, 424) }
+    if (count > 425) { ch = step_425(ch, 425) }
+    if (count > 426) { ch = step_426(ch, 426) }
+    if (count > 427) { ch = step_427(ch, 427) }
+    if (count > 428) { ch = step_428(ch, 428) }
+    if (count > 429) { ch = step_429(ch, 429) }
+    if (count > 430) { ch = step_430(ch, 430) }
+    if (count > 431) { ch = step_431(ch, 431) }
+    if (count > 432) { ch = step_432(ch, 432) }
+    if (count > 433) { ch = step_433(ch, 433) }
+    if (count > 434) { ch = step_434(ch, 434) }
+    if (count > 435) { ch = step_435(ch, 435) }
+    if (count > 436) { ch = step_436(ch, 436) }
+    if (count > 437) { ch = step_437(ch, 437) }
+    if (count > 438) { ch = step_438(ch, 438) }
+    if (count > 439) { ch = step_439(ch, 439) }
+    if (count > 440) { ch = step_440(ch, 440) }
+    if (count > 441) { ch = step_441(ch, 441) }
+    if (count > 442) { ch = step_442(ch, 442) }
+    if (count > 443) { ch = step_443(ch, 443) }
+    if (count > 444) { ch = step_444(ch, 444) }
+    if (count > 445) { ch = step_445(ch, 445) }
+    if (count > 446) { ch = step_446(ch, 446) }
+    if (count > 447) { ch = step_447(ch, 447) }
+    if (count > 448) { ch = step_448(ch, 448) }
+    if (count > 449) { ch = step_449(ch, 449) }
+    if (count > 450) { ch = step_450(ch, 450) }
+    if (count > 451) { ch = step_451(ch, 451) }
+    if (count > 452) { ch = step_452(ch, 452) }
+    if (count > 453) { ch = step_453(ch, 453) }
+    if (count > 454) { ch = step_454(ch, 454) }
+    if (count > 455) { ch = step_455(ch, 455) }
+    if (count > 456) { ch = step_456(ch, 456) }
+    if (count > 457) { ch = step_457(ch, 457) }
+    if (count > 458) { ch = step_458(ch, 458) }
+    if (count > 459) { ch = step_459(ch, 459) }
+    if (count > 460) { ch = step_460(ch, 460) }
+    if (count > 461) { ch = step_461(ch, 461) }
+    if (count > 462) { ch = step_462(ch, 462) }
+    if (count > 463) { ch = step_463(ch, 463) }
+    if (count > 464) { ch = step_464(ch, 464) }
+    if (count > 465) { ch = step_465(ch, 465) }
+    if (count > 466) { ch = step_466(ch, 466) }
+    if (count > 467) { ch = step_467(ch, 467) }
+    if (count > 468) { ch = step_468(ch, 468) }
+    if (count > 469) { ch = step_469(ch, 469) }
+    if (count > 470) { ch = step_470(ch, 470) }
+    if (count > 471) { ch = step_471(ch, 471) }
+    if (count > 472) { ch = step_472(ch, 472) }
+    if (count > 473) { ch = step_473(ch, 473) }
+    if (count > 474) { ch = step_474(ch, 474) }
+    if (count > 475) { ch = step_475(ch, 475) }
+    if (count > 476) { ch = step_476(ch, 476) }
+    if (count > 477) { ch = step_477(ch, 477) }
+    if (count > 478) { ch = step_478(ch, 478) }
+    if (count > 479) { ch = step_479(ch, 479) }
+    if (count > 480) { ch = step_480(ch, 480) }
+    if (count > 481) { ch = step_481(ch, 481) }
+    if (count > 482) { ch = step_482(ch, 482) }
+    if (count > 483) { ch = step_483(ch, 483) }
+    if (count > 484) { ch = step_484(ch, 484) }
+    if (count > 485) { ch = step_485(ch, 485) }
+    if (count > 486) { ch = step_486(ch, 486) }
+    if (count > 487) { ch = step_487(ch, 487) }
+    if (count > 488) { ch = step_488(ch, 488) }
+    if (count > 489) { ch = step_489(ch, 489) }
+    if (count > 490) { ch = step_490(ch, 490) }
+    if (count > 491) { ch = step_491(ch, 491) }
+    if (count > 492) { ch = step_492(ch, 492) }
+    if (count > 493) { ch = step_493(ch, 493) }
+    if (count > 494) { ch = step_494(ch, 494) }
+    if (count > 495) { ch = step_495(ch, 495) }
+    if (count > 496) { ch = step_496(ch, 496) }
+    if (count > 497) { ch = step_497(ch, 497) }
+    if (count > 498) { ch = step_498(ch, 498) }
+    if (count > 499) { ch = step_499(ch, 499) }
+    if (count > 500) { ch = step_500(ch, 500) }
+    if (count > 501) { ch = step_501(ch, 501) }
+    if (count > 502) { ch = step_502(ch, 502) }
+    if (count > 503) { ch = step_503(ch, 503) }
+    if (count > 504) { ch = step_504(ch, 504) }
+    if (count > 505) { ch = step_505(ch, 505) }
+    if (count > 506) { ch = step_506(ch, 506) }
+    if (count > 507) { ch = step_507(ch, 507) }
+    if (count > 508) { ch = step_508(ch, 508) }
+    if (count > 509) { ch = step_509(ch, 509) }
+    if (count > 510) { ch = step_510(ch, 510) }
+    if (count > 511) { ch = step_511(ch, 511) }
+    if (count > 512) { ch = step_512(ch, 512) }
+    if (count > 513) { ch = step_513(ch, 513) }
+    if (count > 514) { ch = step_514(ch, 514) }
+    if (count > 515) { ch = step_515(ch, 515) }
+    if (count > 516) { ch = step_516(ch, 516) }
+    if (count > 517) { ch = step_517(ch, 517) }
+    if (count > 518) { ch = step_518(ch, 518) }
+    if (count > 519) { ch = step_519(ch, 519) }
+    if (count > 520) { ch = step_520(ch, 520) }
+    if (count > 521) { ch = step_521(ch, 521) }
+    if (count > 522) { ch = step_522(ch, 522) }
+    if (count > 523) { ch = step_523(ch, 523) }
+    if (count > 524) { ch = step_524(ch, 524) }
+    if (count > 525) { ch = step_525(ch, 525) }
+    if (count > 526) { ch = step_526(ch, 526) }
+    if (count > 527) { ch = step_527(ch, 527) }
+    if (count > 528) { ch = step_528(ch, 528) }
+    if (count > 529) { ch = step_529(ch, 529) }
+    if (count > 530) { ch = step_530(ch, 530) }
+    if (count > 531) { ch = step_531(ch, 531) }
+    if (count > 532) { ch = step_532(ch, 532) }
+    if (count > 533) { ch = step_533(ch, 533) }
+    if (count > 534) { ch = step_534(ch, 534) }
+    if (count > 535) { ch = step_535(ch, 535) }
+    if (count > 536) { ch = step_536(ch, 536) }
+    if (count > 537) { ch = step_537(ch, 537) }
+    if (count > 538) { ch = step_538(ch, 538) }
+    if (count > 539) { ch = step_539(ch, 539) }
+    if (count > 540) { ch = step_540(ch, 540) }
+    if (count > 541) { ch = step_541(ch, 541) }
+    if (count > 542) { ch = step_542(ch, 542) }
+    if (count > 543) { ch = step_543(ch, 543) }
+    if (count > 544) { ch = step_544(ch, 544) }
+    if (count > 545) { ch = step_545(ch, 545) }
+    if (count > 546) { ch = step_546(ch, 546) }
+    if (count > 547) { ch = step_547(ch, 547) }
+    if (count > 548) { ch = step_548(ch, 548) }
+    if (count > 549) { ch = step_549(ch, 549) }
+    if (count > 550) { ch = step_550(ch, 550) }
+    if (count > 551) { ch = step_551(ch, 551) }
+    if (count > 552) { ch = step_552(ch, 552) }
+    if (count > 553) { ch = step_553(ch, 553) }
+    if (count > 554) { ch = step_554(ch, 554) }
+    if (count > 555) { ch = step_555(ch, 555) }
+    if (count > 556) { ch = step_556(ch, 556) }
+    if (count > 557) { ch = step_557(ch, 557) }
+    if (count > 558) { ch = step_558(ch, 558) }
+    if (count > 559) { ch = step_559(ch, 559) }
+    if (count > 560) { ch = step_560(ch, 560) }
+    if (count > 561) { ch = step_561(ch, 561) }
+    if (count > 562) { ch = step_562(ch, 562) }
+    if (count > 563) { ch = step_563(ch, 563) }
+    if (count > 564) { ch = step_564(ch, 564) }
+    if (count > 565) { ch = step_565(ch, 565) }
+    if (count > 566) { ch = step_566(ch, 566) }
+    if (count > 567) { ch = step_567(ch, 567) }
+    if (count > 568) { ch = step_568(ch, 568) }
+    if (count > 569) { ch = step_569(ch, 569) }
+    if (count > 570) { ch = step_570(ch, 570) }
+    if (count > 571) { ch = step_571(ch, 571) }
+    if (count > 572) { ch = step_572(ch, 572) }
+    if (count > 573) { ch = step_573(ch, 573) }
+    if (count > 574) { ch = step_574(ch, 574) }
+    if (count > 575) { ch = step_575(ch, 575) }
+    if (count > 576) { ch = step_576(ch, 576) }
+    if (count > 577) { ch = step_577(ch, 577) }
+    if (count > 578) { ch = step_578(ch, 578) }
+    if (count > 579) { ch = step_579(ch, 579) }
+    if (count > 580) { ch = step_580(ch, 580) }
+    if (count > 581) { ch = step_581(ch, 581) }
+    if (count > 582) { ch = step_582(ch, 582) }
+    if (count > 583) { ch = step_583(ch, 583) }
+    if (count > 584) { ch = step_584(ch, 584) }
+    if (count > 585) { ch = step_585(ch, 585) }
+    if (count > 586) { ch = step_586(ch, 586) }
+    if (count > 587) { ch = step_587(ch, 587) }
+    if (count > 588) { ch = step_588(ch, 588) }
+    if (count > 589) { ch = step_589(ch, 589) }
+    if (count > 590) { ch = step_590(ch, 590) }
+    if (count > 591) { ch = step_591(ch, 591) }
+    if (count > 592) { ch = step_592(ch, 592) }
+    if (count > 593) { ch = step_593(ch, 593) }
+    if (count > 594) { ch = step_594(ch, 594) }
+    if (count > 595) { ch = step_595(ch, 595) }
+    if (count > 596) { ch = step_596(ch, 596) }
+    if (count > 597) { ch = step_597(ch, 597) }
+    if (count > 598) { ch = step_598(ch, 598) }
+    if (count > 599) { ch = step_599(ch, 599) }
+    if (count > 600) { ch = step_600(ch, 600) }
+    if (count > 601) { ch = step_601(ch, 601) }
+    if (count > 602) { ch = step_602(ch, 602) }
+    if (count > 603) { ch = step_603(ch, 603) }
+    if (count > 604) { ch = step_604(ch, 604) }
+    if (count > 605) { ch = step_605(ch, 605) }
+    if (count > 606) { ch = step_606(ch, 606) }
+    if (count > 607) { ch = step_607(ch, 607) }
+    if (count > 608) { ch = step_608(ch, 608) }
+    if (count > 609) { ch = step_609(ch, 609) }
+    if (count > 610) { ch = step_610(ch, 610) }
+    if (count > 611) { ch = step_611(ch, 611) }
+    if (count > 612) { ch = step_612(ch, 612) }
+    if (count > 613) { ch = step_613(ch, 613) }
+    if (count > 614) { ch = step_614(ch, 614) }
+    if (count > 615) { ch = step_615(ch, 615) }
+    if (count > 616) { ch = step_616(ch, 616) }
+    if (count > 617) { ch = step_617(ch, 617) }
+    if (count > 618) { ch = step_618(ch, 618) }
+    if (count > 619) { ch = step_619(ch, 619) }
+    if (count > 620) { ch = step_620(ch, 620) }
+    if (count > 621) { ch = step_621(ch, 621) }
+    if (count > 622) { ch = step_622(ch, 622) }
+    if (count > 623) { ch = step_623(ch, 623) }
+    if (count > 624) { ch = step_624(ch, 624) }
+    if (count > 625) { ch = step_625(ch, 625) }
+    if (count > 626) { ch = step_626(ch, 626) }
+    if (count > 627) { ch = step_627(ch, 627) }
+    if (count > 628) { ch = step_628(ch, 628) }
+    if (count > 629) { ch = step_629(ch, 629) }
+    if (count > 630) { ch = step_630(ch, 630) }
+    if (count > 631) { ch = step_631(ch, 631) }
+    if (count > 632) { ch = step_632(ch, 632) }
+    if (count > 633) { ch = step_633(ch, 633) }
+    if (count > 634) { ch = step_634(ch, 634) }
+    if (count > 635) { ch = step_635(ch, 635) }
+    if (count > 636) { ch = step_636(ch, 636) }
+    if (count > 637) { ch = step_637(ch, 637) }
+    if (count > 638) { ch = step_638(ch, 638) }
+    if (count > 639) { ch = step_639(ch, 639) }
+    if (count > 640) { ch = step_640(ch, 640) }
+    if (count > 641) { ch = step_641(ch, 641) }
+    if (count > 642) { ch = step_642(ch, 642) }
+    if (count > 643) { ch = step_643(ch, 643) }
+    if (count > 644) { ch = step_644(ch, 644) }
+    if (count > 645) { ch = step_645(ch, 645) }
+    if (count > 646) { ch = step_646(ch, 646) }
+    if (count > 647) { ch = step_647(ch, 647) }
+    if (count > 648) { ch = step_648(ch, 648) }
+    if (count > 649) { ch = step_649(ch, 649) }
+    if (count > 650) { ch = step_650(ch, 650) }
+    if (count > 651) { ch = step_651(ch, 651) }
+    if (count > 652) { ch = step_652(ch, 652) }
+    if (count > 653) { ch = step_653(ch, 653) }
+    if (count > 654) { ch = step_654(ch, 654) }
+    if (count > 655) { ch = step_655(ch, 655) }
+    if (count > 656) { ch = step_656(ch, 656) }
+    if (count > 657) { ch = step_657(ch, 657) }
+    if (count > 658) { ch = step_658(ch, 658) }
+    if (count > 659) { ch = step_659(ch, 659) }
+    if (count > 660) { ch = step_660(ch, 660) }
+    if (count > 661) { ch = step_661(ch, 661) }
+    if (count > 662) { ch = step_662(ch, 662) }
+    if (count > 663) { ch = step_663(ch, 663) }
+    if (count > 664) { ch = step_664(ch, 664) }
+    if (count > 665) { ch = step_665(ch, 665) }
+    if (count > 666) { ch = step_666(ch, 666) }
+    if (count > 667) { ch = step_667(ch, 667) }
+    if (count > 668) { ch = step_668(ch, 668) }
+    if (count > 669) { ch = step_669(ch, 669) }
+    if (count > 670) { ch = step_670(ch, 670) }
+    if (count > 671) { ch = step_671(ch, 671) }
+    if (count > 672) { ch = step_672(ch, 672) }
+    if (count > 673) { ch = step_673(ch, 673) }
+    if (count > 674) { ch = step_674(ch, 674) }
+    if (count > 675) { ch = step_675(ch, 675) }
+    if (count > 676) { ch = step_676(ch, 676) }
+    if (count > 677) { ch = step_677(ch, 677) }
+    if (count > 678) { ch = step_678(ch, 678) }
+    if (count > 679) { ch = step_679(ch, 679) }
+    if (count > 680) { ch = step_680(ch, 680) }
+    if (count > 681) { ch = step_681(ch, 681) }
+    if (count > 682) { ch = step_682(ch, 682) }
+    if (count > 683) { ch = step_683(ch, 683) }
+    if (count > 684) { ch = step_684(ch, 684) }
+    if (count > 685) { ch = step_685(ch, 685) }
+    if (count > 686) { ch = step_686(ch, 686) }
+    if (count > 687) { ch = step_687(ch, 687) }
+    if (count > 688) { ch = step_688(ch, 688) }
+    if (count > 689) { ch = step_689(ch, 689) }
+    if (count > 690) { ch = step_690(ch, 690) }
+    if (count > 691) { ch = step_691(ch, 691) }
+    if (count > 692) { ch = step_692(ch, 692) }
+    if (count > 693) { ch = step_693(ch, 693) }
+    if (count > 694) { ch = step_694(ch, 694) }
+    if (count > 695) { ch = step_695(ch, 695) }
+    if (count > 696) { ch = step_696(ch, 696) }
+    if (count > 697) { ch = step_697(ch, 697) }
+    if (count > 698) { ch = step_698(ch, 698) }
+    if (count > 699) { ch = step_699(ch, 699) }
+    if (count > 700) { ch = step_700(ch, 700) }
+    if (count > 701) { ch = step_701(ch, 701) }
+    if (count > 702) { ch = step_702(ch, 702) }
+    if (count > 703) { ch = step_703(ch, 703) }
+    if (count > 704) { ch = step_704(ch, 704) }
+    if (count > 705) { ch = step_705(ch, 705) }
+    if (count > 706) { ch = step_706(ch, 706) }
+    if (count > 707) { ch = step_707(ch, 707) }
+    if (count > 708) { ch = step_708(ch, 708) }
+    if (count > 709) { ch = step_709(ch, 709) }
+    if (count > 710) { ch = step_710(ch, 710) }
+    if (count > 711) { ch = step_711(ch, 711) }
+    if (count > 712) { ch = step_712(ch, 712) }
+    if (count > 713) { ch = step_713(ch, 713) }
+    if (count > 714) { ch = step_714(ch, 714) }
+    if (count > 715) { ch = step_715(ch, 715) }
+    if (count > 716) { ch = step_716(ch, 716) }
+    if (count > 717) { ch = step_717(ch, 717) }
+    if (count > 718) { ch = step_718(ch, 718) }
+    if (count > 719) { ch = step_719(ch, 719) }
+    if (count > 720) { ch = step_720(ch, 720) }
+    if (count > 721) { ch = step_721(ch, 721) }
+    if (count > 722) { ch = step_722(ch, 722) }
+    if (count > 723) { ch = step_723(ch, 723) }
+    if (count > 724) { ch = step_724(ch, 724) }
+    if (count > 725) { ch = step_725(ch, 725) }
+    if (count > 726) { ch = step_726(ch, 726) }
+    if (count > 727) { ch = step_727(ch, 727) }
+    if (count > 728) { ch = step_728(ch, 728) }
+    if (count > 729) { ch = step_729(ch, 729) }
+    if (count > 730) { ch = step_730(ch, 730) }
+    if (count > 731) { ch = step_731(ch, 731) }
+    if (count > 732) { ch = step_732(ch, 732) }
+    if (count > 733) { ch = step_733(ch, 733) }
+    if (count > 734) { ch = step_734(ch, 734) }
+    if (count > 735) { ch = step_735(ch, 735) }
+    if (count > 736) { ch = step_736(ch, 736) }
+    if (count > 737) { ch = step_737(ch, 737) }
+    if (count > 738) { ch = step_738(ch, 738) }
+    if (count > 739) { ch = step_739(ch, 739) }
+    if (count > 740) { ch = step_740(ch, 740) }
+    if (count > 741) { ch = step_741(ch, 741) }
+    if (count > 742) { ch = step_742(ch, 742) }
+    if (count > 743) { ch = step_743(ch, 743) }
+    if (count > 744) { ch = step_744(ch, 744) }
+    if (count > 745) { ch = step_745(ch, 745) }
+    if (count > 746) { ch = step_746(ch, 746) }
+    if (count > 747) { ch = step_747(ch, 747) }
+    if (count > 748) { ch = step_748(ch, 748) }
+    if (count > 749) { ch = step_749(ch, 749) }
+    if (count > 750) { ch = step_750(ch, 750) }
+    if (count > 751) { ch = step_751(ch, 751) }
+    if (count > 752) { ch = step_752(ch, 752) }
+    if (count > 753) { ch = step_753(ch, 753) }
+    if (count > 754) { ch = step_754(ch, 754) }
+    if (count > 755) { ch = step_755(ch, 755) }
+    if (count > 756) { ch = step_756(ch, 756) }
+    if (count > 757) { ch = step_757(ch, 757) }
+    if (count > 758) { ch = step_758(ch, 758) }
+    if (count > 759) { ch = step_759(ch, 759) }
+    if (count > 760) { ch = step_760(ch, 760) }
+    if (count > 761) { ch = step_761(ch, 761) }
+    if (count > 762) { ch = step_762(ch, 762) }
+    if (count > 763) { ch = step_763(ch, 763) }
+    if (count > 764) { ch = step_764(ch, 764) }
+    if (count > 765) { ch = step_765(ch, 765) }
+    if (count > 766) { ch = step_766(ch, 766) }
+    if (count > 767) { ch = step_767(ch, 767) }
+    if (count > 768) { ch = step_768(ch, 768) }
+    if (count > 769) { ch = step_769(ch, 769) }
+    if (count > 770) { ch = step_770(ch, 770) }
+    if (count > 771) { ch = step_771(ch, 771) }
+    if (count > 772) { ch = step_772(ch, 772) }
+    if (count > 773) { ch = step_773(ch, 773) }
+    if (count > 774) { ch = step_774(ch, 774) }
+    if (count > 775) { ch = step_775(ch, 775) }
+    if (count > 776) { ch = step_776(ch, 776) }
+    if (count > 777) { ch = step_777(ch, 777) }
+    if (count > 778) { ch = step_778(ch, 778) }
+    if (count > 779) { ch = step_779(ch, 779) }
+    if (count > 780) { ch = step_780(ch, 780) }
+    if (count > 781) { ch = step_781(ch, 781) }
+    if (count > 782) { ch = step_782(ch, 782) }
+    if (count > 783) { ch = step_783(ch, 783) }
+    if (count > 784) { ch = step_784(ch, 784) }
+    if (count > 785) { ch = step_785(ch, 785) }
+    if (count > 786) { ch = step_786(ch, 786) }
+    if (count > 787) { ch = step_787(ch, 787) }
+    if (count > 788) { ch = step_788(ch, 788) }
+    if (count > 789) { ch = step_789(ch, 789) }
+    if (count > 790) { ch = step_790(ch, 790) }
+    if (count > 791) { ch = step_791(ch, 791) }
+    if (count > 792) { ch = step_792(ch, 792) }
+    if (count > 793) { ch = step_793(ch, 793) }
+    if (count > 794) { ch = step_794(ch, 794) }
+    if (count > 795) { ch = step_795(ch, 795) }
+    if (count > 796) { ch = step_796(ch, 796) }
+    if (count > 797) { ch = step_797(ch, 797) }
+    if (count > 798) { ch = step_798(ch, 798) }
+    if (count > 799) { ch = step_799(ch, 799) }
+    if (count > 800) { ch = step_800(ch, 800) }
+    if (count > 801) { ch = step_801(ch, 801) }
+    if (count > 802) { ch = step_802(ch, 802) }
+    if (count > 803) { ch = step_803(ch, 803) }
+    if (count > 804) { ch = step_804(ch, 804) }
+    if (count > 805) { ch = step_805(ch, 805) }
+    if (count > 806) { ch = step_806(ch, 806) }
+    if (count > 807) { ch = step_807(ch, 807) }
+    if (count > 808) { ch = step_808(ch, 808) }
+    if (count > 809) { ch = step_809(ch, 809) }
+    if (count > 810) { ch = step_810(ch, 810) }
+    if (count > 811) { ch = step_811(ch, 811) }
+    if (count > 812) { ch = step_812(ch, 812) }
+    if (count > 813) { ch = step_813(ch, 813) }
+    if (count > 814) { ch = step_814(ch, 814) }
+    if (count > 815) { ch = step_815(ch, 815) }
+    if (count > 816) { ch = step_816(ch, 816) }
+    if (count > 817) { ch = step_817(ch, 817) }
+    if (count > 818) { ch = step_818(ch, 818) }
+    if (count > 819) { ch = step_819(ch, 819) }
+    if (count > 820) { ch = step_820(ch, 820) }
+    if (count > 821) { ch = step_821(ch, 821) }
+    if (count > 822) { ch = step_822(ch, 822) }
+    if (count > 823) { ch = step_823(ch, 823) }
+    if (count > 824) { ch = step_824(ch, 824) }
+    if (count > 825) { ch = step_825(ch, 825) }
+    if (count > 826) { ch = step_826(ch, 826) }
+    if (count > 827) { ch = step_827(ch, 827) }
+    if (count > 828) { ch = step_828(ch, 828) }
+    if (count > 829) { ch = step_829(ch, 829) }
+    if (count > 830) { ch = step_830(ch, 830) }
+    if (count > 831) { ch = step_831(ch, 831) }
+    if (count > 832) { ch = step_832(ch, 832) }
+    if (count > 833) { ch = step_833(ch, 833) }
+    if (count > 834) { ch = step_834(ch, 834) }
+    if (count > 835) { ch = step_835(ch, 835) }
+    if (count > 836) { ch = step_836(ch, 836) }
+    if (count > 837) { ch = step_837(ch, 837) }
+    if (count > 838) { ch = step_838(ch, 838) }
+    if (count > 839) { ch = step_839(ch, 839) }
+    if (count > 840) { ch = step_840(ch, 840) }
+    if (count > 841) { ch = step_841(ch, 841) }
+    if (count > 842) { ch = step_842(ch, 842) }
+    if (count > 843) { ch = step_843(ch, 843) }
+    if (count > 844) { ch = step_844(ch, 844) }
+    if (count > 845) { ch = step_845(ch, 845) }
+    if (count > 846) { ch = step_846(ch, 846) }
+    if (count > 847) { ch = step_847(ch, 847) }
+    if (count > 848) { ch = step_848(ch, 848) }
+    if (count > 849) { ch = step_849(ch, 849) }
+    if (count > 850) { ch = step_850(ch, 850) }
+    if (count > 851) { ch = step_851(ch, 851) }
+    if (count > 852) { ch = step_852(ch, 852) }
+    if (count > 853) { ch = step_853(ch, 853) }
+    if (count > 854) { ch = step_854(ch, 854) }
+    if (count > 855) { ch = step_855(ch, 855) }
+    if (count > 856) { ch = step_856(ch, 856) }
+    if (count > 857) { ch = step_857(ch, 857) }
+    if (count > 858) { ch = step_858(ch, 858) }
+    if (count > 859) { ch = step_859(ch, 859) }
+    if (count > 860) { ch = step_860(ch, 860) }
+    if (count > 861) { ch = step_861(ch, 861) }
+    if (count > 862) { ch = step_862(ch, 862) }
+    if (count > 863) { ch = step_863(ch, 863) }
+    if (count > 864) { ch = step_864(ch, 864) }
+    if (count > 865) { ch = step_865(ch, 865) }
+    if (count > 866) { ch = step_866(ch, 866) }
+    if (count > 867) { ch = step_867(ch, 867) }
+    if (count > 868) { ch = step_868(ch, 868) }
+    if (count > 869) { ch = step_869(ch, 869) }
+    if (count > 870) { ch = step_870(ch, 870) }
+    if (count > 871) { ch = step_871(ch, 871) }
+    if (count > 872) { ch = step_872(ch, 872) }
+    if (count > 873) { ch = step_873(ch, 873) }
+    if (count > 874) { ch = step_874(ch, 874) }
+    if (count > 875) { ch = step_875(ch, 875) }
+    if (count > 876) { ch = step_876(ch, 876) }
+    if (count > 877) { ch = step_877(ch, 877) }
+    if (count > 878) { ch = step_878(ch, 878) }
+    if (count > 879) { ch = step_879(ch, 879) }
+    if (count > 880) { ch = step_880(ch, 880) }
+    if (count > 881) { ch = step_881(ch, 881) }
+    if (count > 882) { ch = step_882(ch, 882) }
+    if (count > 883) { ch = step_883(ch, 883) }
+    if (count > 884) { ch = step_884(ch, 884) }
+    if (count > 885) { ch = step_885(ch, 885) }
+    if (count > 886) { ch = step_886(ch, 886) }
+    if (count > 887) { ch = step_887(ch, 887) }
+    if (count > 888) { ch = step_888(ch, 888) }
+    if (count > 889) { ch = step_889(ch, 889) }
+    if (count > 890) { ch = step_890(ch, 890) }
+    if (count > 891) { ch = step_891(ch, 891) }
+    if (count > 892) { ch = step_892(ch, 892) }
+    if (count > 893) { ch = step_893(ch, 893) }
+    if (count > 894) { ch = step_894(ch, 894) }
+    if (count > 895) { ch = step_895(ch, 895) }
+    if (count > 896) { ch = step_896(ch, 896) }
+    if (count > 897) { ch = step_897(ch, 897) }
+    if (count > 898) { ch = step_898(ch, 898) }
+    if (count > 899) { ch = step_899(ch, 899) }
+    if (count > 900) { ch = step_900(ch, 900) }
+    if (count > 901) { ch = step_901(ch, 901) }
+    if (count > 902) { ch = step_902(ch, 902) }
+    if (count > 903) { ch = step_903(ch, 903) }
+    if (count > 904) { ch = step_904(ch, 904) }
+    if (count > 905) { ch = step_905(ch, 905) }
+    if (count > 906) { ch = step_906(ch, 906) }
+    if (count > 907) { ch = step_907(ch, 907) }
+    if (count > 908) { ch = step_908(ch, 908) }
+    if (count > 909) { ch = step_909(ch, 909) }
+    if (count > 910) { ch = step_910(ch, 910) }
+    if (count > 911) { ch = step_911(ch, 911) }
+    if (count > 912) { ch = step_912(ch, 912) }
+    if (count > 913) { ch = step_913(ch, 913) }
+    if (count > 914) { ch = step_914(ch, 914) }
+    if (count > 915) { ch = step_915(ch, 915) }
+    if (count > 916) { ch = step_916(ch, 916) }
+    if (count > 917) { ch = step_917(ch, 917) }
+    if (count > 918) { ch = step_918(ch, 918) }
+    if (count > 919) { ch = step_919(ch, 919) }
+    if (count > 920) { ch = step_920(ch, 920) }
+    if (count > 921) { ch = step_921(ch, 921) }
+    if (count > 922) { ch = step_922(ch, 922) }
+    if (count > 923) { ch = step_923(ch, 923) }
+    if (count > 924) { ch = step_924(ch, 924) }
+    if (count > 925) { ch = step_925(ch, 925) }
+    if (count > 926) { ch = step_926(ch, 926) }
+    if (count > 927) { ch = step_927(ch, 927) }
+    if (count > 928) { ch = step_928(ch, 928) }
+    if (count > 929) { ch = step_929(ch, 929) }
+    if (count > 930) { ch = step_930(ch, 930) }
+    if (count > 931) { ch = step_931(ch, 931) }
+    if (count > 932) { ch = step_932(ch, 932) }
+    if (count > 933) { ch = step_933(ch, 933) }
+    if (count > 934) { ch = step_934(ch, 934) }
+    if (count > 935) { ch = step_935(ch, 935) }
+    if (count > 936) { ch = step_936(ch, 936) }
+    if (count > 937) { ch = step_937(ch, 937) }
+    if (count > 938) { ch = step_938(ch, 938) }
+    if (count > 939) { ch = step_939(ch, 939) }
+    if (count > 940) { ch = step_940(ch, 940) }
+    if (count > 941) { ch = step_941(ch, 941) }
+    if (count > 942) { ch = step_942(ch, 942) }
+    if (count > 943) { ch = step_943(ch, 943) }
+    if (count > 944) { ch = step_944(ch, 944) }
+    if (count > 945) { ch = step_945(ch, 945) }
+    if (count > 946) { ch = step_946(ch, 946) }
+    if (count > 947) { ch = step_947(ch, 947) }
+    if (count > 948) { ch = step_948(ch, 948) }
+    if (count > 949) { ch = step_949(ch, 949) }
+    if (count > 950) { ch = step_950(ch, 950) }
+    if (count > 951) { ch = step_951(ch, 951) }
+    if (count > 952) { ch = step_952(ch, 952) }
+    if (count > 953) { ch = step_953(ch, 953) }
+    if (count > 954) { ch = step_954(ch, 954) }
+    if (count > 955) { ch = step_955(ch, 955) }
+    if (count > 956) { ch = step_956(ch, 956) }
+    if (count > 957) { ch = step_957(ch, 957) }
+    if (count > 958) { ch = step_958(ch, 958) }
+    if (count > 959) { ch = step_959(ch, 959) }
+    if (count > 960) { ch = step_960(ch, 960) }
+    if (count > 961) { ch = step_961(ch, 961) }
+    if (count > 962) { ch = step_962(ch, 962) }
+    if (count > 963) { ch = step_963(ch, 963) }
+    if (count > 964) { ch = step_964(ch, 964) }
+    if (count > 965) { ch = step_965(ch, 965) }
+    if (count > 966) { ch = step_966(ch, 966) }
+    if (count > 967) { ch = step_967(ch, 967) }
+    if (count > 968) { ch = step_968(ch, 968) }
+    if (count > 969) { ch = step_969(ch, 969) }
+    if (count > 970) { ch = step_970(ch, 970) }
+    if (count > 971) { ch = step_971(ch, 971) }
+    if (count > 972) { ch = step_972(ch, 972) }
+    if (count > 973) { ch = step_973(ch, 973) }
+    if (count > 974) { ch = step_974(ch, 974) }
+    if (count > 975) { ch = step_975(ch, 975) }
+    if (count > 976) { ch = step_976(ch, 976) }
+    if (count > 977) { ch = step_977(ch, 977) }
+    if (count > 978) { ch = step_978(ch, 978) }
+    if (count > 979) { ch = step_979(ch, 979) }
+    if (count > 980) { ch = step_980(ch, 980) }
+    if (count > 981) { ch = step_981(ch, 981) }
+    if (count > 982) { ch = step_982(ch, 982) }
+    if (count > 983) { ch = step_983(ch, 983) }
+    if (count > 984) { ch = step_984(ch, 984) }
+    if (count > 985) { ch = step_985(ch, 985) }
+    if (count > 986) { ch = step_986(ch, 986) }
+    if (count > 987) { ch = step_987(ch, 987) }
+    if (count > 988) { ch = step_988(ch, 988) }
+    if (count > 989) { ch = step_989(ch, 989) }
+    if (count > 990) { ch = step_990(ch, 990) }
+    if (count > 991) { ch = step_991(ch, 991) }
+    if (count > 992) { ch = step_992(ch, 992) }
+    if (count > 993) { ch = step_993(ch, 993) }
+    if (count > 994) { ch = step_994(ch, 994) }
+    if (count > 995) { ch = step_995(ch, 995) }
+    if (count > 996) { ch = step_996(ch, 996) }
+    if (count > 997) { ch = step_997(ch, 997) }
+    if (count > 998) { ch = step_998(ch, 998) }
+    if (count > 999) { ch = step_999(ch, 999) }
 }

--- a/benches/comparative/run_comparison.sh
+++ b/benches/comparative/run_comparison.sh
@@ -1,65 +1,102 @@
 #!/usr/bin/env bash
 # oxo-flow 对比基准运行器 (Phase 4)
 #
-# 需要安装: Nextflow, Snakemake, oxo-flow
-# 用法: ./benches/comparative/run_comparison.sh
-
+# 在等价的 N 步串行链上对比三个引擎的调度开销:
+#   - oxo-flow:  dry-run（解析 + DAG 构建 + 拓扑执行模拟）
+#   - Nextflow:  完整运行（echo 链，include 别名静态展开）
+#   - Snakemake: 完整运行（通配符链）
+#
+# 语义注记: oxo-flow 计时的是 dry-run（不实际 spawn 进程），
+# Nextflow/Snakemake 计时的是真实执行（含 echo 子进程）。
+# 由于每步都是微秒级 echo， wall time 由引擎调度开销主导，可作
+# 调度吞吐的量级对比；严格同语义对比请参考结果中的说明。
+#
+# 需要安装: Nextflow, Snakemake, oxo-flow, hyperfine
+# 用法: ./benches/comparative/run_comparison.sh [N_RULES] [OXO_FLOW_BIN]
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel 2>/dev/null || echo "${0%/*}")"
+# 定位仓库根（脚本可能被 bash 直接执行；无 git 时退回脚本上两级目录）
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "$0")/../.." && pwd)"
+cd "${REPO_ROOT}"
 OUTPUT="benches/comparative/results"
 mkdir -p "${OUTPUT}"
 
-echo "==> oxo-flow 对比基准测试"
-echo ""
-echo "需要安装以下工具:"
-echo "  - Nextflow  (https://www.nextflow.io/)"
-echo "  - Snakemake (https://snakemake.readthedocs.io/)"
-echo "  - hyperfine (https://github.com/sharkdp/hyperfine)"
-echo ""
+N_RULES="${1:-100}"
+OXO_BIN="${2:-target/release/oxo-flow}"
+WORKFLOW_FILE="/tmp/oxo_bench_hello_${N_RULES}.oxoflow"
+NF_DIR="benches/comparative/nextflow"
+SM_DIR="benches/comparative/snakemake"
 
-# 检查工具可用性
+# 检查工具可用性（缺哪个就跳过哪个引擎，全部缺失则报错）
 MISSING=""
-command -v nextflow  >/dev/null 2>&1 || MISSING="${MISSING} nextflow"
-command -v snakemake >/dev/null 2>&1 || MISSING="${MISSING} snakemake"
-command -v oxo-flow  >/dev/null 2>&1 || MISSING="${MISSING} oxo-flow"
-command -v hyperfine >/dev/null 2>&1 || MISSING="${MISSING} hyperfine"
+HAVE_NF=0; HAVE_SM=0; HAVE_OXO=0; HAVE_HF=0
+command -v nextflow  >/dev/null 2>&1 && HAVE_NF=1 || MISSING="${MISSING} nextflow"
+command -v snakemake >/dev/null 2>&1 && HAVE_SM=1 || MISSING="${MISSING} snakemake"
+[ -f "${OXO_BIN}" ]                   && HAVE_OXO=1 || MISSING="${MISSING} oxo-flow(${OXO_BIN})"
+command -v hyperfine >/dev/null 2>&1 && HAVE_HF=1 || MISSING="${MISSING} hyperfine"
 
 if [ -n "${MISSING}" ]; then
-    echo "缺少:${MISSING}"
-    echo "请安装缺失的工具后重试。"
-    echo ""
-    echo "配置定义位于:"
-    echo "  benches/comparative/nextflow/hello.nf"
-    echo "  benches/comparative/snakemake/Snakefile"
-    exit 1
+    echo "警告: 缺少${MISSING} —— 对应引擎将被跳过。"
+    [ "${HAVE_OXO}" = "0" ] && { echo "错误: oxo-flow 二进制必须存在，请先 cargo build 或指定路径。"; exit 1; }
+    [ "${HAVE_HF}" = "0" ] && { echo "错误: hyperfine 是计时工具，必须安装。"; exit 1; }
 fi
 
-# 运行对比基准 (使用 hyperfine)
-N_RULES=100
-WORKFLOW_FILE="/tmp/oxo_bench_hello_${N_RULES}.oxoflow"
-
-# 生成 oxo-flow 工作流
+# 生成 oxo-flow 工作流（与 hello.nf --count N / Snakefile count=N 等价的链）
 python3 -c "
 from benches.macro.suite import generate_hello
 with open('${WORKFLOW_FILE}', 'w') as f:
     f.write(generate_hello(${N_RULES}))
 "
 
-echo "运行对比基准 (N=${N_RULES} rules)..."
+echo "==> 对比基准 (N=${N_RULES} 步串行链, oxo-flow=${OXO_BIN})"
 echo ""
 
-hyperfine --warmup 2 --min-runs 5 \
-    -n "oxo-flow validate" \
-    "oxo-flow validate ${WORKFLOW_FILE}" \
-    -n "oxo-flow dry-run" \
-    "oxo-flow dry-run ${WORKFLOW_FILE}" \
-    --export-json "${OUTPUT}/macro_comparison.json"
+# hy 标签数组 -> hyperfine 参数
+HYPERFINE_ARGS=(--warmup 2 --min-runs 5 --style basic)
+
+# 1) oxo-flow: dry-run（纯调度开销，无进程 spawn）
+if [ "${HAVE_OXO}" = "1" ]; then
+    HYPERFINE_ARGS+=(-n "oxo-flow dry-run" "${OXO_BIN} dry-run ${WORKFLOW_FILE}")
+    HYPERFINE_ARGS+=(-n "oxo-flow validate" "${OXO_BIN} validate ${WORKFLOW_FILE}")
+fi
+
+# 2) Nextflow: 真实执行 echo 链
+#    -ansi-log false 关闭进度条; -work-dir 每轮独立避免缓存命中导致空转
+if [ "${HAVE_NF}" = "1" ]; then
+    NF_RUN_DIR=$(mktemp -d /tmp/nf_bench_run.XXXXXX)
+    HYPERFINE_ARGS+=(
+        -n "nextflow run"
+        "cd ${NF_RUN_DIR} && touch input.txt && nextflow run ${OLDPWD}/${NF_DIR}/hello.nf --count ${N_RULES} -work-dir ${NF_RUN_DIR}/work -ansi-log false > /dev/null && cd ${OLDPWD}"
+    )
+fi
+
+# 3) Snakemake: 真实执行通配符链
+#    注: Snakemake 9.x DAG 构建链深 >484 会 RecursionError（已知边界），
+#    超限时跳过并在结果中注记。
+if [ "${HAVE_SM}" = "1" ] && [ "${N_RULES}" -le 484 ]; then
+    SM_RUN_DIR=$(mktemp -d /tmp/sm_bench_run.XXXXXX)
+    cp "${SM_DIR}/Snakefile" "${SM_RUN_DIR}/Snakefile"
+    HYPERFINE_ARGS+=(
+        -n "snakemake run"
+        "cd ${SM_RUN_DIR} && snakemake --cores 1 --config count=${N_RULES} --quiet all > /dev/null && cd ${OLDPWD}"
+    )
+elif [ "${HAVE_SM}" = "1" ]; then
+    echo "注: N=${N_RULES} > 484，跳过 snakemake（DAG 递归深度边界，见 Snakefile 说明）。"
+fi
+
+hyperfine "${HYPERFINE_ARGS[@]}" --export-json "${OUTPUT}/macro_comparison.json"
+
+# 清理运行目录
+[ -n "${NF_RUN_DIR:-}" ] && rm -rf "${NF_RUN_DIR}"
+[ -n "${SM_RUN_DIR:-}" ] && rm -rf "${SM_RUN_DIR}"
 
 echo ""
 echo "结果: ${OUTPUT}/macro_comparison.json"
 echo ""
 echo "管线定义:"
-echo "  oxo-flow:  ${WORKFLOW_FILE}"
-echo "  Nextflow:  benches/comparative/nextflow/hello.nf"
-echo "  Snakemake: benches/comparative/snakemake/Snakefile"
+echo "  oxo-flow:  ${WORKFLOW_FILE} (generate_hello(${N_RULES}))"
+echo "  Nextflow:  ${NF_DIR}/hello.nf --count ${N_RULES}"
+echo "  Snakemake: ${SM_DIR}/Snakefile --config count=${N_RULES}"
+echo ""
+echo "语义注记: oxo-flow 为 dry-run（无进程 spawn），nextflow/snakemake 为真实执行；"
+echo "每步均为微秒级 echo，wall time 由引擎调度开销主导。"

--- a/benches/comparative/snakemake/Snakefile
+++ b/benches/comparative/snakemake/Snakefile
@@ -2,27 +2,40 @@
 oxo-flow 对比基准 — Snakemake 等效管线
 
 与 benches/macro/suite.py 中 generate_hello(N) 生成的 oxo-flow
-管线等价: N 步顺序链。
+管线等价: N 步顺序链（step_0 -> step_1 -> ... -> step_{N-1}）。
 
 用法:
     snakemake --cores 1
+
+COUNT 可通过 config 覆盖:
+    snakemake --cores 1 --config count=100
+
+已知边界: Snakemake 9.x 的 DAG 构建是递归实现，链深超过约 484 步会触发
+RecursionError（Python 默认 recursionlimit=1000；实测 484 OK / 485 FAIL）。
+这不是本 Snakefile 的问题 —— 单文件通配符链天然有这样的深度上限。
+macro 基准覆盖到 1000 规模，如需在 Snakemake 侧复现，可在运行前
+抬高递归限制（snakemake 没有直接开关，需在 sitecustomize 或 profile 里
+设 sys.setrecursionlimit），或接受该引擎的深度边界并在结果中注记。
 """
 
-COUNT = 10
+COUNT = int(config.get("count", 10))
 
 rule all:
     input:
         f"step_{COUNT - 1}_output.txt"
 
 rule step_0:
-    output: "step_0_output.txt"
-    shell: "echo 0 > {output}"
+    output:
+        "step_0_output.txt"
+    shell:
+        "echo 0 > {output}"
 
 rule step_i:
     input:
-        f"step_{{wildcards.i - 1}}_output.txt"
+        lambda wc: f"step_{int(wc.i) - 1}_output.txt"
     output:
         "step_{i}_output.txt"
     wildcard_constraints:
-        i = "[1-9][0-9]*"
-    shell: "echo {wildcards.i} > {output}"
+        i = r"[0-9]+"
+    shell:
+        "echo {wildcards.i} > {output}"

--- a/benches/macro/suite.py
+++ b/benches/macro/suite.py
@@ -53,6 +53,8 @@ def generate_hello(rule_count: int) -> str:
         lines.append(f'input = ["{_toml_escape(inp)}"]')
         lines.append(f'output = ["{_toml_escape(out)}"]')
         lines.append(f'shell = "echo {i} > {{output[0]}}"')
+        lines.append('')
+        lines.append('[rules.resources]')
         lines.append(f'threads = 1')
         lines.append('')
     return '\n'.join(lines)
@@ -74,6 +76,8 @@ def generate_parallel(sample_count: int) -> str:
         lines.append(f'input = ["input_{sample}.txt"]')
         lines.append(f'output = ["processed_{sample}.txt"]')
         lines.append(f'shell = "echo process {sample} > processed_{sample}.txt"')
+        lines.append('')
+        lines.append('[rules.resources]')
         lines.append(f'threads = 1')
         lines.append('')
     # 汇总规则
@@ -83,6 +87,8 @@ def generate_parallel(sample_count: int) -> str:
     lines.append(f'input = [{inputs}]')
     lines.append(f'output = ["merged_output.txt"]')
     lines.append(f'shell = "cat {{input[0]}} > merged_output.txt"')
+    lines.append('')
+    lines.append('[rules.resources]')
     lines.append(f'threads = 1')
     lines.append('')
     return '\n'.join(lines)
@@ -102,6 +108,8 @@ def generate_scatter_gather(sample_count: int) -> str:
     lines.append(f'input = ["input.txt"]')
     lines.append(f'output = [{", ".join(f'"chunk_{i}.txt"' for i in range(sample_count))}]')
     lines.append(f'shell = "echo split > {{output[0]}}"')
+    lines.append('')
+    lines.append('[rules.resources]')
     lines.append(f'threads = 1')
     lines.append('')
 
@@ -112,6 +120,8 @@ def generate_scatter_gather(sample_count: int) -> str:
         lines.append(f'input = ["chunk_{i}.txt"]')
         lines.append(f'output = ["processed_{i}.txt"]')
         lines.append(f'shell = "echo process {i} > processed_{i}.txt"')
+        lines.append('')
+        lines.append('[rules.resources]')
         lines.append(f'threads = 1')
         lines.append('')
 
@@ -122,6 +132,8 @@ def generate_scatter_gather(sample_count: int) -> str:
     lines.append(f'input = [{inputs}]')
     lines.append(f'output = ["final_output.txt"]')
     lines.append(f'shell = "cat {{input[0]}} > final_output.txt"')
+    lines.append('')
+    lines.append('[rules.resources]')
     lines.append(f'threads = 1')
     lines.append('')
     return '\n'.join(lines)
@@ -159,7 +171,12 @@ def benchmark_lifecycle(oxo_bin: str, counts: list[int], output: dict[str, Any],
                                 ("dry-run", ["dry-run", str(tmp)]),
                                 ("lint", ["lint", str(tmp)])]:
             full_cmd = [oxo_bin] + args
-            elapsed, rc, stdout, stderr = _run_command(full_cmd)
+            # 多次迭代取最小值（降低系统噪声），与 hyperfine 的 min 语义一致
+            elapsed, rc, stdout, stderr = float("inf"), 1, "", ""
+            for _ in range(iterations):
+                e, r, so, se = _run_command(full_cmd)
+                if e < elapsed:
+                    elapsed, rc, stdout, stderr = e, r, so, se
             status = "OK" if rc == 0 else "FAIL"
             print(f"    {cmd_name:10s}  {count:5d} rules  {_format_duration(elapsed):>10s}  [{status}]")
             output.setdefault("lifecycle", []).append({
@@ -167,6 +184,7 @@ def benchmark_lifecycle(oxo_bin: str, counts: list[int], output: dict[str, Any],
                 "rule_count": count,
                 "wall_time_sec": round(elapsed, 4),
                 "exit_code": rc,
+                "iterations": iterations,
             })
             if rc != 0 and stderr:
                 print(f"      stderr: {stderr[:200]}")
@@ -186,7 +204,11 @@ def benchmark_scaling(oxo_bin: str, sample_counts: list[int], output: dict[str, 
         for cmd_name, args in [("validate", ["validate", str(tmp)]),
                                 ("dry-run", ["dry-run", str(tmp)])]:
             full_cmd = [oxo_bin] + args
-            elapsed, rc, _, _ = _run_command(full_cmd)
+            elapsed, rc, _, _ = float("inf"), 1, "", ""
+            for _ in range(iterations):
+                e, r, _, _ = _run_command(full_cmd)
+                if e < elapsed:
+                    elapsed, rc = e, r
             status = "OK" if rc == 0 else "FAIL"
             print(f"    {cmd_name:10s}  {sc:5d} samples  {_format_duration(elapsed):>10s}  [{status}]")
             output.setdefault("scaling", []).append({
@@ -194,6 +216,7 @@ def benchmark_scaling(oxo_bin: str, sample_counts: list[int], output: dict[str, 
                 "sample_count": sc,
                 "wall_time_sec": round(elapsed, 4),
                 "exit_code": rc,
+                "iterations": iterations,
             })
 
         tmp.unlink()
@@ -228,7 +251,7 @@ def benchmark_reliability(oxo_bin: str, output: dict[str, Any], iterations: int 
     tmp.write_text(toml)
 
     checksums = []
-    for _ in range(3):
+    for _ in range(max(3, iterations)):
         elapsed, rc, stdout, _ = _run_command(
             [oxo_bin, "lint", str(tmp)])
         if rc == 0:
@@ -280,7 +303,12 @@ def main():
                         choices=["all", "lifecycle", "scaling",
                                  "reliability"],
                         help="要运行的基准类型")
+    parser.add_argument("--iterations", type=int, default=1,
+                        help="每条命令的重复运行次数（取最小值，降低噪声）")
     args = parser.parse_args()
+
+    if args.iterations < 1:
+        parser.error("--iterations 必须 >= 1")
 
     oxo_bin = Path(args.oxo_flow)
     if not oxo_bin.exists():
@@ -307,14 +335,17 @@ def main():
     # 生命周期基准: 不同管线规模
     if args.benchmark in ("all", "lifecycle"):
         benchmark_lifecycle(str(oxo_bin.resolve()),
-                            [10, 50, 100, 500, 1000], output["results"])
+                            [10, 50, 100, 500, 1000], output["results"],
+                            iterations=args.iterations)
     # 扩展性基准: 并行样本数
     if args.benchmark in ("all", "scaling"):
         benchmark_scaling(str(oxo_bin.resolve()),
-                          [10, 50, 100], output["results"])
+                          [10, 50, 100], output["results"],
+                          iterations=args.iterations)
     # 可靠性基准
     if args.benchmark in ("all", "reliability"):
-        benchmark_reliability(str(oxo_bin.resolve()), output["results"])
+        benchmark_reliability(str(oxo_bin.resolve()), output["results"],
+                              iterations=args.iterations)
 
     # 输出
     json_output = json.dumps(output, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## 问题

`benches/comparative/`（issue #67 中 andrewbudge 指出的陈旧基准）存在三处失效:

1. **Snakefile**: 通配符歧义导致 DAG 构建崩溃，从未能实际运行
2. **hello.nf**: 文档声称 N 步串行链，实际结构不符（且 DSL2 单调用限制下原设计无法成立）
3. **run_comparison.sh**: 检查了 nextflow/snakemake 是否安装，却从未调用它们 —— 只对 oxo-flow validate vs dry-run 做 hyperfine，属自比自

## 修复

- **Snakefile**: 通配符 rule `step_i` + input function 实现任意深度链；已在 snakemake 9.19.0 实测（count=10/100/484 通过）。实测发现并记录 Snakemake 9.x DAG 构建器在链深 >484 时 RecursionError（484 OK / 485 FAIL，Python recursionlimit=1000）
- **hello.nf + echo_step.nf**: DSL2 规定同一 process 在一个 workflow 内只能调用一次（docs.seqera.io/nextflow/dsl2，7 个探针脚本逐一验证），串行链必须静态展开。预展开 1000 个 include 别名（覆盖 macro 基准的 1000 规模上限），已在 nextflow 25.10.4 实测 --count 5/10/100/1000 全部正确
- **run_comparison.sh**: 真正以 hyperfine 计时三引擎 —— oxo-flow dry-run/validate + nextflow/snakemake 真实执行等价 echo 链；缺引擎跳过并警告；snakemake >484 步时注记跳过；修复非 git 目录下的仓库根定位
- **README**: 修正等价性表；新增实测的引擎语义差异（DSL2 单调用限制、snakemake 递归深度上限）、测量语义注记（dry-run vs 真实执行）、bioinfo-wsx 参考数据

## 实测结果（bioinfo-wsx: nextflow 25.10.4 / snakemake 9.19.0 / oxo-flow 0.17.2）

| N | oxo-flow dry-run | nextflow run | snakemake run |
|---|---|---|---|
| 10 | ~27 ms | ~6.6 s | ~1.04 s |
| 100 | ~161 ms | ~8.1 s | ~1.09 s |
| 1000 | ~1.27 s | ~25.7 s | 跳过 (>484) |

## 引擎语义差异（基准可量化，写入 README）

- oxo-flow / Snakemake: 通配符/生成规则支持任意深度动态链，零每步定义成本
- Nextflow DSL2: 串行链需 1000 行静态别名（hello.nf 达 2041 行 vs Snakefile 34 行），--count >1000 越界失败
- Snakemake: 链深 >484 触发 DAG 构建器 RecursionError（已知边界）

Closes 部分 #67（bench harness 小节；其余小节为集群实测项，非本 PR 范围）

🤖 Generated with [Claude Code](https://claude.com/claude-code)