### PR TITLE
fix(core): executable inline conda package lists + deterministic gate repair (83% → 98% generation pass)

### DIFF
--- a/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
+++ b/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
@@ -26,6 +26,13 @@ use crate::types::Message;
 /// correction by the orchestrator.
 pub type OutputValidator = Arc<dyn Fn(&str) -> ValidationResult + Send + Sync>;
 
+/// Caller-injected deterministic text repair, applied to the extracted TOML
+/// BEFORE validation. Mechanical error classes (missing config declarations,
+/// joined-dialect keys) are cheaper and more reliable to fix in code than to
+/// spend a paid model round on — the orchestrator validates and adopts the
+/// FIXED text, so a successful fix never reaches the model at all.
+pub type TextFixer = Arc<dyn Fn(String) -> (String, Vec<String>) + Send + Sync>;
+
 // ── System prompt ──────────────────────────────────────────────────────────
 
 /// The generation persona's system prompt: oxo-flow TOML syntax reference,
@@ -243,12 +250,14 @@ pub fn basic_structure_errors(toml: &str) -> Vec<String> {
 // ── Agent ──────────────────────────────────────────────────────────────────
 
 /// The shared generation agent. Surfaces customize it with prompt
-/// additions (skills, data reports) and an engine-bound validator.
+/// additions (skills, data reports), an engine-bound validator, and an
+/// optional deterministic text fixer.
 pub struct PipelineGenAgent {
     intent: String,
     system_additions: Vec<String>,
     user_additions: Vec<String>,
     validator: Option<OutputValidator>,
+    fixer: Option<TextFixer>,
 }
 
 impl PipelineGenAgent {
@@ -258,6 +267,7 @@ impl PipelineGenAgent {
             system_additions: Vec::new(),
             user_additions: Vec::new(),
             validator: None,
+            fixer: None,
         }
     }
 
@@ -265,6 +275,12 @@ impl PipelineGenAgent {
     /// one, only the structural floor (`basic_structure_errors`) applies.
     pub fn with_validator(mut self, validator: OutputValidator) -> Self {
         self.validator = Some(validator);
+        self
+    }
+
+    /// Inject a deterministic repair pass (see [`TextFixer`]).
+    pub fn with_text_fixer(mut self, fixer: TextFixer) -> Self {
+        self.fixer = Some(fixer);
         self
     }
 
@@ -330,7 +346,23 @@ impl Agent for PipelineGenAgent {
     }
 
     fn extract_content(&self, response_content: &str) -> Option<String> {
-        extract_toml(response_content)
+        let toml = extract_toml(response_content)?;
+        match &self.fixer {
+            None => Some(toml),
+            // A fixer failure must never lose the artifact — fall back to
+            // the unfixed text and let validation report the problem.
+            Some(fix) => {
+                let (fixed, notes) = fix(toml.clone());
+                if fixed.trim().is_empty() {
+                    Some(toml)
+                } else {
+                    if !notes.is_empty() {
+                        tracing::info!(notes = ?notes, "deterministic fixes applied to the draft");
+                    }
+                    Some(fixed)
+                }
+            }
+        }
     }
 }
 

--- a/crates/oxo-flow-cli/src/commands/ai_template.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_template.rs
@@ -322,7 +322,9 @@ pub async fn generate_workflow(
         let curator_brief = curator_brief.clone();
         let contract = contract.clone();
         move |findings: Option<&str>| -> PipelineGenAgent {
-            let mut agent = PipelineGenAgent::new(intent).with_validator(validator.clone());
+            let mut agent = PipelineGenAgent::new(intent)
+                .with_validator(validator.clone())
+                .with_text_fixer(Arc::new(fix_undefined_config_keys));
             if !runtime.skill_context.is_empty() {
                 agent = agent.with_system_addition(format!(
                     "## Activated Custom Skills\n{}",
@@ -671,6 +673,60 @@ fn archive_session(session: &AiSession) {
     }
 }
 
+/// Deterministic repair for the mechanical E005 class: the draft references
+/// `{config.X}` without declaring X. The model feedback loop CAN fix these,
+/// but a paid round is a wasteful way to add a line — the fixer declares the
+/// missing keys (value = the key name, self-describing in paths) directly
+/// under `[config]` and lets validation re-check the result. Returns the
+/// (possibly unchanged) TOML plus human-readable fix notes.
+fn fix_undefined_config_keys(toml: String) -> (String, Vec<String>) {
+    let config: oxo_flow_core::config::WorkflowConfig = match toml::from_str(&toml) {
+        Ok(c) => c,
+        Err(_) => return (toml, Vec::new()),
+    };
+    let mut missing: Vec<String> = Vec::new();
+    for rule in &config.rules {
+        for d in oxo_flow_core::format::undefined_config_refs(rule, &config) {
+            if d.code != "E005" {
+                continue;
+            }
+            if let Some(start) = d.message.find('\'')
+                && let Some(end) = d.message[start + 1..].find('\'')
+            {
+                let key = &d.message[start + 1..start + 1 + end];
+                if !missing.iter().any(|k| k == key) {
+                    missing.push(key.to_string());
+                }
+            }
+        }
+    }
+    if missing.is_empty() {
+        return (toml, Vec::new());
+    }
+
+    let mut fixed = toml;
+    let insert_block: String = missing
+        .iter()
+        .map(|k| format!("{k} = \"{k}\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if let Some(pos) = fixed.find("[config]") {
+        // Insert directly after the [config] header line.
+        let after = pos + "[config]".len();
+        fixed.insert_str(after, &format!("\n{insert_block}"));
+    } else if let Some(pos) = fixed.find("[[rules]]") {
+        // No [config] section at all: open one right before the first rule.
+        fixed.insert_str(pos, &format!("[config]\n{insert_block}\n\n"));
+    } else {
+        return (fixed, Vec::new());
+    }
+    let notes = missing
+        .iter()
+        .map(|k| format!("declared missing config key '{k}' (value defaults to the key name)"))
+        .collect();
+    (fixed, notes)
+}
+
 /// Basic structural validation before passing to core engine.
 fn validate_basic_structure(toml: &str) -> Result<()> {
     if !toml.contains("[workflow]") {
@@ -691,6 +747,36 @@ fn validate_basic_structure(toml: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fixer_declares_missing_config_keys() {
+        // The measured failure class: the draft references {config.prefix}
+        // without declaring it — a paid model round used to be the fix.
+        let draft = "[workflow]\nname = \"x\"\n\n[config]\nsample = \"S1\"\n\n[[rules]]\nname = \"r\"\noutput = [\"{{config.prefix}}_qc.txt\"]\nshell = \"echo hi\"";
+        let (fixed, notes) = fix_undefined_config_keys(draft.to_string());
+        assert_eq!(notes.len(), 1, "notes: {notes:?}");
+        assert!(notes[0].contains("prefix"));
+        assert!(fixed.contains("prefix = \"prefix\""), "fixed: {fixed}");
+        // The fix must satisfy the engine check it targets.
+        let config: oxo_flow_core::config::WorkflowConfig = toml::from_str(&fixed).unwrap();
+        for rule in &config.rules {
+            assert!(oxo_flow_core::format::undefined_config_refs(rule, &config).is_empty());
+        }
+    }
+
+    #[test]
+    fn fixer_creates_config_section_when_absent_and_leaves_clean_toml_alone() {
+        let no_config = "[workflow]\nname = \"x\"\n\n[[rules]]\nname = \"r\"\noutput = [\"{{config.root}}/a.txt\"]\nshell = \"echo hi\"";
+        let (fixed, notes) = fix_undefined_config_keys(no_config.to_string());
+        assert_eq!(notes.len(), 1);
+        assert!(fixed.contains("[config]"));
+
+        // Clean TOML passes through byte-identical.
+        let clean = "[workflow]\nname = \"x\"\n\n[config]\nsample = \"S1\"\n\n[[rules]]\nname = \"r\"\noutput = [\"a.txt\"]\nshell = \"echo hi\"";
+        let (fixed, notes) = fix_undefined_config_keys(clean.to_string());
+        assert_eq!(fixed, clean);
+        assert!(notes.is_empty());
+    }
 
     #[test]
     fn truncate_utf8_cuts_at_char_boundary() {

--- a/crates/oxo-flow-cli/src/commands/ai_template.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_template.rs
@@ -174,6 +174,7 @@ pub async fn generate_workflow(
     output: Option<PathBuf>,
     ai_max_retries: Option<u32>,
     team_profile: Option<oxo_flow_ai::agent::team::TeamProfile>,
+    ai_attempts: u32,
 ) -> Result<()> {
     // Resolve and prepare the destination BEFORE anything is sent to the
     // provider: a bad `-o` must fail cheaply, not after a paid generation.
@@ -324,7 +325,7 @@ pub async fn generate_workflow(
         move |findings: Option<&str>| -> PipelineGenAgent {
             let mut agent = PipelineGenAgent::new(intent)
                 .with_validator(validator.clone())
-                .with_text_fixer(Arc::new(fix_undefined_config_keys));
+                .with_text_fixer(Arc::new(oxo_flow_core::format::fix_undefined_config_keys));
             if !runtime.skill_context.is_empty() {
                 agent = agent.with_system_addition(format!(
                     "## Activated Custom Skills\n{}",
@@ -383,7 +384,6 @@ pub async fn generate_workflow(
         crate::commands::ai_runtime::prompt_tool_approval_blocking(&def.name, args)
     });
 
-    let agent = build_agent(None);
     let mut ctx = AgentContext {
         intent: intent.to_string(),
         command: "template".into(),
@@ -401,72 +401,114 @@ pub async fn generate_workflow(
         ),
     };
 
-    let outcome = runtime
-        .orchestrator
-        .execute_with_sink(&agent, &ctx, Some(&mut sink), None)
-        .await;
-
-    // Independent review (Full profile): a fresh instance sees the contract
-    // and the artifact — never the generation transcript. A request_changes
-    // verdict triggers ONE regeneration, which replaces the artifact only if
-    // IT ALSO VALIDATES: review can only improve the outcome, never trade a
-    // validated draft for an unvalidated one (the first ablation showed a
-    // replace-unconditionally review regressing pass@1 83% → 56%).
-    let outcome = if full {
-        match outcome {
-            Ok(first) if first.success && first.content.is_some() => {
-                let artifact = first.content.clone().expect("checked above");
-                match run_review(provider, contract.as_deref(), &artifact).await {
-                    Some(team::Verdict::RequestChanges(findings)) => {
-                        println!(
-                            "{} Review: request_changes — one bounded regeneration",
-                            "  ⚠".yellow()
-                        );
-                        if let Ok(mut s) = sessions.lock() {
-                            s.push(first.session.clone());
-                        }
-                        let fix_agent = build_agent(Some(&findings));
-                        ctx.session = AiSession::new(
-                            "template",
-                            intent,
-                            provider.name(),
-                            &provider.model().unwrap_or_else(|| "default".into()),
-                        );
-                        match runtime
-                            .orchestrator
-                            .execute_with_sink(&fix_agent, &ctx, Some(&mut sink), None)
-                            .await
-                        {
-                            Ok(o) if o.success && o.content.is_some() => {
-                                println!("{} Review fix validated — adopting it", "  ✓".green());
-                                Ok(o)
-                            }
-                            other => {
-                                println!(
-                                    "{} Review fix did not validate — keeping the original artifact",
-                                    "  ⚠".yellow()
-                                );
-                                if let Ok(mut s) = sessions.lock()
-                                    && let Ok(o) = &other
-                                {
-                                    s.push(o.session.clone());
-                                }
-                                Ok(first)
-                            }
-                        }
-                    }
-                    Some(team::Verdict::Approve) => {
-                        println!("{} Review: approved", "  ✓".green());
-                        Ok(first)
-                    }
-                    None => Ok(first),
-                }
-            }
-            other => other,
+    // pass@k with early exit: every attempt is a fresh draw with its own
+    // session; the gates are deterministic, so the first validating draw
+    // wins and later attempts are never paid. Only failing runs pay for
+    // attempt 2..N.
+    let attempts = ai_attempts.max(1);
+    let mut outcome = None;
+    for attempt in 1..=attempts {
+        if attempt > 1 {
+            println!(
+                "{} Generation attempt {attempt}/{attempts} (fresh draw)...",
+                "  •".dimmed()
+            );
         }
-    } else {
-        outcome
-    };
+        let agent = build_agent(None);
+        ctx.session = AiSession::new(
+            "template",
+            intent,
+            provider.name(),
+            &provider.model().unwrap_or_else(|| "default".into()),
+        );
+
+        let attempt_outcome = runtime
+            .orchestrator
+            .execute_with_sink(&agent, &ctx, Some(&mut sink), None)
+            .await;
+
+        // Independent review (Full profile): a fresh instance sees the contract
+        // and the artifact — never the generation transcript. A request_changes
+        // verdict triggers ONE regeneration, which replaces the artifact only if
+        // IT ALSO VALIDATES: review can only improve the outcome, never trade a
+        // validated draft for an unvalidated one (the first ablation showed a
+        // replace-unconditionally review regressing pass@1 83% → 56%).
+        let attempt_outcome = if full {
+            match attempt_outcome {
+                Ok(first) if first.success && first.content.is_some() => {
+                    let artifact = first.content.clone().expect("checked above");
+                    match run_review(provider, contract.as_deref(), &artifact).await {
+                        Some(team::Verdict::RequestChanges(findings)) => {
+                            println!(
+                                "{} Review: request_changes — one bounded regeneration",
+                                "  ⚠".yellow()
+                            );
+                            if let Ok(mut s) = sessions.lock() {
+                                s.push(first.session.clone());
+                            }
+                            let fix_agent = build_agent(Some(&findings));
+                            ctx.session = AiSession::new(
+                                "template",
+                                intent,
+                                provider.name(),
+                                &provider.model().unwrap_or_else(|| "default".into()),
+                            );
+                            match runtime
+                                .orchestrator
+                                .execute_with_sink(&fix_agent, &ctx, Some(&mut sink), None)
+                                .await
+                            {
+                                Ok(o) if o.success && o.content.is_some() => {
+                                    println!(
+                                        "{} Review fix validated — adopting it",
+                                        "  ✓".green()
+                                    );
+                                    Ok(o)
+                                }
+                                other => {
+                                    println!(
+                                        "{} Review fix did not validate — keeping the original artifact",
+                                        "  ⚠".yellow()
+                                    );
+                                    if let Ok(mut s) = sessions.lock()
+                                        && let Ok(o) = &other
+                                    {
+                                        s.push(o.session.clone());
+                                    }
+                                    Ok(first)
+                                }
+                            }
+                        }
+                        Some(team::Verdict::Approve) => {
+                            println!("{} Review: approved", "  ✓".green());
+                            Ok(first)
+                        }
+                        None => Ok(first),
+                    }
+                }
+                other => other,
+            }
+        } else {
+            attempt_outcome
+        };
+
+        let produced = matches!(&attempt_outcome, Ok(o) if o.success && o.content.is_some());
+        if produced {
+            outcome = Some(attempt_outcome);
+            break;
+        }
+        // A failed attempt's spend must stay visible: archive its session
+        // now (the tail archives the final outcome's session itself).
+        if attempt < attempts
+            && let Ok(mut s) = sessions.lock()
+            && let Ok(o) = &attempt_outcome
+        {
+            s.push(o.session.clone());
+        }
+        outcome = Some(attempt_outcome);
+    }
+
+    let outcome = outcome.expect("attempts >= 1");
 
     // Archive every session the team produced (contract/review calls are
     // archived inside their helpers; generation + review-fix here).
@@ -673,60 +715,6 @@ fn archive_session(session: &AiSession) {
     }
 }
 
-/// Deterministic repair for the mechanical E005 class: the draft references
-/// `{config.X}` without declaring X. The model feedback loop CAN fix these,
-/// but a paid round is a wasteful way to add a line — the fixer declares the
-/// missing keys (value = the key name, self-describing in paths) directly
-/// under `[config]` and lets validation re-check the result. Returns the
-/// (possibly unchanged) TOML plus human-readable fix notes.
-fn fix_undefined_config_keys(toml: String) -> (String, Vec<String>) {
-    let config: oxo_flow_core::config::WorkflowConfig = match toml::from_str(&toml) {
-        Ok(c) => c,
-        Err(_) => return (toml, Vec::new()),
-    };
-    let mut missing: Vec<String> = Vec::new();
-    for rule in &config.rules {
-        for d in oxo_flow_core::format::undefined_config_refs(rule, &config) {
-            if d.code != "E005" {
-                continue;
-            }
-            if let Some(start) = d.message.find('\'')
-                && let Some(end) = d.message[start + 1..].find('\'')
-            {
-                let key = &d.message[start + 1..start + 1 + end];
-                if !missing.iter().any(|k| k == key) {
-                    missing.push(key.to_string());
-                }
-            }
-        }
-    }
-    if missing.is_empty() {
-        return (toml, Vec::new());
-    }
-
-    let mut fixed = toml;
-    let insert_block: String = missing
-        .iter()
-        .map(|k| format!("{k} = \"{k}\""))
-        .collect::<Vec<_>>()
-        .join("\n");
-    if let Some(pos) = fixed.find("[config]") {
-        // Insert directly after the [config] header line.
-        let after = pos + "[config]".len();
-        fixed.insert_str(after, &format!("\n{insert_block}"));
-    } else if let Some(pos) = fixed.find("[[rules]]") {
-        // No [config] section at all: open one right before the first rule.
-        fixed.insert_str(pos, &format!("[config]\n{insert_block}\n\n"));
-    } else {
-        return (fixed, Vec::new());
-    }
-    let notes = missing
-        .iter()
-        .map(|k| format!("declared missing config key '{k}' (value defaults to the key name)"))
-        .collect();
-    (fixed, notes)
-}
-
 /// Basic structural validation before passing to core engine.
 fn validate_basic_structure(toml: &str) -> Result<()> {
     if !toml.contains("[workflow]") {
@@ -753,7 +741,7 @@ mod tests {
         // The measured failure class: the draft references {config.prefix}
         // without declaring it — a paid model round used to be the fix.
         let draft = "[workflow]\nname = \"x\"\n\n[config]\nsample = \"S1\"\n\n[[rules]]\nname = \"r\"\noutput = [\"{{config.prefix}}_qc.txt\"]\nshell = \"echo hi\"";
-        let (fixed, notes) = fix_undefined_config_keys(draft.to_string());
+        let (fixed, notes) = oxo_flow_core::format::fix_undefined_config_keys(draft.to_string());
         assert_eq!(notes.len(), 1, "notes: {notes:?}");
         assert!(notes[0].contains("prefix"));
         assert!(fixed.contains("prefix = \"prefix\""), "fixed: {fixed}");
@@ -767,13 +755,14 @@ mod tests {
     #[test]
     fn fixer_creates_config_section_when_absent_and_leaves_clean_toml_alone() {
         let no_config = "[workflow]\nname = \"x\"\n\n[[rules]]\nname = \"r\"\noutput = [\"{{config.root}}/a.txt\"]\nshell = \"echo hi\"";
-        let (fixed, notes) = fix_undefined_config_keys(no_config.to_string());
+        let (fixed, notes) =
+            oxo_flow_core::format::fix_undefined_config_keys(no_config.to_string());
         assert_eq!(notes.len(), 1);
         assert!(fixed.contains("[config]"));
 
         // Clean TOML passes through byte-identical.
         let clean = "[workflow]\nname = \"x\"\n\n[config]\nsample = \"S1\"\n\n[[rules]]\nname = \"r\"\noutput = [\"a.txt\"]\nshell = \"echo hi\"";
-        let (fixed, notes) = fix_undefined_config_keys(clean.to_string());
+        let (fixed, notes) = oxo_flow_core::format::fix_undefined_config_keys(clean.to_string());
         assert_eq!(fixed, clean);
         assert!(notes.is_empty());
     }

--- a/crates/oxo-flow-cli/src/commands/project.rs
+++ b/crates/oxo-flow-cli/src/commands/project.rs
@@ -551,14 +551,21 @@ fn apply_template(template_name: &str, output: Option<PathBuf>) -> Result<()> {
 // Public entry point
 // ---------------------------------------------------------------------------
 
+/// AI-generation knobs for `template --ai`, resolved from CLI flags over
+/// the `[ai]` config (see [`crate::commands::ai_template::generate_workflow`]).
+pub struct TemplateAiOptions {
+    pub max_retries: Option<u32>,
+    pub team_profile: Option<oxo_flow_ai::agent::team::TeamProfile>,
+    pub attempts: u32,
+}
+
 pub async fn template_command(
     name: Option<String>,
     output: Option<PathBuf>,
     ai: bool,
     from_url: Vec<String>,
     from_file: Vec<PathBuf>,
-    ai_max_retries: Option<u32>,
-    ai_team_profile: Option<String>,
+    options: TemplateAiOptions,
 ) -> Result<()> {
     print_banner();
 
@@ -581,12 +588,10 @@ pub async fn template_command(
             );
         }
 
-        // CLI flag wins over `[ai] team_profile` in the resolved config.
-        let team_profile = match ai_team_profile.as_deref() {
-            Some(flag) => Some(
-                flag.parse::<oxo_flow_ai::agent::team::TeamProfile>()
-                    .map_err(|e| anyhow::anyhow!(e))?,
-            ),
+        // `options.team_profile` (CLI flag) wins over `[ai] team_profile`
+        // in the resolved config.
+        let team_profile = match options.team_profile {
+            Some(flag) => Some(flag),
             None => oxo_flow_ai::AI.config().ok().and_then(|c| c.team_profile),
         };
 
@@ -595,8 +600,9 @@ pub async fn template_command(
             &from_url,
             &from_file,
             output,
-            ai_max_retries,
+            options.max_retries,
             team_profile,
+            options.attempts,
         )
         .await?;
         return Ok(());

--- a/crates/oxo-flow-cli/src/main.rs
+++ b/crates/oxo-flow-cli/src/main.rs
@@ -394,6 +394,11 @@ pub enum Commands {
         /// fix). Overrides `[ai] team_profile` in the config.
         #[arg(long = "ai-team-profile", value_name = "PROFILE")]
         ai_team_profile: Option<String>,
+        /// Fresh-draw attempts for the whole generation (pass@k with early
+        /// exit: the deterministic gates decide, so later attempts are only
+        /// paid when earlier ones fail).
+        #[arg(long = "ai-attempts", value_name = "N", default_value_t = 1)]
+        ai_attempts: u32,
     },
     /// AI status, test, setup, and workflow explanation.
     ///
@@ -1522,15 +1527,27 @@ async fn main() -> Result<()> {
             from_file,
             ai_max_retries,
             ai_team_profile,
+            ai_attempts,
         } => {
+            // CLI flag wins over `[ai] team_profile` in the resolved config.
+            let team_profile = match ai_team_profile.as_deref() {
+                Some(flag) => Some(
+                    flag.parse::<oxo_flow_ai::agent::team::TeamProfile>()
+                        .map_err(|e| anyhow::anyhow!(e))?,
+                ),
+                None => oxo_flow_ai::AI.config().ok().and_then(|c| c.team_profile),
+            };
             template_command(
                 template,
                 output,
                 ai,
                 from_url,
                 from_file,
-                ai_max_retries,
-                ai_team_profile,
+                crate::commands::project::TemplateAiOptions {
+                    max_retries: ai_max_retries,
+                    team_profile,
+                    attempts: ai_attempts,
+                },
             )
             .await?
         }

--- a/crates/oxo-flow-core/src/environment.rs
+++ b/crates/oxo-flow-core/src/environment.rs
@@ -81,6 +81,33 @@ pub(crate) fn conda_env_name_from_spec(kind: &str, spec: &str) -> Result<String>
 /// missing-env diagnosis (issue #300) can name both the derivation and the
 /// plain name an older env may have been created under.
 fn conda_env_name_parts(kind: &str, spec: &str) -> Result<(String, String)> {
+    // Inline package lists (`bioconda::fastp=0.23.4 bioconda::samtools=1.24`)
+    // get a content-addressed name derived from their first package, so two
+    // rules sharing the exact package set share one env while a changed set
+    // builds a fresh one — the same property file-backed specs get from
+    // their hash suffix (issue #159).
+    if let Some(packages) = crate::rule::EnvironmentSpec::inline_conda_packages(spec) {
+        let first = packages[0].rsplit("::").next().unwrap_or(&packages[0]);
+        let stem: String = first
+            .split('=')
+            .next()
+            .unwrap_or(first)
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+        use sha2::Digest as _;
+        let digest = sha2::Sha256::digest(spec.as_bytes());
+        let hash8: String = digest[..4].iter().map(|b| format!("{b:02x}")).collect();
+        let name = format!("{stem}-{hash8}");
+        return Ok((name.clone(), name));
+    }
+
     // Try reading the YAML file to extract `name:` field
     let file_content = std::fs::read(spec).ok();
     let from_yaml = file_content
@@ -295,6 +322,17 @@ impl EnvironmentBackend for CondaBackend {
     }
 
     fn setup_command(&self, spec: &str) -> Result<String> {
+        // Inline package lists install directly — the same form container
+        // export has always rendered (`conda create -n <name> <packages>`).
+        // Each token was allowlist-validated by `inline_conda_packages`, so
+        // interpolation is argv-safe.
+        if let Some(packages) = crate::rule::EnvironmentSpec::inline_conda_packages(spec) {
+            let env_name = conda_env_name_from_spec("conda", spec)?;
+            let joined = packages.join(" ");
+            return Ok(format!(
+                "conda create -n {env_name} -y {joined} || conda install -n {env_name} -y {joined}"
+            ));
+        }
         // `-n <name>` keeps setup consistent with `wrap_command` (which runs
         // `conda run -n <name>`): the name comes from the YAML's `name:` field
         // or the file stem. Without `-n`, conda 25+ fails with "Unable to

--- a/crates/oxo-flow-core/src/executor/process.rs
+++ b/crates/oxo-flow-core/src/executor/process.rs
@@ -4724,15 +4724,37 @@ mod tests {
     }
 
     #[test]
-    fn resolve_command_fails_hard_when_declared_environment_cannot_wrap() {
-        // A conda spec that cannot derive an env name (the `bioconda::bwa=`
-        // form) used to log a warning and run the bare command — silently
-        // using whatever the tool is on PATH instead of the declared env.
+    fn resolve_command_wraps_inline_package_specs_and_still_fails_on_garbage() {
+        // The audit finding behind this test stands: a declared environment
+        // that cannot be wrapped must fail the rule rather than silently run
+        // the tool from PATH. The `bioconda::bwa=` form USED to be the
+        // cannot-wrap example — inline package lists are now first-class
+        // (content-addressed env name + direct `conda create`), so the
+        // wrap succeeds under the derived name, while a genuinely
+        // unrenderable spec still fails hard.
         let ex = executor_with(4, 2048);
         let rule = Rule {
             name: "bwa_align".to_string(),
             environment: EnvironmentSpec {
                 conda: Some("bioconda::bwa=0.7.17".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let wrapped = ex
+            .resolve_command("bwa mem ref.fa", &rule, None)
+            .expect("inline package specs are wrappable now");
+        assert!(
+            wrapped.contains("conda run --no-capture-output -n bwa-"),
+            "expected a derived content-addressed env name, got: {wrapped}"
+        );
+
+        // A spec outside the package grammar and not a readable file still
+        // cannot wrap — and must fail loudly, never fall back to PATH.
+        let rule = Rule {
+            name: "bwa_align".to_string(),
+            environment: EnvironmentSpec {
+                conda: Some("bioconda::fastp=0.23.4; rm -rf /".to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -4744,7 +4766,6 @@ mod tests {
             matches!(err, OxoFlowError::Environment { .. }),
             "expected an Environment error, got {err:?}"
         );
-        assert!(err.to_string().contains("bioconda::bwa=0.7.17"), "{err}");
 
         // No environment declared: there is nothing to wrap, so the plain
         // command is still correct.

--- a/crates/oxo-flow-core/src/format.rs
+++ b/crates/oxo-flow-core/src/format.rs
@@ -303,6 +303,65 @@ pub fn undefined_config_refs(rule: &Rule, config: &WorkflowConfig) -> Vec<Diagno
     diagnostics
 }
 
+/// Deterministic repair for the mechanical E005 class: the draft references
+/// `{config.X}` without declaring X. The model feedback loop CAN fix these,
+/// but a paid generation round is a wasteful way to add a line — this pass
+/// declares the missing keys (value = the key name, self-describing in
+/// paths) directly under `[config]`. String-level insertion keeps the rest
+/// of the artifact (formatting, comments) byte-identical. Returns the
+/// (possibly unchanged) TOML plus human-readable fix notes.
+///
+/// Pure (no I/O, no model): surfaces inject this as the generation agent's
+/// text fixer, before validation and before any model feedback round.
+#[must_use]
+pub fn fix_undefined_config_keys(toml: String) -> (String, Vec<String>) {
+    let config: WorkflowConfig = match toml::from_str(&toml) {
+        Ok(c) => c,
+        Err(_) => return (toml, Vec::new()),
+    };
+    let mut missing: Vec<String> = Vec::new();
+    for rule in &config.rules {
+        for d in undefined_config_refs(rule, &config) {
+            if d.code != "E005" {
+                continue;
+            }
+            if let Some(start) = d.message.find('\'')
+                && let Some(end) = d.message[start + 1..].find('\'')
+            {
+                let key = &d.message[start + 1..start + 1 + end];
+                if !missing.iter().any(|k| k == key) {
+                    missing.push(key.to_string());
+                }
+            }
+        }
+    }
+    if missing.is_empty() {
+        return (toml, Vec::new());
+    }
+
+    let mut fixed = toml;
+    let insert_block: String = missing
+        .iter()
+        .map(|k| format!("{k} = \"{k}\""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if let Some(pos) = fixed.find("[config]") {
+        // Insert directly after the [config] header line.
+        let after = pos + "[config]".len();
+        fixed.insert_str(after, &format!("\n{insert_block}"));
+    } else if let Some(pos) = fixed.find("[[rules]]") {
+        // No [config] section at all: open one right before the first rule.
+        fixed.insert_str(pos, &format!("[config]\n{insert_block}\n\n"));
+    } else {
+        return (fixed, Vec::new());
+    }
+    let notes = missing
+        .iter()
+        .map(|k| format!("declared missing config key '{k}' (value defaults to the key name)"))
+        .collect();
+    (fixed, notes)
+}
+
 pub fn validate_format(config: &WorkflowConfig) -> ValidationResult {
     let mut diagnostics = Vec::new();
 

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -488,6 +488,49 @@ impl EnvironmentSpec {
         }
     }
 
+    /// Parse a `conda`/`mamba` spec as an inline package list.
+    ///
+    /// The AI-facing form — `conda = "bioconda::fastp=0.23.4 bioconda::samtools=1.24"`
+    /// (whitespace- or comma-joined, channel-qualified) — is what the
+    /// generation prompt mandates and what models naturally write. Each
+    /// token must match a strict package charset; anything else (a YAML
+    /// path, a lockfile, a typo) yields `None` and the spec keeps its
+    /// path-tier handling.
+    ///
+    /// Returns `Some(tokens)` only when at least one token is
+    /// channel-qualified (`contains "::"`), so ordinary filesystem paths
+    /// never misparse as package lists.
+    #[must_use]
+    pub fn inline_conda_packages(spec: &str) -> Option<Vec<String>> {
+        const PKG_CHARS: &str =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:+/=-";
+        let tokens: Vec<String> = spec
+            .split([' ', ',', '\t'])
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(String::from)
+            .collect();
+        if tokens.is_empty() || !tokens.iter().any(|t| t.contains("::")) {
+            return None;
+        }
+        if tokens
+            .iter()
+            .all(|t| !t.is_empty() && t.chars().all(|c| PKG_CHARS.contains(c)))
+        {
+            Some(tokens)
+        } else {
+            None
+        }
+    }
+
+    /// Convenience wrapper: the inline package list for THIS spec's `conda`
+    /// field, used by the conda backend's direct-create path and by the
+    /// validator's package-list-aware shell-risk scan.
+    #[must_use]
+    pub fn conda_packages(&self) -> Option<Vec<String>> {
+        self.conda.as_deref().and_then(Self::inline_conda_packages)
+    }
+
     /// Returns the first shell-unsafe character in this environment spec,
     /// tagged with the offending field name.
     ///
@@ -543,9 +586,23 @@ impl EnvironmentSpec {
         .find_map(|(field, value)| scan(field, value, true));
         refs.or_else(|| self.modules.iter().find_map(|m| scan("modules", m, true)))
             .or_else(|| {
+                // A validated inline package list skips the path-tier scan
+                // entirely: every token already passed the strict package
+                // charset (an ALLOWLIST — strictly tighter than the
+                // metacharacter blacklist), and the conda backend renders
+                // the tokens as separate argv items. Anything that fails
+                // the parse keeps the plain path-tier rules.
+                let conda_scan = match self.conda_packages() {
+                    Some(_) => None,
+                    None => self.conda.as_deref().map(|v| ("conda", v)),
+                };
+                let mamba_scan = match self.mamba.as_deref().and_then(Self::inline_conda_packages) {
+                    Some(_) => None,
+                    None => self.mamba.as_deref().map(|v| ("mamba", v)),
+                };
                 [
-                    self.conda.as_deref().map(|v| ("conda", v)),
-                    self.mamba.as_deref().map(|v| ("mamba", v)),
+                    conda_scan,
+                    mamba_scan,
                     self.pixi.as_deref().map(|v| ("pixi", v)),
                     self.venv.as_deref().map(|v| ("venv", v)),
                     self.conda_prefix.as_deref().map(|v| ("conda_prefix", v)),
@@ -1918,6 +1975,78 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(env.shell_risk(), Some(("docker", ' ')));
+    }
+
+    #[test]
+    fn inline_conda_packages_parses_the_ai_form() {
+        // The exact form the generation prompt mandates: space- or
+        // comma-joined, channel-qualified, version-pinned.
+        let spec = "bioconda::fastp=0.23.4 bioconda::samtools=1.24";
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages(spec),
+            Some(vec![
+                "bioconda::fastp=0.23.4".to_string(),
+                "bioconda::samtools=1.24".to_string()
+            ])
+        );
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages(
+                "bioconda::fastp=0.23.4,bioconda::samtools=1.24"
+            )
+            .as_deref(),
+            Some(
+                [
+                    "bioconda::fastp=0.23.4".to_string(),
+                    "bioconda::samtools=1.24".to_string()
+                ]
+                .as_slice()
+            )
+        );
+        // Single channel-qualified package is a one-element list.
+        assert!(EnvironmentSpec::inline_conda_packages("bioconda::bwa=0.7.17").is_some());
+    }
+
+    #[test]
+    fn inline_conda_packages_rejects_paths_injection_and_unqualified() {
+        // YAML paths / lockfiles are never package lists.
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("envs/tools.yaml"),
+            None
+        );
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("envs/tools.lock"),
+            None
+        );
+        // Unqualified bare names ("fastp samtools") are not channel
+        // references — keep them on the strict path-tier rules.
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("fastp samtools"),
+            None
+        );
+        // Shell metacharacters fail the charset allowlist even with "::".
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("bioconda::fastp; touch /tmp/pwn"),
+            None
+        );
+        assert_eq!(EnvironmentSpec::inline_conda_packages(""), None);
+    }
+
+    #[test]
+    fn shell_risk_accepts_valid_package_lists_but_flags_injection() {
+        // A validated package list carries no shell risk: every token
+        // passed the charset allowlist.
+        let env = EnvironmentSpec {
+            conda: Some("bioconda::fastp=0.23.4 bioconda::samtools=1.24".into()),
+            ..Default::default()
+        };
+        assert_eq!(env.shell_risk(), None, "valid package list must wrap");
+        // An injection attempt fails the package parse and falls back to
+        // the path-tier scan, which still rejects it (';' appears first).
+        let evil = EnvironmentSpec {
+            conda: Some("bioconda::fastp=0.23.4; touch HOSTPWN".into()),
+            ..Default::default()
+        };
+        assert_eq!(evil.shell_risk(), Some(("conda", ';')));
     }
 
     #[test]

--- a/crates/oxo-flow-core/src/rule.rs
+++ b/crates/oxo-flow-core/src/rule.rs
@@ -491,11 +491,18 @@ impl EnvironmentSpec {
     /// Parse a `conda`/`mamba` spec as an inline package list.
     ///
     /// The AI-facing form — `conda = "bioconda::fastp=0.23.4 bioconda::samtools=1.24"`
-    /// (whitespace- or comma-joined, channel-qualified) — is what the
-    /// generation prompt mandates and what models naturally write. Each
-    /// token must match a strict package charset; anything else (a YAML
+    /// (whitespace-, comma-, or semicolon-joined, channel-qualified) — is
+    /// what the generation prompt mandates and what models naturally write.
+    /// Each token must match a strict package charset; anything else (a YAML
     /// path, a lockfile, a typo) yields `None` and the spec keeps its
     /// path-tier handling.
+    ///
+    /// Two argv-safety rules beyond the charset, because the backend renders
+    /// the tokens as separate `conda create` arguments:
+    /// - a token may not start with `-` (no conda-CLI flag injection such as
+    ///   `--override-channels -c <attacker>`);
+    /// - `;` is a JOINER here, not a shell metacharacter — it is split on
+    ///   before validation, so shell chaining can never survive the parse.
     ///
     /// Returns `Some(tokens)` only when at least one token is
     /// channel-qualified (`contains "::"`), so ordinary filesystem paths
@@ -505,7 +512,7 @@ impl EnvironmentSpec {
         const PKG_CHARS: &str =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:+/=-";
         let tokens: Vec<String> = spec
-            .split([' ', ',', '\t'])
+            .split([' ', ',', ';', '\t'])
             .map(str::trim)
             .filter(|t| !t.is_empty())
             .map(String::from)
@@ -515,7 +522,7 @@ impl EnvironmentSpec {
         }
         if tokens
             .iter()
-            .all(|t| !t.is_empty() && t.chars().all(|c| PKG_CHARS.contains(c)))
+            .all(|t| !t.starts_with('-') && t.chars().all(|c| PKG_CHARS.contains(c)))
         {
             Some(tokens)
         } else {
@@ -2025,10 +2032,49 @@ mod tests {
         );
         // Shell metacharacters fail the charset allowlist even with "::".
         assert_eq!(
-            EnvironmentSpec::inline_conda_packages("bioconda::fastp; touch /tmp/pwn"),
+            EnvironmentSpec::inline_conda_packages("bioconda::fastp && touch /tmp/pwn"),
             None
         );
         assert_eq!(EnvironmentSpec::inline_conda_packages(""), None);
+    }
+
+    #[test]
+    fn inline_conda_packages_accepts_semicolon_join_and_blocks_flag_injection() {
+        // Live-measured variant: semicolon-joined packages (atacseq seed 2
+        // generated exactly this form and tripped E016 pre-fix).
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages(
+                "bioconda::bwa-mem2=2.3;bioconda::samtools=1.24"
+            ),
+            Some(vec![
+                "bioconda::bwa-mem2=2.3".to_string(),
+                "bioconda::samtools=1.24".to_string()
+            ])
+        );
+        // The tokens become separate argv items, so a leading '-' (conda-CLI
+        // flag injection: `--override-channels -c <attacker>`) is rejected.
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages(
+                "bioconda::bwa --override-channels -c https://evil.example"
+            ),
+            None
+        );
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("bioconda::bwa -y"),
+            None
+        );
+        // A '; '-injection pattern parses as harmless package tokens — safe
+        // because the backend renders them as ONE conda command's argv (no
+        // shell), and conda then fails on the bogus package names. The
+        // charset still blocks any token carrying a shell metacharacter.
+        assert_eq!(
+            EnvironmentSpec::inline_conda_packages("bioconda::fastp; touch /tmp/pwn"),
+            Some(vec![
+                "bioconda::fastp".to_string(),
+                "touch".to_string(),
+                "/tmp/pwn".to_string()
+            ])
+        );
     }
 
     #[test]
@@ -2040,10 +2086,14 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(env.shell_risk(), None, "valid package list must wrap");
-        // An injection attempt fails the package parse and falls back to
-        // the path-tier scan, which still rejects it (';' appears first).
+        // ';'-joined injection attempts now parse as harmless package
+        // tokens (safe: rendered as ONE conda command's argv, no shell —
+        // conda itself rejects the bogus package names). What still trips
+        // the path-tier scan is a PATH-shaped spec carrying a shell-active
+        // character: no channel-qualified token, so the package parse
+        // declines and the strict scan takes over.
         let evil = EnvironmentSpec {
-            conda: Some("bioconda::fastp=0.23.4; touch HOSTPWN".into()),
+            conda: Some("envs/a;rm.yaml".into()),
             ..Default::default()
         };
         assert_eq!(evil.shell_risk(), Some(("conda", ';')));

--- a/crates/oxo-flow-web/src/domains/ai/service.rs
+++ b/crates/oxo-flow-web/src/domains/ai/service.rs
@@ -171,7 +171,8 @@ pub async fn translate_intent(
     // Read-only knowledge tools only, no approver: non-read-only calls are
     // refused by construction (the module's zero-write guarantee).
     let mut agent = oxo_flow_ai::agent::pipeline_gen::PipelineGenAgent::new(intent)
-        .with_validator(workflow_svc::pipeline_output_validator());
+        .with_validator(workflow_svc::pipeline_output_validator())
+        .with_text_fixer(workflow_svc::pipeline_output_fixer());
     if let Some(summary) = data_summary {
         agent = agent.with_user_addition(format!("## Data Context\n{summary}"));
     }

--- a/crates/oxo-flow-web/src/domains/chat/agent.rs
+++ b/crates/oxo-flow-web/src/domains/chat/agent.rs
@@ -23,6 +23,7 @@ impl ChatAgent {
         Self {
             inner: PipelineGenAgent::new(intent)
                 .with_validator(workflow_svc::pipeline_output_validator())
+                .with_text_fixer(workflow_svc::pipeline_output_fixer())
                 // The raw user message (free-form chat turn) supplements the
                 // intent-derived request line the shared persona builds.
                 .with_user_addition(format!("## User Message\n{user_message}")),

--- a/crates/oxo-flow-web/src/domains/workflow/service.rs
+++ b/crates/oxo-flow-web/src/domains/workflow/service.rs
@@ -264,6 +264,13 @@ pub fn pipeline_output_validator() -> oxo_flow_ai::agent::pipeline_gen::OutputVa
     })
 }
 
+/// The same deterministic E005 repair the CLI injects: mechanical class,
+/// no model round spent. Pure string transform — keeps the web surfaces'
+/// zero-write guarantee intact.
+pub fn pipeline_output_fixer() -> oxo_flow_ai::agent::pipeline_gen::TextFixer {
+    std::sync::Arc::new(oxo_flow_core::format::fix_undefined_config_keys)
+}
+
 // ---------------------------------------------------------------------------
 // Prepare
 // ---------------------------------------------------------------------------

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -129,6 +129,13 @@ loop. The steps:
   correction-round budget (default from `[ai]` config, 6 when unset —
   knowledge lookups and the correction pass share the budget, and the
   loop stops as soon as a draft validates).
+- `--ai-attempts N` is the fresh-draw budget **across** generations
+  (pass@k with early exit): every attempt starts from a new draw, the
+  deterministic gates decide, and later attempts are only paid when
+  earlier ones fail. Default 1.
+- Before any model round is spent on a failed draft, mechanical error
+  classes are repaired in code (e.g. a missing `[config]` declaration —
+  E005); only what the fixer cannot repair reaches the model.
 - If the budget runs out after a pipeline was drafted, the command
   **degrades instead of discarding**: the generated TOML is extracted
   from the transcript and written with a prominent review warning —

--- a/docs/guide/src/commands/lint.md
+++ b/docs/guide/src/commands/lint.md
@@ -114,3 +114,7 @@ never flags them — see
 - Linting checks for common mistakes, missing metadata, and potential performance issues
 - Rules are checked for valid input/output patterns and environment declarations
 - Use `--strict` to ensure high-quality workflow definitions in production environments
+
+Every finding carries a stable code (`E0xx` = validation error, `W0xx` =
+lint warning). The full code index with one-line meanings lives in the
+[Glossary → Diagnostic Codes](../reference/glossary.md#diagnostic-codes).

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -140,6 +140,13 @@ oxo-flow template "RNA-seq" --ai -o my-pipeline.oxoflow
 ```bash
 # Limit correction rounds
 oxo-flow template "RNA-seq" --ai --ai-max-retries 5
+
+# Fresh-draw attempts (pass@k with early exit): attempt 2..N is only paid
+# when earlier attempts fail — the deterministic gates decide
+oxo-flow template "RNA-seq" --ai --ai-attempts 2
+
+# Opt into the Scientist Team roles (contract + Curator + review)
+oxo-flow template "RNA-seq" --ai --ai-team-profile full
 ```
 
 ---

--- a/docs/guide/src/reference/ai-eval.md
+++ b/docs/guide/src/reference/ai-eval.md
@@ -8,6 +8,11 @@ oxo-flow's own fresh knowledge base plus its own validators
 provide (see [issue #167](https://github.com/Traitome/oxo-flow/issues/167)
 for the design rationale).
 
+> Terminology: **pass@1 / pass@k**, **fidelity**, and **seed** are defined
+> in the [Glossary](glossary.md#benchmark-terms); diagnostic codes in
+> gate verdicts are listed under
+> [Diagnostic Codes](glossary.md#diagnostic-codes).
+
 ## Three layers
 
 | Layer | What is evaluated | Example metric |

--- a/docs/guide/src/reference/glossary.md
+++ b/docs/guide/src/reference/glossary.md
@@ -306,3 +306,85 @@ changes do ([Cloud Storage](./cloud-storage.md#content-addressed-invalidation)).
 - [Workflow Format Reference](./workflow-format.md) — complete TOML specification
 - [DAG Engine](./dag-engine.md) — how dependencies are resolved
 - [Wildcards Reference](./wildcards.md) — pattern expansion details
+---
+
+## Diagnostic Codes
+
+Every static check in oxo-flow tags its findings with a stable code so
+tools (and you) can branch on them programmatically:
+
+- **`Exx`** — an **error**: the workflow is rejected (`validate` fails) or
+  flagged as not runnable. Example: `E017` — an unknown key in a rule, the
+  engine's way of saying "this TOML uses a dialect the schema does not
+  have".
+- **`Wxx`** — a **warning**: the workflow runs, but the check found a
+  likely mistake worth fixing (see `oxo-flow lint`).
+
+Codes are three characters: the letter, then a zero-padded number. The
+authoritative, machine-readable source is the `--json` output of each
+command (`validate --json`, `dry-run --json`, `lint --json`); the tables
+below cover the codes referenced across this documentation.
+
+### Validation errors (`validate` / `dry-run`)
+
+| Code | Meaning |
+|---|---|
+| `E001` | Workflow name is empty |
+| `E003` | A wildcard appears in a rule's output but not in its input — the engine cannot key instances |
+| `E005` | A `{config.key}` reference points at a key absent from `[config]` |
+| `E006` | DAG construction error (e.g. a cycle) |
+| `E007` | `depends_on` names a rule that does not exist |
+| `E008` | `extends` names a rule that does not exist |
+| `E009` | An input path contains `..` and may escape the working directory |
+| `E010` | A rule references an undefined `env_group` |
+| `E011` | A rule command matches a dangerous shell pattern (destructive command class) |
+| `E013` | A `checkpoint = true` rule lacks `checkpoint_manifest` |
+| `E014` | A checkpoint rule is parameterized by `{sample}`/`{group}`/`{pair_id}` (not allowed) |
+| `E015` | Re-entry declares a `pair_id` with conflicting content |
+| `E016` | An environment field contains a shell-unsafe character — the spec would not render as safe argv |
+| `E017` | Unknown key in a rule — usually a foreign workflow dialect (e.g. `foreach`, `inputs = {...}`) |
+
+### Lint warnings (`lint`)
+
+| Code | Meaning |
+|---|---|
+| `W001`/`W002` | Workflow missing `description` / `author` |
+| `W003` | Rule missing a description |
+| `W004` | Rule has a shell command but no `log` file specified |
+| `W005` | Rule uses >8 threads with no `memory` |
+| `W007` | Rule declares no environment — runs in the bare system shell |
+| `W011` | Rule has `retries` but no `retry_delay` |
+| `W014` | `depends_on` references an unknown rule |
+| `W016` | Conda/pixi spec is not a lockfile — builds may not be reproducible |
+| `W017` | Input path is absolute |
+| `W018` | Input path references a home directory |
+| `W019` | Rule executes a command but declares no outputs |
+| `W020`/`W021`/`W022` | `pre_exec`/`on_success`/`on_failure` contain a risky pattern |
+| `W024` | A wildcard has no declared source — it will stay literal at run time |
+| `W025` | Legacy `threads =`/`memory =` keys under the rule body (use `resources.`) |
+| `W027` | A `when` condition references a wildcard nothing can bind — evaluates false |
+| `W028` | Docker image is not fully qualified (resolves against docker.io) |
+| `W029` | `len(config.x)` compared against a non-numeric value |
+| `W030` | Malformed `regex_extract` in a `when` condition |
+| `W031` | Producer is when-gated but its consumer expands the output unconditionally |
+| `W032` | A config key looks like a secret but is not declared `sensitive` |
+
+The full, current list with suggestions is best read from the commands:
+`oxo-flow lint --json` prints every code with its message and suggestion
+(see [lint](../commands/lint.md)). AI-generated drafts that fail a gate
+have their errors fed back to the model for correction
+([AI CLI](../commands/ai.md)); deterministic repairs for purely mechanical
+classes run first, before any model round is spent.
+
+### Benchmark terms
+
+- **pass@1 / pass@k** — the probability that a single generation (or at
+  least one of k attempts) passes all gates. Used in
+  [AI evaluation](./ai-eval.md) and `eval/frontier/`.
+- **fidelity** — a deterministic check that the tools an intent names
+  actually appear in the generated pipeline. Gates alone cannot see a
+  "wrong but valid" pipeline; the frontier benchmark reports
+  **success = gates ∧ fidelity**.
+- **seed** — one repeat of the same intent under identical settings;
+  multiple seeds measure sampling variance instead of quoting a single
+  lucky/unlucky run.

--- a/docs/guide/src/reference/workflow-format.md
+++ b/docs/guide/src/reference/workflow-format.md
@@ -679,6 +679,24 @@ nf-core-derived images ship bash, and their scripts rely on bash features
 (`set -o pipefail`, `[[ ]]`) that the container default `sh` (often dash)
 rejects — the re-exec shim keeps these scripts working unmodified.
 
+**Inline conda package lists:** besides a YAML path, a conda/mamba spec may
+be a channel-qualified **package list** — the concise form for rules whose
+environment is a handful of pinned tools:
+
+```toml
+[[rules]]
+name = "qc"
+environment = { conda = "bioconda::fastp=0.23.4 bioconda::samtools=1.24" }
+```
+
+Whitespace- or comma-joined packages are the same list. Every package must
+be channel-qualified (`channel::name=version`) and match the strict package
+charset — the tokens are rendered as separate `conda create` arguments, so
+shell metacharacters are still rejected (E016). The env name is derived
+from the first package plus a content hash of the whole list: identical
+package sets share one environment, a changed set builds a fresh one.
+Specs without `::` (paths, lockfiles) keep the YAML-path semantics.
+
 **Singularity spec shapes:** a `singularity` spec is either a **pull URI**
 (`docker://`, `library://`, `oras://`, `https://`) — the engine pulls and
 converts it to a SIF in the workdir on first use, reusing the SIF when it

--- a/eval/frontier/PILOT_FINDINGS.md
+++ b/eval/frontier/PILOT_FINDINGS.md
@@ -153,3 +153,41 @@ Conclusion: **compact stays the shipped default**; full remains available
 scoped to FAILED generations (rescue-only, where it has upside without
 destabilizing passes), a larger intent set, and more seeds before any
 tier-conditional recommendation.
+
+## Gate-reliability round: deterministic repair + first-class package lists
+
+Dissecting the compact baseline's 9 failures (58-run arm above) showed they
+are NOT random: two mechanical classes dominate — `E016` (multi-package
+inline conda specs joined by spaces/commas, which the schema rejected) and
+`E005` (`{config.x}` references without a `[config]` declaration). Worse,
+the inline package form was accepted by `validate` but **failed at run
+time** ("refusing to run the tool from PATH") — gate-valid was not
+runnable. Three fixes landed and the identical arm re-measured:
+
+| arm | all-gates | success (gates ∧ fidelity) | easy | medium | hard | vague | cost |
+|---|---|---|---|---|---|---|---|
+| compact, pre-fix | 48/58 (83%) | n/a | 10/10 | 21/24 | 17/24 | 5/6 | $0.25 |
+| compact, post-fix | **57/58 (98%)** | **56/58 (97%)** | 10/10 | 24/24 | 22/24 | 6/6 | $0.26 |
+
+The fixes, in the order that matters:
+
+1. **Engine: inline conda package lists are first-class** —
+   `conda = "bioconda::fastp=0.23.4 bioconda::samtools=1.24"` parses as an
+   allowlist-validated package list, derives a content-addressed env name
+   (`fastp-<hash8>`), and installs via direct `conda create`. This is the
+   exact form the generation prompt mandates; making it executable is an
+   engine improvement for every user, not a benchmark patch. Injection
+   attempts still fail the charset allowlist and the hard-error path.
+2. **Deterministic E005 fixer** (injected as the generation agent's text
+   fixer): missing config keys are declared under `[config]` in code, so
+   the mechanical class never reaches a paid model round. The
+   orchestrator validates and adopts the fixed text.
+3. **Fidelity criterion** (benchmark): each intent names its required
+   tools; a run now succeeds only with gates ∧ fidelity — a gate-valid
+   pipeline that never mentions the requested tools no longer counts.
+
+Residual (2/58): one fidelity miss (`somatic-mutect2` used GATK4's
+MarkDuplicates instead of the Picard name — the checker does not know
+tool equivalences yet) and one lint-level failure. Both are the next
+iteration's input: tool-equivalence awareness in the fidelity checker,
+and whatever lint code the atacseq artifact trips.

--- a/eval/frontier/PILOT_FINDINGS.md
+++ b/eval/frontier/PILOT_FINDINGS.md
@@ -186,8 +186,37 @@ The fixes, in the order that matters:
    tools; a run now succeeds only with gates ∧ fidelity — a gate-valid
    pipeline that never mentions the requested tools no longer counts.
 
-Residual (2/58): one fidelity miss (`somatic-mutect2` used GATK4's
-MarkDuplicates instead of the Picard name — the checker does not know
-tool equivalences yet) and one lint-level failure. Both are the next
-iteration's input: tool-equivalence awareness in the fidelity checker,
-and whatever lint code the atacseq artifact trips.
+Both residuals were then closed in the same round:
+- the fidelity checker gained `|` alternates (`"picard|gatk"` — GATK4
+  absorbed the Picard tools, so a `gatk` MarkDuplicates satisfies a
+  picard requirement), fixing the mutect2 false positive;
+- the last gate failure was a THIRD natural spec variant, semicolon-joined
+  packages (`bioconda::a=1;bioconda::b=2`), now also first-class — with an
+  argv-safety rule that tokens may not start with `-`, closing conda-CLI
+  flag injection (`--override-channels -c <attacker>`) that a naive
+  separator widening would have allowed.
+
+Final measurement (full 58-run arm, deepseek-chat, ceilings 8192/180s,
+success = gates ∧ fidelity, `--ai-attempts 2` available):
+
+| scope | success |
+|---|---|
+| **specified intents** | **52/52 (100%)** |
+| vague intents (deliberately under-specified) | 5/6 |
+| **all runs** | **57/58 (98.3%)** |
+
+Attempt 2 was never needed (0/58 runs required a second draw — the
+deterministic repair + first-class package lists removed the failure
+classes before retries could pay), so the pass@k safety net cost nothing.
+The single remaining failure is one seed of a DELIBERATELY vague intent —
+the cell class the report isolates from the specified tiers precisely
+because its bar is not comparable.
+
+What this round establishes about reaching ~100% scientifically: the gates
+are deterministic, so the failure set decomposes; every failure class
+either gets a deterministic repair (E005 fixer, package-list grammar) or
+an engine capability (executable inline specs), and the multi-seed
+benchmark with the fidelity criterion verifies the fixes generalize
+rather than overfit. The residual is confined to the vague tier, where
+the honest lever is the task contract / clarification design, not more
+retries.

--- a/eval/frontier/intents.json
+++ b/eval/frontier/intents.json
@@ -150,8 +150,7 @@
       "intent": "Somatic SNV and indel calling with GATK Mutect2 on a tumor-normal pair: bwa-mem alignment, MarkDuplicates, Mutect2 with PON filtering, and bcftools PASS extraction",
       "requires": [
         "bwa",
-        "picard",
-        "gatk",
+        "gatk|picard",
         "bcftools"
       ]
     },

--- a/eval/frontier/intents.json
+++ b/eval/frontier/intents.json
@@ -6,178 +6,312 @@
       "id": "qc-fastp-multiqc",
       "tier": "easy",
       "domain": "qc",
-      "intent": "Quality control of paired-end FASTQ reads with fastp, and aggregate reports with MultiQC"
+      "intent": "Quality control of paired-end FASTQ reads with fastp, and aggregate reports with MultiQC",
+      "requires": [
+        "fastp",
+        "multiqc"
+      ]
     },
     {
       "id": "qc-fastqc",
       "tier": "easy",
       "domain": "qc",
-      "intent": "Run FastQC quality check on raw sequencing reads for a cohort of samples"
+      "intent": "Run FastQC quality check on raw sequencing reads for a cohort of samples",
+      "requires": [
+        "fastqc"
+      ]
     },
     {
       "id": "trim-cutadapt",
       "tier": "easy",
       "domain": "qc",
-      "intent": "Adapter and quality trimming of small RNA sequencing reads with cutadapt"
+      "intent": "Adapter and quality trimming of small RNA sequencing reads with cutadapt",
+      "requires": [
+        "cutadapt"
+      ]
     },
     {
       "id": "qc-fastq-screen",
       "tier": "medium",
       "domain": "qc",
-      "intent": "Screen raw reads for contaminant organisms with FastQ Screen after fastp trimming, and summarize with MultiQC"
+      "intent": "Screen raw reads for contaminant organisms with FastQ Screen after fastp trimming, and summarize with MultiQC",
+      "requires": [
+        "fastp",
+        "fastq-screen",
+        "multiqc"
+      ]
     },
     {
       "id": "qc-nanoq",
       "tier": "easy",
       "domain": "qc",
-      "intent": "Quality control of Oxford Nanopore long reads with NanoPlot and filtering with filtlong"
+      "intent": "Quality control of Oxford Nanopore long reads with NanoPlot and filtering with filtlong",
+      "requires": [
+        "nanoplot",
+        "filtlong"
+      ]
     },
     {
       "id": "rnaseq-star",
       "tier": "medium",
       "domain": "rna-seq",
-      "intent": "RNA-seq analysis pipeline: fastp QC and trimming, STAR alignment to a reference genome, featureCounts gene quantification, and MultiQC summary"
+      "intent": "RNA-seq analysis pipeline: fastp QC and trimming, STAR alignment to a reference genome, featureCounts gene quantification, and MultiQC summary",
+      "requires": [
+        "fastp",
+        "star",
+        "featurecounts",
+        "multiqc"
+      ]
     },
     {
       "id": "rnaseq-hisat2",
       "tier": "medium",
       "domain": "rna-seq",
-      "intent": "Bulk RNA-seq: fastp trimming, HISAT2 alignment to a reference genome, samtools sorting and indexing, StringTie transcript assembly"
+      "intent": "Bulk RNA-seq: fastp trimming, HISAT2 alignment to a reference genome, samtools sorting and indexing, StringTie transcript assembly",
+      "requires": [
+        "fastp",
+        "hisat2",
+        "samtools",
+        "stringtie"
+      ]
     },
     {
       "id": "rnaseq-salmon",
       "tier": "medium",
       "domain": "rna-seq",
-      "intent": "Transcript-level quantification: fastp QC, Salmon quant on a decoy-aware transcriptome index for a cohort of samples"
+      "intent": "Transcript-level quantification: fastp QC, Salmon quant on a decoy-aware transcriptome index for a cohort of samples",
+      "requires": [
+        "fastp",
+        "salmon"
+      ]
     },
     {
       "id": "rnaseq-de-deseq2",
       "tier": "hard",
       "domain": "rna-seq",
-      "intent": "RNA-seq differential expression: fastp QC, HISAT2 alignment, featureCounts counting, DESeq2 differential expression with an R script, and MultiQC"
+      "intent": "RNA-seq differential expression: fastp QC, HISAT2 alignment, featureCounts counting, DESeq2 differential expression with an R script, and MultiQC",
+      "requires": [
+        "fastp",
+        "hisat2",
+        "featurecounts",
+        "deseq2"
+      ]
     },
     {
       "id": "scrna-starsolo",
       "tier": "hard",
       "domain": "single-cell",
-      "intent": "Single-cell RNA-seq preprocessing: fastp QC on FASTQs, STARsolo alignment and cell barcode counting, then cell-level QC metrics with fastqc-style reports via MultiQC"
+      "intent": "Single-cell RNA-seq preprocessing: fastp QC on FASTQs, STARsolo alignment and cell barcode counting, then cell-level QC metrics with fastqc-style reports via MultiQC",
+      "requires": [
+        "fastp",
+        "star",
+        "multiqc"
+      ]
     },
     {
       "id": "germline-variant",
       "tier": "medium",
       "domain": "variant-calling",
-      "intent": "Germline SNV calling: fastp preprocessing, bwa-mem alignment, samtools sorting and indexing, bcftools variant calling and filtering"
+      "intent": "Germline SNV calling: fastp preprocessing, bwa-mem alignment, samtools sorting and indexing, bcftools variant calling and filtering",
+      "requires": [
+        "fastp",
+        "bwa",
+        "samtools",
+        "bcftools"
+      ]
     },
     {
       "id": "germline-gatk",
       "tier": "hard",
       "domain": "variant-calling",
-      "intent": "GATK germline best practice: bwa-mem alignment, picard MarkDuplicates, GATK HaplotypeCaller in gVCF mode, joint genotyping with GenotypeGVCFs"
+      "intent": "GATK germline best practice: bwa-mem alignment, picard MarkDuplicates, GATK HaplotypeCaller in gVCF mode, joint genotyping with GenotypeGVCFs",
+      "requires": [
+        "bwa",
+        "picard",
+        "gatk"
+      ]
     },
     {
       "id": "somatic-tumor-normal",
       "tier": "hard",
       "domain": "variant-calling",
-      "intent": "Tumor-normal somatic variant calling: fastp QC, bwa-mem alignment of both samples, samtools processing, Strelka2 somatic SNV and indel calling"
+      "intent": "Tumor-normal somatic variant calling: fastp QC, bwa-mem alignment of both samples, samtools processing, Strelka2 somatic SNV and indel calling",
+      "requires": [
+        "fastp",
+        "bwa",
+        "samtools",
+        "strelka2"
+      ]
     },
     {
       "id": "somatic-mutect2",
       "tier": "hard",
       "domain": "variant-calling",
-      "intent": "Somatic SNV and indel calling with GATK Mutect2 on a tumor-normal pair: bwa-mem alignment, MarkDuplicates, Mutect2 with PON filtering, and bcftools PASS extraction"
+      "intent": "Somatic SNV and indel calling with GATK Mutect2 on a tumor-normal pair: bwa-mem alignment, MarkDuplicates, Mutect2 with PON filtering, and bcftools PASS extraction",
+      "requires": [
+        "bwa",
+        "picard",
+        "gatk",
+        "bcftools"
+      ]
     },
     {
       "id": "cnv-cnvkit",
       "tier": "hard",
       "domain": "variant-calling",
-      "intent": "Copy-number aberration detection with CNVkit: bwa-mem alignment of tumor and normal, MarkDuplicates, CNVkit batch with an access panel, and segment PDF reports"
+      "intent": "Copy-number aberration detection with CNVkit: bwa-mem alignment of tumor and normal, MarkDuplicates, CNVkit batch with an access panel, and segment PDF reports",
+      "requires": [
+        "bwa",
+        "cnvkit"
+      ]
     },
     {
       "id": "variant-annotate",
       "tier": "medium",
       "domain": "variant-calling",
-      "intent": "Annotate a cohort VCF with SnpEff functional consequences, hard-filter with bcftools, and produce a summary statistics table"
+      "intent": "Annotate a cohort VCF with SnpEff functional consequences, hard-filter with bcftools, and produce a summary statistics table",
+      "requires": [
+        "snpeff",
+        "bcftools"
+      ]
     },
     {
       "id": "chipseq-macs2",
       "tier": "medium",
       "domain": "chip-seq",
-      "intent": "ChIP-seq peak calling pipeline: fastp QC, bowtie2 alignment against a reference genome, samtools processing, MACS2 peak calling"
+      "intent": "ChIP-seq peak calling pipeline: fastp QC, bowtie2 alignment against a reference genome, samtools processing, MACS2 peak calling",
+      "requires": [
+        "fastp",
+        "bowtie2",
+        "samtools",
+        "macs2"
+      ]
     },
     {
       "id": "chipseq-broad",
       "tier": "medium",
       "domain": "chip-seq",
-      "intent": "Broad-domain ChIP-seq (H3K27me3 style): fastp QC, bowtie2 alignment, samtools processing, MACS2 broad peak calling with a control sample"
+      "intent": "Broad-domain ChIP-seq (H3K27me3 style): fastp QC, bowtie2 alignment, samtools processing, MACS2 broad peak calling with a control sample",
+      "requires": [
+        "fastp",
+        "bowtie2",
+        "samtools",
+        "macs2"
+      ]
     },
     {
       "id": "atacseq",
       "tier": "hard",
       "domain": "atac-seq",
-      "intent": "ATAC-seq analysis: fastp QC, bwa-mem2 alignment, properly paired read filtering, MACS2 peak calling with shift model, and fragment-size QC"
+      "intent": "ATAC-seq analysis: fastp QC, bwa-mem2 alignment, properly paired read filtering, MACS2 peak calling with shift model, and fragment-size QC",
+      "requires": [
+        "fastp",
+        "bwa-mem2",
+        "macs2"
+      ]
     },
     {
       "id": "wgbs-bismark",
       "tier": "hard",
       "domain": "methylation",
-      "intent": "Whole-genome bisulfite sequencing: fastp QC, bwa-mem alignment under a bismark genome, bismark methylation extractor, and a coverage-scaled bigWig per sample"
+      "intent": "Whole-genome bisulfite sequencing: fastp QC, bwa-mem alignment under a bismark genome, bismark methylation extractor, and a coverage-scaled bigWig per sample",
+      "requires": [
+        "fastp",
+        "bismark"
+      ]
     },
     {
       "id": "amplicon-dada2",
       "tier": "medium",
       "domain": "metagenomics",
-      "intent": "16S amplicon pipeline: cutadapt primer trimming, DADA2 ASV inference and chimera removal, and a taxa barplot summary"
+      "intent": "16S amplicon pipeline: cutadapt primer trimming, DADA2 ASV inference and chimera removal, and a taxa barplot summary",
+      "requires": [
+        "cutadapt",
+        "dada2"
+      ]
     },
     {
       "id": "metagenomics-kraken2",
       "tier": "hard",
       "domain": "metagenomics",
-      "intent": "Metagenomic profiling of shotgun reads: fastp QC, kraken2 taxonomic classification, bracken abundance re-estimation, and a Krona visualization chart"
+      "intent": "Metagenomic profiling of shotgun reads: fastp QC, kraken2 taxonomic classification, bracken abundance re-estimation, and a Krona visualization chart",
+      "requires": [
+        "fastp",
+        "kraken2",
+        "bracken",
+        "krona"
+      ]
     },
     {
       "id": "metag-assembly",
       "tier": "hard",
       "domain": "metagenomics",
-      "intent": "Metagenome assembly: fastp QC with host removal via bowtie2, MEGAHIT assembly, QUAST assembly metrics, and prodigal gene prediction"
+      "intent": "Metagenome assembly: fastp QC with host removal via bowtie2, MEGAHIT assembly, QUAST assembly metrics, and prodigal gene prediction",
+      "requires": [
+        "fastp",
+        "bowtie2",
+        "megahit",
+        "quast",
+        "prodigal"
+      ]
     },
     {
       "id": "assembly-spades",
       "tier": "medium",
       "domain": "assembly",
-      "intent": "Bacterial isolate assembly: fastp QC, SPAdes de novo assembly, QUAST quality metrics"
+      "intent": "Bacterial isolate assembly: fastp QC, SPAdes de novo assembly, QUAST quality metrics",
+      "requires": [
+        "fastp",
+        "spades",
+        "quast"
+      ]
     },
     {
       "id": "assembly-flye-polish",
       "tier": "hard",
       "domain": "assembly",
-      "intent": "Long-read genome assembly: NanoPlot QC, Flye assembly, medaka polishing, and QUAST metrics against a reference"
+      "intent": "Long-read genome assembly: NanoPlot QC, Flye assembly, medaka polishing, and QUAST metrics against a reference",
+      "requires": [
+        "nanoplot",
+        "flye",
+        "medaka",
+        "quast"
+      ]
     },
     {
       "id": "hic-cooler",
       "tier": "hard",
       "domain": "epigenomics",
-      "intent": "Hi-C contact maps: fastp QC, bwa-mem alignment with read-pair parsing, pairix indexing, and cooler cload plus balance to produce balanced contact matrices"
+      "intent": "Hi-C contact maps: fastp QC, bwa-mem alignment with read-pair parsing, pairix indexing, and cooler cload plus balance to produce balanced contact matrices",
+      "requires": [
+        "fastp",
+        "bwa",
+        "cooler"
+      ]
     },
     {
       "id": "qc-vague",
       "tier": "easy",
       "domain": "qc",
       "vague": true,
-      "intent": "Do basic quality control on my sequencing data"
+      "intent": "Do basic quality control on my sequencing data",
+      "requires": []
     },
     {
       "id": "rnaseq-vague",
       "tier": "medium",
       "domain": "rna-seq",
       "vague": true,
-      "intent": "I need differential expression analysis for my RNA-seq samples"
+      "intent": "I need differential expression analysis for my RNA-seq samples",
+      "requires": []
     },
     {
       "id": "variant-vague",
       "tier": "medium",
       "domain": "variant-calling",
       "vague": true,
-      "intent": "Call variants on my exome data"
+      "intent": "Call variants on my exome data",
+      "requires": []
     }
   ]
 }

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -200,6 +200,8 @@ def run_generation(variant: str, intent: str, model: str, run_dir: Path,
             cmd += ["--ai-max-retries", str(args.max_retries)]
         if args.profile != "compact":
             cmd += ["--ai-team-profile", args.profile]
+        if args.attempts != 1:
+            cmd += ["--ai-attempts", str(args.attempts)]
         try:
             proc = subprocess.run(cmd, cwd=run_dir, env=env, timeout=args.timeout,
                                   capture_output=True, text=True)
@@ -209,7 +211,9 @@ def run_generation(variant: str, intent: str, model: str, run_dir: Path,
         except subprocess.TimeoutExpired:
             meta["error"] = "generation timed out"
             return meta
-        # Token accounting: newest template session created by this run.
+        # Token accounting: ALL template sessions created by this run
+        # (multi-attempt runs archive one session per attempt — the spend
+        # is the sum, and quoting only the newest would undercount).
         if sessions.exists():
             new = [p for p in sessions.glob("*-template-*.json")
                    if p.stat().st_mtime > started
@@ -217,15 +221,21 @@ def run_generation(variant: str, intent: str, model: str, run_dir: Path,
             if new:
                 snap = max(new, key=lambda p: p.stat().st_mtime)
                 (run_dir / "session.json").write_text(snap.read_text())
-                try:
-                    s = json.loads(snap.read_text())
-                    u = s.get("total_usage", {})
-                    meta["input_tokens"] = u.get("prompt_tokens", 0)
-                    meta["output_tokens"] = u.get("completion_tokens", 0)
-                    meta["tool_calls"] = len(s.get("tool_calls", []))
-                    meta["rounds"] = s.get("rounds")
-                except json.JSONDecodeError:
-                    pass
+                tin = tout = 0
+                tools = 0
+                for p in new:
+                    try:
+                        s = json.loads(p.read_text())
+                        u = s.get("total_usage", {})
+                        tin += u.get("prompt_tokens", 0)
+                        tout += u.get("completion_tokens", 0)
+                        tools += len(s.get("tool_calls", []))
+                    except json.JSONDecodeError:
+                        pass
+                meta["input_tokens"] = tin
+                meta["output_tokens"] = tout
+                meta["tool_calls"] = tools
+                meta["sessions"] = len(new)
         # rglob: a relative -o target resolved inside a relative run_dir can
         # nest the artifact one level deeper — find it wherever it landed.
         wf = sorted(run_dir.rglob("*.oxoflow"))
@@ -293,6 +303,9 @@ def main() -> None:
     ap.add_argument("--binary", default=None,
                     help="pin the CLI binary for the whole campaign (default: "
                          "find_binary()); use when code may be rebuilt mid-run")
+    ap.add_argument("--attempts", type=int, default=1,
+                    help="fresh-draw attempts per run (--ai-attempts); pass@k "
+                         "with early exit — attempt 2..N is only paid on failures")
     ap.add_argument("--profile", default="compact", choices=["compact", "full"],
                     help="team profile to benchmark (compact = single agent + "
                          "gates; full = Scientist Team roles; full needs a binary "
@@ -349,10 +362,18 @@ def main() -> None:
                     # that never mentions them passes the gates but does not
                     # do what was asked. Deterministic substring check on the
                     # lowercased artifact (tool names, not flags/paths).
+                    # A requires entry may carry '|' alternates for tool
+                    # equivalences (e.g. "picard|gatk": GATK4 absorbed the
+                    # Picard tools, so MarkDuplicates under gatk4 satisfies a
+                    # picard requirement).
                     artifact_text = wf.read_text().lower() if wf else ""
                     missing_tools = [
-                        t for t in spec.get("requires", [])
-                        if t.lower() not in artifact_text
+                        group
+                        for group in spec.get("requires", [])
+                        if not any(
+                            alt.strip().lower() in artifact_text
+                            for alt in group.split("|")
+                        )
                     ]
                     result = {
                         "intent_id": spec["id"], "tier": spec["tier"],
@@ -387,6 +408,7 @@ def main() -> None:
         "default_model": default_model,
         "max_retries": args.max_retries,
         "seeds": args.seeds,
+        "attempts": args.attempts,
         "profile": args.profile,
         "runs": runs,
     }, indent=2))

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -345,6 +345,15 @@ def main() -> None:
                         else:
                             wf = None
                     gates = run_gates(binary, wf, run_dir) if wf else {}
+                    # Fidelity: the intent names tools; a gate-valid artifact
+                    # that never mentions them passes the gates but does not
+                    # do what was asked. Deterministic substring check on the
+                    # lowercased artifact (tool names, not flags/paths).
+                    artifact_text = wf.read_text().lower() if wf else ""
+                    missing_tools = [
+                        t for t in spec.get("requires", [])
+                        if t.lower() not in artifact_text
+                    ]
                     result = {
                         "intent_id": spec["id"], "tier": spec["tier"],
                         "domain": spec["domain"], "model": model, "variant": variant,
@@ -353,6 +362,11 @@ def main() -> None:
                         **gen,
                         "gates": gates,
                         "all_gates_pass": bool(gates) and all(g["pass"] for g in gates.values()),
+                        "missing_required_tools": missing_tools,
+                        "fidelity_pass": not missing_tools,
+                        "success": bool(gates)
+                        and all(g["pass"] for g in gates.values())
+                        and not missing_tools,
                         "workflow_file": str(wf) if wf else None,
                         "est_cost_usd": round(cost_usd(model, gen["input_tokens"],
                                                        gen["output_tokens"]), 5),
@@ -361,6 +375,7 @@ def main() -> None:
                     runs.append(result)
                     print(f"    generated={result['generated']} "
                           f"gates={'PASS' if result['all_gates_pass'] else 'FAIL'} "
+                          f"fidelity={'OK' if result['fidelity_pass'] else 'MISSING:' + ','.join(missing_tools)} "
                           f"tok(in/out)={result['input_tokens']}/{result['output_tokens']} "
                           f"wall={result.get('wall_s')}s", flush=True)
                     time.sleep(args.sleep)
@@ -389,6 +404,8 @@ def main() -> None:
         d = sum(r["gates"].get("dry-run", {}).get("pass", False) for r in rs)
         l = sum(r["gates"].get("lint", {}).get("pass", False) for r in rs)
         allp = sum(r["all_gates_pass"] for r in rs)
+        fid = sum(r["fidelity_pass"] for r in rs)
+        ok = sum(r["success"] for r in rs)
         tok_in = sum(r["input_tokens"] for r in rs)
         tok_out = sum(r["output_tokens"] for r in rs)
         wall = [r.get("wall_s", 0) for r in rs]
@@ -398,33 +415,38 @@ def main() -> None:
             f"- runs: {n}, generated: {gen_n}",
             f"- gate pass@1: validate {v}/{n}, dry-run {d}/{n}, lint {l}/{n}, "
             f"**all-gates {allp}/{n}** ({allp / n:.0%})",
+            f"- fidelity (named tools present): {fid}/{n} — "
+            f"**success (gates ∧ fidelity) {ok}/{n}** ({ok / n:.0%})",
             f"- tokens: in {tok_in:,} / out {tok_out:,} "
             f"(mean {tok_in // max(n, 1):,}/{tok_out // max(n, 1):,} per run)",
             f"- est. cost: ${cost:.4f} (price table {PRICE_PER_MTOK.get(model, PRICE_PER_MTOK['*'])}/Mtok)",
             f"- wall: mean {sum(wall) / max(n, 1):.0f}s, max {max(wall or [0]):.0f}s",
             "",
-            "| tier | all-gates | runs |",
+            "| tier | success (gates ∧ fidelity) | runs |",
             "|---|---|---|",
         ]
         for tier in ("easy", "medium", "hard"):
             trs = [r for r in rs if r["tier"] == tier]
             if trs:
-                tp = sum(r["all_gates_pass"] for r in trs)
+                tp = sum(r["success"] for r in trs)
                 lines.append(f"| {tier} | {tp}/{len(trs)} | {len(trs)} |")
         vague = [r for r in rs if r.get("vague")]
         if vague:
-            vp = sum(r["all_gates_pass"] for r in vague)
+            vp = sum(r["success"] for r in vague)
             lines.append(f"| vague | {vp}/{len(vague)} | {len(vague)} |")
         lines += [
             "",
-            "| intent | tier | all-gates | tok in | tok out | wall s | note |",
-            "|---|---|---|---|---|---|---|",
+            "| intent | tier | gates | fidelity | tok in | tok out | wall s | note |",
+            "|---|---|---|---|---|---|---|---|",
         ]
         for r in rs:
             note = r.get("error") or ""
+            if r["missing_required_tools"]:
+                note = (note + " missing:" + ",".join(r["missing_required_tools"])).strip()
             lines.append(
                 f"| {r['intent_id']} | {r['tier']} | "
                 f"{'✅' if r['all_gates_pass'] else '❌'} | "
+                f"{'✅' if r['fidelity_pass'] else '❌'} | "
                 f"{r['input_tokens']:,} | {r['output_tokens']:,} | "
                 f"{r.get('wall_s', '')} | {note[:60]} |")
         lines.append("")


### PR DESCRIPTION
Follows #350/#351. Dissecting the frontier baseline's remaining gate failures exposed a **production bug** and two mechanical failure classes that turned out to be fixable in code — this branch fixes all three and re-measures.

## The bug

An inline package-list conda spec — the exact form the generation prompt mandates and models naturally write — **passed `validate` but failed at run time**:

```toml
[rules.environment]
conda = "bioconda::fastp=0.23.4"
```
→ run: `invalid environment name 'bioconda::fastp=0.23' … refusing to run the tool from PATH`

Gate-valid was not runnable.

## Fixes

**Engine (oxo-flow-core) — inline package lists are first-class**
- `EnvironmentSpec::inline_conda_packages`: channel-qualified, whitespace/comma-joined lists parse behind a strict charset **allowlist** (strictly tighter than the old metacharacter blacklist); non-package specs keep path-tier semantics.
- `shell_risk`: a validated package list skips the path-tier scan; injection attempts still fail the parse and the hard-error path.
- Env names for package lists are content-addressed (`fastp-<hash8>`) — identical package sets share one env, a changed set rebuilds (issue #159 semantics for inline specs).
- `CondaBackend` installs lists via direct `conda create -n <name> -y <pkgs> || conda install` with tokens as separate argv items.
- Live evidence: the previously unrunnable probe now derives `fastp-<hash>` and executes the real `conda create` (only failure mode left on the probe box: network reachability).

**AI generation — deterministic repair before paid model rounds**
- `PipelineGenAgent` accepts an injectable `TextFixer` applied between extraction and validation; the orchestrator validates and adopts the **fixed** text.
- The CLI injects `fix_undefined_config_keys`: E005 (`{config.x}` referenced but not declared) is repaired in code — declaring the missing keys — instead of spending a model round.

**Benchmark — fidelity criterion**
- Each intent now names its required tools; a run succeeds only with **gates ∧ fidelity** — a gate-valid pipeline that ignores the request no longer counts. Tool-equivalence knowledge is a known follow-up (see residual below).

**Docs readability round**
- The Glossary gains a **Diagnostic Codes** section: the E/W code system plus a one-line index of every code referenced across the docs, cross-linked from `lint.md` and `ai-eval.md`.
- `workflow-format.md` documents the inline package-list form (previously undocumented despite being the AI-mandated dialect).

## Measured effect (identical arm: 29 intents × 2 seeds × deepseek-chat)

| arm | all-gates | success (gates ∧ fidelity) | easy | medium | hard | vague |
|---|---|---|---|---|---|---|
| pre-fix | 48/58 (83%) | n/a | 10/10 | 21/24 | 17/24 | 5/6 |
| **post-fix** | **57/58 (98%)** | **56/58 (97%)** | 10/10 | 24/24 | 22/24 | 6/6 |

Cost unchanged (~$0.26/arm); wall unchanged (mean 15 s). Full mechanism notes in `eval/frontier/PILOT_FINDINGS.md`.

## Verification

- `make ci` green; 1484 core tests (new tests: package-list parsing incl. injection rejection, content-addressed naming, direct-create command, fixer behavior incl. idempotence and byte-identical passthrough).
- mkdocs `--strict` build green with the new glossary section.