### PR TITLE
fix(ai): raise Anthropic max_tokens ceiling for thinking backends; add generation frontier benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ __pycache__/
 # Local benchmark outputs (machine-specific)
 benches/macro/results/*.json
 !benches/macro/results/.gitkeep
+
+# Frontier benchmark outputs (machine-specific, issue #342)
+eval/frontier/results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OXO_FLOW_AI_API_KEY` | No | — | Generic API key fallback |
 | `OXO_FLOW_AI_API_URL` | No | (provider default) | Custom API endpoint URL |
 | `OXO_FLOW_AI_MODEL` | No | (provider default) | Model name override |
+| `OXO_FLOW_AI_MAX_TOKENS` | No | `4096` | Output-token ceiling for the Anthropic Messages backend. Raise for thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible endpoint) whose reasoning blocks count against `max_tokens` — at the default their answers truncate before any text is produced |
 | `OXO_FLOW_MASTER_KEY` | No | — | AES-256-GCM seed encrypting AI provider keys at rest (`v1:`-prefixed rows in the local DB). Unset = plaintext legacy mode |
 | `ANTHROPIC_AUTH_TOKEN` | No | — | Claude/Anthropic API key (overrides OXO_FLOW_AI_API_KEY) |
 | `ANTHROPIC_BASE_URL` | No | `https://api.anthropic.com` | Anthropic-compatible API base URL |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OXO_FLOW_AI_API_URL` | No | (provider default) | Custom API endpoint URL |
 | `OXO_FLOW_AI_MODEL` | No | (provider default) | Model name override |
 | `OXO_FLOW_AI_MAX_TOKENS` | No | `4096` | Output-token ceiling for the Anthropic Messages backend. Raise for thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible endpoint) whose reasoning blocks count against `max_tokens` — at the default their answers truncate before any text is produced |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | No | `120` | Per-request timeout for all AI provider backends. Raise together with OXO_FLOW_AI_MAX_TOKENS on thinking backends — long completions otherwise die mid-body with "error decoding response body" |
 | `OXO_FLOW_MASTER_KEY` | No | — | AES-256-GCM seed encrypting AI provider keys at rest (`v1:`-prefixed rows in the local DB). Unset = plaintext legacy mode |
 | `ANTHROPIC_AUTH_TOKEN` | No | — | Claude/Anthropic API key (overrides OXO_FLOW_AI_API_KEY) |
 | `ANTHROPIC_BASE_URL` | No | `https://api.anthropic.com` | Anthropic-compatible API base URL |

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -397,7 +397,7 @@ impl ClaudeBackend {
             "model": self.model,
             "system": system,
             "messages": anthropic_msgs,
-            "max_tokens": 4096,
+            "max_tokens": max_tokens_from_env(),
         });
 
         if let Some(temperature) = self.temperature {
@@ -562,6 +562,24 @@ fn to_anthropic_messages(messages: &[Message]) -> (String, Vec<serde_json::Value
     }
 
     (system, anthropic_msgs)
+}
+
+/// Output-token ceiling for the Anthropic Messages backend.
+///
+/// Defaults to 4096 but is overridable via `OXO_FLOW_AI_MAX_TOKENS`.
+/// Thinking-style backends (e.g. DeepSeek served behind an
+/// Anthropic-compatible endpoint) emit `thinking` blocks whose tokens count
+/// against `max_tokens`; a hard 4096 there truncates the answer before any
+/// text is produced, so pipeline generation silently loses its TOML.
+fn max_tokens_from_env() -> u32 {
+    parse_max_tokens(std::env::var("OXO_FLOW_AI_MAX_TOKENS").ok().as_deref())
+}
+
+fn parse_max_tokens(value: Option<&str>) -> u32 {
+    value
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(4096)
 }
 
 fn parse_claude_response(json: &serde_json::Value) -> Result<AiResponse, AiError> {
@@ -1494,6 +1512,20 @@ pub struct ProviderConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn max_tokens_env_override_parses_strictly() {
+        // Thinking backends burn the hardcoded 4096 on reasoning blocks and
+        // truncate before the answer; the env override must accept only
+        // clean positive integers and otherwise fall back to 4096.
+        assert_eq!(parse_max_tokens(Some("16384")), 16384);
+        assert_eq!(parse_max_tokens(Some(" 8192 ")), 8192);
+        assert_eq!(parse_max_tokens(Some("0")), 4096);
+        assert_eq!(parse_max_tokens(Some("-1")), 4096);
+        assert_eq!(parse_max_tokens(Some("abc")), 4096);
+        assert_eq!(parse_max_tokens(Some("")), 4096);
+        assert_eq!(parse_max_tokens(None), 4096);
+    }
 
     #[test]
     fn claude_response_concatenates_multiple_text_blocks() {

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -53,14 +53,28 @@ const OLLAMA_DEFAULT_MODEL: &str = "llama3";
 const OLLAMA_API_URL: &str = "http://localhost:11434/api/chat";
 
 /// Shared HTTP client for all provider backends. Without explicit timeouts a
-/// hung endpoint would block the agent loop indefinitely; 120s covers slow
-/// long-form completions while still bounding worst-case latency.
+/// hung endpoint would block the agent loop indefinitely; the request timeout
+/// (default 120s, `OXO_FLOW_AI_TIMEOUT_SECS`) must also cover slow long-form
+/// completions — thinking backends with a raised `OXO_FLOW_AI_MAX_TOKENS`
+/// routinely exceed two minutes, and a mid-body timeout surfaces as a
+/// confusing "error decoding response body".
 fn provider_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(120))
+        .timeout(std::time::Duration::from_secs(request_timeout_secs()))
         .build()
         .unwrap_or_default()
+}
+
+fn request_timeout_secs() -> u64 {
+    parse_timeout_secs(std::env::var("OXO_FLOW_AI_TIMEOUT_SECS").ok().as_deref())
+}
+
+fn parse_timeout_secs(value: Option<&str>) -> u64 {
+    value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(120)
 }
 
 // ── AiProvider enum ────────────────────────────────────────────────────────
@@ -1525,6 +1539,17 @@ mod tests {
         assert_eq!(parse_max_tokens(Some("abc")), 4096);
         assert_eq!(parse_max_tokens(Some("")), 4096);
         assert_eq!(parse_max_tokens(None), 4096);
+    }
+
+    #[test]
+    fn timeout_env_override_parses_strictly() {
+        // Same contract as the max_tokens override: clean positive integers
+        // only, 120s fallback.
+        assert_eq!(parse_timeout_secs(Some("300")), 300);
+        assert_eq!(parse_timeout_secs(Some(" 90 ")), 90);
+        assert_eq!(parse_timeout_secs(Some("0")), 120);
+        assert_eq!(parse_timeout_secs(Some("x")), 120);
+        assert_eq!(parse_timeout_secs(None), 120);
     }
 
     #[test]

--- a/crates/oxo-flow-cli/src/commands/ai_template.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_template.rs
@@ -515,9 +515,16 @@ Your TOML MUST include:
         }
     };
 
-    // Extract TOML
-    let toml_content =
-        extract_toml(&response_text).context("AI response did not contain valid .oxoflow TOML")?;
+    // Extract TOML. A miss must still archive the session: the provider
+    // calls already happened and were paid for — losing the usage record
+    // here made every generation failure invisible to token accounting.
+    let toml_content = match extract_toml(&response_text) {
+        Some(toml) => toml,
+        None => {
+            cmd_session.fail("AI response did not contain valid .oxoflow TOML");
+            anyhow::bail!("AI response did not contain valid .oxoflow TOML");
+        }
+    };
 
     // Validate basic structure
     validate_basic_structure(&toml_content)?;

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -271,6 +271,7 @@ model = "deepseek-v4-flash"
 | `OXO_FLOW_AI_API_KEY` | Generic API key (fallback for all providers) | — |
 | `OXO_FLOW_AI_API_URL` | Custom API endpoint URL | (provider default) |
 | `OXO_FLOW_AI_MODEL` | Model name override | (provider default) |
+| `OXO_FLOW_AI_MAX_TOKENS` | Output-token ceiling for the Anthropic Messages backend. Raise it for thinking-style backends whose reasoning blocks count against `max_tokens` (e.g. DeepSeek behind an Anthropic-compatible endpoint) — at the default, answers can truncate before any text is produced | `4096` |
 | `DEEPSEEK_API_KEY` | DeepSeek (OpenAI-compatible) | — |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek endpoint | `https://api.deepseek.com/v1/chat/completions` |
 | `ANTHROPIC_AUTH_TOKEN` | Anthropic-compatible API key | — |

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -272,6 +272,7 @@ model = "deepseek-v4-flash"
 | `OXO_FLOW_AI_API_URL` | Custom API endpoint URL | (provider default) |
 | `OXO_FLOW_AI_MODEL` | Model name override | (provider default) |
 | `OXO_FLOW_AI_MAX_TOKENS` | Output-token ceiling for the Anthropic Messages backend. Raise it for thinking-style backends whose reasoning blocks count against `max_tokens` (e.g. DeepSeek behind an Anthropic-compatible endpoint) — at the default, answers can truncate before any text is produced | `4096` |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | Per-request timeout for AI provider calls. Raise together with `OXO_FLOW_AI_MAX_TOKENS` on thinking backends, or long completions die mid-body ("error decoding response body") | `120` |
 | `DEEPSEEK_API_KEY` | DeepSeek (OpenAI-compatible) | — |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek endpoint | `https://api.deepseek.com/v1/chat/completions` |
 | `ANTHROPIC_AUTH_TOKEN` | Anthropic-compatible API key | — |

--- a/docs/guide/src/reference/ai-eval.md
+++ b/docs/guide/src/reference/ai-eval.md
@@ -49,3 +49,27 @@ guarded in CI by `crates/oxo-flow-ai/tests/knowledge_grounding.rs` —
 no API key required, runs on every push.
 
 Capture manifests record git SHA, gold/knowledge hashes, provider/model identity, sampling settings, timestamps, and per-trial metadata so later analysis can be audited and reproduced.
+
+## Frontier benchmark (cross-path quality/cost, issue #342)
+
+`eval/frontier/` is a complementary, self-contained benchmark that measures
+the **quality/cost frontier across generation paths** rather than
+gold-set coverage on a single path. It runs a tiered intent set (easy /
+medium / hard) through two variants — the full CLI path
+(`template --ai`: rich prompt, knowledge tools, tool loop) and a faithful
+replication of the weakest embedded prompt (no tools, single shot) — and
+judges every artifact with the three deterministic static gates
+(`validate`, `dry-run`, `lint`; exit code only, no LLM judge).
+
+Per-run token usage comes from the AI session archives (CLI variant) or
+the provider response (minimal variant), so each cell of the
+{path × model} matrix reports gate pass@1 alongside tokens, estimated
+cost, and wall time. This is the evidence base for unifying the AI
+generation paths (#342) and for sizing its TeamProfile cost tiers.
+
+```bash
+python3 eval/frontier/run_eval.py --variants minimal,cli
+```
+
+See `eval/frontier/README.md` for the full method, price-table
+configuration, and known limitations.

--- a/eval/frontier/PILOT_FINDINGS.md
+++ b/eval/frontier/PILOT_FINDINGS.md
@@ -1,0 +1,59 @@
+# Pilot findings — DeepSeek v4-flash (Anthropic-compatible endpoint)
+
+First run of the frontier benchmark, 2026-09-09. 9 intents (3 easy /
+3 medium / 3 hard), one seed per cell, `deepseek-v4-flash-vision-exp`
+via `https://api.deepseek.com/anthropic` (the same wire protocol Claude
+Code uses). Machine-local artifacts under `results/` (gitignored).
+
+## Headline
+
+| cell | runs | artifacts | all-gates pass | tokens in/out | est. cost* |
+|---|---|---|---|---|---|
+| `minimal` (weak embedded prompt) | 9 | 8 | **0/9** | 2,382 / 51,447 | ~$0.057 |
+| `cli` @ default (max_tokens 4096, timeout 120s) | 9 | **0** | 0/9 | n/a (sessions lost — pre-fix) | wasted |
+| `cli` @ raised (16384 / 300s) | 9 | 4 | **3/9** | ~79k / ~65k (two batches) | ~$0.094 |
+
+\* price table: $0.28/M in, $1.10/M out (repo constant, `oxo-flow-ai/src/types.rs`).
+
+Both provider-side ceilings were found **by this benchmark** and are fixed
+in the same PR: `OXO_FLOW_AI_MAX_TOKENS` (thinking blocks count against
+`max_tokens`; 4096 truncates before any text) and
+`OXO_FLOW_AI_TIMEOUT_SECS` (120s kills long completions mid-body).
+
+## Failure taxonomy
+
+- `minimal`, 8/9: generates **a wrong dialect** — Snakemake-style
+  `[rules.x]` tables, `inputs = {...}` maps, `depends` keys. The gate
+  rejects with structured `E017` (unknown key). The weakest embedded path
+  does not merely underperform; it teaches the model a schema oxo-flow
+  does not have. This is the quantified case for #342's P1 (one shared,
+  engine-accurate generation persona).
+- `minimal`, 1/9 (hard tier): hit the 8192 completion cap mid-fence → no
+  extractable TOML at all.
+- `cli` @ raised, 4/9: tool loop ends without text TOML ("did not contain
+  valid .oxoflow TOML") — rounds burned on knowledge tools, and the
+  tool-free final round has no retry. 1/9: contentless (thinking-only)
+  response, no retry. 1/9 (`qc-fastqc`): valid-looking artifact using a
+  Nextflow-ism (`foreach`) → `E017`; **the strong path also lacks a
+  validation-feedback loop** (it warns on schema errors and writes
+  anyway).
+- 3/9 PASS with all three gates, including the hard-tier
+  `metagenomics-kraken2`.
+
+## Implications for #342
+
+1. The cross-path quality gap is real and measurable (0/9 vs 3/9 on the
+   same model) — unification P1–P4 is justified by data, not aesthetics.
+2. The dominant CLI failure mode (tool-loop TOML miss + no final-round
+   retry) is an orchestrator-robustness gap that P3 resolves by
+   construction; a cheap interim fix is a bounded retry of the
+   tool-free final round.
+3. The `E017` class (wrong-dialect keys) is exactly what P2's gate tools
+   + correction loop eliminate: the engine already returns structured,
+   actionable codes.
+4. Cost: even on a cheap backend, every failed path costs real tokens.
+   Token accounting (session archives) must never be silently skipped —
+   fixed here for the CLI failure paths.
+
+Method and caveats: see README ("Known limitations" — small intent set,
+single seed, tool-loop budget is not yet a correction loop).

--- a/eval/frontier/README.md
+++ b/eval/frontier/README.md
@@ -1,0 +1,71 @@
+# AI Generation Frontier Benchmark (issue #342 / proposal P6)
+
+Measures the **quality/cost frontier** of the AI pipeline-generation paths
+against the engine's three deterministic static gates. Success is judged
+**only** by the gates — never by an LLM judge — so numbers are reproducible
+and cheap.
+
+This complements the gold-set evaluation in [`eval/`](../README.md) and
+[docs/guide/src/reference/ai-eval.md](https://traitome.github.io/oxo-flow/latest/reference/ai-eval/):
+that system scores coverage against reviewed gold rows on a single
+generation path; this one compares **paths and models** (quality per token
+spent) on a tiered intent set, which is the evidence base for the #342
+unification proposal and its TeamProfile tiers.
+
+## Method
+
+| | variants |
+|---|---|
+| `cli` | full CLI path: `oxo-flow template --ai` — rich prompt + knowledge tools + tool-calling loop (the "strong" path) |
+| `minimal` | faithful replication of the weakest embedded path (web chat `process_chat` prompt: 7 generic rules, no tools, single shot) (the "floor") |
+
+Gates (exit 0 = pass, machine-readable JSON captured per run):
+
+1. `oxo-flow validate --json` — structure / DAG / wildcard syntax
+2. `oxo-flow dry-run --json` — expansion preview, resource audit
+3. `oxo-flow lint --json` — best practices
+
+Token accounting: `cli` reads the AI session archive
+(`~/.oxo-flow/ai_sessions/*-template-*.json`); `minimal` reads the provider
+response usage. Cost is derived from the price table in `run_eval.py`
+(defaults mirror the repo constant in `oxo-flow-ai/src/types.rs`).
+
+## Usage
+
+```bash
+# credentials: ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL
+# from env, or parsed silently from ~/.zshrc (never printed)
+
+python3 run_eval.py                          # pilot: 9 intents x minimal,cli
+python3 run_eval.py --filter rnaseq-star     # subset
+python3 run_eval.py --models deepseek-chat   # model axis (quality/cost frontier)
+python3 run_eval.py --variants minimal       # cheapest full sweep
+```
+
+Thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible
+endpoint) need a raised output budget: export
+`OXO_FLOW_AI_MAX_TOKENS=16384` or the loop truncates before the TOML is
+written (the default 4096 is consumed by reasoning blocks).
+
+Results land in `results/<stamp>/` (gitignored): one directory per run
+(generated workflow, gate JSON/stderr, CLI log, session snapshot), plus
+`results.json` (machine-readable) and `report.md` (aggregated pass@1,
+tokens, cost, latency).
+
+## Interpreting
+
+- `all-gates pass@1` is the headline quality metric (deterministic).
+- `minimal` vs `cli` quantifies what the rich prompt + tool loop buy —
+  the core empirical claim behind unifying the four generation paths (#342).
+- The `model` axis gives a quality/cost frontier for the `TeamProfile`
+  tiers (Full vs Compact) proposed in #342.
+- Gate failures carry structured error codes (e.g. `E017` unknown key),
+  which classify failure modes without any LLM involvement.
+
+## Known limitations
+
+- Intent set is small (9); scale `intents.json` before quoting absolute
+  numbers. Relative gaps between variants stabilize faster than absolutes.
+- The `cli` variant's correction budget is a tool-loop budget (`--ai-max-retries`);
+  the CLI path has no validation-feedback loop yet (that is proposal P1–P3).
+- Single seed per cell (no repetition); rerun for variance estimates.

--- a/eval/frontier/intents.json
+++ b/eval/frontier/intents.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "description": "AI generation benchmark intent set. Tiers follow BioAgents L1-L3 complexity levels; success = all three static gates pass (validate/dry-run/lint, deterministic).",
+  "intents": [
+    {
+      "id": "qc-fastp-multiqc",
+      "tier": "easy",
+      "domain": "qc",
+      "intent": "Quality control of paired-end FASTQ reads with fastp, and aggregate reports with MultiQC"
+    },
+    {
+      "id": "qc-fastqc",
+      "tier": "easy",
+      "domain": "qc",
+      "intent": "Run FastQC quality check on raw sequencing reads for a cohort of samples"
+    },
+    {
+      "id": "trim-cutadapt",
+      "tier": "easy",
+      "domain": "qc",
+      "intent": "Adapter and quality trimming of small RNA sequencing reads with cutadapt"
+    },
+    {
+      "id": "rnaseq-star",
+      "tier": "medium",
+      "domain": "rna-seq",
+      "intent": "RNA-seq analysis pipeline: fastp QC and trimming, STAR alignment to a reference genome, featureCounts gene quantification, and MultiQC summary"
+    },
+    {
+      "id": "germline-variant",
+      "tier": "medium",
+      "domain": "variant-calling",
+      "intent": "Germline SNV calling: fastp preprocessing, bwa-mem alignment, samtools sorting and indexing, bcftools variant calling and filtering"
+    },
+    {
+      "id": "chipseq-macs2",
+      "tier": "medium",
+      "domain": "chip-seq",
+      "intent": "ChIP-seq peak calling pipeline: fastp QC, bowtie2 alignment against a reference genome, samtools processing, MACS2 peak calling"
+    },
+    {
+      "id": "atacseq",
+      "tier": "hard",
+      "domain": "atac-seq",
+      "intent": "ATAC-seq analysis: fastp QC, bwa-mem2 alignment, properly paired read filtering, MACS2 peak calling with shift model, and fragment-size QC"
+    },
+    {
+      "id": "metagenomics-kraken2",
+      "tier": "hard",
+      "domain": "metagenomics",
+      "intent": "Metagenomic profiling of shotgun reads: fastp QC, kraken2 taxonomic classification, bracken abundance re-estimation, and a Krona visualization chart"
+    },
+    {
+      "id": "somatic-tumor-normal",
+      "tier": "hard",
+      "domain": "variant-calling",
+      "intent": "Tumor-normal somatic variant calling: fastp QC, bwa-mem alignment of both samples, samtools processing, Strelka2 somatic SNV and indel calling"
+    }
+  ]
+}

--- a/eval/frontier/rejudge.py
+++ b/eval/frontier/rejudge.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Re-judge existing benchmark artifacts without re-calling the provider.
+
+For every run directory under <results_dir>: locate the generated
+*.oxoflow (wherever the variant left it), canonicalize it to
+workflow.oxoflow, re-run the three static gates, and patch result.json.
+Use after engine changes to re-score the same generations, or to repair
+runs whose gate step missed a nested artifact.
+
+    python3 rejudge.py results/ab-16384 [--binary /path/to/oxo-flow]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from run_eval import find_binary, run_gates  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("results_dir", type=Path)
+    ap.add_argument("--binary", default=None)
+    args = ap.parse_args()
+
+    binary = args.binary or find_binary()
+    run_dirs = sorted(p for p in args.results_dir.iterdir() if p.is_dir())
+    print(f"re-judging {len(run_dirs)} run(s) in {args.results_dir} with {binary}")
+
+    for run_dir in run_dirs:
+        result_file = run_dir / "result.json"
+        if not result_file.exists():
+            print(f"  skip {run_dir.name}: no result.json")
+            continue
+        result = json.loads(result_file.read_text())
+
+        wf = run_dir / "workflow.oxoflow"
+        if not wf.exists():
+            candidates = [p for p in sorted(run_dir.rglob("*.oxoflow"))
+                          if p != wf]
+            if candidates:
+                wf.write_text(candidates[0].read_text())
+        if not wf.exists():
+            print(f"  {run_dir.name}: no artifact — keeping generated={result['generated']}")
+            continue
+
+        gates = run_gates(binary, wf, run_dir)
+        result["generated"] = True
+        result["gates"] = gates
+        result["all_gates_pass"] = all(g["pass"] for g in gates.values())
+        result["workflow_file"] = str(wf)
+        result_file.write_text(json.dumps(result, indent=2))
+        verdict = "PASS" if result["all_gates_pass"] else "FAIL"
+        detail = " ".join(f"{g}={'ok' if v['pass'] else v['exit']}"
+                          for g, v in gates.items())
+        print(f"  {run_dir.name}: {verdict} ({detail})")
+
+    print("done — re-run the report aggregation in run_eval.py or read result.json files")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""AI generation benchmark for oxo-flow (issue #342 / proposal P6).
+
+Measures the quality/cost frontier of the AI pipeline-generation paths
+against the engine's three deterministic static gates:
+
+    oxo-flow validate --json   (structure, DAG, wildcard syntax)
+    oxo-flow dry-run  --json   (expansion preview, resource audit)
+    oxo-flow lint     --json   (best practices)
+
+Variants
+    cli      full CLI path: `oxo-flow template --ai` (rich prompt + knowledge
+             tools + tool-calling loop) — the "strong" path.
+    minimal  faithful replication of the weakest embedded path (web chat
+             `process_chat` prompt: 7 generic rules, no tools, no knowledge
+             injection, single shot) — the "floor" path.
+
+Success is judged ONLY by the deterministic gates (never by an LLM judge),
+so the numbers are reproducible and cheap. Token usage comes from the AI
+session archives (cli) or the provider response (minimal); cost is derived
+from a configurable price table.
+
+Usage
+    # pilot: all intents, both variants, the model configured in the env
+    python3 run_eval.py
+
+    # subset, specific models, custom output dir
+    python3 run_eval.py --filter rnaseq-star,atacseq \
+        --models deepseek-chat --out results/pilot2
+
+Credentials are read from the environment (ANTHROPIC_BASE_URL /
+ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL) or, as a fallback, parsed silently
+from ~/.zshrc. Values are never printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# USD per 1M tokens. Defaults mirror the repo's own cost constant
+# (crates/oxo-flow-ai/src/types.rs: deepseek-v4-pro 0.28 in / 1.10 out,
+# pricing as of 2026-08). Add per-model overrides here as needed.
+PRICE_PER_MTOK = {
+    "*": (0.28, 1.10),
+}
+
+ZSHRC = Path.home() / ".zshrc"
+ZSHRC_KEYS = ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL")
+
+MINIMAL_SYSTEM = """You are a bioinformatics pipeline expert. Generate valid .oxoflow TOML configurations.
+
+Intent: {intent}
+
+Rules:
+1. Output TOML in ```toml code fences
+2. Use well-known bioinformatics tools with correct command-line syntax
+3. Include [workflow] section with name, version, description
+4. Define rules with name, shell, inputs, outputs, depends
+5. Use {{sample}} wildcard for sample-varying paths
+6. Specify conda environment for each rule when possible
+7. Include resource hints (threads, memory) in [resources] section"""
+
+
+def load_credentials() -> dict[str, str]:
+    """ANTHROPIC_* from the environment, falling back to ~/.zshrc exports."""
+    creds = {k: os.environ.get(k, "") for k in ZSHRC_KEYS}
+    if all(creds.values()):
+        return creds
+    if ZSHRC.exists():
+        for line in ZSHRC.read_text().splitlines():
+            m = re.match(r"\s*export\s+(ANTHROPIC_[A-Z_]+)=(.*)$", line)
+            if not m:
+                continue
+            key, val = m.group(1), m.group(2).strip().strip("\"'")
+            if not creds.get(key):
+                creds[key] = val
+    missing = [k for k in ZSHRC_KEYS if not creds.get(k)]
+    if missing:
+        sys.exit(f"missing credentials: {', '.join(missing)} (env or {ZSHRC})")
+    return creds
+
+
+def find_binary() -> str:
+    for cand in (REPO / "target/debug/oxo-flow", "oxo-flow"):
+        p = Path(cand)
+        if p.is_file() or which(cand):
+            return str(p)
+    sys.exit("oxo-flow binary not found (build with: cargo build -p oxo-flow-cli)")
+
+
+def which(name: str) -> str | None:
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        p = Path(d) / name
+        if p.is_file() and os.access(p, os.X_OK):
+            return str(p)
+    return None
+
+
+def extract_toml(text: str) -> str | None:
+    """Mirror of chat/service.rs extract_toml_from_response."""
+    if "```toml" in text:
+        block = text.split("```toml", 1)[1]
+        if "```" in block:
+            content = block.split("```", 1)[0].strip()
+            if content:
+                return content
+    if "```" in text:
+        block = text.split("```", 1)[1]
+        if "```" in block:
+            content = block.split("```", 1)[0].strip()
+            if "[workflow]" in content:
+                return content
+    if "[workflow]" in text:
+        return text[text.index("[workflow]"):].strip()
+    return None
+
+
+def anthropic_chat(creds: dict, model: str, system: str, user: str,
+                   max_tokens: int, timeout: float) -> tuple[str | None, dict, str | None]:
+    """One Anthropic-messages call. Returns (text, usage, error)."""
+    base = creds["ANTHROPIC_BASE_URL"].rstrip("/")
+    body = json.dumps({
+        "model": model,
+        "max_tokens": max_tokens,
+        "system": system,
+        "messages": [{"role": "user", "content": user}],
+    }).encode()
+    req = urllib.request.Request(
+        f"{base}/v1/messages", data=body, method="POST",
+        headers={
+            "content-type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": creds["ANTHROPIC_AUTH_TOKEN"],
+            "authorization": f"Bearer {creds['ANTHROPIC_AUTH_TOKEN']}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.load(resp)
+    except Exception as e:  # noqa: BLE001 — report any transport/API error verbatim
+        return None, {}, str(e)[:500]
+    if data.get("type") == "error":
+        return None, {}, data.get("error", {}).get("message", "unknown API error")[:500]
+    text = "".join(b.get("text", "") for b in data.get("content", [])
+                   if b.get("type") == "text")
+    usage_in = data.get("usage", {}).get("input_tokens", 0)
+    usage_out = data.get("usage", {}).get("output_tokens", 0)
+    return text or None, {"input": usage_in, "output": usage_out}, None
+
+
+def run_generation(variant: str, intent: str, model: str, run_dir: Path,
+                   creds: dict, binary: str, args) -> dict:
+    """Generate a workflow. Returns usage/meta dict; writes workflow.oxoflow."""
+    meta: dict = {"generated": False, "input_tokens": 0, "output_tokens": 0,
+                  "tool_calls": None, "rounds": None, "error": None}
+    started = time.time()
+    meta["wall_s"] = None
+
+    if variant == "minimal":
+        text, usage, err = anthropic_chat(
+            creds, model, MINIMAL_SYSTEM.format(intent=intent),
+            f"## User Request\nGenerate a .oxoflow pipeline for: {intent}\n\n"
+            "## Task\nGenerate the optimized .oxoflow TOML configuration now. "
+            "Output inside ```toml fences.",
+            max_tokens=8192, timeout=args.timeout,
+        )
+        meta["input_tokens"] = usage.get("input", 0)
+        meta["output_tokens"] = usage.get("output", 0)
+        if err:
+            meta["error"] = err
+            return meta
+        toml = extract_toml(text or "")
+        if not toml:
+            meta["error"] = "no TOML found in response"
+            return meta
+        (run_dir / "workflow.oxoflow").write_text(toml)
+        meta["generated"] = True
+
+    elif variant == "cli":
+        env = dict(os.environ)
+        env["OXO_FLOW_AI_PROVIDER"] = "claude"
+        env["ANTHROPIC_MODEL"] = model
+        sessions = Path.home() / ".oxo-flow/ai_sessions"
+        before = {p.name: p.stat().st_mtime for p in sessions.glob("*-template-*.json")} \
+            if sessions.exists() else {}
+        cmd = [binary, "template", "--ai", intent, "-o", f"{run_dir}/",
+               "--ai-max-retries", str(args.max_retries), "--no-color"]
+        try:
+            proc = subprocess.run(cmd, cwd=run_dir, env=env, timeout=args.timeout,
+                                  capture_output=True, text=True)
+            (run_dir / "cli.log").write_text(proc.stdout + "\n--- stderr ---\n" + proc.stderr)
+            if proc.returncode != 0:
+                meta["error"] = f"template exited {proc.returncode}"
+        except subprocess.TimeoutExpired:
+            meta["error"] = "generation timed out"
+            return meta
+        # Token accounting: newest template session created by this run.
+        if sessions.exists():
+            new = [p for p in sessions.glob("*-template-*.json")
+                   if p.stat().st_mtime > started
+                   and p.name not in before]
+            if new:
+                snap = max(new, key=lambda p: p.stat().st_mtime)
+                (run_dir / "session.json").write_text(snap.read_text())
+                try:
+                    s = json.loads(snap.read_text())
+                    u = s.get("total_usage", {})
+                    meta["input_tokens"] = u.get("prompt_tokens", 0)
+                    meta["output_tokens"] = u.get("completion_tokens", 0)
+                    meta["tool_calls"] = len(s.get("tool_calls", []))
+                    meta["rounds"] = s.get("rounds")
+                except json.JSONDecodeError:
+                    pass
+        wf = sorted(run_dir.glob("*.oxoflow"))
+        if wf:
+            meta["generated"] = True
+        elif not meta["error"]:
+            meta["error"] = "no .oxoflow file produced"
+    else:
+        sys.exit(f"unknown variant: {variant}")
+
+    meta["wall_s"] = round(time.time() - started, 1)
+    return meta
+
+
+def run_gates(binary: str, wf: Path, run_dir: Path) -> dict:
+    """The three static gates. Exit 0 = pass. JSON captured separately."""
+    gates = {}
+    for gate in ("validate", "dry-run", "lint"):
+        out = run_dir / f"{gate}.json"
+        err = run_dir / f"{gate}.err"
+        try:
+            proc = subprocess.run([binary, gate, "--json", str(wf)],
+                                  cwd=run_dir, timeout=120,
+                                  capture_output=True, text=True)
+        except subprocess.TimeoutExpired:
+            gates[gate] = {"exit": 124, "pass": False}
+            continue
+        out.write_text(proc.stdout)
+        err.write_text(proc.stderr)
+        entry: dict = {"exit": proc.returncode, "pass": proc.returncode == 0}
+        try:
+            j = json.loads(proc.stdout)
+            if gate == "validate":
+                entry["valid"] = j.get("valid")
+                entry["n_errors"] = len(j.get("errors", []))
+                entry["n_missing_inputs"] = len(j.get("missing_inputs", []))
+            elif gate == "lint":
+                entry["n_warnings"] = len(j.get("warnings", [])) or None
+        except json.JSONDecodeError:
+            pass
+        gates[gate] = entry
+    return gates
+
+
+def cost_usd(model: str, tin: int, tout: int) -> float:
+    pin, pout = PRICE_PER_MTOK.get(model, PRICE_PER_MTOK["*"])
+    return tin * pin / 1e6 + tout * pout / 1e6
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--intents", default=str(Path(__file__).parent / "intents.json"))
+    ap.add_argument("--out", default=None, help="results directory (default: results/<stamp>)")
+    ap.add_argument("--variants", default="minimal,cli")
+    ap.add_argument("--models", default="", help="comma list; default: env ANTHROPIC_MODEL")
+    ap.add_argument("--filter", default="", help="comma list of intent ids to include")
+    ap.add_argument("--max-retries", type=int, default=2,
+                    help="CLI tool-loop budget (--ai-max-retries)")
+    ap.add_argument("--timeout", type=float, default=900, help="per-generation timeout (s)")
+    ap.add_argument("--sleep", type=float, default=1.0, help="pause between runs (s)")
+    args = ap.parse_args()
+
+    creds = load_credentials()
+    binary = find_binary()
+    default_model = creds["ANTHROPIC_MODEL"]
+    models = [m for m in args.models.split(",") if m] or [default_model]
+    variants = [v for v in args.variants.split(",") if v]
+
+    intents = json.loads(Path(args.intents).read_text())["intents"]
+    if args.filter:
+        keep = {x.strip() for x in args.filter.split(",")}
+        intents = [i for i in intents if i["id"] in keep]
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_dir = Path(args.out) if args.out else Path(__file__).parent / "results" / stamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = []
+    total = len(intents) * len(models) * len(variants)
+    done = 0
+    print(f"benchmark: {len(intents)} intents x {len(models)} model(s) x "
+          f"{len(variants)} variant(s) = {total} runs -> {out_dir}")
+    for model in models:
+        for variant in variants:
+            for spec in intents:
+                done += 1
+                run_dir = out_dir / f"{model}__{variant}__{spec['id']}"
+                run_dir.mkdir(parents=True, exist_ok=True)
+                print(f"[{done}/{total}] {model} / {variant} / {spec['id']} ...", flush=True)
+                gen = run_generation(variant, spec["intent"], model, run_dir,
+                                     creds, binary, args)
+                wf = run_dir / "workflow.oxoflow"
+                if not wf.exists():
+                    alt = sorted(run_dir.glob("*.oxoflow"))
+                    wf = alt[0] if alt else None
+                gates = run_gates(binary, wf, run_dir) if wf else {}
+                result = {
+                    "intent_id": spec["id"], "tier": spec["tier"],
+                    "domain": spec["domain"], "model": model, "variant": variant,
+                    **gen,
+                    "gates": gates,
+                    "all_gates_pass": bool(gates) and all(g["pass"] for g in gates.values()),
+                    "workflow_file": str(wf) if wf else None,
+                    "est_cost_usd": round(cost_usd(model, gen["input_tokens"],
+                                                   gen["output_tokens"]), 5),
+                }
+                (run_dir / "result.json").write_text(json.dumps(result, indent=2))
+                runs.append(result)
+                print(f"    generated={result['generated']} "
+                      f"gates={'PASS' if result['all_gates_pass'] else 'FAIL'} "
+                      f"tok(in/out)={result['input_tokens']}/{result['output_tokens']} "
+                      f"wall={result.get('wall_s')}s", flush=True)
+                time.sleep(args.sleep)
+
+    (out_dir / "results.json").write_text(json.dumps({
+        "stamp": stamp,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "binary": binary,
+        "default_model": default_model,
+        "max_retries": args.max_retries,
+        "runs": runs,
+    }, indent=2))
+
+    # Aggregate report
+    lines = ["# AI generation benchmark report", "",
+             f"Stamp: `{stamp}` · binary: `{binary}` · success = all three gates exit 0", ""]
+    groups: dict[tuple, list] = {}
+    for r in runs:
+        groups.setdefault((r["model"], r["variant"]), []).append(r)
+    for (model, variant), rs in sorted(groups.items()):
+        n = len(rs)
+        gen_n = sum(r["generated"] for r in rs)
+        v = sum(r["gates"].get("validate", {}).get("pass", False) for r in rs)
+        d = sum(r["gates"].get("dry-run", {}).get("pass", False) for r in rs)
+        l = sum(r["gates"].get("lint", {}).get("pass", False) for r in rs)
+        allp = sum(r["all_gates_pass"] for r in rs)
+        tok_in = sum(r["input_tokens"] for r in rs)
+        tok_out = sum(r["output_tokens"] for r in rs)
+        wall = [r.get("wall_s", 0) for r in rs]
+        cost = sum(r["est_cost_usd"] for r in rs)
+        lines += [
+            f"## {model} / {variant}", "",
+            f"- runs: {n}, generated: {gen_n}",
+            f"- gate pass@1: validate {v}/{n}, dry-run {d}/{n}, lint {l}/{n}, "
+            f"**all-gates {allp}/{n}** ({allp / n:.0%})",
+            f"- tokens: in {tok_in:,} / out {tok_out:,} "
+            f"(mean {tok_in // max(n, 1):,}/{tok_out // max(n, 1):,} per run)",
+            f"- est. cost: ${cost:.4f} (price table {PRICE_PER_MTOK.get(model, PRICE_PER_MTOK['*'])}/Mtok)",
+            f"- wall: mean {sum(wall) / max(n, 1):.0f}s, max {max(wall or [0]):.0f}s",
+            "",
+            "| intent | tier | all-gates | tok in | tok out | wall s | note |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for r in rs:
+            note = r.get("error") or ""
+            lines.append(
+                f"| {r['intent_id']} | {r['tier']} | "
+                f"{'✅' if r['all_gates_pass'] else '❌'} | "
+                f"{r['input_tokens']:,} | {r['output_tokens']:,} | "
+                f"{r.get('wall_s', '')} | {note[:60]} |")
+        lines.append("")
+    (out_dir / "report.md").write_text("\n".join(lines))
+    print(f"\ndone: {out_dir / 'report.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -222,7 +222,9 @@ def run_generation(variant: str, intent: str, model: str, run_dir: Path,
                     meta["rounds"] = s.get("rounds")
                 except json.JSONDecodeError:
                     pass
-        wf = sorted(run_dir.glob("*.oxoflow"))
+        # rglob: a relative -o target resolved inside a relative run_dir can
+        # nest the artifact one level deeper — find it wherever it landed.
+        wf = sorted(run_dir.rglob("*.oxoflow"))
         if wf:
             meta["generated"] = True
         elif not meta["error"]:
@@ -241,7 +243,9 @@ def run_gates(binary: str, wf: Path, run_dir: Path) -> dict:
         out = run_dir / f"{gate}.json"
         err = run_dir / f"{gate}.err"
         try:
-            proc = subprocess.run([binary, gate, "--json", str(wf)],
+            # Same convention as eval/scripts/runner.py: cwd = run dir, file
+            # addressed by basename — safe even when `wf` is a relative path.
+            proc = subprocess.run([binary, gate, "--json", wf.name],
                                   cwd=run_dir, timeout=120,
                                   capture_output=True, text=True)
         except subprocess.TimeoutExpired:
@@ -294,7 +298,8 @@ def main() -> None:
         intents = [i for i in intents if i["id"] in keep]
 
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    out_dir = Path(args.out) if args.out else Path(__file__).parent / "results" / stamp
+    out_dir = Path(args.out).resolve() if args.out \
+        else Path(__file__).resolve().parent / "results" / stamp
     out_dir.mkdir(parents=True, exist_ok=True)
 
     runs = []
@@ -313,8 +318,11 @@ def main() -> None:
                                      creds, binary, args)
                 wf = run_dir / "workflow.oxoflow"
                 if not wf.exists():
-                    alt = sorted(run_dir.glob("*.oxoflow"))
-                    wf = alt[0] if alt else None
+                    alt = sorted(run_dir.rglob("*.oxoflow"))
+                    if alt:
+                        wf.write_text(alt[0].read_text())
+                    else:
+                        wf = None
                 gates = run_gates(binary, wf, run_dir) if wf else {}
                 result = {
                     "intent_id": spec["id"], "tier": spec["tier"],


### PR DESCRIPTION
Refs #342 (partial — evidence + P6 groundwork; the unification phases P1–P5 remain).

## What

Three pieces, driven by actually running the benchmark against a real provider (DeepSeek v4-flash via the Anthropic-compatible endpoint, i.e. the same wire protocol Claude Code uses):

### 1. Provider fix: `OXO_FLOW_AI_MAX_TOKENS` (oxo-flow-ai)

The Anthropic Messages body hardcoded `max_tokens: 4096`. Thinking-style backends emit `thinking` blocks whose tokens count against that ceiling — measured: a single generation can spend ~4k tokens on reasoning alone. Result: `template --ai` on such backends reliably failed with "AI response did not contain valid .oxoflow TOML" after burning paid calls, because the answer truncated before any text block existed.

- New env override `OXO_FLOW_AI_MAX_TOKENS` (strict positive-int parse, default **4096 unchanged**), unit-tested.

### 2. CLI accounting fix (oxo-flow-cli)

On the same failure path, `template --ai` bailed on TOML extraction **without archiving the AI session** — every such generation was invisible to token accounting. The session is now saved before the bail.

### 3. Frontier benchmark (eval/frontier)

Complements the existing gold-set eval (`eval/`, #167): that system measures coverage on one path; this one measures the **quality/cost frontier across paths and models** — the evidence base #342 needs.

- Tiered intent set (easy/medium/hard × 6 domains, extensible)
- Variants: `cli` (full `template --ai`) vs `minimal` (faithful replication of the weakest embedded prompt — web chat `process_chat`)
- Judged **solely** by the three deterministic gates (`validate`/`dry-run`/`lint --json`, exit codes; no LLM judge)
- Token accounting from AI session archives (cli) / provider usage (minimal); configurable price table; wall time
- Model axis for sizing the TeamProfile tiers proposed in #342

## Pilot evidence (9 intents × 2 variants, DeepSeek v4-flash)

- **The minimal prompt teaches a wrong schema.** Its "rules" describe Snakemake-style `[rules.x]` tables with `inputs = {...}` maps and `depends` keys — every artifact failed `validate` with structured `E017` (unknown key). The weak embedded path is not just weaker; it is actively wrong. This quantifies what unification (P1) fixes.
- **The CLI path truncated at 4096 max_tokens** on this thinking backend (root cause of fix #1 above) — the intervention (raised ceiling) is what fix #1 enables and is re-measured with the benchmark itself.

Full method + limitations in `eval/frontier/README.md`; docs updated (AGENTS.md, `reference/ai-cli.md`, `reference/ai-eval.md`).

## Test plan

- [x] `make ci` (fmt, clippy, build, workspace tests, frontend lint)
- [x] New `parse_max_tokens` unit tests
- [x] Benchmark ran end-to-end against a live provider (18 runs); artifacts and report generated
