### PR TITLE
fix(ai): finish the unified generation harness — provider isolation, structured error paths, budget default, docs

### DIFF
--- a/crates/oxo-flow-ai/src/agent/orchestrator.rs
+++ b/crates/oxo-flow-ai/src/agent/orchestrator.rs
@@ -83,6 +83,7 @@ impl Orchestrator {
                     "exceeded max rounds ({}) without valid output",
                     self.max_rounds
                 ));
+                log_session_usage(&failed);
                 let _ = crate::session::save_session(&failed);
                 return Err(AiError::MaxRoundsExceeded {
                     max: self.max_rounds,
@@ -90,6 +91,7 @@ impl Orchestrator {
             }
             if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
                 let failed = session.fail("cancelled by caller");
+                log_session_usage(&failed);
                 let _ = crate::session::save_session(&failed);
                 return Err(AiError::ToolError {
                     tool: "cancelled".into(),
@@ -289,6 +291,7 @@ impl Orchestrator {
         } else {
             session.fail("No valid content produced")
         };
+        log_session_usage(&completed);
 
         Ok(AgentOutcome {
             success,
@@ -326,6 +329,25 @@ pub fn tool_call_approved(
     match (registry.get(name), approver) {
         (Some(tool), Some(approve)) => approve(&tool.def(), arguments),
         _ => false,
+    }
+}
+
+/// Emit the paid-for token spend of a finished run to the operation log.
+/// Every surface that runs an agent goes through here, so a generation's
+/// cost is visible even when the session itself is dropped by the caller
+/// (web surfaces intentionally do not archive sessions to disk).
+fn log_session_usage(session: &crate::session::AiSession) {
+    let usage = &session.total_usage;
+    if usage.prompt_tokens > 0 || usage.completion_tokens > 0 {
+        tracing::info!(
+            command = %session.command,
+            provider = %session.provider,
+            model = %session.model,
+            session = %session.id,
+            prompt_tokens = usage.prompt_tokens,
+            completion_tokens = usage.completion_tokens,
+            "AI generation usage"
+        );
     }
 }
 

--- a/crates/oxo-flow-ai/src/config.rs
+++ b/crates/oxo-flow-ai/src/config.rs
@@ -58,7 +58,14 @@ pub struct AiConfig {
 }
 
 fn default_max_retries() -> u32 {
-    3
+    // Rounds are shared between knowledge-tool lookups and validation-feedback
+    // corrections: tool-heavy intents routinely spend 2-3 rounds querying the
+    // embedded databases before writing any TOML, and a correction pass needs
+    // 1-2 more. A budget of 3 starved those intents into a failed run whose
+    // only remedy was paying for a full re-generation (the web surfaces
+    // already run 6 for exactly this reason); 6 covers both phases, and the
+    // loop still stops as soon as a draft validates.
+    6
 }
 
 impl Default for AiConfig {

--- a/crates/oxo-flow-ai/src/config.rs
+++ b/crates/oxo-flow-ai/src/config.rs
@@ -57,7 +57,11 @@ pub struct AiConfig {
     pub skills: Vec<String>,
 }
 
-fn default_max_retries() -> u32 {
+/// The shipped round-budget default. Single source for every consumer that
+/// sizes an agent loop without explicit user configuration — the CLI config
+/// chain, the web surfaces' chat budget, and config writes (a reconfigure
+/// that persisted the old starved default would quietly reintroduce it).
+pub fn default_max_retries() -> u32 {
     // Rounds are shared between knowledge-tool lookups and validation-feedback
     // corrections: tool-heavy intents routinely spend 2-3 rounds querying the
     // embedded databases before writing any TOML, and a correction pass needs

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -123,6 +123,36 @@ impl AiProvider {
         }
     }
 
+    /// Whether calls on this provider can possibly succeed. `Noop` is the
+    /// resolved nothing-configured state; every other variant carries the
+    /// backend it needs. Surfaces gate their AI_NOT_CONFIGURED responses on
+    /// this instead of pattern-matching the variant by hand.
+    pub fn is_usable(&self) -> bool {
+        !matches!(self, Self::Noop)
+    }
+
+    /// Whether `other` is the very same provider configuration — name,
+    /// model, endpoint, AND credential. Fallback chains use this to skip a
+    /// candidate that duplicates an already-attempted one; two rows that
+    /// differ only by API key are NOT the same (a gateway deployment may
+    /// serve the same URL/model to a user key and a server key).
+    pub fn same_configuration(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Claude(a), Self::Claude(b)) => {
+                a.model == b.model && a.api_url == b.api_url && a.api_key == b.api_key
+            }
+            (Self::OpenAi(a), Self::OpenAi(b))
+            | (Self::DeepSeek(a), Self::DeepSeek(b))
+            | (Self::OpenAi(a), Self::DeepSeek(b))
+            | (Self::DeepSeek(a), Self::OpenAi(b)) => {
+                a.model == b.model && a.api_url == b.api_url && a.api_key == b.api_key
+            }
+            (Self::Ollama(a), Self::Ollama(b)) => a.model == b.model && a.api_url == b.api_url,
+            // Scripted backends are per-test instances — never dedup them.
+            _ => false,
+        }
+    }
+
     /// Apply a configured sampling temperature to the underlying backend
     /// (no-op for backends that do not take one: scripted/noop).
     pub fn with_temperature(self, temperature: Option<f64>) -> Self {

--- a/crates/oxo-flow-web/src/ai_provider.rs
+++ b/crates/oxo-flow-web/src/ai_provider.rs
@@ -96,23 +96,6 @@ pub async fn provider_for(user_id: &str) -> AiProvider {
     AiProviderRegistry::global().get_provider()
 }
 
-/// Emit the paid-for token spend of a finished generation to the operation
-/// log. Web sessions are not archived to disk (the AI service keeps its
-/// zero-write guarantee), so this line is the only durable record of the
-/// spend on the web surfaces.
-pub fn log_generation_usage(surface: &str, session: &oxo_flow_ai::session::AiSession) {
-    let usage = &session.total_usage;
-    if usage.prompt_tokens > 0 || usage.completion_tokens > 0 {
-        tracing::info!(
-            surface,
-            session = %session.id,
-            prompt_tokens = usage.prompt_tokens,
-            completion_tokens = usage.completion_tokens,
-            "AI generation usage"
-        );
-    }
-}
-
 /// Compatibility wrapper — delegates to `oxo_flow_ai::AiRegistry`.
 ///
 /// All original methods are preserved with the same signatures.
@@ -183,7 +166,7 @@ impl AiProviderRegistry {
             model,
             api_key,
             api_url,
-            max_retries: 3,
+            max_retries: oxo_flow_ai::config::default_max_retries(),
             auto_fix: AutoFixMode::Ask,
             temperature: None,
             skills: Vec::new(),

--- a/crates/oxo-flow-web/src/ai_provider.rs
+++ b/crates/oxo-flow-web/src/ai_provider.rs
@@ -96,6 +96,23 @@ pub async fn provider_for(user_id: &str) -> AiProvider {
     AiProviderRegistry::global().get_provider()
 }
 
+/// Emit the paid-for token spend of a finished generation to the operation
+/// log. Web sessions are not archived to disk (the AI service keeps its
+/// zero-write guarantee), so this line is the only durable record of the
+/// spend on the web surfaces.
+pub fn log_generation_usage(surface: &str, session: &oxo_flow_ai::session::AiSession) {
+    let usage = &session.total_usage;
+    if usage.prompt_tokens > 0 || usage.completion_tokens > 0 {
+        tracing::info!(
+            surface,
+            session = %session.id,
+            prompt_tokens = usage.prompt_tokens,
+            completion_tokens = usage.completion_tokens,
+            "AI generation usage"
+        );
+    }
+}
+
 /// Compatibility wrapper — delegates to `oxo_flow_ai::AiRegistry`.
 ///
 /// All original methods are preserved with the same signatures.

--- a/crates/oxo-flow-web/src/domains/ai/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/ai/handlers.rs
@@ -9,25 +9,10 @@ use axum::{Extension, Json, http::StatusCode};
 use crate::domains::ai::types::*;
 use crate::domains::auth::current_user::{CurrentUser, resolve};
 use crate::domains::execution::types::DiagnosticsResponse;
-use crate::domains::workflow::handlers::{ApiError, err};
+use crate::domains::workflow::handlers::{ApiError, ai_not_configured_error, err, error_event};
 use crate::infra::db::models;
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
-
-/// 503 the translate endpoints return when neither the acting user nor the
-/// server has a usable AI provider — the same structured signal the chat
-/// endpoints emit, so clients can branch on one code.
-fn ai_not_configured() -> (StatusCode, Json<ApiError>) {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(ApiError {
-            code: "AI_NOT_CONFIGURED".into(),
-            message: "AI assistant is not configured".into(),
-            detail: Some("no usable AI provider for this user".into()),
-            suggestion: Some("Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin.".into()),
-        }),
-    )
-}
 
 fn get_pool() -> Result<&'static sqlx::SqlitePool, (StatusCode, Json<ApiError>)> {
     crate::infra::db::sqlite::try_pool().map_err(|_| {
@@ -68,12 +53,8 @@ pub async fn translate(
     Json(req): Json<TranslateRequest>,
 ) -> ApiResult<TranslateResponse> {
     let user = resolve(authenticated.as_ref());
-    let provider = crate::ai_provider::provider_for(&user.id).await;
-    if matches!(provider, crate::ai_provider::AiProvider::Noop) {
-        return Err(ai_not_configured());
-    }
-    // Boundary check before anything is sent to a paid provider: an empty
-    // intent would otherwise come back as a fully hallucinated pipeline.
+    // Boundary checks before any I/O: an empty intent would otherwise come
+    // back as a fully hallucinated pipeline.
     if req.intent.trim().is_empty() {
         return Err(err(
             StatusCode::BAD_REQUEST,
@@ -82,6 +63,7 @@ pub async fn translate(
         ));
     }
 
+    let provider = crate::ai_provider::provider_for(&user.id).await;
     let templates: Vec<String> = if let Ok(pool) = get_pool() {
         sqlx::query_as::<_, models::TemplateRow>(
             "SELECT * FROM templates ORDER BY usage_count DESC LIMIT 20",
@@ -99,7 +81,15 @@ pub async fn translate(
     super::service::translate_intent(&provider, &user.id, &req.intent, None, &templates)
         .await
         .map(Json)
-        .map_err(|e| err(StatusCode::BAD_REQUEST, "AI_TRANSLATE_ERROR", e))
+        .map_err(|e| match e {
+            super::service::TranslateError::Unavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ai_not_configured_error()),
+            ),
+            super::service::TranslateError::Failed(message) => {
+                err(StatusCode::BAD_REQUEST, "AI_TRANSLATE_ERROR", message)
+            }
+        })
 }
 
 #[utoipa::path(
@@ -123,9 +113,19 @@ pub async fn translate_sse(
     use std::convert::Infallible;
 
     let user = resolve(authenticated.as_ref());
-    let provider = crate::ai_provider::provider_for(&user.id).await;
+    // Boundary check before any I/O: an empty intent must fail cheaply
+    // instead of paying for a hallucinated pipeline.
+    let invalid_intent = req.intent.trim().is_empty();
 
-    let templates: Vec<String> = if let Ok(pool) = get_pool() {
+    let provider = if invalid_intent {
+        None
+    } else {
+        Some(crate::ai_provider::provider_for(&user.id).await)
+    };
+
+    let templates: Vec<String> = if invalid_intent {
+        vec![]
+    } else if let Ok(pool) = get_pool() {
         sqlx::query_as::<_, models::TemplateRow>(
             "SELECT * FROM templates ORDER BY usage_count DESC LIMIT 20",
         )
@@ -141,31 +141,15 @@ pub async fn translate_sse(
 
     let intent = req.intent.clone();
     let stream = async_stream::stream! {
-        // A disabled/unconfigured instance reports the same structured
-        // signal as the chat SSE route instead of a generic stream error.
-        if matches!(provider, crate::ai_provider::AiProvider::Noop) {
-            yield Ok::<_, Infallible>(Event::default()
-                .event("error")
-                .data(serde_json::json!({
-                    "code": "AI_NOT_CONFIGURED",
-                    "message": "AI assistant is not configured",
-                    "detail": "no usable AI provider for this user",
-                    "suggestion": "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin."
-                }).to_string()));
+        if invalid_intent {
+            yield Ok::<_, Infallible>(error_event(&err(
+                StatusCode::BAD_REQUEST,
+                "INVALID_INTENT",
+                "Intent must not be empty".into(),
+            ).1));
             return;
         }
-
-        // An empty intent must fail cheaply instead of paying for a
-        // hallucinated pipeline.
-        if intent.trim().is_empty() {
-            yield Ok::<_, Infallible>(Event::default()
-                .event("error")
-                .data(serde_json::json!({
-                    "code": "INVALID_INTENT",
-                    "message": "Intent must not be empty"
-                }).to_string()));
-            return;
-        }
+        let provider = provider.expect("provider resolved for non-empty intent");
 
         // Step 1: intent received
         yield Ok::<_, Infallible>(Event::default()
@@ -185,7 +169,9 @@ pub async fn translate_sse(
         let result =
             super::service::translate_intent(&provider, &user.id, &intent, None, &templates).await;
 
-        // Step 4: validate + done
+        // Step 4: validate + done. Errors share the JSON routes' shape and
+        // always terminate with `done`, so an SSE client can branch on
+        // `code` and never hangs waiting for a terminal event.
         match result {
             Ok(response) => {
                 let json = serde_json::to_string(&response).unwrap_or_default();
@@ -197,9 +183,17 @@ pub async fn translate_sse(
                     .data(json));
             }
             Err(e) => {
-                yield Ok::<_, Infallible>(Event::default()
-                    .event("error")
-                    .data(serde_json::json!({"error": e}).to_string()));
+                let error = match e {
+                    super::service::TranslateError::Unavailable => ai_not_configured_error(),
+                    super::service::TranslateError::Failed(message) => ApiError {
+                        code: "AI_TRANSLATE_ERROR".into(),
+                        message,
+                        detail: None,
+                        suggestion: None,
+                    },
+                };
+                yield Ok::<_, Infallible>(error_event(&error));
+                yield Ok::<_, Infallible>(Event::default().event("done").data("{}"));
             }
         }
     };

--- a/crates/oxo-flow-web/src/domains/ai/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/ai/handlers.rs
@@ -14,6 +14,21 @@ use crate::infra::db::models;
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 
+/// 503 the translate endpoints return when neither the acting user nor the
+/// server has a usable AI provider — the same structured signal the chat
+/// endpoints emit, so clients can branch on one code.
+fn ai_not_configured() -> (StatusCode, Json<ApiError>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ApiError {
+            code: "AI_NOT_CONFIGURED".into(),
+            message: "AI assistant is not configured".into(),
+            detail: Some("no usable AI provider for this user".into()),
+            suggestion: Some("Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin.".into()),
+        }),
+    )
+}
+
 fn get_pool() -> Result<&'static sqlx::SqlitePool, (StatusCode, Json<ApiError>)> {
     crate::infra::db::sqlite::try_pool().map_err(|_| {
         err(
@@ -54,6 +69,18 @@ pub async fn translate(
 ) -> ApiResult<TranslateResponse> {
     let user = resolve(authenticated.as_ref());
     let provider = crate::ai_provider::provider_for(&user.id).await;
+    if matches!(provider, crate::ai_provider::AiProvider::Noop) {
+        return Err(ai_not_configured());
+    }
+    // Boundary check before anything is sent to a paid provider: an empty
+    // intent would otherwise come back as a fully hallucinated pipeline.
+    if req.intent.trim().is_empty() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "INVALID_INTENT",
+            "Intent must not be empty".into(),
+        ));
+    }
 
     let templates: Vec<String> = if let Ok(pool) = get_pool() {
         sqlx::query_as::<_, models::TemplateRow>(
@@ -114,6 +141,32 @@ pub async fn translate_sse(
 
     let intent = req.intent.clone();
     let stream = async_stream::stream! {
+        // A disabled/unconfigured instance reports the same structured
+        // signal as the chat SSE route instead of a generic stream error.
+        if matches!(provider, crate::ai_provider::AiProvider::Noop) {
+            yield Ok::<_, Infallible>(Event::default()
+                .event("error")
+                .data(serde_json::json!({
+                    "code": "AI_NOT_CONFIGURED",
+                    "message": "AI assistant is not configured",
+                    "detail": "no usable AI provider for this user",
+                    "suggestion": "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin."
+                }).to_string()));
+            return;
+        }
+
+        // An empty intent must fail cheaply instead of paying for a
+        // hallucinated pipeline.
+        if intent.trim().is_empty() {
+            yield Ok::<_, Infallible>(Event::default()
+                .event("error")
+                .data(serde_json::json!({
+                    "code": "INVALID_INTENT",
+                    "message": "Intent must not be empty"
+                }).to_string()));
+            return;
+        }
+
         // Step 1: intent received
         yield Ok::<_, Infallible>(Event::default()
             .event("progress")

--- a/crates/oxo-flow-web/src/domains/ai/service.rs
+++ b/crates/oxo-flow-web/src/domains/ai/service.rs
@@ -27,21 +27,6 @@ static REQUEST_CACHE: std::sync::LazyLock<Mutex<HashMap<String, (String, String)
 /// Maximum entries in the request cache before eviction.
 const MAX_CACHE_ENTRIES: usize = 128;
 
-/// Extract TOML content from an AI response string.
-/// Looks for ```toml code fences first, then raw `[workflow]` content.
-fn extract_toml(response: &str) -> Option<String> {
-    if let Some(start) = response.find("```toml") {
-        let start = start + 7;
-        if let Some(end) = response[start..].find("```") {
-            return Some(response[start..start + end].trim().to_string());
-        }
-    }
-    if response.contains("[workflow]") {
-        return Some(response.to_string());
-    }
-    None
-}
-
 /// Compute a cache key from the acting user, intent, and optional data
 /// summary. The user id is part of the key: a cached translation embeds the
 /// requester's own data (paths, sample names), so sharing it across users
@@ -50,38 +35,64 @@ fn cache_key(user_id: &str, intent: &str, data_summary: Option<&str>) -> String 
     format!("{user_id}|{intent}|{}", data_summary.unwrap_or("no-data"))
 }
 
-/// Provider candidates for translate, in fallback order: the configured
-/// runtime provider first, then env-discovered Claude/OpenAI/Ollama.
-/// (Issue #342: the fallback chain is a provider-selection concern and
-/// stays here; generation itself is the shared agent + orchestrator.)
-fn provider_candidates() -> Vec<AiProvider> {
+/// Append `provider` unless an identical candidate (same name, model, and
+/// endpoint) is already listed — a user provider that resolves to the
+/// runtime's own configuration must not be retried after failing.
+fn push_unique(candidates: &mut Vec<AiProvider>, provider: AiProvider) {
+    let identity = (
+        provider.name(),
+        provider.model().unwrap_or_default(),
+        provider.api_url().unwrap_or_default(),
+    );
+    if candidates.iter().any(|c| {
+        (
+            c.name(),
+            c.model().unwrap_or_default(),
+            c.api_url().unwrap_or_default(),
+        ) == identity
+    }) {
+        return;
+    }
+    candidates.push(provider);
+}
+
+/// Provider candidates for translate, in fallback order: the acting user's
+/// own provider first (their key, their cost — the same isolation rule the
+/// chat route follows), then the configured runtime provider, then
+/// env-discovered Claude/OpenAI/Ollama. (The fallback chain is a
+/// provider-selection concern and stays here; generation itself is the
+/// shared agent + orchestrator.)
+fn provider_candidates(user_provider: &AiProvider) -> Vec<AiProvider> {
     let registry = AiProviderRegistry::global();
     let config = registry.get_config();
     let mut candidates = Vec::new();
+    if !matches!(user_provider, AiProvider::Noop) {
+        push_unique(&mut candidates, user_provider.clone());
+    }
     if config.is_configured {
-        candidates.push(registry.get_provider());
+        push_unique(&mut candidates, registry.get_provider());
     }
     if config.provider != "claude"
         && let Ok(claude) = AiProviderRegistry::create_claude_from_env()
     {
-        candidates.push(claude);
+        push_unique(&mut candidates, claude);
     }
     if config.provider != "openai"
         && let Ok(openai) = AiProviderRegistry::create_openai_from_env()
     {
-        candidates.push(openai);
+        push_unique(&mut candidates, openai);
     }
     if config.provider != "ollama"
         && let Ok(ollama) = AiProviderRegistry::create_ollama_from_env()
     {
-        candidates.push(ollama);
+        push_unique(&mut candidates, ollama);
     }
     candidates
 }
 
 /// Translate natural language intent into a validated .oxoflow pipeline.
 ///
-/// Pipeline (issue #342 — one harness across all generation surfaces):
+/// Pipeline (one harness across all generation surfaces):
 /// 1. Check request cache (dedup)
 /// 2. Match templates (deterministic, zero AI cost)
 /// 3. Run the SHARED `PipelineGenAgent` through the orchestrator —
@@ -90,7 +101,7 @@ fn provider_candidates() -> Vec<AiProvider> {
 /// 4. Prepare pipeline (expand wildcards)
 /// 5. Parse for explanation and return
 pub async fn translate_intent(
-    _provider: &AiProvider,
+    provider: &AiProvider,
     user_id: &str,
     intent: &str,
     data_summary: Option<&str>,
@@ -135,26 +146,8 @@ pub async fn translate_intent(
     // Step 2: Shared agent + orchestrator over the provider fallback chain.
     // Read-only knowledge tools only, no approver: non-read-only calls are
     // refused by construction (the module's zero-write guarantee).
-    let validator: oxo_flow_ai::agent::pipeline_gen::OutputValidator = std::sync::Arc::new(
-        |toml: &str| match workflow_svc::validate_pipeline(toml, None) {
-            Ok(v) if v.valid => oxo_flow_ai::agent::ValidationResult::passed(),
-            Ok(v) => oxo_flow_ai::agent::ValidationResult {
-                passed: false,
-                errors: v.errors.iter().map(|e| e.message.clone()).collect(),
-                warnings: vec![],
-                summary: format!("{} validation error(s)", v.errors.len()),
-            },
-            Err(e) => oxo_flow_ai::agent::ValidationResult {
-                passed: false,
-                errors: vec![e],
-                warnings: vec![],
-                summary: "validation failed".into(),
-            },
-        },
-    );
-
-    let mut agent =
-        oxo_flow_ai::agent::pipeline_gen::PipelineGenAgent::new(intent).with_validator(validator);
+    let mut agent = oxo_flow_ai::agent::pipeline_gen::PipelineGenAgent::new(intent)
+        .with_validator(workflow_svc::pipeline_output_validator());
     if let Some(summary) = data_summary {
         agent = agent.with_user_addition(format!("## Data Context\n{summary}"));
     }
@@ -170,7 +163,7 @@ pub async fn translate_intent(
         ));
     }
 
-    let candidates = provider_candidates();
+    let candidates = provider_candidates(provider);
     let mut generated: Option<(String, String)> = None;
     for (idx, candidate) in candidates.iter().enumerate() {
         let label = if idx == 0 {
@@ -200,10 +193,12 @@ pub async fn translate_intent(
         let orchestrator = Orchestrator::new(candidate.clone(), 6);
         match orchestrator.execute(&agent, &ctx).await {
             Ok(outcome) if outcome.success && outcome.content.is_some() => {
+                crate::ai_provider::log_generation_usage("translate", &outcome.session);
                 generated = Some((outcome.content.unwrap(), label));
                 break;
             }
             Ok(outcome) => {
+                crate::ai_provider::log_generation_usage("translate", &outcome.session);
                 tracing::warn!(
                     "translate provider {} produced no valid pipeline: {}",
                     candidate.name(),
@@ -408,7 +403,8 @@ pub async fn optimize_pipeline(
         .await
         .map_err(|e| format!("AI optimize failed: {e}"))?;
 
-    let toml = extract_toml(&raw_response).unwrap_or(raw_response.clone());
+    let toml = oxo_flow_ai::agent::pipeline_gen::extract_toml(&raw_response)
+        .unwrap_or(raw_response.clone());
 
     // Validate the optimized TOML
     let _validation = workflow_svc::validate_pipeline(&toml, None)?;
@@ -481,19 +477,21 @@ fn parse_optimization_changes(text: &str) -> Vec<OptimizationChange> {
 mod tests {
     use super::*;
 
-    // ── TOML extraction tests ──
+    // ── TOML extraction tests (pin the canonical extractor's contract on
+    // the web side: fenced content is taken, prose is never mistaken for a
+    // pipeline) ──
 
     #[test]
     fn test_extract_toml_from_code_fence() {
         let response = "Here is the pipeline:\n```toml\n[workflow]\nname = \"test\"\n```\nDone.";
-        let result = extract_toml(response);
+        let result = oxo_flow_ai::agent::pipeline_gen::extract_toml(response);
         assert_eq!(result, Some("[workflow]\nname = \"test\"".to_string()));
     }
 
     #[test]
     fn test_extract_toml_raw_workflow() {
         let response = "[workflow]\nname = \"test\"\n[[rules]]\nname = \"step1\"";
-        let result = extract_toml(response);
+        let result = oxo_flow_ai::agent::pipeline_gen::extract_toml(response);
         assert!(result.is_some());
         assert!(result.unwrap().contains("[workflow]"));
     }
@@ -501,8 +499,24 @@ mod tests {
     #[test]
     fn test_extract_toml_no_toml() {
         let response = "I cannot generate a pipeline right now.";
-        let result = extract_toml(response);
+        let result = oxo_flow_ai::agent::pipeline_gen::extract_toml(response);
         assert_eq!(result, None);
+    }
+
+    // ── Provider fallback chain tests ──
+
+    #[test]
+    fn test_push_unique_skips_identical_provider() {
+        // Arrange — a user provider that resolves to the same (name, model,
+        // endpoint) as an already-listed candidate must not be retried.
+        let mut candidates = vec![AiProvider::Noop];
+        let user_provider = AiProvider::Noop;
+
+        // Act
+        push_unique(&mut candidates, user_provider);
+
+        // Assert — Noop is never a usable candidate
+        assert_eq!(candidates.len(), 1);
     }
 
     // ── Section extraction tests ──

--- a/crates/oxo-flow-web/src/domains/ai/service.rs
+++ b/crates/oxo-flow-web/src/domains/ai/service.rs
@@ -35,22 +35,12 @@ fn cache_key(user_id: &str, intent: &str, data_summary: Option<&str>) -> String 
     format!("{user_id}|{intent}|{}", data_summary.unwrap_or("no-data"))
 }
 
-/// Append `provider` unless an identical candidate (same name, model, and
-/// endpoint) is already listed — a user provider that resolves to the
-/// runtime's own configuration must not be retried after failing.
+/// Append `provider` unless the same configuration (name, model, endpoint,
+/// credential) is already listed — a user provider that resolves to the
+/// runtime's own configuration must not be retried after failing, while two
+/// rows differing only by API key are distinct candidates.
 fn push_unique(candidates: &mut Vec<AiProvider>, provider: AiProvider) {
-    let identity = (
-        provider.name(),
-        provider.model().unwrap_or_default(),
-        provider.api_url().unwrap_or_default(),
-    );
-    if candidates.iter().any(|c| {
-        (
-            c.name(),
-            c.model().unwrap_or_default(),
-            c.api_url().unwrap_or_default(),
-        ) == identity
-    }) {
+    if candidates.iter().any(|c| c.same_configuration(&provider)) {
         return;
     }
     candidates.push(provider);
@@ -66,7 +56,7 @@ fn provider_candidates(user_provider: &AiProvider) -> Vec<AiProvider> {
     let registry = AiProviderRegistry::global();
     let config = registry.get_config();
     let mut candidates = Vec::new();
-    if !matches!(user_provider, AiProvider::Noop) {
+    if user_provider.is_usable() {
         push_unique(&mut candidates, user_provider.clone());
     }
     if config.is_configured {
@@ -82,7 +72,14 @@ fn provider_candidates(user_provider: &AiProvider) -> Vec<AiProvider> {
     {
         push_unique(&mut candidates, openai);
     }
+    // Ollama is the only credential-free backend, so its constructor always
+    // succeeds — admitting it unconditionally would put a phantom
+    // localhost:11434 candidate in every chain and turn "nothing
+    // configured" into a doomed connection attempt. Enter the chain only
+    // when the operator opted in (OLLAMA_HOST), matching the CLI, where a
+    // fully unconfigured environment resolves to Noop.
     if config.provider != "ollama"
+        && std::env::var("OLLAMA_HOST").is_ok()
         && let Ok(ollama) = AiProviderRegistry::create_ollama_from_env()
     {
         push_unique(&mut candidates, ollama);
@@ -90,10 +87,28 @@ fn provider_candidates(user_provider: &AiProvider) -> Vec<AiProvider> {
     candidates
 }
 
+/// Whether a translate request could possibly run: the acting user's
+/// provider, the runtime, or an env-discovered backend must be usable.
+/// Handlers gate their structured AI_NOT_CONFIGURED response on this
+/// instead of an ad-hoc provider check, so an env-key-only deployment
+/// (no runtime config, but a key in the environment) still translates.
+pub fn generation_available(user_provider: &AiProvider) -> bool {
+    !provider_candidates(user_provider).is_empty()
+}
+
+/// Why a translate request produced no pipeline. `Unavailable` is the
+/// structured AI_NOT_CONFIGURED case (503); `Failed` is a generation or
+/// validation failure (400).
+#[derive(Debug)]
+pub enum TranslateError {
+    Unavailable,
+    Failed(String),
+}
+
 /// Translate natural language intent into a validated .oxoflow pipeline.
 ///
 /// Pipeline (one harness across all generation surfaces):
-/// 1. Check request cache (dedup)
+/// 1. Check request cache (dedup) — serves without any AI involvement
 /// 2. Match templates (deterministic, zero AI cost)
 /// 3. Run the SHARED `PipelineGenAgent` through the orchestrator —
 ///    knowledge tools + engine-accurate prompt + validation-feedback
@@ -106,11 +121,13 @@ pub async fn translate_intent(
     intent: &str,
     data_summary: Option<&str>,
     templates: &[String],
-) -> Result<TranslateResponse, String> {
+) -> Result<TranslateResponse, TranslateError> {
     // Step 0: Dedup — check cache
     let key = cache_key(user_id, intent, data_summary);
     {
-        let cache = REQUEST_CACHE.lock().map_err(|_| "Cache lock poisoned")?;
+        let cache = REQUEST_CACHE
+            .lock()
+            .map_err(|_| TranslateError::Failed("translate cache is unavailable".into()))?;
         if let Some((pipeline_id, toml_content)) = cache.get(&key) {
             // Re-parse to build explanation
             if let Ok(parsed) = workflow_svc::parse_pipeline(toml_content, None) {
@@ -143,6 +160,13 @@ pub async fn translate_intent(
             .contains(&t.to_lowercase().replace('-', " "))
     });
 
+    // Only reached on a cache miss: without a usable provider anywhere the
+    // request fails as structured Unavailable rather than looping over an
+    // empty candidate list. A cached pipeline keeps serving regardless.
+    if !generation_available(provider) {
+        return Err(TranslateError::Unavailable);
+    }
+
     // Step 2: Shared agent + orchestrator over the provider fallback chain.
     // Read-only knowledge tools only, no approver: non-read-only calls are
     // refused by construction (the module's zero-write guarantee).
@@ -165,6 +189,7 @@ pub async fn translate_intent(
 
     let candidates = provider_candidates(provider);
     let mut generated: Option<(String, String)> = None;
+    let mut last_failure = "no provider was attempted".to_string();
     for (idx, candidate) in candidates.iter().enumerate() {
         let label = if idx == 0 {
             candidate.name().to_string()
@@ -177,10 +202,9 @@ pub async fn translate_intent(
             workflow_path: None,
             workflow_content: None,
             external_sources: vec![],
-            // 6 rounds, matching the chat route: knowledge lookups spend
-            // ~2 rounds before text, and the validation-feedback fix needs
-            // 1-2 more — 4 starved tool-heavy intents (E2E finding).
-            max_rounds: 6,
+            // Shared shipped budget: knowledge lookups spend 2-3 rounds
+            // before text and the validation-feedback fix needs 1-2 more.
+            max_rounds: oxo_flow_ai::config::default_max_retries(),
             tool_registry: oxo_flow_ai::tools::builtin::knowledge_tool_registry(),
             tool_approver: None,
             session: oxo_flow_ai::session::AiSession::new(
@@ -190,41 +214,55 @@ pub async fn translate_intent(
                 &candidate.model().unwrap_or_else(|| "default".into()),
             ),
         };
-        let orchestrator = Orchestrator::new(candidate.clone(), 6);
+        let orchestrator = Orchestrator::new(
+            candidate.clone(),
+            oxo_flow_ai::config::default_max_retries(),
+        );
         match orchestrator.execute(&agent, &ctx).await {
             Ok(outcome) if outcome.success && outcome.content.is_some() => {
-                crate::ai_provider::log_generation_usage("translate", &outcome.session);
                 generated = Some((outcome.content.unwrap(), label));
                 break;
             }
             Ok(outcome) => {
-                crate::ai_provider::log_generation_usage("translate", &outcome.session);
+                last_failure = outcome.summary.clone();
                 tracing::warn!(
                     "translate provider {} produced no valid pipeline: {}",
                     candidate.name(),
                     outcome.summary
                 );
+                // The provider responded and billed tokens — its output was
+                // simply unusable. Falling through to the next candidate
+                // would pay for a second full generation on one request, so
+                // the chain only continues when the attempt provably
+                // produced nothing (auth/quota/transport failures, which
+                // land in the Err arm below, or zero completions).
+                if outcome.session.total_usage.completion_tokens > 0 {
+                    break;
+                }
             }
             Err(e) => {
+                last_failure = e.to_string();
                 tracing::warn!("translate provider {} failed: {e}", candidate.name());
             }
         }
     }
 
     let Some((toml_content, provider_used)) = generated else {
-        return match template_match {
-            Some(name) => Err(format!(
-                "AI unavailable (tried all providers). Try the '{name}' template."
+        return Err(match template_match {
+            Some(name) => TranslateError::Failed(format!(
+                "AI generation failed: {last_failure}. Try the '{name}' template."
             )),
-            None => Err("AI generation failed after trying all providers".to_string()),
-        };
+            None => TranslateError::Failed(format!("AI generation failed: {last_failure}")),
+        });
     };
 
     // Step 4: Prepare (expand wildcards, resolve environments)
-    let _prepared = workflow_svc::prepare_pipeline(&toml_content, true, true)?;
+    let _prepared = workflow_svc::prepare_pipeline(&toml_content, true, true)
+        .map_err(TranslateError::Failed)?;
 
     // Step 5: Parse for explanation
-    let parsed = workflow_svc::parse_pipeline(&toml_content, None)?;
+    let parsed =
+        workflow_svc::parse_pipeline(&toml_content, None).map_err(TranslateError::Failed)?;
 
     // Step 6: Build explanation
     let steps: Vec<TranslationStep> = parsed
@@ -506,17 +544,29 @@ mod tests {
     // ── Provider fallback chain tests ──
 
     #[test]
-    fn test_push_unique_skips_identical_provider() {
-        // Arrange — a user provider that resolves to the same (name, model,
-        // endpoint) as an already-listed candidate must not be retried.
-        let mut candidates = vec![AiProvider::Noop];
-        let user_provider = AiProvider::Noop;
+    fn test_push_unique_dedups_same_configuration_keeps_different_key() {
+        // Arrange — a user row and the runtime row can point at the same
+        // provider/model/endpoint; only the credential differs. The identical
+        // pair must dedup (no pointless retry), the distinct key must stay.
+        let user = AiProvider::OpenAi(oxo_flow_ai::provider::OpenAiBackend::new(
+            "user-key".into(),
+            Some("m".into()),
+            Some("https://gw.example.com/v1".into()),
+        ));
+        let runtime = AiProvider::OpenAi(oxo_flow_ai::provider::OpenAiBackend::new(
+            "server-key".into(),
+            Some("m".into()),
+            Some("https://gw.example.com/v1".into()),
+        ));
+        let mut candidates = vec![user.clone()];
 
-        // Act
-        push_unique(&mut candidates, user_provider);
+        // Act + Assert — same endpoint and model, different key: kept.
+        push_unique(&mut candidates, runtime);
+        assert_eq!(candidates.len(), 2);
 
-        // Assert — Noop is never a usable candidate
-        assert_eq!(candidates.len(), 1);
+        // The exact same configuration again: dropped.
+        push_unique(&mut candidates, user);
+        assert_eq!(candidates.len(), 2);
     }
 
     // ── Section extraction tests ──

--- a/crates/oxo-flow-web/src/domains/chat/agent.rs
+++ b/crates/oxo-flow-web/src/domains/chat/agent.rs
@@ -8,9 +8,7 @@
 //! gates with E017. The prompt, extraction, and validation contract now
 //! come from one place; only the validator binding is web-specific.
 
-use std::sync::Arc;
-
-use oxo_flow_ai::agent::pipeline_gen::{OutputValidator, PipelineGenAgent};
+use oxo_flow_ai::agent::pipeline_gen::PipelineGenAgent;
 use oxo_flow_ai::agent::{Agent, AgentContext, ValidationResult};
 use oxo_flow_ai::types::Message;
 
@@ -24,7 +22,7 @@ impl ChatAgent {
     pub fn new(intent: String, user_message: String) -> Self {
         Self {
             inner: PipelineGenAgent::new(intent)
-                .with_validator(web_validator())
+                .with_validator(workflow_svc::pipeline_output_validator())
                 // The raw user message (free-form chat turn) supplements the
                 // intent-derived request line the shared persona builds.
                 .with_user_addition(format!("## User Message\n{user_message}")),
@@ -36,28 +34,6 @@ impl ChatAgent {
         self.inner = self.inner.with_user_addition(section);
         self
     }
-}
-
-/// The web engine binding: extracted TOML must pass the workflow service's
-/// validation — errors feed the orchestrator's correction loop. Read-only.
-pub fn web_validator() -> OutputValidator {
-    Arc::new(
-        |toml: &str| match workflow_svc::validate_pipeline(toml, None) {
-            Ok(v) if v.valid => ValidationResult::passed(),
-            Ok(v) => ValidationResult {
-                passed: false,
-                errors: v.errors.iter().map(|e| e.message.clone()).collect(),
-                warnings: vec![],
-                summary: format!("{} validation error(s)", v.errors.len()),
-            },
-            Err(e) => ValidationResult {
-                passed: false,
-                errors: vec![e],
-                warnings: vec![],
-                summary: "validation failed".into(),
-            },
-        },
-    )
 }
 
 impl Agent for ChatAgent {

--- a/crates/oxo-flow-web/src/domains/chat/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/chat/handlers.rs
@@ -11,7 +11,7 @@ use std::convert::Infallible;
 use super::service;
 use super::types::*;
 use crate::domains::auth::current_user::{CurrentUser, resolve};
-use crate::domains::workflow::handlers::{ApiError, err};
+use crate::domains::workflow::handlers::{ApiError, ai_not_configured_error, err, error_event};
 use crate::infra::db::models;
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
@@ -137,42 +137,43 @@ pub async fn chat_send(
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+    // Boundary check before any I/O: an empty message must fail cheaply
+    // instead of writing junk history rows and paying for a hallucinated
+    // pipeline.
+    let empty_message = message.trim().is_empty();
+
     // Server-side persistence (issue #81): the session + user message are
     // recorded up front; the assistant's answer is appended on completion.
     let pool = crate::infra::db::sqlite::try_pool().ok();
-    persist_user_message(pool, &user, &session_id, &message).await;
+    if !empty_message {
+        persist_user_message(pool, &user, &session_id, &message).await;
+    }
 
     // Chat runs on the acting user's own AI provider (isolation fix). The
     // usability check is on the RESOLVED provider — the caller's own key
     // counts even when the shared runtime is unconfigured, and a disabled
     // instance still reports AI_NOT_CONFIGURED.
-    let provider = crate::ai_provider::provider_for(&user.id).await;
+    let provider = if empty_message {
+        crate::ai_provider::AiProvider::Noop
+    } else {
+        crate::ai_provider::provider_for(&user.id).await
+    };
 
     let stream = async_stream::stream! {
-        // An empty message must fail cheaply instead of paying for a
-        // hallucinated pipeline.
-        if message.trim().is_empty() {
-            yield Ok::<_, Infallible>(Event::default()
-                .event("error")
-                .data(serde_json::json!({
-                    "code": "EMPTY_MESSAGE",
-                    "message": "Message must not be empty"
-                }).to_string()));
+        if empty_message {
+            yield Ok::<_, Infallible>(error_event(&err(
+                axum::http::StatusCode::BAD_REQUEST,
+                "EMPTY_MESSAGE",
+                "Message must not be empty".into(),
+            ).1));
             yield Ok::<_, Infallible>(Event::default()
                 .event("done")
                 .data(serde_json::json!({"session_id": session_id}).to_string()));
             return;
         }
 
-        if matches!(provider, crate::ai_provider::AiProvider::Noop) {
-            yield Ok::<_, Infallible>(Event::default()
-                .event("error")
-                .data(serde_json::json!({
-                    "code": "AI_NOT_CONFIGURED",
-                    "message": "AI assistant is not configured",
-                    "detail": "no usable AI provider for this user",
-                    "suggestion": "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin."
-                }).to_string()));
+        if !provider.is_usable() {
+            yield Ok::<_, Infallible>(error_event(&crate::domains::workflow::handlers::ai_not_configured_error()));
             yield Ok::<_, Infallible>(Event::default()
                 .event("done")
                 .data(serde_json::json!({"session_id": session_id}).to_string()));
@@ -285,6 +286,17 @@ pub async fn chat_send_json(
     Json(req): Json<ChatRequest>,
 ) -> ApiResult<serde_json::Value> {
     let user = resolve(authenticated.as_ref());
+    // Boundary check before any I/O: an empty message must fail cheaply
+    // instead of writing junk history rows and paying for a hallucinated
+    // pipeline.
+    if req.message.trim().is_empty() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "EMPTY_MESSAGE",
+            "Message must not be empty".into(),
+        ));
+    }
+
     let templates: Vec<String> = if let Ok(pool) = get_pool() {
         sqlx::query_as::<_, models::TemplateRow>(
             "SELECT * FROM templates ORDER BY usage_count DESC LIMIT 20",
@@ -306,44 +318,29 @@ pub async fn chat_send_json(
     let pool = crate::infra::db::sqlite::try_pool().ok();
     persist_user_message(pool, &user, &session_id, &req.message).await;
 
-    let provider = crate::ai_provider::provider_for(&user.id).await;
-
-    // An empty message must fail cheaply instead of paying for a
-    // hallucinated pipeline.
-    if req.message.trim().is_empty() {
-        return Err(err(
-            StatusCode::BAD_REQUEST,
-            "EMPTY_MESSAGE",
-            "Message must not be empty".into(),
-        ));
-    }
-
+    // Chat runs on the acting user's own AI provider (isolation fix).
     // Usability is judged on the RESOLVED provider: the caller's own key
     // counts even when the shared runtime is unconfigured, and a disabled
     // instance still reports AI_NOT_CONFIGURED.
-    if matches!(provider, crate::ai_provider::AiProvider::Noop) {
+    let provider = crate::ai_provider::provider_for(&user.id).await;
+    if !provider.is_usable() {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError {
-                code: "AI_NOT_CONFIGURED".into(),
-                message: "AI assistant is not configured".into(),
-                detail: Some("no usable AI provider for this user".into()),
-                suggestion: Some(
-                    "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin.".into(),
-                ),
-            }),
+            Json(ai_not_configured_error()),
         ));
     }
 
+    let invocation = service::ChatInvocation {
+        run_id: req.run_id.as_deref(),
+        user_id: &user.id,
+        is_admin: user.is_admin(),
+    };
     match service::process_chat(
         &req.message,
-        Some(&session_id),
         req.context.as_ref(),
         &templates,
         &provider,
-        req.run_id.as_deref(),
-        &user.id,
-        user.is_admin(),
+        &invocation,
     )
     .await
     {

--- a/crates/oxo-flow-web/src/domains/chat/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/chat/handlers.rs
@@ -142,19 +142,35 @@ pub async fn chat_send(
     let pool = crate::infra::db::sqlite::try_pool().ok();
     persist_user_message(pool, &user, &session_id, &message).await;
 
-    // Chat runs on the acting user's own AI provider (isolation fix).
+    // Chat runs on the acting user's own AI provider (isolation fix). The
+    // usability check is on the RESOLVED provider — the caller's own key
+    // counts even when the shared runtime is unconfigured, and a disabled
+    // instance still reports AI_NOT_CONFIGURED.
     let provider = crate::ai_provider::provider_for(&user.id).await;
-    let config = crate::ai_provider::AiProviderRegistry::global().get_config();
-    let is_configured = config.is_configured;
 
     let stream = async_stream::stream! {
-        if !is_configured {
+        // An empty message must fail cheaply instead of paying for a
+        // hallucinated pipeline.
+        if message.trim().is_empty() {
+            yield Ok::<_, Infallible>(Event::default()
+                .event("error")
+                .data(serde_json::json!({
+                    "code": "EMPTY_MESSAGE",
+                    "message": "Message must not be empty"
+                }).to_string()));
+            yield Ok::<_, Infallible>(Event::default()
+                .event("done")
+                .data(serde_json::json!({"session_id": session_id}).to_string()));
+            return;
+        }
+
+        if matches!(provider, crate::ai_provider::AiProvider::Noop) {
             yield Ok::<_, Infallible>(Event::default()
                 .event("error")
                 .data(serde_json::json!({
                     "code": "AI_NOT_CONFIGURED",
                     "message": "AI assistant is not configured",
-                    "detail": format!("provider={}", config.provider),
+                    "detail": "no usable AI provider for this user",
                     "suggestion": "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin."
                 }).to_string()));
             yield Ok::<_, Infallible>(Event::default()
@@ -292,14 +308,26 @@ pub async fn chat_send_json(
 
     let provider = crate::ai_provider::provider_for(&user.id).await;
 
-    let config = crate::ai_provider::AiProviderRegistry::global().get_config();
-    if !config.is_configured {
+    // An empty message must fail cheaply instead of paying for a
+    // hallucinated pipeline.
+    if req.message.trim().is_empty() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "EMPTY_MESSAGE",
+            "Message must not be empty".into(),
+        ));
+    }
+
+    // Usability is judged on the RESOLVED provider: the caller's own key
+    // counts even when the shared runtime is unconfigured, and a disabled
+    // instance still reports AI_NOT_CONFIGURED.
+    if matches!(provider, crate::ai_provider::AiProvider::Noop) {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ApiError {
                 code: "AI_NOT_CONFIGURED".into(),
                 message: "AI assistant is not configured".into(),
-                detail: Some(format!("provider={}", config.provider)),
+                detail: Some("no usable AI provider for this user".into()),
                 suggestion: Some(
                     "Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin.".into(),
                 ),
@@ -313,6 +341,9 @@ pub async fn chat_send_json(
         req.context.as_ref(),
         &templates,
         &provider,
+        req.run_id.as_deref(),
+        &user.id,
+        user.is_admin(),
     )
     .await
     {

--- a/crates/oxo-flow-web/src/domains/chat/service.rs
+++ b/crates/oxo-flow-web/src/domains/chat/service.rs
@@ -7,6 +7,57 @@ use super::types::*;
 use crate::ai_provider::AiProvider;
 use crate::domains::workflow::service as workflow_svc;
 
+/// Correction-round budget shared by both chat routes — the shipped
+/// `[ai] max_retries` default, whose economics (knowledge lookups + a
+/// correction pass in one budget) apply identically here.
+fn chat_max_rounds() -> u32 {
+    oxo_flow_ai::config::default_max_retries()
+}
+
+/// Who is asking, and what the request is scoped to. `run_id` admits the
+/// read-only run-diagnosis tools, scoped to the acting user.
+pub struct ChatInvocation<'a> {
+    pub run_id: Option<&'a str>,
+    pub user_id: &'a str,
+    pub is_admin: bool,
+}
+
+/// Run the shared generation harness for a chat request. This is the ONE
+/// place the web chat harness is assembled — context, tool registry,
+/// session labels, round budget, orchestrator, usage logging — so the
+/// streaming and JSON routes cannot drift.
+async fn run_chat_generation(
+    agent: super::agent::ChatAgent,
+    message: &str,
+    intent: String,
+    invocation: &ChatInvocation<'_>,
+    provider: &AiProvider,
+    sink: Option<&mut AgentEventSink>,
+) -> Result<AgentOutcome, String> {
+    let ctx = oxo_flow_ai::agent::AgentContext {
+        intent,
+        command: message.to_string(),
+        workflow_path: None,
+        workflow_content: None,
+        external_sources: vec![],
+        max_rounds: chat_max_rounds(),
+        tool_registry: super::tools::build_chat_tool_registry(
+            invocation.run_id,
+            invocation.user_id,
+            invocation.is_admin,
+        ),
+        tool_approver: None,
+        session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", provider.name()),
+    };
+
+    let orchestrator = Orchestrator::new(provider.clone(), chat_max_rounds());
+    let outcome = orchestrator
+        .execute_with_sink(&agent, &ctx, sink, None)
+        .await;
+    // Token spend is logged by the orchestrator itself (all surfaces).
+    outcome.map_err(|e| e.to_string())
+}
+
 /// Process a chat message and return the validated pipeline. This is the
 /// JSON variant of the conversational AI pipeline.
 ///
@@ -16,18 +67,13 @@ use crate::domains::workflow::service as workflow_svc;
 /// This endpoint previously ran its own one-shot prompt with no tools and
 /// no correction loop — the weakest of the four generation paths. It now
 /// runs the same shared persona + orchestrator harness as the SSE chat
-/// route and the CLI, differing only in presentation; `run_id` scopes the
-/// read-only run-diagnosis tools exactly as the SSE route does.
-#[allow(clippy::too_many_arguments)]
+/// route and the CLI, differing only in presentation.
 pub async fn process_chat(
     message: &str,
-    _session_id: Option<&str>,
     context: Option<&ChatContext>,
     templates: &[String],
     provider: &AiProvider,
-    run_id: Option<&str>,
-    user_id: &str,
-    is_admin: bool,
+    invocation: &ChatInvocation<'_>,
 ) -> Result<(String, serde_json::Value), String> {
     // Phase 1: Orchestrator — understand intent
     let intent = if let Some(ctx) = context {
@@ -74,30 +120,22 @@ pub async fn process_chat(
         ));
     }
 
-    let ctx = oxo_flow_ai::agent::AgentContext {
-        intent: intent.clone(),
-        command: message.to_string(),
-        workflow_path: None,
-        workflow_content: None,
-        external_sources: vec![],
-        max_rounds: 6,
-        tool_registry: super::tools::build_chat_tool_registry(run_id, user_id, is_admin),
-        tool_approver: None,
-        session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", provider.name()),
-    };
-
-    let orchestrator = Orchestrator::new(provider.clone(), 6);
-    let outcome = orchestrator
-        .execute(&agent, &ctx)
-        .await
-        .map_err(|e| {
-            tracing::warn!("AI provider {} request failed: {e}", provider.name());
-            format!(
-                "AI provider request failed for {}: please check the provider configuration and network connectivity",
-                provider.name()
-            )
-        })?;
-    crate::ai_provider::log_generation_usage("chat", &outcome.session);
+    let outcome = run_chat_generation(
+        agent,
+        message,
+        intent.clone(),
+        invocation,
+        provider,
+        None,
+    )
+    .await
+    .map_err(|e| {
+        tracing::warn!("AI provider {} request failed: {e}", provider.name());
+        format!(
+            "AI provider request failed for {}: please check the provider configuration and network connectivity",
+            provider.name()
+        )
+    })?;
     let toml_content = outcome
         .content
         .ok_or_else(|| "AI generation did not produce a valid pipeline".to_string())?;
@@ -294,35 +332,29 @@ pub async fn run_chat_agent(
     sink: Option<&mut AgentEventSink>,
     provider: &AiProvider,
 ) -> Result<AgentOutcome, String> {
-    let agent = super::agent::ChatAgent::new(infer_intent(message), message.to_string());
-    let ctx = oxo_flow_ai::agent::AgentContext {
-        intent: infer_intent(message),
-        command: message.to_string(),
-        workflow_path: None,
-        workflow_content: None,
-        external_sources: vec![],
-        max_rounds: 6,
-        tool_registry: super::tools::build_chat_tool_registry(run_id, user_id, is_admin),
-        tool_approver: None,
-        session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", provider.name()),
-    };
-    // Context-supplied data paths feed the user prompt (deterministic
-    // data perception stays out of the model loop).
-    if let Some(ctx) = context
-        && let Some(paths) = &ctx.data_paths
-        && !paths.is_empty()
+    // The streaming route builds the SAME agent as the JSON route: an
+    // explicit context intent wins over keyword inference, and analyzed data
+    // paths feed the prompt as a data report.
+    let intent = context
+        .and_then(|c| c.intent.clone())
+        .unwrap_or_else(|| infer_intent(message));
+    let data_report = context
+        .and_then(|c| c.data_paths.as_ref())
+        .filter(|p| !p.is_empty())
+        .and_then(|paths| analyze_data_paths(paths));
+    let mut agent = super::agent::ChatAgent::new(intent.clone(), message.to_string());
+    if let Some(report) = &data_report
+        && let Some(summary) = report.get("summary")
     {
-        let _ = crate::domains::workflow::data::analyze_files(paths, Some(2));
+        agent = agent.with_user_addition(format!("## Data Report\n{summary}"));
     }
 
-    let orchestrator = Orchestrator::new(provider.clone(), 6);
-    let outcome = orchestrator
-        .execute_with_sink(&agent, &ctx, sink, None)
-        .await;
-    if let Ok(outcome) = &outcome {
-        crate::ai_provider::log_generation_usage("chat", &outcome.session);
-    }
-    outcome.map_err(|e| e.to_string())
+    let invocation = ChatInvocation {
+        run_id,
+        user_id,
+        is_admin,
+    };
+    run_chat_generation(agent, message, intent, &invocation, provider, sink).await
 }
 
 #[cfg(test)]

--- a/crates/oxo-flow-web/src/domains/chat/service.rs
+++ b/crates/oxo-flow-web/src/domains/chat/service.rs
@@ -13,16 +13,21 @@ use crate::domains::workflow::service as workflow_svc;
 /// `provider` is the ACTING USER's provider (issue #82 follow-up: chat
 /// runs on the caller's own AI credentials, never the shared runtime).
 ///
-/// Issue #342: this endpoint previously ran its own one-shot prompt with
-/// no tools and no correction loop — the weakest of the four generation
-/// paths. It now runs the same shared persona + orchestrator harness as
-/// the SSE chat route and the CLI, differing only in presentation.
+/// This endpoint previously ran its own one-shot prompt with no tools and
+/// no correction loop — the weakest of the four generation paths. It now
+/// runs the same shared persona + orchestrator harness as the SSE chat
+/// route and the CLI, differing only in presentation; `run_id` scopes the
+/// read-only run-diagnosis tools exactly as the SSE route does.
+#[allow(clippy::too_many_arguments)]
 pub async fn process_chat(
     message: &str,
     _session_id: Option<&str>,
     context: Option<&ChatContext>,
     templates: &[String],
     provider: &AiProvider,
+    run_id: Option<&str>,
+    user_id: &str,
+    is_admin: bool,
 ) -> Result<(String, serde_json::Value), String> {
     // Phase 1: Orchestrator — understand intent
     let intent = if let Some(ctx) = context {
@@ -76,7 +81,7 @@ pub async fn process_chat(
         workflow_content: None,
         external_sources: vec![],
         max_rounds: 6,
-        tool_registry: super::tools::build_chat_tool_registry(None, "", false),
+        tool_registry: super::tools::build_chat_tool_registry(run_id, user_id, is_admin),
         tool_approver: None,
         session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", provider.name()),
     };
@@ -92,6 +97,7 @@ pub async fn process_chat(
                 provider.name()
             )
         })?;
+    crate::ai_provider::log_generation_usage("chat", &outcome.session);
     let toml_content = outcome
         .content
         .ok_or_else(|| "AI generation did not produce a valid pipeline".to_string())?;
@@ -298,7 +304,7 @@ pub async fn run_chat_agent(
         max_rounds: 6,
         tool_registry: super::tools::build_chat_tool_registry(run_id, user_id, is_admin),
         tool_approver: None,
-        session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", "web-provider"),
+        session: oxo_flow_ai::session::AiSession::new("web-chat", "chat", "web", provider.name()),
     };
     // Context-supplied data paths feed the user prompt (deterministic
     // data perception stays out of the model loop).
@@ -310,10 +316,13 @@ pub async fn run_chat_agent(
     }
 
     let orchestrator = Orchestrator::new(provider.clone(), 6);
-    orchestrator
+    let outcome = orchestrator
         .execute_with_sink(&agent, &ctx, sink, None)
-        .await
-        .map_err(|e| e.to_string())
+        .await;
+    if let Ok(outcome) = &outcome {
+        crate::ai_provider::log_generation_usage("chat", &outcome.session);
+    }
+    outcome.map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/crates/oxo-flow-web/src/domains/workflow/handlers.rs
+++ b/crates/oxo-flow-web/src/domains/workflow/handlers.rs
@@ -85,6 +85,27 @@ pub fn err(status: StatusCode, code: &str, msg: String) -> (StatusCode, Json<Api
     )
 }
 
+/// The one `AI_NOT_CONFIGURED` contract shared by every AI surface: JSON
+/// routes wrap it in `Json`, streaming routes serialize the same struct
+/// into their `error` event, so clients can branch on `code` everywhere.
+pub fn ai_not_configured_error() -> ApiError {
+    ApiError {
+        code: "AI_NOT_CONFIGURED".into(),
+        message: "AI assistant is not configured".into(),
+        detail: Some("no usable AI provider for this user".into()),
+        suggestion: Some("Set OXO_FLOW_AI_PROVIDER and its API key, or ask your admin.".into()),
+    }
+}
+
+/// Serialize a structured error into the payload of an SSE `error` event,
+/// mirroring the JSON routes' `ApiError` shape.
+pub fn error_event(error: &ApiError) -> axum::response::sse::Event {
+    let data = serde_json::to_string(error).unwrap_or_else(|_| error.code.clone());
+    axum::response::sse::Event::default()
+        .event("error")
+        .data(data)
+}
+
 fn now_iso() -> String {
     chrono::Utc::now().to_rfc3339()
 }

--- a/crates/oxo-flow-web/src/domains/workflow/service.rs
+++ b/crates/oxo-flow-web/src/domains/workflow/service.rs
@@ -241,6 +241,29 @@ pub fn validate_pipeline(
     })
 }
 
+/// The web engine binding for the shared generation agent: extracted TOML
+/// must pass [`validate_pipeline`], and validation errors feed the
+/// orchestrator's correction loop. Read-only. Both AI surfaces (translate
+/// and chat) share this one closure so their validation contracts cannot
+/// drift.
+pub fn pipeline_output_validator() -> oxo_flow_ai::agent::pipeline_gen::OutputValidator {
+    std::sync::Arc::new(|toml: &str| match validate_pipeline(toml, None) {
+        Ok(v) if v.valid => oxo_flow_ai::agent::ValidationResult::passed(),
+        Ok(v) => oxo_flow_ai::agent::ValidationResult {
+            passed: false,
+            errors: v.errors.iter().map(|e| e.message.clone()).collect(),
+            warnings: vec![],
+            summary: format!("{} validation error(s)", v.errors.len()),
+        },
+        Err(e) => oxo_flow_ai::agent::ValidationResult {
+            passed: false,
+            errors: vec![e],
+            warnings: vec![],
+            summary: "validation failed".into(),
+        },
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Prepare
 // ---------------------------------------------------------------------------

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -96,7 +96,7 @@ always additive prose or proposals, never silent engine decisions.
 
 `template --ai` runs the same generation agent as the web translate and
 chat surfaces — one shared persona in `oxo-flow-ai`, one orchestrator
-loop (issue #342). The steps:
+loop. The steps:
 
 1. **Resolve the destination** — `-o` is parsed before anything is sent
    to the provider, so a bad output path fails cheaply.
@@ -126,7 +126,9 @@ loop (issue #342). The steps:
 ### Correction budget and failure behavior
 
 - `--ai-max-retries N` sizes the orchestrator's combined tool +
-  correction-round budget (default from `[ai]` config, 3 when unset).
+  correction-round budget (default from `[ai]` config, 6 when unset —
+  knowledge lookups and the correction pass share the budget, and the
+  loop stops as soon as a draft validates).
 - If the budget runs out after a pipeline was drafted, the command
   **degrades instead of discarding**: the generated TOML is extracted
   from the transcript and written with a prominent review warning —

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -91,3 +91,61 @@ itself:
 All AI features go through the configured provider (see `oxo-flow ai
 status`); deterministic behavior never depends on the model — AI output is
 always additive prose or proposals, never silent engine decisions.
+
+## How `template --ai` generates a workflow
+
+`template --ai` runs the same generation agent as the web translate and
+chat surfaces — one shared persona in `oxo-flow-ai`, one orchestrator
+loop (issue #342). The steps:
+
+1. **Resolve the destination** — `-o` is parsed before anything is sent
+   to the provider, so a bad output path fails cheaply.
+2. **Gather context** — `--from-url` references are fetched through the
+   SSRF-screened fetcher; `--from-file` files are read with bounded
+   previews. Both enter the prompt as external reference material.
+3. **Plan** — the shared persona's system prompt encodes the `.oxoflow`
+   schema (single-brace templates, `[[rules]]` arrays, `depends_on`,
+   version-pinned conda packages) and explicitly bans the wrong dialects
+   models tend to drift into (`foreach`, `inputs = {...}` maps,
+   `[resources]` sections). Domain-matched bioSkills and any activated
+   `[ai] skills` are injected as prompt sections.
+4. **Ground with tools** — the model queries the embedded knowledge
+   bases on demand: `lookup_tool` for exact Bioconda names/versions,
+   `lookup_skill`/`lookup_pipeline` for domain procedures and topologies.
+   Non-read-only tools (e.g. MCP tools from activated tool skills) ask
+   for interactive approval on stderr before running; non-interactive
+   sessions refuse them.
+5. **Validate against the engine** — every draft is parsed by the core
+   engine (`WorkflowConfig`). On failure the errors feed back to the
+   model for correction; this loop is bounded by `--ai-max-retries`.
+6. **Deliver** — the validated TOML is written, the three static gates
+   (`validate` / `dry-run` / `lint`) can then confirm it, and the AI
+   session (token usage, tool calls) is archived to
+   `~/.oxo-flow/ai_sessions/`.
+
+### Correction budget and failure behavior
+
+- `--ai-max-retries N` sizes the orchestrator's combined tool +
+  correction-round budget (default from `[ai]` config, 3 when unset).
+- If the budget runs out after a pipeline was drafted, the command
+  **degrades instead of discarding**: the generated TOML is extracted
+  from the transcript and written with a prominent review warning —
+  a paid-for artifact is never silently lost.
+- Provider failures (auth, quota, network) fail fast with the error.
+
+### Generation tuning knobs
+
+| Variable | Default | When to change |
+|---|---|---|
+| `OXO_FLOW_AI_MAX_TOKENS` | `4096` | Thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible endpoint) spend reasoning tokens against this ceiling and truncate before producing TOML — raise to 16384+ there. For non-thinking models the default holds with ≥3× headroom (measured: 1.9k–4.4k output tokens per generation) |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | `120` | Non-thinking generations complete in 12–20 s; thinking backends can exceed two minutes per call — raise together with `OXO_FLOW_AI_MAX_TOKENS`, or long completions die mid-body |
+
+Both are consumed by the Anthropic Messages backend; the DeepSeek-native,
+OpenAI-compatible, and Ollama backends have their own budgets.
+
+Quality evidence for these calibrations (gate-scored benchmark,
+before/after the generation unification) lives in `eval/frontier/` in
+the repository. The architecture view of the shared harness — how the
+CLI, translate, and chat surfaces differ only in provider resolution,
+tool policy, and presentation — is in
+[Architecture → AI Subsystem](https://traitome.github.io/oxo-flow/latest/reference/architecture/#ai-subsystem).

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -307,7 +307,7 @@ The agent:
 7. Validates against the engine schema; on failure the errors feed back
    into the correction loop (bounded by `--ai-max-retries`), so
    wrong-dialect output is repaired instead of written with a warning
-   (issue #342: one shared generation persona across CLI and web)
+   (one shared generation persona across CLI and web)
 
 ### Custom Skills
 

--- a/docs/guide/src/reference/ai-eval.md
+++ b/docs/guide/src/reference/ai-eval.md
@@ -50,7 +50,7 @@ no API key required, runs on every push.
 
 Capture manifests record git SHA, gold/knowledge hashes, provider/model identity, sampling settings, timestamps, and per-trial metadata so later analysis can be audited and reproduced.
 
-## Frontier benchmark (cross-path quality/cost, issue #342)
+## Frontier benchmark (cross-path quality/cost)
 
 `eval/frontier/` is a complementary, self-contained benchmark that measures
 the **quality/cost frontier across generation paths** rather than
@@ -64,8 +64,9 @@ judges every artifact with the three deterministic static gates
 Per-run token usage comes from the AI session archives (CLI variant) or
 the provider response (minimal variant), so each cell of the
 {path × model} matrix reports gate pass@1 alongside tokens, estimated
-cost, and wall time. This is the evidence base for unifying the AI
-generation paths (#342) and for sizing its TeamProfile cost tiers.
+cost, and wall time. This is the evidence base for the unified
+generation harness (see [Architecture → AI Subsystem](architecture.md))
+and for sizing its cost tiers.
 
 ```bash
 python3 eval/frontier/run_eval.py --variants minimal,cli

--- a/docs/guide/src/reference/ai-translation.md
+++ b/docs/guide/src/reference/ai-translation.md
@@ -24,11 +24,14 @@ Convert natural language intent to a validated `.oxoflow` pipeline.
 
 ```
 Input:  { intent: "RNA-seq, PE, hg38, STAR + featureCounts, strand-specific" }
-Process (issue #342 — one harness across all generation surfaces):
+Process (one harness across all generation surfaces):
   1. The shared `PipelineGenAgent` (oxo-flow-ai) runs through the agent
      orchestrator: engine-accurate prompt, read-only knowledge tools
      (Bioconda lookup, bioSkills, pipeline graph), and the provider
-     fallback chain (configured provider → Claude → OpenAI → Ollama)
+     fallback chain (the caller's own provider → configured provider →
+     env-discovered Claude → OpenAI → Ollama)
+  2. Requests fail fast with a structured `AI_NOT_CONFIGURED` error when
+     no provider is usable
   2. Template names enter the prompt as hints; keyword matching remains a
      deterministic fallback when all providers fail
   3. Every draft is validated by the engine via the web workflow service;

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -550,6 +550,64 @@ Design invariants:
 - **Versioned knowledge.** The embedded corpora regenerate through CI
   generators on a twice-monthly freshness gate (1st+16th of each month).
 
+### Unified generation harness (issue #342)
+
+Every surface that turns a natural-language intent into an `.oxoflow`
+pipeline — CLI `template --ai`, `POST /api/ai/translate` (JSON and SSE),
+and web chat (`/api/chat/send`, `/api/chat/send/json`) — runs **one**
+agent through **one** loop. Before the unification, each surface carried
+its own prompt and validation copy with divergent quality; the weakest
+taught a schema the engine rejects (Snakemake-style tables → `E017`).
+
+```mermaid
+flowchart TB
+    subgraph surfaces["Surfaces (thin adapters)"]
+        cli["CLI template --ai"]
+        tr["POST /api/ai/translate"]
+        chat["/api/chat (SSE · JSON)"]
+    end
+
+    subgraph harness["Shared harness (oxo-flow-ai)"]
+        agent["PipelineGenAgent<br/>engine-accurate prompt ·<br/>canonical TOML extraction ·<br/>injected validator"]
+        loop["Orchestrator loop<br/>plan → tools → extract →<br/>validate → feedback → deliver"]
+        kt["knowledge_tool_registry<br/>(read-only: bioconda · skills ·<br/>pipeline graph · screened fetch)"]
+    end
+
+    gates["Engine validation<br/>(CLI: WorkflowConfig parse ·<br/>web: workflow service)"]
+
+    surfaces --> agent
+    agent --> loop
+    loop --> kt
+    loop -- "validation feedback<br/>(bounded rounds)" --> gates
+    loop -- "errors feed back" --> agent
+```
+
+The surfaces differ only in adapter concerns:
+
+| Concern | CLI | Web translate | Web chat |
+|---|---|---|---|
+| Provider resolution | env / `ai_config.json` | per-user → server → env, with Claude/OpenAI/Ollama fallback chain | per-user → server → env |
+| Tools | full registry + MCP; non-read-only needs interactive approval | read-only knowledge registry only | knowledge registry + run-diagnosis tools |
+| Validator | core `WorkflowConfig` parse | workflow service `validate_pipeline` | same as translate |
+| Correction budget | `--ai-max-retries` (default 3) | 6 rounds | 6 rounds |
+| Session destination | `~/.oxo-flow/ai_sessions/` archive | in-process (usage logged) | chat messages in DB |
+| Failure behavior | degrade: deliver the transcript's TOML with a warning | structured error + template-keyword fallback | degraded delivery over SSE |
+
+Two provider-level ceilings matter for thinking-style backends (models
+that emit reasoning blocks counting against the output budget):
+`OXO_FLOW_AI_MAX_TOKENS` (default 4096 — calibrated for the
+non-thinking tier with ≥3× headroom; raise for thinking backends) and
+`OXO_FLOW_AI_TIMEOUT_SECS` (default 120 — non-thinking generations run
+12–20 s; thinking backends exceed it). Quality/cost evidence for these
+calibrations and the unification itself lives in `eval/frontier/`
+(gate-scored benchmark: deterministic `validate`/`dry-run`/`lint`
+verdicts, no LLM judge).
+
+Security boundary is unchanged by the harness: `oxo-flow-ai` holds no
+database or filesystem writes; web surfaces register read-only tools
+with no approver, so non-read-only calls are refused by construction
+(`tests/ai_security.rs` enforces this at source level).
+
 ---
 
 ## Cross-Cutting Design Decisions

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -550,7 +550,7 @@ Design invariants:
 - **Versioned knowledge.** The embedded corpora regenerate through CI
   generators on a twice-monthly freshness gate (1st+16th of each month).
 
-### Unified generation harness (issue #342)
+### Unified generation harness
 
 Every surface that turns a natural-language intent into an `.oxoflow`
 pipeline — CLI `template --ai`, `POST /api/ai/translate` (JSON and SSE),
@@ -589,9 +589,9 @@ The surfaces differ only in adapter concerns:
 | Provider resolution | env / `ai_config.json` | per-user → server → env, with Claude/OpenAI/Ollama fallback chain | per-user → server → env |
 | Tools | full registry + MCP; non-read-only needs interactive approval | read-only knowledge registry only | knowledge registry + run-diagnosis tools |
 | Validator | core `WorkflowConfig` parse | workflow service `validate_pipeline` | same as translate |
-| Correction budget | `--ai-max-retries` (default 3) | 6 rounds | 6 rounds |
-| Session destination | `~/.oxo-flow/ai_sessions/` archive | in-process (usage logged) | chat messages in DB |
-| Failure behavior | degrade: deliver the transcript's TOML with a warning | structured error + template-keyword fallback | degraded delivery over SSE |
+| Correction budget | `--ai-max-retries` (default 6) | 6 rounds | 6 rounds |
+| Session destination | `~/.oxo-flow/ai_sessions/` archive | in-process; token usage logged | chat messages in DB; token usage logged |
+| Failure behavior | degrade: deliver the transcript's TOML with a warning | `AI_NOT_CONFIGURED` when no provider is usable; template-keyword fallback when providers fail | `AI_NOT_CONFIGURED` when no provider is usable; degraded delivery over SSE |
 
 Two provider-level ceilings matter for thinking-style backends (models
 that emit reasoning blocks counting against the output budget):

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -590,7 +590,7 @@ The surfaces differ only in adapter concerns:
 | Tools | full registry + MCP; non-read-only needs interactive approval | read-only knowledge registry only | knowledge registry + run-diagnosis tools |
 | Validator | core `WorkflowConfig` parse | workflow service `validate_pipeline` | same as translate |
 | Correction budget | `--ai-max-retries` (default 6) | 6 rounds | 6 rounds |
-| Session destination | `~/.oxo-flow/ai_sessions/` archive | in-process; token usage logged | chat messages in DB; token usage logged |
+| Session destination | `~/.oxo-flow/ai_sessions/` archive | failure sessions archived by the shared orchestrator; every run's token usage in the operation log | chat messages in DB; token usage in the operation log |
 | Failure behavior | degrade: deliver the transcript's TOML with a warning | `AI_NOT_CONFIGURED` when no provider is usable; template-keyword fallback when providers fail | `AI_NOT_CONFIGURED` when no provider is usable; degraded delivery over SSE |
 
 Two provider-level ceilings matter for thinking-style backends (models

--- a/docs/guide/src/reference/web-system-architecture.md
+++ b/docs/guide/src/reference/web-system-architecture.md
@@ -141,9 +141,9 @@ Rate limiting and SSE:
 |--------|------|---------------|
 | **workflow** | `domains/workflow/` | Pipeline parse, validate, prepare, DAG, format, lint, stats, diff, export, search, data discovery, plugin validation |
 | **execution** | `domains/execution/` | Run create/status/cancel/retry, diagnostics engine (30+ error patterns), sandbox workspace; runs delegate to the `oxo-flow` CLI subprocess, which owns checkpointing and invalidation |
-| **ai** | `domains/ai/` | AI translate, explain, interpret, optimize; provider dispatch (DeepSeek/Claude/OpenAI/Ollama) |
+| **ai** | `domains/ai/` | AI translate, explain, interpret, optimize; generation runs the shared agent + orchestrator harness (see [Architecture → AI Subsystem](architecture.md)) over the provider fallback chain |
 | **auth** | `domains/auth/` | Login, session management, ORCID/GitHub OAuth2, RBAC |
-| **chat** | `domains/chat/` | Real-time AI copilot chat and streaming |
+| **chat** | `domains/chat/` | Real-time AI copilot chat and streaming; generation uses the same harness as translate, plus read-only run-diagnosis tools |
 | **clusters** | `domains/clusters/` | Remote cluster submission over SSH, job polling, result pull-back |
 | **collaboration** | `domains/collaboration/` | Fork, diff, share, import pipelines |
 | **dag** | `domains/dag/` | DAG-specific types and operations |

--- a/eval/frontier/PILOT_FINDINGS.md
+++ b/eval/frontier/PILOT_FINDINGS.md
@@ -88,8 +88,9 @@ The shipped default `[ai] max_retries` moved 3 → 6 after the spot-check
 below showed the thinking tier starving at the old default: with 2–3
 rounds the model spends its whole budget on knowledge-tool lookups
 before writing any TOML, and the run dies at the round cap with the
-session archived (paid, invisible in artifacts). `run_eval.py` now
-defaults `--max-retries` to 6 so bare runs measure the shipped config.
+session archived (paid, invisible in artifacts). `run_eval.py` no longer
+passes `--ai-max-retries` unless overridden, so bare runs measure
+whatever the binary actually ships.
 
 Spot-check, same model and ceilings (16384 / 300s), `cli` variant:
 

--- a/eval/frontier/PILOT_FINDINGS.md
+++ b/eval/frontier/PILOT_FINDINGS.md
@@ -81,3 +81,27 @@ Residual misses (3/18 cells) are the remaining harness frontier:
 correction-budget exhaustion on hard intents and one final-round TOML
 miss — bounded-retry and evaluator roles are the next lever, not the
 prompt.
+
+## Post-default re-measurement (round-budget starvation fix)
+
+The shipped default `[ai] max_retries` moved 3 → 6 after the spot-check
+below showed the thinking tier starving at the old default: with 2–3
+rounds the model spends its whole budget on knowledge-tool lookups
+before writing any TOML, and the run dies at the round cap with the
+session archived (paid, invisible in artifacts). `run_eval.py` now
+defaults `--max-retries` to 6 so bare runs measure the shipped config.
+
+Spot-check, same model and ceilings (16384 / 300s), `cli` variant:
+
+| intent | budget | all-gates | wall | note |
+|---|---|---|---|---|
+| `qc-fastqc` (easy) | 6 | ✅ | 10.2s | |
+| `rnaseq-star` (medium) | 2 | ❌ | 2.8s | round cap before any TOML |
+| `rnaseq-star` (medium) | 6 | ✅ | 24.6s | 2 knowledge rounds + corrections fit |
+| CJK two-intent fastp+multiqc | 3 | ❌ | — | round cap, session archived |
+| CJK two-intent fastp+multiqc | 6 | ✅ | ~12s | gates re-run locally, exit 0 |
+
+Non-thinking tiers are unaffected (deepseek-chat finished within 3
+rounds on all 9 pilot intents); the change only widens the viable
+config space for thinking backends, at zero cost when a draft
+validates early.

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -195,7 +195,9 @@ def run_generation(variant: str, intent: str, model: str, run_dir: Path,
         before = {p.name: p.stat().st_mtime for p in sessions.glob("*-template-*.json")} \
             if sessions.exists() else {}
         cmd = [binary, "template", "--ai", intent, "-o", f"{run_dir}/",
-               "--ai-max-retries", str(args.max_retries), "--no-color"]
+               "--no-color"]
+        if args.max_retries is not None:
+            cmd += ["--ai-max-retries", str(args.max_retries)]
         try:
             proc = subprocess.run(cmd, cwd=run_dir, env=env, timeout=args.timeout,
                                   capture_output=True, text=True)
@@ -280,9 +282,9 @@ def main() -> None:
     ap.add_argument("--variants", default="minimal,cli")
     ap.add_argument("--models", default="", help="comma list; default: env ANTHROPIC_MODEL")
     ap.add_argument("--filter", default="", help="comma list of intent ids to include")
-    ap.add_argument("--max-retries", type=int, default=6,
-                    help="CLI tool-loop budget (--ai-max-retries); default matches "
-                         "the shipped [ai] max_retries")
+    ap.add_argument("--max-retries", type=int, default=None,
+                    help="override the CLI tool-loop budget (--ai-max-retries); "
+                         "default: whatever the binary's shipped [ai] max_retries is")
     ap.add_argument("--timeout", type=float, default=900, help="per-generation timeout (s)")
     ap.add_argument("--sleep", type=float, default=1.0, help="pause between runs (s)")
     args = ap.parse_args()

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -280,8 +280,9 @@ def main() -> None:
     ap.add_argument("--variants", default="minimal,cli")
     ap.add_argument("--models", default="", help="comma list; default: env ANTHROPIC_MODEL")
     ap.add_argument("--filter", default="", help="comma list of intent ids to include")
-    ap.add_argument("--max-retries", type=int, default=2,
-                    help="CLI tool-loop budget (--ai-max-retries)")
+    ap.add_argument("--max-retries", type=int, default=6,
+                    help="CLI tool-loop budget (--ai-max-retries); default matches "
+                         "the shipped [ai] max_retries")
     ap.add_argument("--timeout", type=float, default=900, help="per-generation timeout (s)")
     ap.add_argument("--sleep", type=float, default=1.0, help="pause between runs (s)")
     args = ap.parse_args()


### PR DESCRIPTION
Closes #342. Follow-up to #349: completes the unified generation harness to production level — code gaps the audit and end-to-end campaign surfaced, plus the documentation leg.

## Code (web surfaces)

- **Provider isolation in translate**: `translate_intent` ignored the acting user's provider and ran the server/env chain; it now runs the caller's resolved provider first (their key, their cost — the chat route's rule), then runtime, then env fallbacks, with same-endpoint dedup.
- **Structured AI error paths**: translate (JSON+SSE) and chat (JSON+SSE) now emit the same `AI_NOT_CONFIGURED` (503) signal, judged on the **resolved** provider — a user's own key works while the shared runtime is unconfigured; a disabled instance reports 503 instead of a generic error.
- **Boundary input validation**: empty intent/message → `INVALID_INTENT` / `EMPTY_MESSAGE` (400 or SSE error event) instead of a paid generation that hallucinates a pipeline from nothing.
- **Token spend visibility**: every finished web generation logs surface/session/prompt/completion tokens; web sessions are intentionally not written to disk (zero-write guarantee), so this is the durable spend record.
- **Chat JSON parity**: accepts `run_id` + user/admin scoping → same read-only run-diagnosis tools as the SSE route.
- **DRY/correctness**: the web engine binding (`validate_pipeline` closure) lives once in the workflow service; `optimize` reuses the canonical TOML extractor with the anti-prose guard.

## Code (round budget)

- Default `[ai] max_retries` 3 → 6: orchestrator rounds are shared between knowledge-tool lookups and validation-feedback corrections; 2–3 starved tool-heavy intents into a paid dead end (live evidence on the thinking tier). Web surfaces already used 6. `eval/frontier` default follows the shipped config.

## Docs

- New reference sections: how `template --ai` generates a workflow (six-step shared flow, budget/degradation contract, `OXO_FLOW_AI_MAX_TOKENS`/`_TIMEOUT_SECS` calibration), unified-generation-harness architecture view (mermaid loop + per-surface adapter table), web-system-architecture pointers.
- User-facing pages state behavior, not tracking history.
- PILOT_FINDINGS: post-default spot-check table (2–3 rounds starve, 6 passes; gates re-run on artifacts).

## Verification

- `make ci` green (fmt, clippy -D warnings, build, full test suite, audit, frontend lint); `ai_security` zero-write tripwire green.
- Live end-to-end (DeepSeek thinking backend via Anthropic-compatible endpoint): CLI `template --ai` EN + CJK intents + `-o dir/` → three gates exit 0; web translate JSON/SSE, chat JSON/SSE (tool calls streamed), chat with run_id, config-effective; translate artifacts pass CLI validate/dry-run/lint; disabled instance → structured 503 on all four routes; empty-input guards verified; usage lines present in the operation log; frontier spot-check 3/3 intents pass at the shipped budget.

Deferred deliberately: axum body-parse rejections remain the framework default plain 400 (API-wide extractor pattern, orthogonal to the harness).