### PR TITLE
fix(ai): model-axis harness calibration + degraded-delivery, transport hardening, and exploration-budget nudge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ benches/macro/results/*.json
 
 # Frontier benchmark outputs (machine-specific, issue #342)
 eval/frontier/results/
+/results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OXO_FLOW_AI_API_KEY` | No | — | Generic API key fallback |
 | `OXO_FLOW_AI_API_URL` | No | (provider default) | Custom API endpoint URL |
 | `OXO_FLOW_AI_MODEL` | No | (provider default) | Model name override |
-| `OXO_FLOW_AI_MAX_TOKENS` | No | `4096` | Output-token ceiling for the Anthropic Messages backend. Raise for thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible endpoint) whose reasoning blocks count against `max_tokens` — at the default their answers truncate before any text is produced |
+| `OXO_FLOW_AI_MAX_TOKENS` | No | `16384` | Output-token ceiling for the Anthropic Messages backend. Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint) whose reasoning blocks count against `max_tokens` — the old 4096 default truncated before any text was produced |
 | `OXO_FLOW_AI_TIMEOUT_SECS` | No | `120` | Per-request timeout for all AI provider backends. Raise together with OXO_FLOW_AI_MAX_TOKENS on thinking backends — long completions otherwise die mid-body with "error decoding response body" |
 | `OXO_FLOW_MASTER_KEY` | No | — | AES-256-GCM seed encrypting AI provider keys at rest (`v1:`-prefixed rows in the local DB). Unset = plaintext legacy mode |
 | `ANTHROPIC_AUTH_TOKEN` | No | — | Claude/Anthropic API key (overrides OXO_FLOW_AI_API_KEY) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ docker run -d -p 3000:3000 -v oxo-flow-data:/app/data oxo-flow
 | `OXO_FLOW_AI_API_URL` | No | (provider default) | Custom API endpoint URL |
 | `OXO_FLOW_AI_MODEL` | No | (provider default) | Model name override |
 | `OXO_FLOW_AI_MAX_TOKENS` | No | `16384` | Output-token ceiling for the Anthropic Messages backend. Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint) whose reasoning blocks count against `max_tokens` — the old 4096 default truncated before any text was produced |
-| `OXO_FLOW_AI_TIMEOUT_SECS` | No | `120` | Per-request timeout for all AI provider backends. Raise together with OXO_FLOW_AI_MAX_TOKENS on thinking backends — long completions otherwise die mid-body with "error decoding response body" |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | No | `300` | Per-request timeout for all AI provider backends. A measured GLM thinking round took 145 s — the old 120 s default killed it mid-round. Raise further for slower endpoints, together with OXO_FLOW_AI_MAX_TOKENS |
 | `OXO_FLOW_MASTER_KEY` | No | — | AES-256-GCM seed encrypting AI provider keys at rest (`v1:`-prefixed rows in the local DB). Unset = plaintext legacy mode |
 | `ANTHROPIC_AUTH_TOKEN` | No | — | Claude/Anthropic API key (overrides OXO_FLOW_AI_API_KEY) |
 | `ANTHROPIC_BASE_URL` | No | `https://api.anthropic.com` | Anthropic-compatible API base URL |

--- a/crates/oxo-flow-ai/src/agent/orchestrator.rs
+++ b/crates/oxo-flow-ai/src/agent/orchestrator.rs
@@ -230,7 +230,18 @@ impl Orchestrator {
                 // found made GLM regenerate blind. One-shot per generation,
                 // and never during the final round: an injection the loop
                 // never surfaces (the head check fails first) is dead text.
-                tool_only_rounds = tool_only_rounds.saturating_add(1);
+                // A round that streamed prose alongside the tool calls is
+                // not silent exploration — the model is narrating its work,
+                // so it breaks the streak instead of feeding it.
+                if response
+                    .content
+                    .as_deref()
+                    .is_some_and(|text| !text.trim().is_empty())
+                {
+                    tool_only_rounds = 0;
+                } else {
+                    tool_only_rounds = tool_only_rounds.saturating_add(1);
+                }
                 if !exploration_nudged
                     && tool_only_rounds >= exploration_nudge_threshold
                     && rounds < self.max_rounds
@@ -340,7 +351,13 @@ impl Orchestrator {
             // nothing to echo — fabricating assistant text would put words
             // in the model's mouth (audit finding).
             let final_round = rounds + 1 == self.max_rounds;
-            if let Some(content) = &response.content {
+            // An empty or whitespace-only text block is not prose: echoing
+            // it would put an empty assistant text block on the wire, which
+            // Anthropic-compatible endpoints reject with 400. It takes the
+            // bare-nudge branch below instead.
+            if let Some(content) = &response.content
+                && !content.trim().is_empty()
+            {
                 let rc = response.reasoning_content.as_deref().unwrap_or("");
                 push_retry_feedback(
                     &mut messages,
@@ -355,7 +372,19 @@ impl Orchestrator {
                 if final_round {
                     nudge.push_str(FINAL_ROUND_NOTICE);
                 }
-                messages.push(Message::user(&nudge));
+                // A nudge directly after an echo round's user directive
+                // would land consecutive user turns on the wire — fold it
+                // into the standing directive instead.
+                if messages
+                    .last()
+                    .is_some_and(|m| m.role == crate::types::MessageRole::User)
+                {
+                    let directive = messages.last_mut().expect("length checked above");
+                    directive.content.push_str("\n\n");
+                    directive.content.push_str(&nudge);
+                } else {
+                    messages.push(Message::user(&nudge));
+                }
             }
         }
 
@@ -965,6 +994,95 @@ mod tests {
                 .flatten()
                 .any(|m| m.content.contains("Exploration budget warning")),
             "the prose round must reset the streak: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn narrated_tool_rounds_do_not_feed_the_exploration_streak() {
+        // A model that narrates a sentence before every lookup is writing
+        // output, not silently exploring — such rounds reset the streak,
+        // so the nudge (whose text claims "no written output") must never
+        // fire for them.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+        use crate::types::ToolCall;
+
+        let narrated_turn = |id: &str| ScriptedTurn {
+            content: Some("Checking the knowledge base for exact tool pins.".into()),
+            tool_calls: Some(vec![ToolCall {
+                id: id.into(),
+                name: "read_only_tool".into(),
+                arguments: "{}".into(),
+            }]),
+            error: None,
+            delay_ms: 0,
+        };
+        let backend = ScriptedBackend::new(vec![
+            narrated_turn("tc-1"),
+            narrated_turn("tc-2"),
+            narrated_turn("tc-3"),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 6);
+        let ctx = tool_registry_with_read_only_tool();
+        let outcome = orch.execute(&FenceAgent, &ctx).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 4, "one provider call per round");
+        assert!(
+            !calls
+                .iter()
+                .flatten()
+                .any(|m| m.content.contains("Exploration budget warning")),
+            "narrated tool rounds are not silent exploration: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_text_response_folds_into_the_standing_directive() {
+        // Round 1's unextractable prose leaves an assistant echo plus a
+        // user directive; round 2 returning an EMPTY text block must not
+        // echo that block (an empty assistant text block gets 400'd by
+        // Anthropic-compatible endpoints) nor push a second user turn
+        // after the directive — the nudge folds into the standing
+        // directive instead.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::content("Here is my plan: trim the reads, then align."),
+            ScriptedTurn::content(""),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 4);
+        let ctx = tool_registry_with_read_only_tool();
+        let outcome = orch.execute(&FenceAgent, &ctx).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 3, "one provider call per round");
+        let final_call = &calls[2];
+        for pair in final_call.windows(2) {
+            assert!(
+                !(matches!(pair[0].role, crate::types::MessageRole::User)
+                    && matches!(pair[1].role, crate::types::MessageRole::User)),
+                "no consecutive user turns may reach the wire: {final_call:?}"
+            );
+        }
+        assert!(
+            !final_call
+                .iter()
+                .any(|m| m.role == crate::types::MessageRole::Assistant && m.content.is_empty()),
+            "an empty assistant text block must not be echoed: {final_call:?}"
+        );
+        let folded = final_call.iter().any(|m| {
+            m.role == crate::types::MessageRole::User
+                && m.content.contains("could not be processed")
+                && m.content
+                    .contains("did not contain any content or tool calls")
+        });
+        assert!(
+            folded,
+            "the empty-response nudge must ride the standing directive: {final_call:?}"
         );
     }
 

--- a/crates/oxo-flow-ai/src/agent/orchestrator.rs
+++ b/crates/oxo-flow-ai/src/agent/orchestrator.rs
@@ -72,6 +72,14 @@ impl Orchestrator {
         let mut rounds: u32 = 0;
         #[allow(unused_assignments)]
         let mut final_content: Option<String> = None;
+        // Exploration-budget tracking: consecutive rounds whose assistant
+        // turn was pure tool calls (no prose). GLM model-axis draws burned
+        // the whole round budget on knowledge lookups without ever writing
+        // output, and the final-round notice lands exactly at the cap — too
+        // late to change behavior — so nudge once, mid-run, instead.
+        let mut tool_only_rounds: u32 = 0;
+        let mut exploration_nudged = false;
+        let exploration_nudge_threshold = (self.max_rounds / 2).max(2);
 
         loop {
             rounds += 1;
@@ -213,9 +221,43 @@ impl Orchestrator {
                         }
                     }
                 }
+                // Exploration-budget nudge: a run of pure tool-call rounds
+                // (zero prose) is the shape that exhausts the round budget.
+                // The notice rides the last tool result — a bare user turn
+                // after tool results would flatten into consecutive user
+                // turns on the Anthropic wire (tool results map to the user
+                // role there), the exact shape the extraction-failure fix
+                // found made GLM regenerate blind. One-shot per generation,
+                // and never during the final round: an injection the loop
+                // never surfaces (the head check fails first) is dead text.
+                tool_only_rounds = tool_only_rounds.saturating_add(1);
+                if !exploration_nudged
+                    && tool_only_rounds >= exploration_nudge_threshold
+                    && rounds < self.max_rounds
+                    && let Some(last) = messages.last_mut()
+                    && last.role == crate::types::MessageRole::Tool
+                {
+                    last.content.push_str(&format!(
+                        "\n\n[system] Exploration budget warning: {tool_only_rounds} \
+                             consecutive rounds produced tool calls only, with no written \
+                             output. Consolidate what you have found and start producing the \
+                             required output now — remaining rounds are limited."
+                    ));
+                    exploration_nudged = true;
+                    tracing::info!(
+                        rounds,
+                        tool_only_rounds,
+                        "exploration budget nudge injected"
+                    );
+                }
                 // Continue loop — model will process tool results
                 continue;
             }
+
+            // No tool calls this round — the pure-tool-call streak is
+            // broken, whether the model wrote usable prose, unextractable
+            // prose, or nothing at all.
+            tool_only_rounds = 0;
 
             // Model returned text content (no tool calls)
             if let Some(content) = &response.content {
@@ -790,6 +832,139 @@ mod tests {
             }),
             "the final-round notice must ride the failure feedback: {:?}",
             calls[2]
+        );
+    }
+
+    /// A scripted turn whose assistant output is a single tool call to the
+    /// registered read-only scripted tool.
+    fn tool_turn(id: &str) -> crate::scripted::ScriptedTurn {
+        crate::scripted::ScriptedTurn {
+            content: None,
+            tool_calls: Some(vec![crate::types::ToolCall {
+                id: id.into(),
+                name: "read_only_tool".into(),
+                arguments: "{}".into(),
+            }]),
+            error: None,
+            delay_ms: 0,
+        }
+    }
+
+    fn tool_registry_with_read_only_tool() -> AgentContext {
+        let mut ctx = test_context();
+        ctx.tool_registry.register(Box::new(ScriptedTool {
+            name: "read_only_tool",
+            read_only: true,
+        }));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn exploration_budget_nudge_fires_at_the_threshold() {
+        // Two consecutive pure-tool rounds in a 3-round budget cross the
+        // threshold (max_rounds/2, min 2); the nudge rides the last tool
+        // result and is visible to the third provider call.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            tool_turn("tc-1"),
+            tool_turn("tc-2"),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 3);
+        let ctx = tool_registry_with_read_only_tool();
+        let outcome = orch.execute(&FenceAgent, &ctx).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 3, "one provider call per round");
+        assert!(
+            !calls[0]
+                .iter()
+                .any(|m| m.content.contains("Exploration budget warning")),
+            "the nudge must not precede the streak: {:?}",
+            calls[0]
+        );
+        assert!(
+            calls[2].iter().any(|m| {
+                m.role == crate::types::MessageRole::Tool
+                    && m.content
+                        .contains("Exploration budget warning: 2 consecutive rounds")
+            }),
+            "the nudge must ride a tool result carrying the streak count: {:?}",
+            calls[2]
+        );
+    }
+
+    #[tokio::test]
+    async fn exploration_budget_nudge_fires_only_once_per_generation() {
+        // Four consecutive tool rounds in a 6-round budget: the nudge
+        // injects at the threshold (3) and must not repeat — the final call
+        // carries exactly one noticed tool result.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            tool_turn("tc-1"),
+            tool_turn("tc-2"),
+            tool_turn("tc-3"),
+            tool_turn("tc-4"),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 6);
+        let ctx = tool_registry_with_read_only_tool();
+        let outcome = orch.execute(&FenceAgent, &ctx).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 5, "one provider call per round");
+        let noticed = |call: &[crate::types::Message]| {
+            call.iter()
+                .filter(|m| {
+                    m.role == crate::types::MessageRole::Tool
+                        && m.content.contains("Exploration budget warning")
+                })
+                .count()
+        };
+        assert_eq!(noticed(&calls[2]), 0, "not yet at the threshold");
+        assert_eq!(
+            noticed(&calls[3]),
+            1,
+            "the nudge injects exactly when the threshold is crossed"
+        );
+        assert_eq!(
+            noticed(&calls[4]),
+            1,
+            "history carries the original notice; no second injection"
+        );
+    }
+
+    #[tokio::test]
+    async fn exploration_budget_nudge_resets_after_a_prose_round() {
+        // tool → unextractable prose → tool → tool in a 6-round budget:
+        // the prose round breaks the streak, so the threshold is never
+        // crossed again and no nudge appears anywhere.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            tool_turn("tc-1"),
+            ScriptedTurn::content("Here is my plan: trim the reads, then align."),
+            tool_turn("tc-2"),
+            tool_turn("tc-3"),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 6);
+        let ctx = tool_registry_with_read_only_tool();
+        let outcome = orch.execute(&FenceAgent, &ctx).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 5, "one provider call per round");
+        assert!(
+            !calls
+                .iter()
+                .flatten()
+                .any(|m| m.content.contains("Exploration budget warning")),
+            "the prose round must reset the streak: {calls:?}"
         );
     }
 

--- a/crates/oxo-flow-ai/src/agent/orchestrator.rs
+++ b/crates/oxo-flow-ai/src/agent/orchestrator.rs
@@ -76,28 +76,28 @@ impl Orchestrator {
         loop {
             rounds += 1;
             if rounds > self.max_rounds {
-                // Archive what the round budget bought before giving up —
-                // the provider calls already happened and were paid for;
-                // dropping the session here made the spend invisible. The
-                // transcript must land in the session too: the CLI's
-                // degraded-delivery path extracts the generated TOML from
-                // it, and an empty shell made that recovery impossible.
-                record_transcript(&mut session, &messages, tool_call_records, modifications);
-                let failed = session.fail(&format!(
-                    "exceeded max rounds ({}) without valid output",
-                    self.max_rounds
-                ));
-                log_session_usage(&failed);
-                let _ = crate::session::save_session(&failed);
+                archive_failed_generation(
+                    session,
+                    &messages,
+                    tool_call_records,
+                    modifications,
+                    format!(
+                        "exceeded max rounds ({}) without valid output",
+                        self.max_rounds
+                    ),
+                );
                 return Err(AiError::MaxRoundsExceeded {
                     max: self.max_rounds,
                 });
             }
             if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
-                record_transcript(&mut session, &messages, tool_call_records, modifications);
-                let failed = session.fail("cancelled by caller");
-                log_session_usage(&failed);
-                let _ = crate::session::save_session(&failed);
+                archive_failed_generation(
+                    session,
+                    &messages,
+                    tool_call_records,
+                    modifications,
+                    "cancelled by caller".into(),
+                );
                 return Err(AiError::ToolError {
                     tool: "cancelled".into(),
                     message: "cancelled by caller".to_string(),
@@ -106,10 +106,28 @@ impl Orchestrator {
 
             // 2. GATHER/ACT — call AI with current messages + tools
             let tool_defs = ctx.tool_registry.to_defs();
-            let response = self
+            let response = match self
                 .provider
                 .chat_with_tools_overflow_safe(&messages, &tool_defs)
-                .await?;
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    // A provider failure aborts the whole generation, but
+                    // the rounds before it were real paid work — archive
+                    // them like the round-cap exit; a bare `?` here dropped
+                    // the transcript and reported 0-token runs for
+                    // generations that had completed many tool rounds.
+                    archive_failed_generation(
+                        session,
+                        &messages,
+                        tool_call_records,
+                        modifications,
+                        format!("provider error: {error}"),
+                    );
+                    return Err(error);
+                }
+            };
 
             session.add_usage(&response.usage);
 
@@ -379,11 +397,32 @@ fn log_session_usage(session: &crate::session::AiSession) {
     }
 }
 
+/// Archive a doomed generation before surfacing `message` — the provider
+/// calls already happened and were paid for, so the transcript and token
+/// spend must land in the saved session (a bare error return made the
+/// spend invisible), and the CLI's degraded-delivery path extracts the
+/// generated TOML from that transcript, which an empty shell made
+/// impossible. One helper for every abort inside the round loop: round
+/// cap, cancellation, provider error.
+fn archive_failed_generation(
+    session: AiSession,
+    messages: &[Message],
+    tool_call_records: Vec<ToolCallRecord>,
+    modifications: Vec<Modification>,
+    message: String,
+) {
+    let mut session = session;
+    record_transcript(&mut session, messages, tool_call_records, modifications);
+    let failed = session.fail(&message);
+    log_session_usage(&failed);
+    let _ = crate::session::save_session(&failed);
+}
+
 /// Snapshot the loop transcript into the session (sanitized previews).
 ///
-/// One helper for all three exit paths — loop exhaustion, cancellation,
-/// and normal exit — so a failed run's paid-for transcript survives into
-/// the archived session exactly as a successful one's does.
+/// Called by every exit path — loop exhaustion, cancellation, provider
+/// error, and normal exit — so a failed run's paid-for transcript
+/// survives into the archived session exactly as a successful one's does.
 fn record_transcript(
     session: &mut AiSession,
     messages: &[Message],
@@ -858,6 +897,37 @@ mod tests {
         assert!(
             matches!(result, Err(AiError::MaxRoundsExceeded { max: 3 })),
             "round-cap exhaustion must surface MaxRoundsExceeded"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_error_archives_and_surfaces_without_retry() {
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        // Arrange: round 1 produces prose the picky agent rejects; round 2
+        // dies with a provider error — the shape every mid-generation
+        // timeout on a thinking backend produced. (Contract pin for the
+        // provider-error arm: the error surfaces as-is and the loop does
+        // not silently retry it; the paid transcript is archived by the
+        // same helper the round-cap path uses.)
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::content("BAD OUTPUT v1"),
+            ScriptedTurn::error("provider:request timeout"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 3);
+
+        // Act
+        let result = orch.execute(&PickyAgent, &test_context()).await;
+
+        // Assert
+        assert!(
+            matches!(result, Err(AiError::Provider { .. })),
+            "the provider error must surface as-is, not as MaxRoundsExceeded"
+        );
+        assert_eq!(
+            backend.observed_calls().await.len(),
+            2,
+            "a provider error must not be silently retried"
         );
     }
 

--- a/crates/oxo-flow-ai/src/agent/orchestrator.rs
+++ b/crates/oxo-flow-ai/src/agent/orchestrator.rs
@@ -14,7 +14,7 @@ use super::events::{AgentEvent, AgentEventSink};
 use super::{Agent, AgentContext, AgentOutcome};
 use crate::error::AiError;
 use crate::provider::AiProvider;
-use crate::session::{Modification, ToolCallRecord, archive_before_modify};
+use crate::session::{AiSession, Modification, ToolCallRecord, archive_before_modify};
 use crate::types::Message;
 
 // ── Orchestrator ───────────────────────────────────────────────────────────
@@ -78,7 +78,11 @@ impl Orchestrator {
             if rounds > self.max_rounds {
                 // Archive what the round budget bought before giving up —
                 // the provider calls already happened and were paid for;
-                // dropping the session here made the spend invisible.
+                // dropping the session here made the spend invisible. The
+                // transcript must land in the session too: the CLI's
+                // degraded-delivery path extracts the generated TOML from
+                // it, and an empty shell made that recovery impossible.
+                record_transcript(&mut session, &messages, tool_call_records, modifications);
                 let failed = session.fail(&format!(
                     "exceeded max rounds ({}) without valid output",
                     self.max_rounds
@@ -90,6 +94,7 @@ impl Orchestrator {
                 });
             }
             if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
+                record_transcript(&mut session, &messages, tool_call_records, modifications);
                 let failed = session.fail("cancelled by caller");
                 log_session_usage(&failed);
                 let _ = crate::session::save_session(&failed);
@@ -249,21 +254,49 @@ impl Orchestrator {
                     // so the model regenerated blind and could burn every
                     // round without ever learning what it wrote.
                     let rc = response.reasoning_content.as_deref().unwrap_or("");
-                    messages.push(Message::assistant_with_reasoning(text, rc));
                     let feedback = format!(
                         "Your previous output failed validation:\n{}\n\nPlease fix these issues and provide the corrected output.",
                         validation.errors.join("\n")
                     );
-                    messages.push(Message::user(&feedback));
+                    push_retry_feedback(
+                        &mut messages,
+                        text,
+                        rc,
+                        &feedback,
+                        rounds + 1 == self.max_rounds,
+                    );
                     // Continue loop — model will fix
                     continue;
                 }
             }
 
-            // No content, no tool calls — ask model to try again
-            messages.push(Message::user(
-                "Your response did not contain any content or tool calls. Please provide the expected output.",
-            ));
+            // Nothing usable came out of this round. Two distinct surfaces
+            // land here: prose whose extraction failed (the agent only
+            // accepts, e.g., fenced TOML) and a truly empty response. The
+            // former must see its OWN prose echoed before the retry
+            // directive — a bare user nudge after the initial user message
+            // put consecutive user turns on the wire and the model
+            // regenerated blind (GLM model-axis finding). The latter has
+            // nothing to echo — fabricating assistant text would put words
+            // in the model's mouth (audit finding).
+            let final_round = rounds + 1 == self.max_rounds;
+            if let Some(content) = &response.content {
+                let rc = response.reasoning_content.as_deref().unwrap_or("");
+                push_retry_feedback(
+                    &mut messages,
+                    content,
+                    rc,
+                    "Your previous response could not be processed: the expected content could not be extracted from it. Please provide the complete output in the format the task requires (for example inside a code fence).",
+                    final_round,
+                );
+            } else {
+                let mut nudge =
+                    "Your response did not contain any content or tool calls. Please provide the expected output.".to_string();
+                if final_round {
+                    nudge.push_str(FINAL_ROUND_NOTICE);
+                }
+                messages.push(Message::user(&nudge));
+            }
         }
 
         // Build outcome
@@ -275,12 +308,7 @@ impl Orchestrator {
         };
 
         // Record messages in session (sanitized previews)
-        session.messages = messages
-            .iter()
-            .map(crate::session::SessionMessage::from_message)
-            .collect();
-        session.tool_calls = tool_call_records;
-        session.modifications = modifications;
+        record_transcript(&mut session, &messages, tool_call_records, modifications);
 
         if let Some(sink) = &mut sink {
             sink(AgentEvent::Done);
@@ -351,6 +379,25 @@ fn log_session_usage(session: &crate::session::AiSession) {
     }
 }
 
+/// Snapshot the loop transcript into the session (sanitized previews).
+///
+/// One helper for all three exit paths — loop exhaustion, cancellation,
+/// and normal exit — so a failed run's paid-for transcript survives into
+/// the archived session exactly as a successful one's does.
+fn record_transcript(
+    session: &mut AiSession,
+    messages: &[Message],
+    tool_calls: Vec<ToolCallRecord>,
+    modifications: Vec<Modification>,
+) {
+    session.messages = messages
+        .iter()
+        .map(crate::session::SessionMessage::from_message)
+        .collect();
+    session.tool_calls = tool_calls;
+    session.modifications = modifications;
+}
+
 /// Preview text capped at 200 chars. Byte-slicing (`&s[..200]`) panics when
 /// the cut lands inside a multi-byte UTF-8 sequence, which is common in
 /// bioinformatics tool output — truncate on a char boundary instead.
@@ -364,6 +411,32 @@ fn truncate_preview(content: &str) -> String {
         end -= 1;
     }
     format!("{}...", &content[..end])
+}
+
+/// Appended to the feedback of the round whose successor is the model's
+/// LAST. A notice pushed after the final round is never seen — the loop
+/// fails at the head before the next provider call — so it must ride the
+/// previous feedback instead.
+const FINAL_ROUND_NOTICE: &str =
+    " This is the final round: produce the complete, final output now.";
+
+/// Echo the model's own output as an assistant turn, then append the retry
+/// feedback as a user turn. Wire-safe on both provider paths (no orphan
+/// tool ids, no consecutive user turns); when the upcoming round is the
+/// last, the feedback carries the final-round notice.
+fn push_retry_feedback(
+    messages: &mut Vec<Message>,
+    model_output: &str,
+    reasoning: &str,
+    feedback: &str,
+    is_final_round: bool,
+) {
+    messages.push(Message::assistant_with_reasoning(model_output, reasoning));
+    let mut feedback = feedback.to_string();
+    if is_final_round {
+        feedback.push_str(FINAL_ROUND_NOTICE);
+    }
+    messages.push(Message::user(&feedback));
 }
 
 #[cfg(test)]
@@ -505,6 +578,30 @@ mod tests {
         }
     }
 
+    /// An agent that only extracts fenced content — bare prose is dropped,
+    /// mirroring how pipeline_gen's extract_toml behaves on fence-less prose.
+    struct FenceAgent;
+    #[async_trait]
+    impl Agent for FenceAgent {
+        fn name(&self) -> &str {
+            "fence-agent"
+        }
+        fn plan(&self, _ctx: &AgentContext) -> Message {
+            Message::system("sys")
+        }
+        fn user_message(&self, _ctx: &AgentContext) -> Message {
+            Message::user("produce")
+        }
+        fn extract_content(&self, response_content: &str) -> Option<String> {
+            response_content
+                .contains("```")
+                .then(|| response_content.trim().to_string())
+        }
+        fn validate(&self, _content: &str, _ctx: &AgentContext) -> ValidationResult {
+            ValidationResult::passed()
+        }
+    }
+
     #[tokio::test]
     async fn validation_failure_replays_the_rejected_output() {
         // The model must see its own rejected output before the error list;
@@ -540,6 +637,120 @@ mod tests {
         assert!(
             rejected < feedback,
             "rejected output must precede the feedback: {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn extraction_failure_echoes_the_prose_before_the_retry_directive() {
+        // A response whose text cannot be extracted (e.g. prose without the
+        // requested code fences) must be echoed back as an assistant turn
+        // BEFORE the retry directive — a bare user nudge after the initial
+        // user message put consecutive user turns on the wire and the model
+        // regenerated blind (GLM model-axis finding).
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::content("Here is my plan: trim the reads, then align."),
+            ScriptedTurn::content("```toml\n[tool]\n```"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 3);
+        let outcome = orch.execute(&FenceAgent, &test_context()).await.unwrap();
+        assert!(outcome.success, "the fenced retry must be accepted");
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 2, "one provider call per round");
+        let second = &calls[1];
+        let prose = second
+            .iter()
+            .position(|m| {
+                matches!(m.role, crate::types::MessageRole::Assistant)
+                    && m.content.contains("Here is my plan")
+            })
+            .expect("the unextractable prose must be echoed as an assistant turn");
+        let directive = second
+            .iter()
+            .rposition(|m| matches!(m.role, crate::types::MessageRole::User))
+            .expect("a user retry directive must follow");
+        assert!(
+            prose < directive,
+            "the echoed prose must precede the directive: {second:?}"
+        );
+        for pair in second.windows(2) {
+            assert!(
+                !(matches!(pair[0].role, crate::types::MessageRole::User)
+                    && matches!(pair[1].role, crate::types::MessageRole::User)),
+                "no consecutive user turns may reach the wire: {second:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_response_gets_a_plain_nudge_without_a_fabricated_assistant_turn() {
+        // A truly empty response (no content, no tool calls) has nothing to
+        // echo — fabricating assistant text was rejected by the audit. Pin
+        // the deliberate choice: the bare user nudge is appended as-is.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::default(),
+            ScriptedTurn::content("ACCEPTED"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 3);
+        let outcome = orch.execute(&TestAgent, &test_context()).await.unwrap();
+        assert!(outcome.success, "the retry must be accepted");
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 2);
+        let second = &calls[1];
+        assert!(
+            !second
+                .iter()
+                .any(|m| matches!(m.role, crate::types::MessageRole::Assistant)),
+            "no assistant turn may be fabricated for an empty response: {second:?}"
+        );
+        assert!(
+            second.last().is_some_and(|m| {
+                matches!(m.role, crate::types::MessageRole::User)
+                    && m.content.contains("did not contain")
+            }),
+            "the retry nudge must be the last message: {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn final_failure_feedback_carries_the_final_round_notice() {
+        // When the upcoming round is the model's LAST, the failure feedback
+        // must tell it to produce the final output now. A notice pushed
+        // after the last round is never seen (the loop fails before the
+        // next provider call), so it must ride the second-to-last feedback.
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::content("BAD OUTPUT v1"),
+            ScriptedTurn::content("BAD OUTPUT v2"),
+            ScriptedTurn::content("ACCEPTED v3"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend.clone()), 3);
+        let outcome = orch.execute(&PickyAgent, &test_context()).await.unwrap();
+        assert!(outcome.success);
+
+        let calls = backend.observed_calls().await;
+        assert_eq!(calls.len(), 3);
+        // Round 2's feedback must NOT yet announce the final round...
+        assert!(
+            !calls[1].iter().any(|m| m.content.contains("final round")),
+            "the notice must wait for the actual final round: {:?}",
+            calls[1]
+        );
+        // ...round 3's feedback must.
+        assert!(
+            calls[2].iter().any(|m| {
+                matches!(m.role, crate::types::MessageRole::User)
+                    && m.content.contains("failed validation")
+                    && m.content.contains("final round")
+            }),
+            "the final-round notice must ride the failure feedback: {:?}",
+            calls[2]
         );
     }
 
@@ -623,5 +834,77 @@ mod tests {
             .execute_with_sink(&TestAgent, &ctx, None, Some(&cancel))
             .await;
         assert!(result.is_err(), "pre-set cancel must abort the loop");
+    }
+
+    #[tokio::test]
+    async fn max_rounds_exhaustion_surfaces_the_max_rounds_error() {
+        use crate::scripted::{ScriptedBackend, ScriptedTurn};
+
+        // Arrange: every round produces content the picky agent rejects,
+        // so the loop must exhaust its budget. (Contract pin for the
+        // round-cap path — web chat matches this error's Display text to
+        // choose the degraded-delivery branch.)
+        let backend = ScriptedBackend::new(vec![
+            ScriptedTurn::content("BAD OUTPUT v1"),
+            ScriptedTurn::content("BAD OUTPUT v2"),
+            ScriptedTurn::content("BAD OUTPUT v3"),
+        ]);
+        let orch = Orchestrator::new(AiProvider::Scripted(backend), 3);
+
+        // Act
+        let result = orch.execute(&PickyAgent, &test_context()).await;
+
+        // Assert
+        assert!(
+            matches!(result, Err(AiError::MaxRoundsExceeded { max: 3 })),
+            "round-cap exhaustion must surface MaxRoundsExceeded"
+        );
+    }
+
+    #[test]
+    fn record_transcript_populates_the_session_before_failure_saves() {
+        use crate::session::ToolCallRecord;
+
+        // Arrange: a transcript shaped like a real failed run — tool
+        // rounds, tool results, a nudge — plus the matching tool-call
+        // records. The round-cap and cancellation exits save the session,
+        // and the CLI's degraded-delivery path reads the generated TOML
+        // from it; before this helper existed both exits saved an empty
+        // shell (messages: [], tool_calls: []).
+        let messages = vec![
+            Message::system("sys prompt"),
+            Message::user("generate the pipeline"),
+            Message::assistant_with_tools(vec![crate::types::ToolCall {
+                id: "tc-1".into(),
+                name: "lookup_tool".into(),
+                arguments: "{\"query\":\"cutadapt\"}".into(),
+            }]),
+            Message::tool("tc-1", "lookup_tool", "found cutadapt"),
+            Message::user("try again"),
+        ];
+        let tool_calls = vec![ToolCallRecord {
+            timestamp: Utc::now(),
+            tool_name: "lookup_tool".into(),
+            arguments: "{\"query\":\"cutadapt\"}".into(),
+            result_preview: "found cutadapt".into(),
+            success: true,
+            duration_ms: 5,
+        }];
+        let mut session = AiSession::new("test", "intent", "noop", "none");
+
+        // Act
+        record_transcript(&mut session, &messages, tool_calls, Vec::new());
+
+        // Assert: every message is sanitized in, roles preserved, tool
+        // calls carried over.
+        assert_eq!(session.messages.len(), messages.len());
+        assert!(
+            session
+                .messages
+                .iter()
+                .any(|m| m.role == "tool" && m.content_preview.contains("cutadapt"))
+        );
+        assert_eq!(session.tool_calls.len(), 1);
+        assert_eq!(session.tool_calls[0].tool_name, "lookup_tool");
     }
 }

--- a/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
+++ b/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
@@ -188,63 +188,150 @@ Your TOML MUST include:
 /// Extract `.oxoflow` TOML from a model response — the single canonical
 /// implementation (previously four divergent copies across CLI and web).
 ///
-/// Order: ```toml fence → case-variant ```TOML fence → generic ``` fence
-/// containing `[workflow]` → raw text from the first `[workflow]`. The two
-/// fallbacks require a `[[rules]]`/`[rules]` table so prose is never
-/// mistaken for a pipeline.
+/// Order: fenced segments, scanned latest first (orchestrator transcripts
+/// accumulate correction rounds, and the last complete draft is the
+/// model's final word) → raw text from the first `[workflow]`. A fenced
+/// candidate is accepted whole only when it parses as TOML and passes the
+/// structural floor, so unparseable round-1 garbage can never leak
+/// through a cross-round fence pairing; a parseable-but-incomplete
+/// segment is kept only as a best-effort fallback so an injected
+/// validator can still steer the correction loop. The raw fallback
+/// applies the same floor, so degraded delivery can never write
+/// structurally broken TOML.
 pub fn extract_toml(response: &str) -> Option<String> {
-    for fence in ["```toml", "```TOML"] {
-        if let Some(content) = fenced_block(response, fence)
-            && !content.is_empty()
-        {
-            return Some(content);
+    let mut fallback = None;
+    for segment in fenced_segments(response).into_iter().rev() {
+        let Ok(value) = toml::from_str::<toml::Value>(&segment) else {
+            continue;
+        };
+        if floor_errors(&value).is_empty() {
+            return Some(segment);
+        }
+        // Parseable but incomplete: keep the latest such fragment as a
+        // best-effort fallback in case no complete draft exists.
+        if fallback.is_none() && value.get("workflow").is_some() {
+            fallback = Some(segment);
         }
     }
-    if let Some(content) = fenced_block(response, "```")
-        && content.contains("[workflow]")
-    {
-        return Some(content);
+    fallback.or_else(|| raw_workflow(response))
+}
+
+/// All ```-delimited segments in document order, with the info tag on the
+/// opening fence (```toml, ```TOML, …) dropped. A tagged fence line while
+/// a segment is open closes it and starts a new one: models correct an
+/// unclosed draft by opening a fresh fence, and that stray opener must
+/// not be mistaken for the missing closer (which would let the stale
+/// draft shadow the corrected one). An unclosed fence yields no segment —
+/// its content has no verified boundary, so it is left to the raw
+/// fallback.
+fn fenced_segments(text: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut open: Option<String> = None;
+    for line in text.lines() {
+        match line.trim_start().strip_prefix("```") {
+            None => {
+                if let Some(buf) = open.as_mut() {
+                    buf.push_str(line);
+                    buf.push('\n');
+                }
+            }
+            // Bare fence: closes the open segment, or opens one from scratch.
+            Some(tag) if tag.trim().is_empty() => match open.take() {
+                Some(buf) => segments.push(buf.trim().to_string()),
+                None => open = Some(String::new()),
+            },
+            // Tagged fence: reopens (implicitly closing any open segment).
+            Some(_) => {
+                if let Some(buf) = open.take() {
+                    segments.push(buf.trim().to_string());
+                }
+                open = Some(String::new());
+            }
+        }
     }
-    raw_workflow(response)
+    segments
 }
 
-fn fenced_block(text: &str, fence: &str) -> Option<String> {
-    let start = text.find(fence)? + fence.len();
-    let after = &text[start..];
-    let end = after.find("```")?;
-    Some(after[..end].trim().to_string())
-}
-
-/// Raw fallback: everything from the first `[workflow]` line, provided at
-/// least one rules table follows — guards against prose-only output.
+/// Raw fallback: everything from the first `[workflow]` line, provided the
+/// candidate parses as TOML and still passes the structural floor — guards
+/// against prose and against truncated output (e.g. an unclosed fence cut
+/// off mid-shell-string) being delivered as a broken artifact. Trailing
+/// prose after the workflow body is tolerated: the candidate is cut at the
+/// first line that breaks the TOML parse.
 fn raw_workflow(response: &str) -> Option<String> {
     let idx = response.find("[workflow]")?;
     let candidate = response[idx..].trim();
-    let looks_like_pipeline = candidate.lines().any(|l| {
-        let t = l.trim_start();
-        t.starts_with("[[rules]]") || t.starts_with("[rules]")
-    });
-    if looks_like_pipeline {
-        Some(candidate.to_string())
-    } else {
-        None
+    // Parse the candidate; on failure retry with successively shorter
+    // prefixes. The first prefix that parses and passes the floor is the
+    // workflow body — prose trailing a complete document can no longer
+    // break it, and a truncation mid-string never yields a parseable
+    // prefix that still satisfies the floor (a truncated rule is dropped
+    // with its table header, so `[[rules]]` alone — parseable TOML but
+    // floor-invalid — cannot masquerade as a pipeline).
+    let lines: Vec<&str> = candidate.lines().collect();
+    for end in (1..=lines.len()).rev() {
+        let prefix = lines[..end].join("\n");
+        let Ok(value) = toml::from_str::<toml::Value>(&prefix) else {
+            continue;
+        };
+        if floor_errors(&value).is_empty() {
+            return Some(prefix);
+        }
     }
+    None
 }
 
-/// Structural floor used when the caller injects no engine validator:
-/// the TOML must declare a workflow, at least one rule, and shells.
-pub fn basic_structure_errors(toml: &str) -> Vec<String> {
+/// Structural floor over a parsed workflow: a `[workflow]` table, at
+/// least one rule, and every rule carrying a shell — checked per rule
+/// (an empty shell counts as absent), so a dangling shell-less rule
+/// cannot survive salvage on the strength of an earlier rule's `shell`,
+/// which substring-level probes cannot distinguish.
+fn floor_errors(value: &toml::Value) -> Vec<String> {
     let mut errors = Vec::new();
-    if !toml.contains("[workflow]") {
+    if value.get("workflow").is_none() {
         errors.push("Generated TOML missing [workflow] section".into());
     }
-    if !toml.contains("[[rules]]") {
+    let Some(rules) = value.get("rules").and_then(|rules| rules.as_array()) else {
+        errors.push("Generated TOML has no [[rules]] sections".into());
+        return errors;
+    };
+    if rules.is_empty() {
         errors.push("Generated TOML has no [[rules]] sections".into());
     }
-    if !toml.contains("shell") {
-        errors.push("Generated TOML rules missing 'shell' field".into());
+    for (idx, rule) in rules.iter().enumerate() {
+        let has_shell = rule
+            .get("shell")
+            .is_some_and(|shell| shell.as_str().is_some_and(|cmd| !cmd.trim().is_empty()));
+        if !has_shell {
+            errors.push(format!("Rule {} has no 'shell' field", idx + 1));
+        }
     }
     errors
+}
+
+/// Structural floor for workflow text: with no engine validator injected
+/// this is the sole acceptance check for generated TOML, and it gates
+/// `raw_workflow`'s salvage even when a validator is in play. Parseable
+/// input is checked per rule via [`floor_errors`]; unparseable input
+/// falls back to substring probes so the caller still learns which
+/// skeleton pieces are absent.
+pub fn basic_structure_errors(toml: &str) -> Vec<String> {
+    match toml::from_str::<toml::Value>(toml) {
+        Ok(value) => floor_errors(&value),
+        Err(_) => {
+            let mut errors = Vec::new();
+            if !toml.contains("[workflow]") {
+                errors.push("Generated TOML missing [workflow] section".into());
+            }
+            if !toml.contains("[[rules]]") {
+                errors.push("Generated TOML has no [[rules]] sections".into());
+            }
+            if !toml.contains("shell") {
+                errors.push("Generated TOML rules missing 'shell' field".into());
+            }
+            errors
+        }
+    }
 }
 
 // ── Agent ──────────────────────────────────────────────────────────────────
@@ -400,6 +487,84 @@ mod tests {
             extract_toml("I cannot generate a pipeline right now."),
             None
         );
+    }
+
+    #[test]
+    fn extract_toml_rejects_unparseable_raw_fallback() {
+        // Live Qwen failure: the round cap hit while the ```toml fence was
+        // still open, so no closing ``` exists and both fenced paths return
+        // None. The raw fallback used to deliver this structurally broken
+        // TOML (unterminated shell string) to the degraded arm, which wrote
+        // it to disk. A raw candidate must parse as TOML or be rejected —
+        // the correction loop then gets the fence-oriented retry directive
+        // instead of a broken artifact.
+        let truncated = concat!(
+            "```toml\n",
+            "[workflow]\n",
+            "name = \"hisat2-align\"\n",
+            "\n",
+            "[[rules]]\n",
+            "name = \"align\"\n",
+            "shell = \"\"\"hisat2 -x {config.index} -1 {input[0]} -2 {input[1]} \\\n",
+        );
+        assert_eq!(extract_toml(truncated), None);
+    }
+
+    #[test]
+    fn extract_toml_raw_rejects_truncated_before_rule_fields() {
+        // Truncation before the rule has any fields: the bare `[[rules]]`
+        // prefix parses as TOML but fails the structural floor (no shell),
+        // so nothing is delivered.
+        let truncated = "```toml\n[workflow]\nname = \"x\"\n\n[[rules]]\n";
+        assert_eq!(extract_toml(truncated), None);
+    }
+
+    #[test]
+    fn extract_toml_prefers_latest_draft_when_fence_reopens() {
+        // Round-1 draft never closes its fence; the corrected round-2 draft
+        // opens its own. The stray tagged opener must close the dangling
+        // fence (not pair as its closer), so the model's final word wins.
+        let response = concat!(
+            "Here is a draft:\n```toml\n[workflow]\nname = \"draft\"\n[[rules]]\nname = \"r\"\nshell = \"echo old\"\n",
+            "Actually, corrected:\n```toml\n[workflow]\nname = \"final\"\n[[rules]]\nname = \"r\"\nshell = \"echo new\"\n```",
+        );
+        let extracted = extract_toml(response).expect("corrected draft extracted");
+        assert!(extracted.contains("final"));
+        assert!(!extracted.contains("draft"));
+    }
+
+    #[test]
+    fn extract_toml_raw_drops_dangling_shell_less_rule() {
+        // A trailing rule missing its shell must not ride on an earlier
+        // rule's shell: the floor is per-rule, so salvage keeps only the
+        // complete rules.
+        let response = "[workflow]\nname = \"x\"\n[[rules]]\nname = \"a\"\nshell = \"echo a\"\n[[rules]]\nname = \"b\"\n";
+        let extracted = extract_toml(response).expect("complete rule salvaged");
+        assert!(extracted.contains("name = \"a\""));
+        assert!(!extracted.contains("name = \"b\""));
+    }
+
+    #[test]
+    fn extract_toml_raw_salvages_prefix_before_trailing_prose() {
+        // Trailing prose must not sink the artifact: the candidate is cut at
+        // the first line that breaks the TOML parse.
+        let ok = extract_toml(
+            "[workflow]\nname = \"x\"\n\n[[rules]]\nname = \"r\"\nshell = \"echo\"\n\nNote: adjust the index path before running.",
+        );
+        assert!(ok.is_some_and(|c| c.starts_with("[workflow]") && c.contains("shell")));
+    }
+
+    #[test]
+    fn floor_requires_shell_in_every_rule() {
+        let value: toml::Value =
+            toml::from_str("[workflow]\n[[rules]]\nname = \"a\"\nshell = \"echo\"").unwrap();
+        assert!(floor_errors(&value).is_empty());
+
+        let dangling: toml::Value = toml::from_str(
+            "[workflow]\n[[rules]]\nname = \"a\"\nshell = \"echo\"\n[[rules]]\nname = \"b\"",
+        )
+        .unwrap();
+        assert!(floor_errors(&dangling).iter().any(|e| e.contains("2")));
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
+++ b/crates/oxo-flow-ai/src/agent/pipeline_gen.rs
@@ -252,14 +252,27 @@ fn fenced_segments(text: &str) -> Vec<String> {
     segments
 }
 
-/// Raw fallback: everything from the first `[workflow]` line, provided the
+/// Raw fallback: everything from a `[workflow]` line, provided the
 /// candidate parses as TOML and still passes the structural floor — guards
 /// against prose and against truncated output (e.g. an unclosed fence cut
 /// off mid-shell-string) being delivered as a broken artifact. Trailing
 /// prose after the workflow body is tolerated: the candidate is cut at the
-/// first line that breaks the TOML parse.
+/// first line that breaks the TOML parse. Anchors are scanned latest-first
+/// — the same stale-draft-cannot-shadow invariant the fenced path got —
+/// so a broken early unfenced draft cannot hide a later complete one.
 fn raw_workflow(response: &str) -> Option<String> {
-    let idx = response.find("[workflow]")?;
+    let anchors: Vec<usize> = response
+        .match_indices("[workflow]")
+        .map(|(i, _)| i)
+        .collect();
+    anchors
+        .iter()
+        .rev()
+        .find_map(|&idx| raw_workflow_from(response, idx))
+}
+
+/// Longest parseable, floor-passing prefix of the tail starting at `idx`.
+fn raw_workflow_from(response: &str, idx: usize) -> Option<String> {
     let candidate = response[idx..].trim();
     // Parse the candidate; on failure retry with successively shorter
     // prefixes. The first prefix that parses and passes the floor is the
@@ -282,9 +295,12 @@ fn raw_workflow(response: &str) -> Option<String> {
 }
 
 /// Structural floor over a parsed workflow: a `[workflow]` table, at
-/// least one rule, and every rule carrying a shell — checked per rule
-/// (an empty shell counts as absent), so a dangling shell-less rule
-/// cannot survive salvage on the strength of an earlier rule's `shell`,
+/// least one rule, and every rule carrying an execution body — `shell`,
+/// `script`, or `transform` (the engine accepts all three; demanding a
+/// `shell` would disqualify engine-valid script/transform rules and
+/// truncate degraded salvage at the first such rule). Checked per rule
+/// (an empty string counts as absent), so a dangling body-less rule
+/// cannot survive salvage on the strength of an earlier rule's body,
 /// which substring-level probes cannot distinguish.
 fn floor_errors(value: &toml::Value) -> Vec<String> {
     let mut errors = Vec::new();
@@ -299,11 +315,15 @@ fn floor_errors(value: &toml::Value) -> Vec<String> {
         errors.push("Generated TOML has no [[rules]] sections".into());
     }
     for (idx, rule) in rules.iter().enumerate() {
-        let has_shell = rule
-            .get("shell")
-            .is_some_and(|shell| shell.as_str().is_some_and(|cmd| !cmd.trim().is_empty()));
-        if !has_shell {
-            errors.push(format!("Rule {} has no 'shell' field", idx + 1));
+        let has_body = ["shell", "script"].iter().any(|key| {
+            rule.get(*key)
+                .is_some_and(|body| body.as_str().is_some_and(|cmd| !cmd.trim().is_empty()))
+        }) || rule.get("transform").is_some();
+        if !has_body {
+            errors.push(format!(
+                "Rule {} has no 'shell', 'script', or 'transform' body",
+                idx + 1
+            ));
         }
     }
     errors
@@ -326,8 +346,9 @@ pub fn basic_structure_errors(toml: &str) -> Vec<String> {
             if !toml.contains("[[rules]]") {
                 errors.push("Generated TOML has no [[rules]] sections".into());
             }
-            if !toml.contains("shell") {
-                errors.push("Generated TOML rules missing 'shell' field".into());
+            if !toml.contains("shell") && !toml.contains("script") && !toml.contains("transform") {
+                errors
+                    .push("Generated TOML rules missing 'shell'/'script'/'transform' body".into());
             }
             errors
         }
@@ -517,6 +538,68 @@ mod tests {
         // so nothing is delivered.
         let truncated = "```toml\n[workflow]\nname = \"x\"\n\n[[rules]]\n";
         assert_eq!(extract_toml(truncated), None);
+    }
+
+    #[test]
+    fn floor_accepts_script_and_transform_rule_bodies() {
+        // The engine accepts `shell`, `script`, or `transform` as a rule's
+        // execution body — the floor must not disqualify engine-valid
+        // script/transform rules and truncate degraded salvage at the
+        // first such rule.
+        let draft = concat!(
+            "[workflow]\n",
+            "name = \"mixed\"\n",
+            "\n",
+            "[[rules]]\n",
+            "name = \"shelled\"\n",
+            "shell = \"true\"\n",
+            "\n",
+            "[[rules]]\n",
+            "name = \"scripted\"\n",
+            "script = \"run.sh\"\n",
+        );
+        let parsed: toml::Value = toml::from_str(draft).unwrap();
+        assert!(
+            floor_errors(&parsed).is_empty(),
+            "engine-valid script rules pass the floor: {:?}",
+            floor_errors(&parsed)
+        );
+        assert!(extract_toml(&format!("```toml\n{draft}\n```")).is_some());
+
+        let bodyless = "[workflow]\nname = \"x\"\n\n[[rules]]\nname = \"empty\"\n";
+        let parsed: toml::Value = toml::from_str(bodyless).unwrap();
+        let errors = floor_errors(&parsed);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("no 'shell', 'script', or 'transform' body")),
+            "a body-less rule still fails: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn raw_salvage_scans_workflow_anchors_latest_first() {
+        // A broken early unfenced draft must not shadow a later complete
+        // unfenced draft — the same latest-first invariant the fenced path
+        // got. All prefixes anchored at the first [workflow] fail (the
+        // draft is truncated mid-value), so the second anchor wins.
+        let response = concat!(
+            "[workflow]\n",
+            "name = \n",
+            "prose between drafts\n",
+            "[workflow]\n",
+            "name = \"good\"\n",
+            "\n",
+            "[[rules]]\n",
+            "name = \"r\"\n",
+            "shell = \"true\"\n",
+        );
+        let salvaged = extract_toml(response)
+            .unwrap_or_else(|| panic!("the later complete draft must be found"));
+        assert!(
+            salvaged.contains("name = \"good\""),
+            "the latest anchor must win, got: {salvaged}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/config.rs
+++ b/crates/oxo-flow-ai/src/config.rs
@@ -596,7 +596,7 @@ enabled = false
 max_retries = 1
 auto_fix = "never"
 "#;
-        let table: toml::Table = toml::from_str(&toml_str).unwrap();
+        let table: toml::Table = toml::from_str(toml_str).unwrap();
         let config = AiConfig::from_rule_table(&table).unwrap();
         assert!(!config.enabled);
         assert_eq!(config.max_retries, 1);

--- a/crates/oxo-flow-ai/src/config.rs
+++ b/crates/oxo-flow-ai/src/config.rs
@@ -66,16 +66,20 @@ pub struct AiConfig {
 /// The shipped round-budget default. Single source for every consumer that
 /// sizes an agent loop without explicit user configuration — the CLI config
 /// chain, the web surfaces' chat budget, and config writes (a reconfigure
-/// that persisted the old starved default would quietly reintroduce it).
+/// that persisted a starved default would quietly reintroduce it).
 pub fn default_max_retries() -> u32 {
     // Rounds are shared between knowledge-tool lookups and validation-feedback
     // corrections: tool-heavy intents routinely spend 2-3 rounds querying the
     // embedded databases before writing any TOML, and a correction pass needs
     // 1-2 more. A budget of 3 starved those intents into a failed run whose
     // only remedy was paying for a full re-generation (the web surfaces
-    // already run 6 for exactly this reason); 6 covers both phases, and the
-    // loop still stops as soon as a draft validates.
-    6
+    // already run 6 for exactly this reason). The model-axis benchmark
+    // (eval/frontier/results/model-axis-csu3) showed exploration-heavy models
+    // like GLM spend 7-10 rounds all-tool-call before drafting — 6 exhausted
+    // on every run while 10 went 5/5 on the same archetypes. The loop stops
+    // as soon as a draft validates, so the extra headroom is only paid when
+    // a run would otherwise fail.
+    10
 }
 
 impl Default for AiConfig {
@@ -120,6 +124,12 @@ impl AiConfig {
         if other.api_url.is_some() {
             self.api_url = other.api_url.clone();
         }
+        // Same sentinel idiom as provider: a default-valued max_retries is
+        // treated as "unset" so an absent key in a higher tier can't shrink a
+        // lower tier's explicit budget. The cost is that an explicit
+        // `max_retries = <default>` in a higher tier cannot override a lower
+        // tier's non-default value — acceptable, since the lower tier's value
+        // is at least deliberate.
         if other.max_retries != default_max_retries() {
             self.max_retries = other.max_retries;
         }
@@ -555,11 +565,27 @@ name = "test"
             ..AiConfig::default()
         };
         let cli = AiConfig {
-            max_retries: 10,
+            max_retries: 12,
             ..Default::default()
         };
         let resolved = AiConfig::resolve_chain(Some(&global), None, None, None, Some(&cli));
-        assert_eq!(resolved.max_retries, 10);
+        assert_eq!(resolved.max_retries, 12);
+    }
+
+    #[test]
+    fn resolve_chain_default_valued_tier_is_treated_as_unset() {
+        // merge() uses default_max_retries() as the "unset" sentinel (same
+        // idiom as provider), so a higher tier still carrying the shipped
+        // default cannot override a lower tier's explicit budget. Pin that
+        // cost at the new default: workflow's explicit 4 survives a CLI tier
+        // left at 10.
+        let workflow = AiConfig {
+            max_retries: 4,
+            ..AiConfig::default()
+        };
+        let cli = AiConfig::default();
+        let resolved = AiConfig::resolve_chain(None, None, Some(&workflow), None, Some(&cli));
+        assert_eq!(resolved.max_retries, 4);
     }
 
     #[test]
@@ -570,10 +596,21 @@ enabled = false
 max_retries = 1
 auto_fix = "never"
 "#;
-        let table: toml::Table = toml::from_str(toml_str).unwrap();
+        let table: toml::Table = toml::from_str(&toml_str).unwrap();
         let config = AiConfig::from_rule_table(&table).unwrap();
         assert!(!config.enabled);
         assert_eq!(config.max_retries, 1);
         assert_eq!(config.auto_fix, AutoFixMode::Never);
+    }
+
+    #[test]
+    fn round_budget_default_covers_exploration_heavy_models() {
+        // Model-axis benchmark (eval/frontier/results/model-axis-csu3): GLM's
+        // explore-then-write style needs 7-10 rounds; at the old default of 6
+        // every one of its 29 benchmark runs died of round exhaustion despite
+        // sound tool choices, while 10 rounds went 5/5 on the same archetypes.
+        // Arrange + Act: read the shipped default.
+        // Assert: it is the calibrated budget.
+        assert_eq!(default_max_retries(), 10);
     }
 }

--- a/crates/oxo-flow-ai/src/knowledge/skills.rs
+++ b/crates/oxo-flow-ai/src/knowledge/skills.rs
@@ -57,11 +57,18 @@ pub fn list_domains() -> Vec<(String, usize)> {
 /// (name, domain, description, tool_type, primary_tool) with prefix
 /// awareness. Ranking: rare terms first (IDF² sum), then the strongest
 /// field hit (name/primary_tool > domain > description), then name.
-/// Skills matching all searchable terms are preferred; when none exist
-/// the best partial matches are returned, so multi-term queries never
-/// die because one term is missing everywhere.
+/// Skills matching all searchable terms rank first; partial matches
+/// backfill the remaining slots, so multi-term queries never die because
+/// one term is missing everywhere. Queries are capped at
+/// [`MAX_QUERY_TERMS`] tokens — the lexicographically first survive, since
+/// term order carries no relevance signal.
 pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
-    let terms = tokenize(query);
+    let mut terms = tokenize(query);
+    // Pathological queries (model loops have emitted hundreds of repeated
+    // lookup terms) cap the O(terms × corpus) work; terms are sorted, so
+    // the lexicographically first survive — term order carries no
+    // relevance signal.
+    terms.truncate(MAX_QUERY_TERMS);
     if terms.is_empty() {
         return Vec::new();
     }
@@ -69,12 +76,16 @@ pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
     // Document frequency per term over the whole corpus (prefix-aware
     // matching); terms that appear nowhere are agent hallucinations and are
     // dropped rather than killing the query (strict AND would return empty).
+    // Each skill's haystack is needed twice — the document-frequency pass
+    // and the scoring loop below — so build them once.
+    let haystacks: Vec<String> = SKILL_DB.iter().map(haystack).collect();
     let dfs: Vec<usize> = terms
         .iter()
         .map(|t| {
             SKILL_DB
                 .iter()
-                .filter(|s| term_matches(t, &haystack(s)))
+                .zip(&haystacks)
+                .filter(|(_, h)| term_matches(t, h))
                 .count()
         })
         .collect();
@@ -94,12 +105,11 @@ pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
     let n = SKILL_DB.len() as f64;
     let mut full: Vec<Candidate> = Vec::new();
     let mut partial: Vec<Candidate> = Vec::new();
-    for skill in SKILL_DB.iter() {
-        let hay = haystack(skill);
+    for (skill, hay) in SKILL_DB.iter().zip(&haystacks) {
         let matched: Vec<(&str, usize)> = present
             .iter()
             .copied()
-            .filter(|(t, _)| term_matches(t, &hay))
+            .filter(|(t, _)| term_matches(t, hay))
             .collect();
         if matched.is_empty() {
             continue;
@@ -125,9 +135,13 @@ pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
         }
     }
 
-    // Prefer skills matching ALL searchable terms; fall back to the best
-    // partial matches when no full-AND skill exists.
-    let mut pool = if !full.is_empty() { full } else { partial };
+    // Full-AND matches always outrank partials: every additional matched
+    // term adds a non-negative (ln(N/df))² to `primary`, so a full match's
+    // primary is ≥ any partial's, with `secondary` (then name) breaking
+    // ties. Merge the pools and sort once — partials backfill the slots the
+    // full matches leave open instead of being dropped outright.
+    let mut pool = full;
+    pool.append(&mut partial);
     pool.sort_by(|a, b| {
         b.primary
             .partial_cmp(&a.primary)
@@ -144,6 +158,11 @@ struct Candidate {
     primary: f64,
     secondary: u8,
 }
+
+/// Upper bound on tokenized query terms handed to the O(terms × corpus)
+/// scan; pathological multi-term queries (model lookup loops) truncate to
+/// their lexicographically first 32.
+const MAX_QUERY_TERMS: usize = 32;
 
 /// Lowercase, split on non-alphanumerics, drop 1-char tokens, dedupe.
 fn tokenize(query: &str) -> Vec<String> {
@@ -519,5 +538,44 @@ mod tests {
         // Unrelated text should match nothing
         let domains = domains_for_intent("hello world");
         assert!(domains.is_empty());
+    }
+
+    #[test]
+    fn partial_matches_backfill_after_full_matches() {
+        // 'markduplicates' fully matches the duplicate-handling skill while
+        // the bam-statistics skill only matches 'bam' — the partial must
+        // still appear (backfilled after the fulls) instead of being
+        // dropped, and rank below the full match.
+        let results = search_skills("bam markduplicates", 5);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+        let dup = names
+            .iter()
+            .position(|n| *n == "bio-duplicate-handling")
+            .unwrap_or_else(|| panic!("the full match must surface, got {names:?}"));
+        let stats = names
+            .iter()
+            .position(|n| *n == "bio-bam-statistics")
+            .unwrap_or_else(|| panic!("the partial match must be backfilled, got {names:?}"));
+        assert!(
+            dup < stats,
+            "full match must outrank the backfilled partial: {names:?}"
+        );
+    }
+
+    #[test]
+    fn pathological_query_is_capped_without_losing_the_signal_term() {
+        // A model lookup loop can emit hundreds of terms; the cap keeps the
+        // lexicographically first 32, and 'markduplicates' sorts before
+        // every 'zzz' filler so the real signal survives.
+        let mut query = "markduplicates".to_string();
+        for i in 0..100 {
+            query.push_str(&format!(" zzznoise{i:03}"));
+        }
+        let results = search_skills(&query, 3);
+        assert!(
+            results.iter().any(|s| s.name == "bio-duplicate-handling"),
+            "the signal term must survive the 32-term cap, got {:?}",
+            results.iter().map(|s| s.name.as_str()).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/oxo-flow-ai/src/knowledge/skills.rs
+++ b/crates/oxo-flow-ai/src/knowledge/skills.rs
@@ -52,34 +52,151 @@ pub fn list_domains() -> Vec<(String, usize)> {
 }
 
 /// Search skills by domain, name, description, or primary tool keyword.
-/// Returns skills ranked by: exact name > domain match > description hit.
+///
+/// The query is tokenized and matched against the searchable fields
+/// (name, domain, description, tool_type, primary_tool) with prefix
+/// awareness. Ranking: rare terms first (IDF² sum), then the strongest
+/// field hit (name/primary_tool > domain > description), then name.
+/// Skills matching all searchable terms are preferred; when none exist
+/// the best partial matches are returned, so multi-term queries never
+/// die because one term is missing everywhere.
 pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
-    let q = query.to_lowercase();
-    let mut domain_hits: Vec<&SkillRecord> = Vec::new();
-    let mut name_hits: Vec<&SkillRecord> = Vec::new();
-    let mut text_hits: Vec<&SkillRecord> = Vec::new();
+    let terms = tokenize(query);
+    if terms.is_empty() {
+        return Vec::new();
+    }
 
+    // Document frequency per term over the whole corpus (prefix-aware
+    // matching); terms that appear nowhere are agent hallucinations and are
+    // dropped rather than killing the query (strict AND would return empty).
+    let dfs: Vec<usize> = terms
+        .iter()
+        .map(|t| {
+            SKILL_DB
+                .iter()
+                .filter(|s| term_matches(t, &haystack(s)))
+                .count()
+        })
+        .collect();
+    let present: Vec<(&str, usize)> = terms
+        .iter()
+        .zip(&dfs)
+        .filter(|(_, df)| **df > 0)
+        .map(|(t, &df)| (t.as_str(), df))
+        .collect();
+    if present.is_empty() {
+        return Vec::new();
+    }
+
+    // Primary score: Σ (ln(N/df))² over matched terms — rare terms dominate
+    // generic ones ('bqsr' outweighs 'bam'). Secondary: strongest field hit
+    // (name/primary_tool > domain > description).
+    let n = SKILL_DB.len() as f64;
+    let mut full: Vec<Candidate> = Vec::new();
+    let mut partial: Vec<Candidate> = Vec::new();
     for skill in SKILL_DB.iter() {
-        let domain = skill.domain.to_lowercase();
-        let name = skill.name.to_lowercase();
-        let desc = skill.description.to_lowercase();
-        let tool = skill.primary_tool.to_lowercase();
-
-        if name.contains(&q) || tool.contains(&q) {
-            name_hits.push(skill);
-        } else if domain.contains(&q) {
-            domain_hits.push(skill);
-        } else if desc.contains(&q) {
-            text_hits.push(skill);
+        let hay = haystack(skill);
+        let matched: Vec<(&str, usize)> = present
+            .iter()
+            .copied()
+            .filter(|(t, _)| term_matches(t, &hay))
+            .collect();
+        if matched.is_empty() {
+            continue;
+        }
+        let primary: f64 = matched
+            .iter()
+            .map(|&(_, df)| (n / df as f64).ln().powi(2))
+            .sum();
+        let secondary = matched
+            .iter()
+            .map(|&(t, _)| field_weight(skill, t))
+            .max()
+            .unwrap_or(0);
+        let candidate = Candidate {
+            skill,
+            primary,
+            secondary,
+        };
+        if matched.len() == present.len() {
+            full.push(candidate);
+        } else {
+            partial.push(candidate);
         }
     }
 
-    name_hits
-        .into_iter()
-        .chain(domain_hits)
-        .chain(text_hits)
-        .take(limit)
-        .collect()
+    // Prefer skills matching ALL searchable terms; fall back to the best
+    // partial matches when no full-AND skill exists.
+    let mut pool = if !full.is_empty() { full } else { partial };
+    pool.sort_by(|a, b| {
+        b.primary
+            .partial_cmp(&a.primary)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(b.secondary.cmp(&a.secondary))
+            .then(a.skill.name.cmp(&b.skill.name))
+    });
+    pool.into_iter().map(|c| c.skill).take(limit).collect()
+}
+
+/// One scored search result.
+struct Candidate {
+    skill: &'static SkillRecord,
+    primary: f64,
+    secondary: u8,
+}
+
+/// Lowercase, split on non-alphanumerics, drop 1-char tokens, dedupe.
+fn tokenize(query: &str) -> Vec<String> {
+    let mut terms: Vec<String> = query
+        .to_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| t.len() >= 2)
+        .map(str::to_owned)
+        .collect();
+    terms.sort_unstable();
+    terms.dedup();
+    terms
+}
+
+/// Lowercased concatenation of all searchable fields.
+fn haystack(skill: &SkillRecord) -> String {
+    format!(
+        "{} {} {} {} {}",
+        skill.name.to_lowercase(),
+        skill.domain.to_lowercase(),
+        skill.description.to_lowercase(),
+        skill.tool_type.to_lowercase(),
+        skill.primary_tool.to_lowercase()
+    )
+}
+
+/// Substring hit, or bidirectional prefix match between the term and a
+/// haystack token when both are ≥5 chars (catches 'markduplicates' ↔
+/// 'markdup', 'recalibration' ↔ 'recalibr' without flooding short tokens).
+fn term_matches(term: &str, haystack: &str) -> bool {
+    if haystack.contains(term) {
+        return true;
+    }
+    if term.len() < 5 {
+        return false;
+    }
+    haystack
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|tok| tok.len() >= 5)
+        .any(|tok| tok.starts_with(term) || term.starts_with(tok))
+}
+
+/// Field-match strength: 3 name/primary_tool, 2 domain, 1 description/other.
+fn field_weight(skill: &SkillRecord, term: &str) -> u8 {
+    let name = skill.name.to_lowercase();
+    let tool = skill.primary_tool.to_lowercase();
+    if name.contains(term) || tool.contains(term) {
+        return 3;
+    }
+    if skill.domain.to_lowercase().contains(term) {
+        return 2;
+    }
+    1
 }
 
 /// Get all skills in a domain (e.g. "variant-calling").
@@ -243,6 +360,113 @@ mod tests {
     #[test]
     fn unknown_query_empty() {
         assert!(search_skills("zzzznonexistentdomain", 5).is_empty());
+    }
+
+    #[test]
+    fn multi_word_bam_preprocessing_query_finds_duplicate_and_bqsr_skills() {
+        // Live-failing agent query: none of the terms appear verbatim in any
+        // skill, so the old single-substring search returned 0 hits.
+        let results = search_skills("bam preprocessing markduplicates bqsr recalibration", 5);
+        assert!(
+            !results.is_empty(),
+            "multi-word query must not return zero hits"
+        );
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"bio-duplicate-handling"),
+            "bio-duplicate-handling should rank for duplicate-marking terms, got {names:?}"
+        );
+        assert!(
+            names.contains(&"bio-gatk-variant-calling"),
+            "bio-gatk-variant-calling should rank for BQSR terms, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn multi_word_gatk_joint_genotyping_query_ranks_variant_calling_first() {
+        // Live-failing agent query: gVCF/reference-confidence vocabulary that
+        // only appears inside the GATK skill description.
+        let results = search_skills(
+            "gatk haplotypecaller gvcf joint genotyping reference confidence interval",
+            5,
+        );
+        assert!(!results.is_empty());
+        assert_eq!(
+            results[0].name,
+            "bio-gatk-variant-calling",
+            "rare GATK-specific terms must rank the variant-calling skill first, got {:?}",
+            results.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn multi_word_fastq_screen_query_finds_contamination_screening() {
+        // Live-failing agent query: 'fastq' and 'screen' are both generic on
+        // their own; only their combination should surface the QC skill.
+        let results = search_skills("fastq screen contamination", 5);
+        assert!(!results.is_empty());
+        assert_eq!(
+            results[0].name,
+            "bio-read-qc-contamination-screening",
+            "contamination-screening terms must rank the QC skill first, got {:?}",
+            results.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn multi_word_rnaseq_de_query_finds_differential_expression() {
+        // Generality check: a common multi-word intent (not one of the three
+        // live failures) must still find its domain skill.
+        let results = search_skills("rna-seq differential expression", 5);
+        assert!(!results.is_empty());
+        assert!(
+            results
+                .iter()
+                .any(|s| s.domain == "differential-expression"),
+            "a differential-expression skill should match, got {:?}",
+            results.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn mixed_real_and_hallucinated_terms_still_return_hits() {
+        // A hallucinated term (zero document frequency) must be dropped
+        // rather than killing the query — live agents invent vocabulary.
+        // The old whole-query substring search returned 0 hits here.
+        let results = search_skills("bam zzzznotaword", 5);
+        assert!(
+            !results.is_empty(),
+            "a hallucinated term must not zero out a query with a real term"
+        );
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"bio-bam-statistics"),
+            "the real term 'bam' should surface bam skills, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn query_with_no_full_match_falls_back_to_best_partials() {
+        // No embedded skill matches both 'kraken2' and 'mutect2', so the
+        // search must fall back to the partial pool instead of returning
+        // nothing — each rare term's best skill should surface.
+        let results = search_skills("kraken2 mutect2", 5);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"bio-workflows-somatic-variant-pipeline"),
+            "the only mutect2 skill should surface via partial fallback, got {names:?}"
+        );
+        assert!(
+            names.contains(&"bio-metagenomics-kraken"),
+            "the main kraken2 skill should surface via partial fallback, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn empty_whitespace_and_zero_limit_queries_return_empty() {
+        assert!(search_skills("", 5).is_empty());
+        assert!(search_skills("   \t\n ", 5).is_empty());
+        assert!(search_skills("bam", 0).is_empty());
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/knowledge/skills.rs
+++ b/crates/oxo-flow-ai/src/knowledge/skills.rs
@@ -77,14 +77,14 @@ pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
     // matching); terms that appear nowhere are agent hallucinations and are
     // dropped rather than killing the query (strict AND would return empty).
     // Each skill's haystack is needed twice — the document-frequency pass
-    // and the scoring loop below — so build them once.
-    let haystacks: Vec<String> = SKILL_DB.iter().map(haystack).collect();
+    // and the scoring loop below; [`HAYSTACKS`] builds them once per
+    // process.
     let dfs: Vec<usize> = terms
         .iter()
         .map(|t| {
             SKILL_DB
                 .iter()
-                .zip(&haystacks)
+                .zip(HAYSTACKS.iter())
                 .filter(|(_, h)| term_matches(t, h))
                 .count()
         })
@@ -105,7 +105,7 @@ pub fn search_skills(query: &str, limit: usize) -> Vec<&'static SkillRecord> {
     let n = SKILL_DB.len() as f64;
     let mut full: Vec<Candidate> = Vec::new();
     let mut partial: Vec<Candidate> = Vec::new();
-    for (skill, hay) in SKILL_DB.iter().zip(&haystacks) {
+    for (skill, hay) in SKILL_DB.iter().zip(HAYSTACKS.iter()) {
         let matched: Vec<(&str, usize)> = present
             .iter()
             .copied()
@@ -163,6 +163,13 @@ struct Candidate {
 /// scan; pathological multi-term queries (model lookup loops) truncate to
 /// their lexicographically first 32.
 const MAX_QUERY_TERMS: usize = 32;
+
+/// Per-skill haystacks: SKILL_DB is a static table, so the lowercase
+/// concatenations are built once per process instead of once per query
+/// (lookup_skill runs in every agent round; ai_explain searches once per
+/// rule plus its tool lookups).
+static HAYSTACKS: std::sync::LazyLock<Vec<String>> =
+    std::sync::LazyLock::new(|| SKILL_DB.iter().map(haystack).collect());
 
 /// Lowercase, split on non-alphanumerics, drop 1-char tokens, dedupe.
 fn tokenize(query: &str) -> Vec<String> {

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -54,10 +54,12 @@ const OLLAMA_API_URL: &str = "http://localhost:11434/api/chat";
 
 /// Shared HTTP client for all provider backends. Without explicit timeouts a
 /// hung endpoint would block the agent loop indefinitely; the request timeout
-/// (default 120s, `OXO_FLOW_AI_TIMEOUT_SECS`) must also cover slow long-form
-/// completions — thinking backends with a raised `OXO_FLOW_AI_MAX_TOKENS`
-/// routinely exceed two minutes, and a mid-body timeout surfaces as a
-/// confusing "error decoding response body".
+/// (default 300s, `OXO_FLOW_AI_TIMEOUT_SECS`) must also cover slow long-form
+/// completions — a single thinking round routinely runs past two minutes (a
+/// measured GLM round on a thinking backend took 145s), and a mid-body
+/// timeout surfaces as a confusing "error decoding response body". The 10s
+/// connect timeout still fails fast on dead endpoints, so the longer wall
+/// only binds while a server is actively generating.
 fn provider_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
@@ -74,7 +76,86 @@ fn parse_timeout_secs(value: Option<&str>) -> u64 {
     value
         .and_then(|v| v.trim().parse::<u64>().ok())
         .filter(|n| *n > 0)
-        .unwrap_or(120)
+        .unwrap_or(300)
+}
+
+// ── Transport retry ────────────────────────────────────────────────────────
+
+/// Backoff between transient-transport retries: one after 2s, one after 5s.
+/// The benchmark's dominant flake class is a single dropped request out of
+/// a healthy session, so two quick retries absorb it without turning a
+/// genuinely dead endpoint into a minute of hanging.
+const TRANSPORT_BACKOFFS: &[std::time::Duration] = &[
+    std::time::Duration::from_secs(2),
+    std::time::Duration::from_secs(5),
+];
+
+/// Whether a [`reqwest::Error`] is a transient transport failure worth
+/// retrying: connection setup/reset and mid-transfer failures ("error
+/// sending request" was the observed benchmark flake). Timeouts are
+/// deliberately excluded — the request timeout has its own documented knob
+/// (`OXO_FLOW_AI_TIMEOUT_SECS`), and a retry would deterministically
+/// re-timeout against the same slow completion.
+fn is_transient_transport_error(e: &reqwest::Error) -> bool {
+    !e.is_timeout() && (e.is_connect() || e.is_request() || e.is_body())
+}
+
+/// Send a prepared request, retrying transient transport failures
+/// (see [`is_transient_transport_error`]) with `backoffs` pauses between
+/// attempts. HTTP error statuses are *not* retried here — they carry
+/// provider semantics (429 back-off, auth, context overflow) that the
+/// caller classifies. When the transport stays broken after every retry,
+/// [`AiError::RetryExhausted`] reports the total attempt count.
+async fn send_with_transport_retry(
+    request: reqwest::RequestBuilder,
+    provider: &str,
+    secret: Option<&str>,
+    backoffs: &[std::time::Duration],
+) -> Result<reqwest::Response, AiError> {
+    let mask = |message: String| match secret {
+        Some(key) => mask_secret(&message, key),
+        None => message,
+    };
+    let mut attempt = 0usize;
+    loop {
+        // `.json()` buffers the body, so the builder is replayable; a
+        // non-clonable body would be a construction bug, not a runtime case.
+        let result = request
+            .try_clone()
+            .ok_or_else(|| AiError::Provider {
+                provider: provider.into(),
+                message: "request body is not replayable for retry".into(),
+            })?
+            .send()
+            .await;
+        match result {
+            Ok(response) => return Ok(response),
+            Err(e) if !is_transient_transport_error(&e) => {
+                return Err(AiError::Provider {
+                    provider: provider.into(),
+                    message: mask(e.to_string()),
+                });
+            }
+            Err(e) if attempt >= backoffs.len() => {
+                return Err(AiError::RetryExhausted {
+                    attempts: attempt as u32 + 1,
+                    message: mask(e.to_string()),
+                });
+            }
+            Err(e) => {
+                let backoff = backoffs[attempt];
+                tracing::warn!(
+                    provider,
+                    attempt = attempt + 1,
+                    backoff_secs = backoff.as_secs(),
+                    error = mask(e.to_string()),
+                    "transient transport error — retrying"
+                );
+                attempt += 1;
+                tokio::time::sleep(backoff).await;
+            }
+        }
+    }
 }
 
 // ── AiProvider enum ────────────────────────────────────────────────────────
@@ -473,19 +554,18 @@ impl ClaudeBackend {
     ) -> Result<AiResponse, AiError> {
         let body = self.build_body(messages, tools);
 
-        let resp = self
-            .client
-            .post(&self.api_url)
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| AiError::Provider {
-                provider: "claude".into(),
-                message: mask_secret(&e.to_string(), &self.api_key),
-            })?;
+        let resp = send_with_transport_retry(
+            self.client
+                .post(&self.api_url)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .json(&body),
+            "claude",
+            Some(&self.api_key),
+            TRANSPORT_BACKOFFS,
+        )
+        .await?;
 
         let status = resp.status();
         let retry_after = retry_after_header(resp.headers());
@@ -809,18 +889,17 @@ impl OpenAiBackend {
     ) -> Result<AiResponse, AiError> {
         let body = self.build_body(messages, tools);
 
-        let resp = self
-            .client
-            .post(&self.api_url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| AiError::Provider {
-                provider: self.label.clone(),
-                message: mask_secret(&e.to_string(), &self.api_key),
-            })?;
+        let resp = send_with_transport_retry(
+            self.client
+                .post(&self.api_url)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("content-type", "application/json")
+                .json(&body),
+            &self.label,
+            Some(&self.api_key),
+            TRANSPORT_BACKOFFS,
+        )
+        .await?;
 
         let status = resp.status();
         let retry_after = retry_after_header(resp.headers());
@@ -974,17 +1053,16 @@ impl OllamaBackend {
     ) -> Result<AiResponse, AiError> {
         let body = build_ollama_body(messages, tools, &self.model, self.temperature);
 
-        let resp = self
-            .client
-            .post(&self.api_url)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| AiError::Provider {
-                provider: "ollama".into(),
-                message: e.to_string(),
-            })?;
+        let resp = send_with_transport_retry(
+            self.client
+                .post(&self.api_url)
+                .header("content-type", "application/json")
+                .json(&body),
+            "ollama",
+            None,
+            TRANSPORT_BACKOFFS,
+        )
+        .await?;
 
         let status = resp.status();
         let json: serde_json::Value = resp.json().await.map_err(|e| AiError::Provider {
@@ -1189,18 +1267,17 @@ impl OpenAiBackend {
         // endpoints this backend serves (OpenAI, DeepSeek) support it.
         body["stream_options"] = serde_json::json!({"include_usage": true});
 
-        let resp = self
-            .client
-            .post(&self.api_url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| AiError::Provider {
-                provider: self.label.clone(),
-                message: mask_secret(&e.to_string(), &self.api_key),
-            })?;
+        let resp = send_with_transport_retry(
+            self.client
+                .post(&self.api_url)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("content-type", "application/json")
+                .json(&body),
+            &self.label,
+            Some(&self.api_key),
+            TRANSPORT_BACKOFFS,
+        )
+        .await?;
 
         let status = resp.status();
         let retry_after = retry_after_header(resp.headers());
@@ -1578,12 +1655,80 @@ mod tests {
     #[test]
     fn timeout_env_override_parses_strictly() {
         // Same contract as the max_tokens override: clean positive integers
-        // only, 120s fallback.
-        assert_eq!(parse_timeout_secs(Some("300")), 300);
+        // only, 300s fallback (a measured thinking round ran 145s).
+        assert_eq!(parse_timeout_secs(Some("600")), 600);
         assert_eq!(parse_timeout_secs(Some(" 90 ")), 90);
-        assert_eq!(parse_timeout_secs(Some("0")), 120);
-        assert_eq!(parse_timeout_secs(Some("x")), 120);
-        assert_eq!(parse_timeout_secs(None), 120);
+        assert_eq!(parse_timeout_secs(Some("0")), 300);
+        assert_eq!(parse_timeout_secs(Some("x")), 300);
+        assert_eq!(parse_timeout_secs(None), 300);
+    }
+
+    #[tokio::test]
+    async fn transport_retry_exhausts_connection_failures_into_retry_exhausted() {
+        // Connection-refused is the benchmark's observed transport flake
+        // class: the send path must retry through the backoff budget and
+        // then report the total attempt count, not a bare provider error.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // nothing listens now — connects are refused
+
+        let client = reqwest::Client::new();
+        let request = client
+            .post(format!("http://127.0.0.1:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"x":1}"#);
+
+        let backoffs = [std::time::Duration::from_millis(1)];
+        let err = send_with_transport_retry(request, "test", None, &backoffs)
+            .await
+            .unwrap_err();
+
+        match err {
+            AiError::RetryExhausted { attempts, message } => {
+                assert_eq!(attempts, backoffs.len() as u32 + 1);
+                assert!(
+                    message.contains("error sending request"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected RetryExhausted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn transport_retry_skips_timeouts() {
+        // A timed-out request would deterministically re-timeout on retry —
+        // the remedy is the documented OXO_FLOW_AI_TIMEOUT_SECS knob — so a
+        // timeout must surface as-is instead of burning the retry budget.
+        // (reqwest classifies timeouts under is_request(), the same kind as
+        // the transient "error sending request" — the exclusion guard is
+        // what keeps them apart.)
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            // Accept and hold the connection open without ever responding.
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(std::time::Duration::from_secs(5));
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let request = client
+            .post(format!("http://127.0.0.1:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"x":1}"#);
+
+        let backoffs = [std::time::Duration::from_millis(1)];
+        let err = send_with_transport_retry(request, "test", None, &backoffs)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AiError::Provider { .. }),
+            "timeouts must not be retried, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -123,6 +123,11 @@ where
     enum StepFailure {
         NonReplayable,
         Transport(reqwest::Error),
+        /// A decode failure on a non-2xx response: the status carries
+        /// provider semantics (429 back-off, auth), so the request must
+        /// not be replayed — surface the status instead of masking it as
+        /// a flaky parse.
+        HttpErrorBody(reqwest::StatusCode, reqwest::Error),
     }
 
     let mask = |message: String| match secret {
@@ -152,7 +157,15 @@ where
                 .map_err(StepFailure::Transport)?;
             let status = response.status();
             let headers = response.headers().clone();
-            let decoded = decode(response).await.map_err(StepFailure::Transport)?;
+            let decoded = decode(response).await.map_err(|e| {
+                if status.is_success() {
+                    // Garbled success body — the flaky-proxy case retrying
+                    // refetches.
+                    StepFailure::Transport(e)
+                } else {
+                    StepFailure::HttpErrorBody(status, e)
+                }
+            })?;
             Ok((status, headers, decoded))
         }
         .await;
@@ -168,6 +181,12 @@ where
                 return Err(AiError::Provider {
                     provider: provider.into(),
                     message: mask(describe(e)),
+                });
+            }
+            Err(StepFailure::HttpErrorBody(status, e)) => {
+                return Err(AiError::Provider {
+                    provider: provider.into(),
+                    message: mask(format!("HTTP {status} — {}", describe(e))),
                 });
             }
             Err(StepFailure::Transport(e)) if attempt >= backoffs.len() => {
@@ -1838,6 +1857,60 @@ mod tests {
                 );
             }
             other => panic!("expected RetryExhausted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_status_with_undecodable_body_is_never_retried() {
+        // A 429 (or 401) answering with an empty/HTML body fails .json()
+        // with a decode error — but the status carries provider semantics,
+        // so the request must not be replayed against the rate-limited
+        // endpoint, and the surfaced message must name the real status
+        // instead of masking it as a flaky parse.
+        use std::io::{Read, Write};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hits_for_server = hits.clone();
+        std::thread::spawn(move || {
+            let response = "HTTP/1.1 429 Too Many Requests\r\ncontent-type: text/html\r\ncontent-length: 5\r\nconnection: close\r\n\r\noops!";
+            if let Ok((mut stream, _)) = listener.accept() {
+                hits_for_server.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let request = client
+            .post(format!("http://127.0.0.1:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"x":1}"#);
+
+        let backoffs = [std::time::Duration::from_millis(1)];
+        let err = send_with_retry(request, "test", None, &backoffs, |resp| {
+            resp.json::<serde_json::Value>()
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "the 429 must not be replayed"
+        );
+        match err {
+            AiError::Provider { message, .. } => {
+                assert!(
+                    message.contains("HTTP 429 Too Many Requests"),
+                    "the real status must surface, got: {message}"
+                );
+            }
+            other => panic!("expected Provider error, got {other:?}"),
         }
     }
 

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -610,11 +610,13 @@ fn to_anthropic_messages(messages: &[Message]) -> (String, Vec<serde_json::Value
 
 /// Output-token ceiling for the Anthropic Messages backend.
 ///
-/// Defaults to 4096 but is overridable via `OXO_FLOW_AI_MAX_TOKENS`.
-/// Thinking-style backends (e.g. DeepSeek served behind an
+/// Defaults to 16384 but is overridable via `OXO_FLOW_AI_MAX_TOKENS`.
+/// Thinking-style backends (e.g. DeepSeek or GLM served behind an
 /// Anthropic-compatible endpoint) emit `thinking` blocks whose tokens count
-/// against `max_tokens`; a hard 4096 there truncates the answer before any
-/// text is produced, so pipeline generation silently loses its TOML.
+/// against `max_tokens`; the old hard 4096 there was consumed by reasoning
+/// before any text was produced (GLM returned empty content on every round),
+/// so pipeline generation silently lost its TOML. 16384 clears the thinking
+/// budget with room for the TOML (model-axis calibration, 5/5 archetypes).
 fn max_tokens_from_env() -> u32 {
     parse_max_tokens(std::env::var("OXO_FLOW_AI_MAX_TOKENS").ok().as_deref())
 }
@@ -623,7 +625,7 @@ fn parse_max_tokens(value: Option<&str>) -> u32 {
     value
         .and_then(|v| v.trim().parse::<u32>().ok())
         .filter(|n| *n > 0)
-        .unwrap_or(4096)
+        .unwrap_or(16384)
 }
 
 fn parse_claude_response(json: &serde_json::Value) -> Result<AiResponse, AiError> {
@@ -1559,16 +1561,18 @@ mod tests {
 
     #[test]
     fn max_tokens_env_override_parses_strictly() {
-        // Thinking backends burn the hardcoded 4096 on reasoning blocks and
-        // truncate before the answer; the env override must accept only
-        // clean positive integers and otherwise fall back to 4096.
+        // Thinking backends burn the default budget on reasoning blocks and
+        // truncate before the answer (GLM produced empty text at 4096); the
+        // default is calibrated above that ceiling (16384) and the env
+        // override must accept only clean positive integers, otherwise
+        // falling back to that default.
         assert_eq!(parse_max_tokens(Some("16384")), 16384);
         assert_eq!(parse_max_tokens(Some(" 8192 ")), 8192);
-        assert_eq!(parse_max_tokens(Some("0")), 4096);
-        assert_eq!(parse_max_tokens(Some("-1")), 4096);
-        assert_eq!(parse_max_tokens(Some("abc")), 4096);
-        assert_eq!(parse_max_tokens(Some("")), 4096);
-        assert_eq!(parse_max_tokens(None), 4096);
+        assert_eq!(parse_max_tokens(Some("0")), 16384);
+        assert_eq!(parse_max_tokens(Some("-1")), 16384);
+        assert_eq!(parse_max_tokens(Some("abc")), 16384);
+        assert_eq!(parse_max_tokens(Some("")), 16384);
+        assert_eq!(parse_max_tokens(None), 16384);
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/provider.rs
+++ b/crates/oxo-flow-ai/src/provider.rs
@@ -92,57 +92,91 @@ const TRANSPORT_BACKOFFS: &[std::time::Duration] = &[
 
 /// Whether a [`reqwest::Error`] is a transient transport failure worth
 /// retrying: connection setup/reset and mid-transfer failures ("error
-/// sending request" was the observed benchmark flake). Timeouts are
-/// deliberately excluded — the request timeout has its own documented knob
-/// (`OXO_FLOW_AI_TIMEOUT_SECS`), and a retry would deterministically
-/// re-timeout against the same slow completion.
+/// sending request" was the observed benchmark flake), plus response
+/// bodies that fail to decode ("error decoding response body" — a
+/// truncated or garbled body from a flaky proxy; retrying refetches it).
+/// Timeouts are deliberately excluded — the request timeout has its own
+/// documented knob (`OXO_FLOW_AI_TIMEOUT_SECS`), and a retry would
+/// deterministically re-timeout against the same slow completion.
 fn is_transient_transport_error(e: &reqwest::Error) -> bool {
-    !e.is_timeout() && (e.is_connect() || e.is_request() || e.is_body())
+    !e.is_timeout() && (e.is_connect() || e.is_request() || e.is_body() || e.is_decode())
 }
 
-/// Send a prepared request, retrying transient transport failures
-/// (see [`is_transient_transport_error`]) with `backoffs` pauses between
-/// attempts. HTTP error statuses are *not* retried here — they carry
-/// provider semantics (429 back-off, auth, context overflow) that the
-/// caller classifies. When the transport stays broken after every retry,
-/// [`AiError::RetryExhausted`] reports the total attempt count.
-async fn send_with_transport_retry(
+/// Send a prepared request and hand the response to `decode` inside the
+/// retry scope, so a transient failure in either half — the send, or
+/// reading/decoding the body — replays the whole attempt with `backoffs`
+/// pauses between tries (see [`is_transient_transport_error`]). HTTP error
+/// statuses are *not* retried here — they carry provider semantics (429
+/// back-off, auth, context overflow) that the caller classifies from the
+/// returned status and body. When the transport stays broken after every
+/// retry, [`AiError::RetryExhausted`] reports the total attempt count.
+async fn send_with_retry<T, Fut>(
     request: reqwest::RequestBuilder,
     provider: &str,
     secret: Option<&str>,
     backoffs: &[std::time::Duration],
-) -> Result<reqwest::Response, AiError> {
+    decode: impl Fn(reqwest::Response) -> Fut,
+) -> Result<(reqwest::StatusCode, reqwest::header::HeaderMap, T), AiError>
+where
+    Fut: std::future::Future<Output = Result<T, reqwest::Error>>,
+{
+    enum StepFailure {
+        NonReplayable,
+        Transport(reqwest::Error),
+    }
+
     let mask = |message: String| match secret {
         Some(key) => mask_secret(&message, key),
         None => message,
     };
+    // Decode failures keep the callers' familiar "response parse failed"
+    // prefix; plain transport errors render as reqwest names them.
+    let describe = |e: reqwest::Error| {
+        if e.is_decode() {
+            format!("response parse failed: {e}")
+        } else {
+            e.to_string()
+        }
+    };
     let mut attempt = 0usize;
     loop {
-        // `.json()` buffers the body, so the builder is replayable; a
-        // non-clonable body would be a construction bug, not a runtime case.
-        let result = request
-            .try_clone()
-            .ok_or_else(|| AiError::Provider {
-                provider: provider.into(),
-                message: "request body is not replayable for retry".into(),
-            })?
-            .send()
-            .await;
+        // The decode closure buffers the body, so the builder is
+        // replayable; a non-clonable body would be a construction bug,
+        // not a runtime case.
+        let result = async {
+            let response = request
+                .try_clone()
+                .ok_or(StepFailure::NonReplayable)?
+                .send()
+                .await
+                .map_err(StepFailure::Transport)?;
+            let status = response.status();
+            let headers = response.headers().clone();
+            let decoded = decode(response).await.map_err(StepFailure::Transport)?;
+            Ok((status, headers, decoded))
+        }
+        .await;
         match result {
-            Ok(response) => return Ok(response),
-            Err(e) if !is_transient_transport_error(&e) => {
+            Ok(decoded) => return Ok(decoded),
+            Err(StepFailure::NonReplayable) => {
                 return Err(AiError::Provider {
                     provider: provider.into(),
-                    message: mask(e.to_string()),
+                    message: "request body is not replayable for retry".into(),
                 });
             }
-            Err(e) if attempt >= backoffs.len() => {
+            Err(StepFailure::Transport(e)) if !is_transient_transport_error(&e) => {
+                return Err(AiError::Provider {
+                    provider: provider.into(),
+                    message: mask(describe(e)),
+                });
+            }
+            Err(StepFailure::Transport(e)) if attempt >= backoffs.len() => {
                 return Err(AiError::RetryExhausted {
                     attempts: attempt as u32 + 1,
-                    message: mask(e.to_string()),
+                    message: mask(describe(e)),
                 });
             }
-            Err(e) => {
+            Err(StepFailure::Transport(e)) => {
                 let backoff = backoffs[attempt];
                 tracing::warn!(
                     provider,
@@ -554,7 +588,7 @@ impl ClaudeBackend {
     ) -> Result<AiResponse, AiError> {
         let body = self.build_body(messages, tools);
 
-        let resp = send_with_transport_retry(
+        let (status, headers, json) = send_with_retry(
             self.client
                 .post(&self.api_url)
                 .header("x-api-key", &self.api_key)
@@ -564,15 +598,10 @@ impl ClaudeBackend {
             "claude",
             Some(&self.api_key),
             TRANSPORT_BACKOFFS,
+            |resp| resp.json::<serde_json::Value>(),
         )
         .await?;
-
-        let status = resp.status();
-        let retry_after = retry_after_header(resp.headers());
-        let json: serde_json::Value = resp.json().await.map_err(|e| AiError::Provider {
-            provider: "claude".into(),
-            message: mask_secret(&format!("response parse failed: {e}"), &self.api_key),
-        })?;
+        let retry_after = retry_after_header(&headers);
 
         if !status.is_success() {
             let err_msg = json["error"]["message"].as_str().unwrap_or("unknown error");
@@ -889,7 +918,7 @@ impl OpenAiBackend {
     ) -> Result<AiResponse, AiError> {
         let body = self.build_body(messages, tools);
 
-        let resp = send_with_transport_retry(
+        let (status, headers, json) = send_with_retry(
             self.client
                 .post(&self.api_url)
                 .header("Authorization", format!("Bearer {}", self.api_key))
@@ -898,15 +927,10 @@ impl OpenAiBackend {
             &self.label,
             Some(&self.api_key),
             TRANSPORT_BACKOFFS,
+            |resp| resp.json::<serde_json::Value>(),
         )
         .await?;
-
-        let status = resp.status();
-        let retry_after = retry_after_header(resp.headers());
-        let json: serde_json::Value = resp.json().await.map_err(|e| AiError::Provider {
-            provider: self.label.clone(),
-            message: mask_secret(&format!("response parse failed: {e}"), &self.api_key),
-        })?;
+        let retry_after = retry_after_header(&headers);
 
         if !status.is_success() {
             let err_msg = json["error"]["message"].as_str().unwrap_or("unknown error");
@@ -1053,7 +1077,7 @@ impl OllamaBackend {
     ) -> Result<AiResponse, AiError> {
         let body = build_ollama_body(messages, tools, &self.model, self.temperature);
 
-        let resp = send_with_transport_retry(
+        let (status, _headers, json) = send_with_retry(
             self.client
                 .post(&self.api_url)
                 .header("content-type", "application/json")
@@ -1061,14 +1085,9 @@ impl OllamaBackend {
             "ollama",
             None,
             TRANSPORT_BACKOFFS,
+            |resp| resp.json::<serde_json::Value>(),
         )
         .await?;
-
-        let status = resp.status();
-        let json: serde_json::Value = resp.json().await.map_err(|e| AiError::Provider {
-            provider: "ollama".into(),
-            message: format!("response parse failed: {e}"),
-        })?;
 
         if !status.is_success() {
             return Err(AiError::Provider {
@@ -1267,7 +1286,9 @@ impl OpenAiBackend {
         // endpoints this backend serves (OpenAI, DeepSeek) support it.
         body["stream_options"] = serde_json::json!({"include_usage": true});
 
-        let resp = send_with_transport_retry(
+        // Streaming keeps the raw response: the body is consumed
+        // incrementally below, so only the send half is replayable.
+        let (status, headers, resp) = send_with_retry(
             self.client
                 .post(&self.api_url)
                 .header("Authorization", format!("Bearer {}", self.api_key))
@@ -1276,11 +1297,10 @@ impl OpenAiBackend {
             &self.label,
             Some(&self.api_key),
             TRANSPORT_BACKOFFS,
+            |resp| async move { Ok::<_, reqwest::Error>(resp) },
         )
         .await?;
-
-        let status = resp.status();
-        let retry_after = retry_after_header(resp.headers());
+        let retry_after = retry_after_header(&headers);
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
             let err_msg = serde_json::from_str::<serde_json::Value>(&text)
@@ -1679,9 +1699,13 @@ mod tests {
             .body(r#"{"x":1}"#);
 
         let backoffs = [std::time::Duration::from_millis(1)];
-        let err = send_with_transport_retry(request, "test", None, &backoffs)
-            .await
-            .unwrap_err();
+        // Pass-through decode, as the streaming site uses: only the send
+        // half is under test here.
+        let err = send_with_retry(request, "test", None, &backoffs, |resp| async move {
+            Ok::<_, reqwest::Error>(resp)
+        })
+        .await
+        .unwrap_err();
 
         match err {
             AiError::RetryExhausted { attempts, message } => {
@@ -1721,14 +1745,100 @@ mod tests {
             .body(r#"{"x":1}"#);
 
         let backoffs = [std::time::Duration::from_millis(1)];
-        let err = send_with_transport_retry(request, "test", None, &backoffs)
-            .await
-            .unwrap_err();
+        let err = send_with_retry(request, "test", None, &backoffs, |resp| async move {
+            Ok::<_, reqwest::Error>(resp)
+        })
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(err, AiError::Provider { .. }),
             "timeouts must not be retried, got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn transport_retry_replays_garbled_response_bodies() {
+        // The wave-F2 benchmark failure: a 200 whose body fails to decode
+        // ("error decoding response body" — a truncated/garbled response
+        // from a flaky proxy). The retry scope covers the decode, so the
+        // request is refetched instead of surfacing the parse failure.
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            let responses = [
+                // Headers claim JSON; the body is not decodable as JSON.
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 8\r\nconnection: close\r\n\r\nnot-json",
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}",
+            ];
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf); // drain the request head
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let request = client
+            .post(format!("http://127.0.0.1:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"x":1}"#);
+
+        let backoffs = [std::time::Duration::from_millis(1)];
+        let (status, _, json) = send_with_retry(request, "test", None, &backoffs, |resp| {
+            resp.json::<serde_json::Value>()
+        })
+        .await
+        .unwrap();
+
+        assert!(status.is_success());
+        assert_eq!(json, serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn transport_retry_exhausts_garbled_bodies_with_parse_prefix() {
+        // Deterministic garbage must not loop forever: after the backoff
+        // budget the decode failure surfaces as RetryExhausted, keeping the
+        // "response parse failed" prefix the session archival path reports.
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            let response = "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 8\r\nconnection: close\r\n\r\nnot-json";
+            while let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let request = client
+            .post(format!("http://127.0.0.1:{port}/v1/messages"))
+            .header("content-type", "application/json")
+            .body(r#"{"x":1}"#);
+
+        let backoffs = [std::time::Duration::from_millis(1)];
+        let err = send_with_retry(request, "test", None, &backoffs, |resp| {
+            resp.json::<serde_json::Value>()
+        })
+        .await
+        .unwrap_err();
+
+        match err {
+            AiError::RetryExhausted { attempts, message } => {
+                assert_eq!(attempts, backoffs.len() as u32 + 1);
+                assert!(
+                    message.contains("response parse failed"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected RetryExhausted, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/tools/builtin.rs
+++ b/crates/oxo-flow-ai/src/tools/builtin.rs
@@ -511,7 +511,10 @@ mod tests {
         // the description never said http/https-only and never said that
         // embedded knowledge comes from lookup_skill instead.
         let desc = tool.def().description;
-        assert!(desc.contains("http"), "description must name the scheme constraint: {desc}");
+        assert!(
+            desc.contains("http"),
+            "description must name the scheme constraint: {desc}"
+        );
         assert!(
             desc.to_lowercase().contains("lookup_skill"),
             "description must point at lookup_skill for embedded knowledge: {desc}"

--- a/crates/oxo-flow-ai/src/tools/builtin.rs
+++ b/crates/oxo-flow-ai/src/tools/builtin.rs
@@ -198,6 +198,20 @@ async fn validate_public_url(raw: &str) -> Result<ScreenedTarget, String> {
     })
 }
 
+/// Classify a final response status. Non-success statuses become a steering
+/// error: the model would otherwise stream 404 or bot-block HTML back to
+/// itself as "documentation" and burn rounds chasing it, while the knowledge
+/// it was hunting (tool/skill docs) is embedded behind lookup_tool/lookup_skill.
+/// `None` means the body is real content and should stream.
+fn status_failure(status: reqwest::StatusCode) -> Option<String> {
+    if status.is_success() {
+        return None;
+    }
+    Some(format!(
+        "HTTP {status} — the page returned no content; for embedded knowledge (tool docs, skills) use lookup_tool or lookup_skill instead of fetch_url"
+    ))
+}
+
 /// GET with manual redirects (max 5 hops), re-running the SSRF screen on
 /// every Location target. DNS-resolved hops are sent through a pinned
 /// client, so each request reaches the address that was just screened.
@@ -343,6 +357,12 @@ impl Tool for FetchUrlTool {
                     tool: "fetch_url".into(),
                     message: format!("blocked: {reason}"),
                 })?;
+        if let Some(reason) = status_failure(response.status()) {
+            return Err(AiError::ToolError {
+                tool: "fetch_url".into(),
+                message: format!("blocked: {reason}"),
+            });
+        }
 
         let mut body = CappedBody::new();
         let mut stream = response.bytes_stream();
@@ -1040,5 +1060,60 @@ mod fetch_url_ssrf_tests {
             .err()
             .unwrap();
         assert!(err.contains("scheme"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod fetch_url_status_tests {
+    use super::*;
+
+    #[test]
+    fn client_and_server_errors_are_steering_errors_not_content() {
+        // Live agents burned ~7 fetch_url rounds feeding 404 and
+        // Cloudflare-block HTML back to themselves as if it were real
+        // documentation; every non-success status must surface as a tool
+        // error that steers back to embedded knowledge instead.
+        for code in [400, 401, 403, 404, 410, 429, 500, 502, 503] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            let reason = status_failure(status)
+                .unwrap_or_else(|| panic!("HTTP {code} must be a tool error"));
+            assert!(
+                reason.contains(&code.to_string()),
+                "must name the status: {reason}"
+            );
+            assert!(
+                reason.contains("no content"),
+                "must say nothing was returned: {reason}"
+            );
+            assert!(
+                reason.contains("lookup_skill"),
+                "must steer to embedded knowledge: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn success_statuses_stream_their_body() {
+        for code in [200, 201, 204, 206] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert!(
+                status_failure(status).is_none(),
+                "HTTP {code} bodies are content and must stream"
+            );
+        }
+    }
+
+    #[test]
+    fn knowledge_chasing_statuses_name_both_lookup_tools() {
+        // The live dead-end pattern: hunting tool/skill docs that only exist
+        // in the embedded libraries — name both lookup tools in the steer.
+        for code in [403, 404, 429] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            let reason = status_failure(status).unwrap();
+            assert!(
+                reason.contains("lookup_tool"),
+                "must mention lookup_tool as well: {reason}"
+            );
+        }
     }
 }

--- a/crates/oxo-flow-ai/src/tools/builtin.rs
+++ b/crates/oxo-flow-ai/src/tools/builtin.rs
@@ -149,7 +149,7 @@ async fn validate_public_url(raw: &str) -> Result<ScreenedTarget, String> {
     let url = reqwest::Url::parse(raw).map_err(|e| format!("unparseable URL: {e}"))?;
     if !matches!(url.scheme(), "http" | "https") {
         return Err(format!(
-            "scheme {:?} not allowed (http/https only)",
+            "scheme {:?} not allowed (http/https only) — embedded knowledge lives behind lookup_skill, not fetch_url",
             url.scheme()
         ));
     }
@@ -306,7 +306,7 @@ impl Tool for FetchUrlTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "fetch_url".into(),
-            description: "Fetch content from a URL. Use this to retrieve protocol documentation, tool references, or other web resources. Returns the text content of the page.".into(),
+            description: "Fetch content from a public http or https URL. Use this to retrieve protocol documentation, tool references, or other web resources; returns the text content of the page. Only http/https URLs are allowed — never invent other schemes. For embedded knowledge (skills, tool docs) use lookup_skill instead of this tool.".into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -506,6 +506,16 @@ mod tests {
     fn fetch_url_tool_has_correct_def() {
         let tool = FetchUrlTool::new();
         assert_eq!(tool.name(), "fetch_url");
+        // Models invent schemes when the constraint is unstated: a run
+        // burned two rounds calling this tool with `skill://...` because
+        // the description never said http/https-only and never said that
+        // embedded knowledge comes from lookup_skill instead.
+        let desc = tool.def().description;
+        assert!(desc.contains("http"), "description must name the scheme constraint: {desc}");
+        assert!(
+            desc.to_lowercase().contains("lookup_skill"),
+            "description must point at lookup_skill for embedded knowledge: {desc}"
+        );
     }
 
     #[test]

--- a/crates/oxo-flow-ai/src/tools/builtin.rs
+++ b/crates/oxo-flow-ai/src/tools/builtin.rs
@@ -24,7 +24,7 @@ impl Tool for ReadFileTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "read_file".into(),
-            description: "Read the contents of a local file. Use this to get information from user-provided reference files or existing workflow configurations.".into(),
+            description: "Read the contents of a local file. Use this to get information from user-provided reference files or existing workflow configurations. Embedded skills and tool docs are not on disk — get them with lookup_skill/lookup_tool instead of reading files.".into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -56,7 +56,9 @@ impl Tool for ReadFileTool {
 
         let content = std::fs::read_to_string(path).map_err(|e| AiError::ToolError {
             tool: "read_file".into(),
-            message: format!("cannot read '{path}': {e}"),
+            message: format!(
+                "cannot read '{path}': {e} — embedded skills and tool docs are not files on disk; get them with lookup_skill and lookup_tool instead of read_file"
+            ),
         })?;
 
         Ok(content)
@@ -523,6 +525,18 @@ mod tests {
     }
 
     #[test]
+    fn read_file_tool_description_points_to_lookup_skill() {
+        // Live germline-gatk runs invented /root/.bioos/.../SKILL.md paths
+        // because skills are described as SKILL.md-standard files; the
+        // description must say up front that embedded skills are not on disk.
+        let desc = ReadFileTool::new().def().description;
+        assert!(
+            desc.contains("lookup_skill"),
+            "description must point at lookup_skill for embedded skills: {desc}"
+        );
+    }
+
+    #[test]
     fn fetch_url_tool_has_correct_def() {
         let tool = FetchUrlTool::new();
         assert_eq!(tool.name(), "fetch_url");
@@ -562,10 +576,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_file_tool_errors_on_missing_file() {
+    async fn read_file_error_on_missing_file_steers_to_embedded_knowledge() {
+        // Live germline-gatk runs retried the same hallucinated path 4×
+        // because the bare os error offered no alternative; the error must
+        // point embedded-knowledge seekers at lookup_skill/lookup_tool.
         let tool = ReadFileTool::new();
-        let result = tool.execute(r#"{"path": "/nonexistent/file.txt"}"#).await;
-        assert!(result.is_err());
+        let err = tool
+            .execute(
+                r#"{"path": "/root/.bioos/skills/variant-calling/bio-gatk-variant-calling/SKILL.md"}"#,
+            )
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot read"),
+            "path context must be preserved: {msg}"
+        );
+        assert!(
+            msg.contains("lookup_skill") || msg.contains("lookup_tool"),
+            "cannot-read error must steer to embedded knowledge tools: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/oxo-flow-cli/src/commands/ai_explain.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_explain.rs
@@ -226,9 +226,10 @@ fn match_tools(shell: &str) -> Vec<String> {
 
 /// Match embedded bioSkills records for one rule.
 ///
-/// `search_skills` matches the whole query as a substring, so each token
-/// (rule name, tool names) is queried separately; results are deduplicated
-/// and capped to keep the prompt bounded.
+/// Each rule name and tool name is queried separately so results carry
+/// per-tool attribution; results are deduplicated and capped to keep the
+/// prompt bounded. (`search_skills` also tokenizes multi-word queries
+/// internally, so a multi-token rule name still matches.)
 const MAX_SKILLS_PER_RULE: usize = 3;
 
 fn match_skills(rule_name: &str, tools: &[String]) -> Vec<SkillRef> {

--- a/crates/oxo-flow-cli/src/commands/ai_template.rs
+++ b/crates/oxo-flow-cli/src/commands/ai_template.rs
@@ -367,6 +367,12 @@ pub async fn generate_workflow(
         if let AgentEvent::Text(ref chunk) = e
             && let Ok(mut buf) = sink_buf.lock()
         {
+            // Rounds concatenate: keep each round's text on its own line so
+            // the line-anchored fence scan cannot glue one round's trailing
+            // prose to the next round's opening ```toml fence.
+            if !buf.is_empty() && !buf.ends_with('\n') {
+                buf.push('\n');
+            }
             buf.push_str(chunk);
         }
         match e {

--- a/crates/oxo-flow-web/src/domains/ai/service.rs
+++ b/crates/oxo-flow-web/src/domains/ai/service.rs
@@ -529,7 +529,9 @@ mod tests {
 
     #[test]
     fn test_extract_toml_raw_workflow() {
-        let response = "[workflow]\nname = \"test\"\n[[rules]]\nname = \"step1\"";
+        // Raw fallback requires the structural floor (workflow + rules +
+        // shell), so the fixture carries a shell field.
+        let response = "[workflow]\nname = \"test\"\n[[rules]]\nname = \"step1\"\nshell = \"echo\"";
         let result = oxo_flow_ai::agent::pipeline_gen::extract_toml(response);
         assert!(result.is_some());
         assert!(result.unwrap().contains("[workflow]"));

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -186,7 +186,7 @@ in the repository (see also
 
 | Variable | Default | When to change |
 |---|---|---|
-| `OXO_FLOW_AI_MAX_TOKENS` | `16384` | Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint): reasoning blocks spend against this ceiling, and the old 4096 default was consumed before any TOML was produced. Non-thinking models keep ≥3× headroom (measured: 1.9k–4.4k output tokens per generation) |
+| `OXO_FLOW_AI_MAX_TOKENS` | `16384` | Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint): reasoning blocks spend against this ceiling, and the old 4096 default was consumed before any TOML was produced. Non-thinking models keep ≥3× headroom (measured: 1.9k–4.4k output tokens per generation). Older first-party `claude-3-*` models cap `max_tokens` at 4096–8192 server-side — lower the knob when targeting them on the real api.anthropic.com |
 | `OXO_FLOW_AI_TIMEOUT_SECS` | `300` | Non-thinking generations complete in 12–20 s; a single thinking round routinely runs past two minutes (a measured GLM round took 145 s, so the old 120 s default killed mid-round) — raise further for slower endpoints, together with `OXO_FLOW_AI_MAX_TOKENS` |
 
 Both are consumed by the Anthropic Messages backend; the DeepSeek-native,

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -140,7 +140,21 @@ loop. The steps:
 - If the budget runs out after a pipeline was drafted, the command
   **degrades instead of discarding**: the generated TOML is extracted
   from the transcript and written with a prominent review warning —
-  a paid-for artifact is never silently lost.
+  a paid-for artifact is never silently lost. Degraded delivery never
+  writes structurally broken TOML. Extraction scans the transcript's
+  toml-fenced drafts latest-first (correction rounds accumulate, and the
+  last complete draft is the model's final word); a fenced candidate is
+  accepted only when it parses as TOML and passes the structural floor
+  (a `[workflow]` table plus every rule carrying a `shell`). A draft the
+  model corrected by opening a fresh fence — without closing the stale
+  one — cannot shadow the correction: the stray fence line closes the
+  dangling draft and reopens. When no complete draft exists, a
+  parseable-but-incomplete fenced fragment is kept as a best-effort
+  fallback (still delivered under the review warning). With no closed
+  fence at all (budget expired mid-block), the raw fallback from the
+  first `[workflow]` line likewise only accepts a prefix that parses and
+  passes the floor — an unterminated draft fails extraction, the
+  artifact is not written, and the error explains why.
 - Provider failures (auth, quota, network) fail fast with the error.
 
 ### Scientist Team profile (opt-in)

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -129,7 +129,13 @@ loop. The steps:
   correction-round budget (default from `[ai]` config, 10 when unset —
   knowledge lookups and the correction pass share the budget, exploration-
   heavy models spend 7–10 rounds before drafting, and the loop stops as
-  soon as a draft validates).
+  soon as a draft validates). When the first half of that budget burns on
+  consecutive rounds whose assistant turns were pure tool calls (zero
+  prose), the orchestrator nudges once: a warning rides the next tool
+  result telling the model to consolidate what it has found and start
+  producing the deliverable — measured on thinking-style backends whose
+  draws otherwise spent every round on lookups and hit the cap with
+  nothing written.
 - `--ai-attempts N` is the fresh-draw budget **across** generations
   (pass@k with early exit): every attempt starts from a new draw, the
   deterministic gates decide, and later attempts are only paid when

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -156,6 +156,12 @@ loop. The steps:
   passes the floor — an unterminated draft fails extraction, the
   artifact is not written, and the error explains why.
 - Provider failures (auth, quota, network) fail fast with the error.
+  One carve-out: a transient transport failure (dropped connection,
+  mid-transfer reset — the classic flake where one request out of a
+  healthy session dies) is retried twice with a short backoff before
+  surfacing, since retrying is what a user would do. Timeouts are not
+  retried — they have their own knob (`OXO_FLOW_AI_TIMEOUT_SECS`) and a
+  retry would deterministically re-timeout.
 
 ### Scientist Team profile (opt-in)
 
@@ -174,7 +180,7 @@ in the repository (see also
 | Variable | Default | When to change |
 |---|---|---|
 | `OXO_FLOW_AI_MAX_TOKENS` | `16384` | Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint): reasoning blocks spend against this ceiling, and the old 4096 default was consumed before any TOML was produced. Non-thinking models keep ≥3× headroom (measured: 1.9k–4.4k output tokens per generation) |
-| `OXO_FLOW_AI_TIMEOUT_SECS` | `120` | Non-thinking generations complete in 12–20 s; thinking backends can exceed two minutes per call — raise together with `OXO_FLOW_AI_MAX_TOKENS`, or long completions die mid-body |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | `300` | Non-thinking generations complete in 12–20 s; a single thinking round routinely runs past two minutes (a measured GLM round took 145 s, so the old 120 s default killed mid-round) — raise further for slower endpoints, together with `OXO_FLOW_AI_MAX_TOKENS` |
 
 Both are consumed by the Anthropic Messages backend; the DeepSeek-native,
 OpenAI-compatible, and Ollama backends have their own budgets.

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -126,9 +126,10 @@ loop. The steps:
 ### Correction budget and failure behavior
 
 - `--ai-max-retries N` sizes the orchestrator's combined tool +
-  correction-round budget (default from `[ai]` config, 6 when unset —
-  knowledge lookups and the correction pass share the budget, and the
-  loop stops as soon as a draft validates).
+  correction-round budget (default from `[ai]` config, 10 when unset —
+  knowledge lookups and the correction pass share the budget, exploration-
+  heavy models spend 7–10 rounds before drafting, and the loop stops as
+  soon as a draft validates).
 - `--ai-attempts N` is the fresh-draw budget **across** generations
   (pass@k with early exit): every attempt starts from a new draw, the
   deterministic gates decide, and later attempts are only paid when
@@ -158,7 +159,7 @@ in the repository (see also
 
 | Variable | Default | When to change |
 |---|---|---|
-| `OXO_FLOW_AI_MAX_TOKENS` | `4096` | Thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible endpoint) spend reasoning tokens against this ceiling and truncate before producing TOML — raise to 16384+ there. For non-thinking models the default holds with ≥3× headroom (measured: 1.9k–4.4k output tokens per generation) |
+| `OXO_FLOW_AI_MAX_TOKENS` | `16384` | Calibrated for thinking-style backends (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint): reasoning blocks spend against this ceiling, and the old 4096 default was consumed before any TOML was produced. Non-thinking models keep ≥3× headroom (measured: 1.9k–4.4k output tokens per generation) |
 | `OXO_FLOW_AI_TIMEOUT_SECS` | `120` | Non-thinking generations complete in 12–20 s; thinking backends can exceed two minutes per call — raise together with `OXO_FLOW_AI_MAX_TOKENS`, or long completions die mid-body |
 
 Both are consumed by the Anthropic Messages backend; the DeepSeek-native,

--- a/docs/guide/src/commands/ai.md
+++ b/docs/guide/src/commands/ai.md
@@ -157,11 +157,12 @@ loop. The steps:
   artifact is not written, and the error explains why.
 - Provider failures (auth, quota, network) fail fast with the error.
   One carve-out: a transient transport failure (dropped connection,
-  mid-transfer reset — the classic flake where one request out of a
-  healthy session dies) is retried twice with a short backoff before
-  surfacing, since retrying is what a user would do. Timeouts are not
-  retried — they have their own knob (`OXO_FLOW_AI_TIMEOUT_SECS`) and a
-  retry would deterministically re-timeout.
+  mid-transfer reset, or a response body that fails to decode — the
+  classic flakes where one request out of a healthy session dies) is
+  retried twice with a short backoff before surfacing, since retrying
+  is what a user would do. Timeouts are not retried — they have their
+  own knob (`OXO_FLOW_AI_TIMEOUT_SECS`) and a retry would
+  deterministically re-timeout.
 
 ### Scientist Team profile (opt-in)
 

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -300,7 +300,7 @@ repository.
 | `OXO_FLOW_AI_API_KEY` | Generic API key (fallback for all providers) | — |
 | `OXO_FLOW_AI_API_URL` | Custom API endpoint URL | (provider default) |
 | `OXO_FLOW_AI_MODEL` | Model name override | (provider default) |
-| `OXO_FLOW_AI_MAX_TOKENS` | Output-token ceiling for the Anthropic Messages backend. Raise it for thinking-style backends whose reasoning blocks count against `max_tokens` (e.g. DeepSeek behind an Anthropic-compatible endpoint) — at the default, answers can truncate before any text is produced | `4096` |
+| `OXO_FLOW_AI_MAX_TOKENS` | Output-token ceiling for the Anthropic Messages backend. Calibrated for thinking-style backends whose reasoning blocks count against `max_tokens` (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint) — the old 4096 default truncated before any text was produced | `16384` |
 | `OXO_FLOW_AI_TIMEOUT_SECS` | Per-request timeout for AI provider calls. Raise together with `OXO_FLOW_AI_MAX_TOKENS` on thinking backends, or long completions die mid-body ("error decoding response body") | `120` |
 | `DEEPSEEK_API_KEY` | DeepSeek (OpenAI-compatible) | — |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek endpoint | `https://api.deepseek.com/v1/chat/completions` |

--- a/docs/guide/src/reference/ai-cli.md
+++ b/docs/guide/src/reference/ai-cli.md
@@ -301,7 +301,7 @@ repository.
 | `OXO_FLOW_AI_API_URL` | Custom API endpoint URL | (provider default) |
 | `OXO_FLOW_AI_MODEL` | Model name override | (provider default) |
 | `OXO_FLOW_AI_MAX_TOKENS` | Output-token ceiling for the Anthropic Messages backend. Calibrated for thinking-style backends whose reasoning blocks count against `max_tokens` (e.g. DeepSeek or GLM behind an Anthropic-compatible endpoint) — the old 4096 default truncated before any text was produced | `16384` |
-| `OXO_FLOW_AI_TIMEOUT_SECS` | Per-request timeout for AI provider calls. Raise together with `OXO_FLOW_AI_MAX_TOKENS` on thinking backends, or long completions die mid-body ("error decoding response body") | `120` |
+| `OXO_FLOW_AI_TIMEOUT_SECS` | Per-request timeout for AI provider calls. A measured GLM thinking round took 145 s — the old 120 s default killed it mid-round. Raise together with `OXO_FLOW_AI_MAX_TOKENS` on slower endpoints | `300` |
 | `DEEPSEEK_API_KEY` | DeepSeek (OpenAI-compatible) | — |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek endpoint | `https://api.deepseek.com/v1/chat/completions` |
 | `ANTHROPIC_AUTH_TOKEN` | Anthropic-compatible API key | — |

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -598,9 +598,19 @@ that emit reasoning blocks counting against the output budget):
 `OXO_FLOW_AI_MAX_TOKENS` (default 16384 — the old 4096 was consumed by
 reasoning blocks before any TOML; 16384 clears thinking with room for the
 draft) and
-`OXO_FLOW_AI_TIMEOUT_SECS` (default 120 — non-thinking generations run
-12–20 s; thinking backends exceed it). Quality/cost evidence for these
-calibrations and the unification itself lives in `eval/frontier/`
+`OXO_FLOW_AI_TIMEOUT_SECS` (default 300 — non-thinking generations run
+12–20 s, but a single thinking round routinely passes two minutes; a
+measured GLM round took 145 s, which the old 120 s default killed
+mid-round). Below the orchestrator, the
+provider backends retry transient transport failures (dropped or
+reset connections) twice with a short backoff before surfacing an
+error — timeouts are excluded, since a retry would deterministically
+re-timeout and the knob above is the remedy. When a provider error does
+abort a generation, the orchestrator archives the transcript and logged
+token spend into the saved session instead of dropping them — the
+rounds before the failure were real paid work, and the CLI's
+degraded-delivery path reads the generated TOML from that transcript. Quality/cost evidence for
+these calibrations and the unification itself lives in `eval/frontier/`
 (gate-scored benchmark: deterministic `validate`/`dry-run`/`lint`
 verdicts, no LLM judge).
 

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -603,9 +603,10 @@ draft) and
 measured GLM round took 145 s, which the old 120 s default killed
 mid-round). Below the orchestrator, the
 provider backends retry transient transport failures (dropped or
-reset connections) twice with a short backoff before surfacing an
-error — timeouts are excluded, since a retry would deterministically
-re-timeout and the knob above is the remedy. When a provider error does
+reset connections, response bodies that fail to decode) twice with a
+short backoff before surfacing an error — timeouts are excluded,
+since a retry would deterministically re-timeout and the knob above
+is the remedy. When a provider error does
 abort a generation, the orchestrator archives the transcript and logged
 token spend into the saved session instead of dropping them — the
 rounds before the failure were real paid work, and the CLI's

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -589,14 +589,15 @@ The surfaces differ only in adapter concerns:
 | Provider resolution | env / `ai_config.json` | per-user → server → env, with Claude/OpenAI/Ollama fallback chain | per-user → server → env |
 | Tools | full registry + MCP; non-read-only needs interactive approval | read-only knowledge registry only | knowledge registry + run-diagnosis tools |
 | Validator | core `WorkflowConfig` parse | workflow service `validate_pipeline` | same as translate |
-| Correction budget | `--ai-max-retries` (default 6) | 6 rounds | 6 rounds |
+| Correction budget | `--ai-max-retries` (default 10) | 10 rounds | 10 rounds |
 | Session destination | `~/.oxo-flow/ai_sessions/` archive | failure sessions archived by the shared orchestrator; every run's token usage in the operation log | chat messages in DB; token usage in the operation log |
 | Failure behavior | degrade: deliver the transcript's TOML with a warning | `AI_NOT_CONFIGURED` when no provider is usable; template-keyword fallback when providers fail | `AI_NOT_CONFIGURED` when no provider is usable; degraded delivery over SSE |
 
 Two provider-level ceilings matter for thinking-style backends (models
 that emit reasoning blocks counting against the output budget):
-`OXO_FLOW_AI_MAX_TOKENS` (default 4096 — calibrated for the
-non-thinking tier with ≥3× headroom; raise for thinking backends) and
+`OXO_FLOW_AI_MAX_TOKENS` (default 16384 — the old 4096 was consumed by
+reasoning blocks before any TOML; 16384 clears thinking with room for the
+draft) and
 `OXO_FLOW_AI_TIMEOUT_SECS` (default 120 — non-thinking generations run
 12–20 s; thinking backends exceed it). Quality/cost evidence for these
 calibrations and the unification itself lives in `eval/frontier/`

--- a/docs/guide/src/reference/architecture.md
+++ b/docs/guide/src/reference/architecture.md
@@ -591,7 +591,7 @@ The surfaces differ only in adapter concerns:
 | Validator | core `WorkflowConfig` parse | workflow service `validate_pipeline` | same as translate |
 | Correction budget | `--ai-max-retries` (default 10) | 10 rounds | 10 rounds |
 | Session destination | `~/.oxo-flow/ai_sessions/` archive | failure sessions archived by the shared orchestrator; every run's token usage in the operation log | chat messages in DB; token usage in the operation log |
-| Failure behavior | degrade: deliver the transcript's TOML with a warning | `AI_NOT_CONFIGURED` when no provider is usable; template-keyword fallback when providers fail | `AI_NOT_CONFIGURED` when no provider is usable; degraded delivery over SSE |
+| Failure behavior | degrade: deliver the transcript's TOML with a warning — extraction accepts only a fence segment (latest-first) or raw prefix that parses as TOML and passes the structural floor; a parseable-but-incomplete fence fragment is a best-effort fallback | `AI_NOT_CONFIGURED` when no provider is usable; template-keyword fallback when providers fail | `AI_NOT_CONFIGURED` when no provider is usable; degraded delivery over SSE |
 
 Two provider-level ceilings matter for thinking-style backends (models
 that emit reasoning blocks counting against the output budget):

--- a/docs/guide/src/reference/web-api.md
+++ b/docs/guide/src/reference/web-api.md
@@ -539,6 +539,13 @@ GET  /api/knowledge/tools       # Tool catalog the AI can call
 GET  /api/knowledge/skills      # Skill catalog the AI can follow
 ```
 
+Both knowledge endpoints accept `?q=<query>&limit=<1-50>` (default 20).
+`/api/knowledge/tools` treats an empty `q` as a browse: it returns the
+first `limit` Bioconda entries. `/api/knowledge/skills` tokenizes the
+query and ranks matches (rare terms first); an empty or unmatched `q`
+returns an empty `skills` array — `total` is always the full catalog
+size, not the hit count.
+
 The translate endpoints take `{ "intent": "<natural-language description>",
 "context": { "data_analysis_id": "<uuid>" } }` — `intent` is REQUIRED (sending
 only a `prompt` field fails deserialization); `context` is optional.

--- a/eval/frontier/README.md
+++ b/eval/frontier/README.md
@@ -51,9 +51,10 @@ well a profile standardizes ambiguous requests. Vague cells are reported
 on their own row and are never compared against the specified tiers.
 
 Thinking-style backends (e.g. DeepSeek behind an Anthropic-compatible
-endpoint) need a raised output budget: export
-`OXO_FLOW_AI_MAX_TOKENS=16384` or the loop truncates before the TOML is
-written (the default 4096 is consumed by reasoning blocks).
+endpoint) truncate before the TOML is written if the output budget is too
+small — reasoning blocks consume it. The default is 16384 (raised from the
+old 4096, which thinking backends consumed entirely); raise it further only
+for extreme reasoning lengths.
 
 Results land in `results/<stamp>/` (gitignored): one directory per run
 (generated workflow, gate JSON/stderr, CLI log, session snapshot), plus

--- a/eval/frontier/run_eval.py
+++ b/eval/frontier/run_eval.py
@@ -51,7 +51,10 @@ REPO = Path(__file__).resolve().parents[2]
 # USD per 1M tokens. Defaults mirror the repo's own cost constant
 # (crates/oxo-flow-ai/src/types.rs: deepseek-v4-pro 0.28 in / 1.10 out,
 # pricing as of 2026-08). Add per-model overrides here as needed.
+# GLM/Qwen: official z.ai / Alibaba DashScope list prices (2026-09).
 PRICE_PER_MTOK = {
+    "GLM": (0.60, 2.20),
+    "Qwen": (0.50, 2.00),
     "*": (0.28, 1.10),
 }
 


### PR DESCRIPTION
## Summary

Model-axis generalization campaign: make the shared generation harness work across thinking-style backends (DeepSeek / GLM / Qwen behind the csu-out Anthropic-compatible endpoint), then harden the degraded-delivery path that the Qwen failures exposed.

### Benchmark evidence (`eval/frontier/results/model-axis-csu3`, 29 intents)

| Model | Before | After | Cost/success |
|---|---|---|---|
| DeepSeek | 24/29 (83%) | unchanged (baseline) | $0.0133 |
| GLM | 0/29 — every run `exceeded max rounds (6)` | 5/5 on the failure prototypes after 027be5da | — |
| Qwen | 6/29 | 6/29 | ~15× DeepSeek |

Key finding: the ranking is **harness fit, not model capability**. GLM's 0/29 was pure resource starvation (4096 max_tokens eaten by thinking blocks + a 6-round budget consumed by exploration); Qwen's losses are transcript/extraction failures, not reasoning failures.

### Fix chain

- `295a37e8` — round-budget transcript archival (the 29/29 "missing messages" mystery: the archival commit postdated the benchmark runs)
- `027be5da` — **fixes ①②**: `parse_max_tokens` default 4096→16384, `default_max_retries()` 6→10 (single-source, merge-sentinel semantics pinned by tests)
- `e39171a9` — docs: q/limit query semantics for knowledge endpoints
- `fa316fad` — **fix ③**: `search_skills` rewritten with tokenization + IDF² ranking so multi-word `lookup_skill` queries hit; `951dcc88` resolves its three deferred MEDIUMs — partial matches now backfill the slots full matches leave open (instead of being dropped whenever any full match exists), queries are capped at 32 tokenized terms against pathological model lookup loops, and each skill's haystack is built once for both the document-frequency pass and the scoring loop
- `11a2888f` — **fix ④**: `fetch_url` non-2xx responses redirect to embedded knowledge tools (`status_failure` for every non-success code; 404/403/429 covered)
- `1a9d6525` — **fix ⑤**: `read_file` dead-ends steer to `lookup_skill`/`lookup_tool` (CLI registration surface verified: web chat never registers read_file, so the redirect text is accurate everywhere it can run)
- `14a5845d` — **fix ⑥**: degraded TOML delivery gated on parse + structural floor
- **fix ⑦**: transient transport failures — dropped/reset connections **and** response bodies that fail to decode — are retried in every provider backend (`fc52ff9d`, `b4ed14fa`); the request-timeout default is raised 120 s → 300 s for thinking rounds
- **fix ⑧**: a provider error aborting a generation now archives the paid transcript instead of dropping it (`bb4b64b7`)
- **fix ⑨**: an exploration-budget nudge fires once after half the round budget burns on consecutive zero-prose tool-only rounds (`2ad2a7b5`)
- **review wave**: an 10-angle adversarial review of the whole branch surfaced five more defects — now fixed in `e4606dc4` (429/401 bodies no longer replayed; status surfaced), `16bd5855` (extraction floor accepts engine-valid `script`/`transform` rules; raw salvage scans `[workflow]` anchors latest-first), `6986a440` (empty text blocks no longer echoed as 400-bait assistant turns; stacked directives no longer duplicated on the wire; narrated tool rounds no longer feed the exploration streak), `06562488` (degraded-delivery buffer keeps rounds on separate lines so line-anchored fences cannot mis-pair), and `77905265` (skill haystacks built once per process)

### Fix ⑥: degraded delivery can no longer write broken TOML

Root cause (Qwen hisat2): the model left its ` ```toml ` fence unclosed → fence-pairing found no block → `raw_workflow` salvaged everything from the first `[workflow]` line with **no parseability requirement** → a TOML with an unterminated shell string was written to disk as a "generated" workflow, failing validate/dry-run/lint afterwards.

The extraction ladder is now gated end-to-end:

1. **Fenced segments, latest-first** — a segment is accepted only when it parses as TOML **and** passes the structural floor (`[workflow]` + non-empty `[[rules]]` + a non-empty `shell` per rule). A parseable-but-incomplete fragment is kept as a best-effort fallback (still delivered only under the ⚠ review warning).
2. **Close-and-reopen fence semantics** — a tagged fence line closes the open segment and reopens, so a correction round that drafts into a fresh fence without closing the stale one can no longer be shadowed by the earlier draft.
3. **Raw fallback, same floor** — from the first `[workflow]` line, the longest line-prefix that parses and passes the floor wins: trailing prose can't break a complete document, and a truncation mid-string can never yield a parseable floor-passing prefix (a truncated rule is dropped together with its table header). An unterminated draft fails extraction; nothing is written and the error explains why.

Review findings: the HIGH (multi-round bypass + no parse gate) and both actionable MEDIUMs fixed; the trailing-prose case covered by a test; LOW #5/#6 documented in-code, LOW #7 (O(n²) salvage — measured 620 ms at 4000 transcript lines) accepted, LOW #8 test renamed. `basic_structure_errors` gained a parse-first path; blast radius verified (no external callers; the CLI's separate private `extract_toml` in `infra.rs` is untouched).

### Fix ⑦: transient transport errors are retried

Re-verification of the 8 remaining frontier failures showed they were not gate failures: every one died with `error sending request for url (…)` mid-generation. Two findings drove the fix:

- **reqwest renders request timeouts with the same `Display` text as connect failures**, so the earlier "transport flake" reading was wrong — most of those runs were the 120 s request timeout (`OXO_FLOW_AI_TIMEOUT_SECS` default) killing a single slow thinking round.
- `is_timeout()` distinguishes them precisely. Transport errors are retried with 2 s/5 s backoffs in every backend through one generic helper; **request timeouts are deliberately excluded** — a retry would deterministically re-timeout, the lever is the existing `OXO_FLOW_AI_TIMEOUT_SECS` knob. And since a measured GLM thinking round ran **145 s** — past the old 120 s default, killed mid-round — that default is now **300 s** (10 s connect timeout still fails fast on a dead endpoint); ai.md's tuning table documents the measured basis.

### Fix ⑦b: the retry scope covers response decoding too (found live, wave F2)

The send-only retry left half the transport path uncovered: the very next GLM draw died **3.3 s** in with `response parse failed: error decoding response body` and 0/0 tokens — a reqwest decode failure at `.json()`, *after* the send had already succeeded, so the send-only retry never saw it. On a proxy endpoint a truncated or garbled 200 at 3 s is a flake, not a protocol change.

`send_with_retry` is now generic over a decode step and returns `(status, headers, decoded)`, so one retry loop covers send **and** decode:

- the transient set gains `is_decode()` (timeouts still excluded); the three JSON backends (Claude, OpenAI-compatible, Ollama) pass `resp.json::<Value>()` and keep the `response parse failed` prefix on both the non-transient and `RetryExhausted` paths;
- the streaming site deliberately keeps a pass-through decode: its body is consumed incrementally *after* the retry scope, so a mid-stream failure cannot be replayed without duplicating already-streamed content;
- deterministic garbage still terminates: two retries, then `RetryExhausted` — which fix ⑧'s provider-error arm archives with the session.

Deterministically re-verified against the real binary: a local mock Anthropic endpoint serving one garbled 200 followed by a valid response shows the `transient transport error — retrying … error="error decoding response body"` warn on stderr, the retried request decodes, and the generation completes end-to-end (workflow written, exit 0) — the exact shape that killed wave F2 at 3.3 s with 0 tokens. The tradeoff is explicit: a decode retry re-sends a request the server may have fully processed, so a garbled 200 re-bills the generation (bounded by the two-retry budget); on a flaky proxy that is the cheaper failure mode by far, since the alternative is a dead paid run.

A review finding tightened the scope further: decode failures on **non-2xx** responses were also classified as transient, so a 429/401 answering with an empty or HTML body was replayed twice against the rate-limited endpoint and the real status was masked as a parse failure. Decode failures on error statuses now surface `HTTP <status> — …` immediately and are never replayed; only garbled success bodies remain retryable (`e4606dc4`).

### Fix ⑧: a provider error aborts the generation, but the spend must stay visible

The orchestrator round loop propagated provider errors with a bare `?`, skipping `record_transcript`/`session.fail`/`log_session_usage`/`save_session`. A generation that completed many successful tool rounds and *then* hit a request timeout reported `input_tokens: 0, output_tokens: 0, rounds: null` — paid work made invisible, and the CLI's degraded-delivery path (fix ⑥) could not extract anything from the empty shell. (The MaxRounds-path comment had already named this bug class: "dropping the session here made the spend invisible".)

`archive_failed_generation` now unifies all three abort arms — round cap, cancellation, and the new provider-error arm — and a scripted-provider regression test pins the contract: the error surfaces as-is, the loop does not silently retry it, and the transcript lands in the saved session.

### Fix ⑨: an exploration-budget nudge, mid-run, before the cap

The wave E/F/F3 over-exploration shape — every assistant turn a pure tool-call turn, zero prose, budget exhausted — had a structural gap: the only steering the harness offers is the final-round notice, which lands exactly at the cap, after every round is already spent. The orchestrator now tracks consecutive zero-prose tool-only rounds and, at `max_rounds/2` (minimum 2), injects a one-shot warning telling the model to consolidate what it has found and start producing the deliverable.

Three design points came from this campaign's earlier findings:

- **The notice rides the last tool result** rather than standing alone: tool results map to the user role on the Anthropic wire, so a bare user turn after them would flatten into consecutive user turns — the exact wire shape the extraction-failure fix found made GLM regenerate blind.
- **One shot per generation**, and the streak resets on any prose round — a model that resumed exploring after writing prose earns a fresh budget, but the harness never nags twice in one run.
- **No dead injections**: a notice computed during the final round would never be surfaced (the loop fails at the head first), so the guard mirrors the final-round-notice invariant.

Three scripted tests pin fire-at-threshold, fire-once (the notice appears in exactly one tool result even across later calls), and reset-on-prose; `docs/guide/src/commands/ai.md` documents the behavior in the correction-budget section.

### Live re-verification on csu-out (2026-09-12)

Waves A–C re-ran the 13 previously failed model×intent pairs on the shipped fixes (5 PASS); the residual 8 were re-run in wave E with the documented `OXO_FLOW_AI_TIMEOUT_SECS=600` knob (an earlier wave D against the same 8 was aborted when the endpoint went unreachable mid-evening; wave E is the complete dataset).

**Wave E tally — 7/8 PASS:**

| Model | Intent | Result | Wall | Tokens (in/out) |
|---|---|---|---|---|
| GLM | trim-cutadapt | FAIL — 10-round cap, 0 prose turns | 491.4 s | 83,633 / 39,765 |
| GLM | germline-gatk | PASS | 428.3 s | 27,859 / 24,525 |
| DeepSeek | somatic-mutect2 | PASS | 89.4 s | 34,297 / 5,253 |
| DeepSeek | amplicon-dada2 | PASS | 46.2 s | 20,480 / 5,787 |
| DeepSeek | hic-cooler | PASS | 61.5 s | 43,425 / 8,163 |
| Qwen | trim-cutadapt | PASS | 272.4 s | 34,001 / 13,977 |
| Qwen | rnaseq-hisat2 | PASS — the fix-⑥ prototype now passes normal delivery | 279.0 s | 43,895 / 16,123 |
| Qwen | rnaseq-salmon | PASS | 822.5 s | 76,850 / 38,601 |

Findings:

- The 8 residual failures were **request-timeout class, not capability class**: with the knob raised, 7 of 8 pass outright — including Qwen rnaseq-hisat2, whose broken-TOML delivery motivated fix ⑥ and which now clears the deterministic gates without needing the degraded path at all.
- New failure shape (GLM trim-cutadapt under the 600 s knob): 491 s, 14 tool calls, 83 k/40 k tokens, then the 10-round cap with **every assistant turn a pure tool-call turn (zero prose)** — including two `fetch_url` detours to external docs. This is model over-exploration, not an orchestration bug: archival and the final-round notice behaved exactly as designed. Recorded as a model-behavior characterization, not a defect.
- Fix ⑧ is observable end-to-end: failed runs now log real `prompt_tokens`/`completion_tokens` and save a populated session, where the same failure class previously reported 0/0.

**Wave F — the committed binary under default knobs** (no `OXO_FLOW_AI_TIMEOUT_SECS`, live check of the new 300 s default): DeepSeek somatic-mutect2 PASS (44 s). GLM germline-gatk hit the round cap on a fast lean draw (15.8 s, 619 output tokens, 16 embedded-KB lookups, zero prose) — the **same over-exploration shape** as wave E's trim-cutadapt, now on a second intent, and against a draw of the same intent that passed in wave E (428 s, 24.5 k output tokens): GLM's losses on exploration-heavy intents are draw-variance, not deterministic. The failure also exercised fix ⑧'s round-cap arm live: real tokens logged, session archived. Neither change can cause this shape (transport retry only fires on transport errors; the higher timeout grants more, never less, time).

**Wave F2 — fix ⑦b found in the wild**: the immediately following GLM draw died at 3.3 s on a garbled response body (fix ⑦b above), which is what motivated the decode half of the retry.

**Wave F3 — third germline-gatk draw, on the fixed binary** (also default knobs): another round-cap loss, this time a *heavy* draw — 158.6 s, 72.5 k/16.5 k tokens, 22 knowledge lookups (9 `lookup_tool`, 6 `lookup_skill`, 6 `lookup_pipeline`, 1 `fetch_url` detour), **all ten assistant turns again zero prose**; `total_usage` logged and the session archived (fix ⑧'s round-cap arm, second live exercise). The three same-intent draws now span PASS 428 s / FAIL 15.8 s lean / FAIL 158.6 s heavy — draw variance is settled as the characterization, and the exploration-budget nudge (fix ⑨) is the direct remedy.

A natural follow-up — out of scope here — is an exploration-budget nudge in the orchestrator (e.g. a warning injected after N consecutive tool-only rounds); the final-round notice already exists but lands exactly at the cap. **Shipped in this PR** (`2ad2a7b5`, see fix ⑨).

**Wave G — the nudge binary live** (defaults, csu-out): the fourth same-intent germline-gatk draw is a healthy one and **PASSes in 137.4 s** (29.7 k/15.0 k tokens, 3 tool rounds then prose — the streak never reaches the threshold, so the nudge correctly stays silent). The firing itself is deterministic rather than draw-dependent, so it was verified through the real binary against a local mock endpoint replaying the over-exploration shape: six pure tool-call rounds, then the deliverable. The binary logs `exploration budget nudge injected rounds=5 tool_only_rounds=5` exactly at the threshold, the final provider request carries the notice exactly once, and the generation completes with the workflow written (exit 0) — a draw that previously died at the cap with nothing written now gets steering at the halfway mark.

### Review disposition (10-angle adversarial pass over `main...HEAD`)

Every finding was re-verified against the code before acting. Fixed: the five defects above plus two stale env-table defaults (AGENTS.md / ai-cli.md still said 120 s after fix ⑦ — `eee3e3d2`). Rejected with cause:

- *"PRICE_PER_MTOK keys GLM/Qwen never match"* — false: the harness passes the raw `--models` token (`GLM`) as both the model id and the cost key, and the endpoint accepts it (waves A–G are live proof); the keys match exactly.
- *"max_retries 6→10 flips the merge sentinel for persisted 6s"* — real but accepted and documented: the sentinel idiom (default-value-means-unset) was a reviewed, test-pinned decision; the affected population is files that stored the old default, for whom the pre-PR behavior already starved rounds. Deliberate 6s are indistinguishable from persisted defaults, so a code-level migration would misclassify; the honest remedy is that affected users re-save the setting.
- *raw-salvage O(n²) re-parse* — previously measured (620 ms at 4000 transcript lines) and accepted as a documented LOW.
- *orchestrator.rs exceeds an 800-line file limit* — non-test code ends at ~560 lines; the repo convention is inline tests (Rust standard), which the line count includes.

### Test plan

- [x] `make ci` fully green (fmt + clippy -D warnings + build + workspace tests `--test-threads=1` + audit + schema/version gates + frontend lint)
- [x] oxo-flow-ai: 13/13 pipeline_gen tests incl. new multi-round reopen, dangling shell-less rule, trailing-prose salvage, raw-truncation, floor unit, injected-validator loop
- [x] oxo-flow-web: 6/6 extract tests (fixture updated for the floor)
- [x] GLM 5/5 on the original failure prototypes with the new defaults (defaults-only change)
- [x] Live re-verification of fixes ①–⑧ end-to-end on csu-out (waves A–F3, ≥2 min intervals; endpoint is free — the DeepSeek cost window does not apply to it)
- [x] Wave G on the nudge binary: healthy GLM draw passes (137.4 s, nudge correctly silent) and the firing is live-verified deterministically through the real binary (mock over-exploration replay: injects at rounds=5, notice exactly once, workflow written)
- [x] New retry tests: garbled-then-valid body is replayed into a successful decode; always-garbled body exhausts into `RetryExhausted` carrying the `response parse failed` prefix; existing tests pin timeout exclusion and attempt counts; decode-retry deterministically re-verified against the real binary via a local mock endpoint (garbled 200 → retried → valid JSON → workflow written, exit 0)
- [x] New regression test: `provider_error_archives_and_surfaces_without_retry` (scripted provider, 2 observed calls, error surfaces unmodified)
- [x] New exploration-budget nudge tests: fire-at-threshold, fire-once-per-generation, reset-on-prose (scripted backend)
- [x] New skills-search tests: partial matches backfill after full matches; a pathological 101-term query keeps its signal term under the 32-term cap; all pre-existing search tests unchanged and green
- [x] Review-wave regression tests: 429-with-HTML-body is sent exactly once and surfaces "HTTP 429"; script/transform rules pass the floor; two-anchor raw salvage is latest-first; empty echoes and stacked directives keep the wire free of empty assistant blocks and consecutive user turns; narrated tool rounds reset the exploration streak (oxo-flow-ai 261/261)
