### PR TITLE
fix(test): make driver sbatch-missing test environment-independent

### DIFF
--- a/crates/oxo-flow-core/src/backend/driver.rs
+++ b/crates/oxo-flow-core/src/backend/driver.rs
@@ -1609,10 +1609,16 @@ mod tests {
     #[test]
     fn driver_errors_when_submit_binary_is_missing() {
         let fx = setup();
-        let executor = Arc::new(ClusterExecutor::new(
-            ClusterBackend::Slurm,
-            cluster_config(),
-        ));
+        // Resolve scheduler commands from an empty directory so the test is
+        // environment-independent: on hosts with a real SLURM install,
+        // `sbatch` in PATH would submit successfully and fail the unwrap
+        // below. The empty dir makes `run_cmd` resolve `<dir>/sbatch`,
+        // which never exists.
+        let empty_bin_dir = tempfile::tempdir().unwrap();
+        let executor = Arc::new(
+            ClusterExecutor::new(ClusterBackend::Slurm, cluster_config())
+                .with_scheduler_dir(empty_bin_dir.path().to_path_buf()),
+        );
         let d = BackendDriver::new(
             executor,
             DriverConfig {


### PR DESCRIPTION
## Problem

Follow-up finding from #347 (non-mainline item at the bottom of the issue body): `backend::driver::tests::driver_errors_when_submit_binary_is_missing` constructs a bare `ClusterExecutor` and expects the submit to fail because `sbatch` is missing. On hosts with a real SLURM install (observed with slurm 22.05.2), `sbatch` **is** on PATH, the submit succeeds, and `unwrap_err()` panics on clean `main` — a host-dependent test failure.

## Fix

Resolve scheduler commands from an **empty temp directory** via the existing `with_scheduler_dir` plumbing (already used by the mock-scheduler tests):

- `run_cmd` resolves `program` to `<empty_dir>/sbatch`, which never exists → the `failed to run '<dir>/sbatch'` error fires on any host;
- the existing assertion (`msg.contains("sbatch")`) still holds because the error message embeds the resolved path;
- no PATH manipulation, no `#[ignore]`, no test-env leakage — the temp dir is dropped with the fixture.

## Verification

- `cargo test -p oxo-flow-core driver_errors_when_submit_binary_is_missing` — 1 passed
- `cargo test -p oxo-flow-core backend::driver` — 24 passed, 0 failed
- `cargo fmt -p oxo-flow-core -- --check` — clean
- `cargo clippy -p oxo-flow-core --all-targets` — clean

Closes #347 (the deadlock itself was fixed by #346; this PR lands the issue's follow-up finding and closes the issue out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
