### PR TITLE
fix(scheduler): treat plan-absent deps as satisfied in ready_rules

### DIFF
--- a/crates/oxo-flow-core/src/scheduler.rs
+++ b/crates/oxo-flow-core/src/scheduler.rs
@@ -111,6 +111,14 @@ impl SchedulerState {
     }
 
     /// Returns all rules that are ready to run (dependencies satisfied, not yet started).
+    ///
+    /// A dependency that is absent from `self.statuses` is outside this run's
+    /// plan (e.g. a when-gated-false producer pruned by the targeted
+    /// execution-order planner, which keeps the consumer via OR-per-output
+    /// propagation as long as a surviving producer exists). Such dependencies
+    /// never appear in the scheduler and must not block readiness; dataflow
+    /// safety is guaranteed by the planner keeping the rule only when all of
+    /// its required outputs have a surviving producer.
     pub fn ready_rules(&self, dag: &WorkflowDag) -> Result<Vec<String>> {
         let mut ready = Vec::new();
 
@@ -121,10 +129,12 @@ impl SchedulerState {
 
             let deps = dag.dependencies(rule)?;
             let all_deps_done = deps.iter().all(|dep| {
-                matches!(
-                    self.statuses.get(dep),
-                    Some(JobStatus::Success | JobStatus::Skipped)
-                )
+                match self.statuses.get(dep) {
+                    // Dependency not scheduled in this run: not our concern.
+                    None => true,
+                    Some(JobStatus::Success | JobStatus::Skipped) => true,
+                    Some(_) => false,
+                }
             });
 
             if all_deps_done {
@@ -874,6 +884,98 @@ mod tests {
 
         let ready = state.ready_rules(&dag).unwrap();
         assert_eq!(ready, vec!["a"]);
+    }
+
+    #[test]
+    fn scheduler_ready_rules_ignores_unscheduled_dep() {
+        // Mirrors a targeted `-t` run: the planner prunes a when-gated-false
+        // producer `p` but keeps its consumer `c` because another producer
+        // survives (OR-per-output propagation). `c` therefore depends on `p`
+        // in the DAG while `p` is absent from the scheduler statuses.
+        let rules = vec![
+            Rule {
+                name: "a".to_string(),
+                input: vec![].into(),
+                output: vec!["a.txt".to_string()].into(),
+                shell: Some("echo a".to_string()),
+                script: None,
+                threads: None,
+                memory: None,
+                resources: Resources::default(),
+                environment: EnvironmentSpec::default(),
+                log: None,
+                benchmark: None,
+                params: HashMap::new(),
+                priority: 0,
+                target: false,
+                group: None,
+                description: None,
+                ..Default::default()
+            },
+            Rule {
+                name: "p".to_string(),
+                input: vec![].into(),
+                output: vec!["p.txt".to_string()].into(),
+                shell: Some("echo p".to_string()),
+                script: None,
+                threads: None,
+                memory: None,
+                resources: Resources::default(),
+                environment: EnvironmentSpec::default(),
+                log: None,
+                benchmark: None,
+                params: HashMap::new(),
+                priority: 0,
+                target: false,
+                group: None,
+                description: None,
+                ..Default::default()
+            },
+            Rule {
+                name: "c".to_string(),
+                input: vec!["a.txt".to_string(), "p.txt".to_string()].into(),
+                output: vec!["c.txt".to_string()].into(),
+                shell: Some("echo c".to_string()),
+                script: None,
+                threads: None,
+                memory: None,
+                resources: Resources::default(),
+                environment: EnvironmentSpec::default(),
+                log: None,
+                benchmark: None,
+                params: HashMap::new(),
+                priority: 0,
+                target: false,
+                group: None,
+                description: None,
+                ..Default::default()
+            },
+        ];
+        let dag = WorkflowDag::from_rules(&rules).unwrap();
+        // Simulate the plan: `a` and `c` are scheduled; pruned producer `p` is not.
+        let state = SchedulerState::new(&["a", "c"]);
+
+        let ready = state.ready_rules(&dag).unwrap();
+        assert_eq!(ready, vec!["a"]);
+        // And once `a` completes, `c` becomes ready despite the absent `p`.
+        let mut state = state;
+        state.mark_completed(JobRecord {
+            rule: "a".to_string(),
+            status: JobStatus::Success,
+            started_at: None,
+            finished_at: None,
+            exit_code: Some(0),
+            stdout: Some(String::new()),
+            stderr: Some(String::new()),
+            command: Some(String::new()),
+            retries: 0,
+            skip_reason: None,
+            max_rss_mb: None,
+            cpu_seconds: None,
+            caption: Some(String::new()),
+        });
+        let ready = state.ready_rules(&dag).unwrap();
+        assert_eq!(ready, vec!["c"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Targeted runs (`oxo-flow run -t <rule>`) plan only the transitive dependency closure of the target instances. The execution-order planner prunes when-gated-false producers but keeps a consumer as long as a surviving producer covers each required output (OR-per-output propagation, #341). The consumer therefore keeps a DAG edge to a rule that never enters the scheduler.

`SchedulerState::ready_rules` treated a missing entry in `self.statuses` as **unsatisfied** (only `Some(Success|Skipped)` passed), so such a consumer stayed not-ready forever. Once nothing else was running, the run deadlocked.

Live repro (oxo-flow-mag tiny fixture, engine 0.18.0):

```
oxo-flow run -t gunc_megahit_metabat2_cohort_S1 ... --arg reads_sheet=test/fixtures/reads_sheet_cluster.tsv
```

main deadlocks silently (ready empty, running empty; debug instrumentation showed `fastp_cohort_SE1` — a when-gated-false pruned producer — as the absent dep blocking the downstream chain). With this fix the same targeted plan completes: `Done: 1 succeeded, 26 skipped, 0 failed`.

## Fix

In `ready_rules`, a dependency absent from `self.statuses` is outside this run's plan and is treated as satisfied. Dataflow safety is unchanged: the planner already guarantees every required output of a planned rule has a surviving producer. Doc comment added; full-run (non-targeted) semantics are untouched because in a full plan every dependency is scheduled.

## Test

`scheduler_ready_rules_ignores_unscheduled_dep` mirrors the targeted-run shape: producer `p` pruned, consumer `c` kept with surviving alt producer `a`; asserts `c` becomes ready once `a` completes.

Note: an unrelated pre-existing env-dependent test failure exists on clean main when sbatch is on PATH (`backend::driver::tests::driver_errors_when_submit_binary_is_missing`, slurm 22.05.2 env) — not introduced by this PR.